### PR TITLE
Modules v2: docks, tabs, panes, right-click and settings + website improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [
     "/preview.html",
     "/preview.ans",
     "/MODULE-GUIDE.md",
+    "/examples",
     "/CONTRIBUTING.md",
     "/SECURITY.md",
     "/install.sh",

--- a/MODULE-GUIDE.md
+++ b/MODULE-GUIDE.md
@@ -3,8 +3,9 @@
 **This guide has moved to the documentation site:**
 
 → **[Writing a Module](https://bohay.dev/docs/extend/writing-modules/)** —
-the complete guide: manifest reference, environment variables, the context
-blob, calling back into bohay, distribution, and troubleshooting.
+the complete guide: manifest reference, right-click menus, settings, docks,
+panes, environment variables, the context blob, calling back into bohay,
+distribution, and troubleshooting.
 
 Quick taste — a module is a directory with a `bohay-module.toml` manifest
 declaring argv commands, in any language, no SDK:
@@ -13,17 +14,48 @@ declaring argv commands, in any language, no SDK:
 id = "you.hello"
 name = "Hello"
 version = "0.1.0"
-min_bohay_version = "0.1.0"
+min_bohay_version = "0.8.3"
 
 [[actions]]
 id = "greet"
+title = "Say hello"
+contexts = ["pane"]          # also offer it on right-click inside a pane
 command = ["sh", "greet.sh"]
+
+[[settings]]
+key = "who"                  # shows up in Settings → Modules
+title = "Greet who?"
+type = "string"
+default = "world"
+```
+
+```sh
+#!/bin/sh
+# greet.sh — everything arrives in the environment, no JSON parsing needed
+"$BOHAY_BIN_PATH" ui toast "hello $BOHAY_SETTING_WHO from $BOHAY_WORKSPACE_CWD"
 ```
 
 ```sh
 bohay module link .              # register it
 bohay module run you.hello greet
+bohay module log                 # status + captured output
 ```
+
+A module can reach docks, panes, tabs, right-click menus, settings, lifecycle
+events, and a startup hook. Anything in `bohay help` is available to it.
+
+## Worked examples
+
+Three complete modules live in [`examples/modules/`](examples/modules), one per
+language:
+
+| Example | Language | Shows |
+|---|---|---|
+| [`branch-dock`](examples/modules/branch-dock) | Bash | A sidebar dock, clickable rows, a startup hook, number + enum settings |
+| [`agent-ping`](examples/modules/agent-ping) | Python | An event hook, a secret setting, an agent right-click action |
+| [`scratch-pane`](examples/modules/scratch-pane) | Node | A pane entrypoint, pane right-click actions, the selection, tab renaming |
+
+Copy one, change the `id`, and `bohay module link` it.
 
 See also [Using Modules](https://bohay.dev/docs/extend/using-modules/)
 for discovering and installing community modules.

--- a/examples/modules/README.md
+++ b/examples/modules/README.md
@@ -1,0 +1,52 @@
+# Example modules
+
+Three complete, working bohay modules — one per language — each covering a
+different part of the extension surface. They are meant to be **copied and
+edited**, not installed as-is.
+
+| Module | Language | Covers |
+|---|---|---|
+| [`branch-dock`](branch-dock) | Bash | A sidebar **dock**, clickable rows with a `value` payload, a **startup hook**, `number` + `enum` **settings**, a `workspace` right-click action |
+| [`agent-ping`](agent-ping) | Python | An **event hook** on agent status, a **secret** setting, an `agent` right-click action, toasts |
+| [`scratch-pane`](scratch-pane) | Node | A **pane** entrypoint, `pane` right-click actions, reading the **selection**, **renaming a tab**, the state dir |
+
+Nothing here needs a build step or a dependency beyond the language runtime
+itself (`sh`, `python3`, `node`).
+
+## Try one
+
+```sh
+bohay module link ./examples/modules/branch-dock
+bohay module list
+```
+
+`branch-dock` paints its dock immediately (its startup hook runs on link), so
+you should see a **BRANCHES** section appear in the left sidebar when the
+active node is a git repo. Click a branch to check it out. Open
+**Settings → Modules** to see its two settings, and right-click a WORKSPACES row
+for its "Refresh branches" entry.
+
+Remove it again with:
+
+```sh
+bohay module unlink example.branch-dock
+```
+
+## Reading them
+
+Start with `branch-dock/refresh.sh`. It is the shortest demonstration of the
+whole idea: read the injected `BOHAY_*` variables, do some work, and call back
+through `$BOHAY_BIN_PATH`. There is no SDK to import in any of these files.
+
+## Writing your own
+
+Full reference: **[bohay.dev/docs/extend/writing-modules](https://bohay.dev/docs/extend/writing-modules/)**.
+
+Two rules worth knowing up front:
+
+- Call back through `$BOHAY_BIN_PATH`, never a bare `bohay` on `PATH`. It points
+  at the running binary, so your module works across Unix sockets and Windows
+  named pipes.
+- Write durable data to `$BOHAY_MODULE_STATE_DIR` or `$BOHAY_MODULE_CONFIG_DIR`,
+  never into the module directory. For a git-installed module that directory is
+  a managed checkout a reinstall replaces.

--- a/examples/modules/agent-ping/bohay-module.toml
+++ b/examples/modules/agent-ping/bohay-module.toml
@@ -1,0 +1,38 @@
+id = "example.agent-ping"
+name = "Agent Ping"
+version = "0.1.0"
+min_bohay_version = "0.8.3"
+description = "Post a webhook when an agent needs you or finishes. Right-click an agent to ping it on demand."
+
+# Fires every time a pane's agent state changes. The payload arrives as
+# BOHAY_MODULE_EVENT_JSON; the pane it happened in is in the usual context vars.
+[[events]]
+on = "pane.agent_status_changed"
+command = ["python3", "ping.py"]
+
+# Adds a row to the right-click menu on a live agent in the AGENTS sidebar.
+# The clicked agent's pane is the invocation target, not whatever had focus.
+[[actions]]
+id = "ping-now"
+title = "Send a ping"
+contexts = ["agent"]
+command = ["python3", "ping.py", "--force"]
+
+[[settings]]
+key = "webhook"
+title = "Webhook URL"
+type = "string"
+secret = true
+
+[[settings]]
+key = "notify-on"
+title = "Notify on"
+type = "enum"
+options = ["blocked", "done", "both"]
+default = "blocked"
+
+[[settings]]
+key = "toast"
+title = "Also show a toast"
+type = "bool"
+default = true

--- a/examples/modules/agent-ping/ping.py
+++ b/examples/modules/agent-ping/ping.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Post a webhook when an agent goes blocked or finishes.
+
+bohay runs this as a plain subprocess, so there is no SDK to import. Two ways in:
+
+  * the flat vars, easiest from any language:
+      BOHAY_PANE_ID / BOHAY_PANE_AGENT / BOHAY_PANE_STATUS
+      BOHAY_WORKSPACE_CWD, BOHAY_SETTING_WEBHOOK, BOHAY_SETTING_NOTIFY_ON, ...
+  * the full snapshot, when you want more:
+      BOHAY_MODULE_CONTEXT_JSON, and for an event hook BOHAY_MODULE_EVENT_JSON
+
+Talk back to bohay through BOHAY_BIN_PATH, never a bare `bohay` on PATH -- that
+keeps the module working on Windows named pipes as well as Unix sockets.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+BOHAY = os.environ.get("BOHAY_BIN_PATH", "bohay")
+
+
+def bohay(*args: str) -> None:
+    """Call back into bohay, ignoring failures (a module must never wedge the UI)."""
+    try:
+        subprocess.run([BOHAY, *args], check=False, capture_output=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def main() -> int:
+    forced = "--force" in sys.argv
+
+    # Settings arrive pre-resolved: manifest defaults with the user's choices on
+    # top, already type-checked and clamped by bohay.
+    webhook = os.environ.get("BOHAY_SETTING_WEBHOOK", "").strip()
+    notify_on = os.environ.get("BOHAY_SETTING_NOTIFY_ON", "blocked")
+    want_toast = os.environ.get("BOHAY_SETTING_TOAST", "true") == "true"
+
+    agent = os.environ.get("BOHAY_PANE_AGENT") or "agent"
+    status = os.environ.get("BOHAY_PANE_STATUS") or "unknown"
+    pane = os.environ.get("BOHAY_PANE_ID") or "?"
+
+    # An event hook prefers the event payload, which describes the pane that
+    # actually changed rather than the one in focus.
+    raw = os.environ.get("BOHAY_MODULE_EVENT_JSON")
+    if raw:
+        try:
+            event = json.loads(raw)
+            agent = event.get("agent") or agent
+            status = event.get("status") or status
+            pane = event.get("pane") or pane
+        except json.JSONDecodeError:
+            pass
+
+    # Right-click always pings; an event only pings for the states asked for.
+    if not forced:
+        wanted = {"both": {"blocked", "done"}}.get(notify_on, {notify_on})
+        if status not in wanted:
+            return 0
+
+    where = os.path.basename(os.environ.get("BOHAY_WORKSPACE_CWD", "") or "") or "bohay"
+    message = f"{agent} is {status} in {where} (pane {pane})"
+
+    if want_toast:
+        bohay("ui", "toast", message)
+
+    if not webhook:
+        # Nothing configured yet: point the user at where to set it, once.
+        if forced:
+            bohay("ui", "toast", "set a Webhook URL in Settings > Modules")
+        return 0
+
+    body = json.dumps({"text": message}).encode()
+    request = urllib.request.Request(
+        webhook, data=body, headers={"Content-Type": "application/json"}
+    )
+    try:
+        urllib.request.urlopen(request, timeout=10).close()
+    except (urllib.error.URLError, OSError) as err:
+        # stderr lands in `bohay module log`, which is where you debug a module.
+        print(f"webhook failed: {err}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/modules/branch-dock/bohay-module.toml
+++ b/examples/modules/branch-dock/bohay-module.toml
@@ -1,0 +1,57 @@
+id = "example.branch-dock"
+name = "Branch Dock"
+version = "0.1.0"
+min_bohay_version = "0.8.3"
+description = "A sidebar dock listing the active node's git branches. Click one to check it out."
+platforms = ["macos", "linux"]
+
+# The dock bohay reserves for this module. The module fills it over the socket
+# with `ui.dock.push`; bohay owns the rendering and the user can move it to the
+# other sidebar from Settings -> Layout.
+[[docks]]
+id = "branches"
+title = "BRANCHES"
+placement = "sidebar.left"
+
+# Run once when the session is up and the socket is listening. Dock contents are
+# deliberately not persisted, so this is what repaints the dock after a restart.
+[[startup]]
+command = ["sh", "refresh.sh"]
+
+# Keep the dock honest as the user moves around.
+[[events]]
+on = "workspace.created"
+command = ["sh", "refresh.sh"]
+
+[[events]]
+on = "tab.created"
+command = ["sh", "refresh.sh"]
+
+# Right-click a WORKSPACES row to refresh that node's branches on demand.
+[[actions]]
+id = "refresh"
+title = "Refresh branches"
+contexts = ["workspace"]
+command = ["sh", "refresh.sh"]
+
+# Clicking a dock row invokes this with the branch in BOHAY_MODULE_ROW_ACTION.
+[[actions]]
+id = "checkout"
+title = "Check out branch"
+command = ["sh", "checkout.sh"]
+
+[[settings]]
+key = "limit"
+title = "Branches to show"
+type = "number"
+default = 8
+min = 1
+max = 30
+step = 1
+
+[[settings]]
+key = "sort"
+title = "Sort by"
+type = "enum"
+options = ["recent", "name"]
+default = "recent"

--- a/examples/modules/branch-dock/checkout.sh
+++ b/examples/modules/branch-dock/checkout.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Check out the branch whose dock row was clicked.
+#
+# A clicked dock row invokes its action with the row's identity in the env:
+#   BOHAY_MODULE_ROW_VALUE  the row's `value` (here: the branch name)
+#   BOHAY_MODULE_ROW_TEXT   the row's visible text
+#   BOHAY_MODULE_ROW_INDEX  its position in the dock
+set -eu
+
+bohay="${BOHAY_BIN_PATH:-bohay}"
+repo="${BOHAY_WORKSPACE_CWD:-$PWD}"
+branch="${BOHAY_MODULE_ROW_VALUE:-}"
+
+if [ -z "$branch" ]; then
+  "$bohay" ui toast "no branch selected"
+  exit 1
+fi
+
+if git -C "$repo" checkout "$branch" >/dev/null 2>&1; then
+  "$bohay" ui toast "switched to $branch"
+  sh "$(dirname "$0")/refresh.sh"   # repaint so the current-branch dot moves
+else
+  # A dirty tree is the usual reason, so say so rather than failing silently.
+  "$bohay" ui toast "cannot switch to $branch (uncommitted changes?)"
+  exit 1
+fi

--- a/examples/modules/branch-dock/refresh.sh
+++ b/examples/modules/branch-dock/refresh.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Fill the BRANCHES dock with the active node's git branches.
+#
+# Everything this needs arrives in the environment, so there is no JSON parsing:
+#   BOHAY_BIN_PATH        the running bohay binary (use it, not `bohay` on PATH)
+#   BOHAY_WORKSPACE_CWD   the folder of the node this was invoked against
+#   BOHAY_SETTING_LIMIT   the "Branches to show" setting
+#   BOHAY_SETTING_SORT    the "Sort by" setting
+set -eu
+
+bohay="${BOHAY_BIN_PATH:-bohay}"
+repo="${BOHAY_WORKSPACE_CWD:-$PWD}"
+limit="${BOHAY_SETTING_LIMIT:-8}"
+sort="${BOHAY_SETTING_SORT:-recent}"
+
+# Not a git repo: show one inert row rather than an empty dock.
+if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+  "$bohay" ui dock push --id branches --title BRANCHES \
+    --rows '[{"text":"not a git repo"}]'
+  exit 0
+fi
+
+case "$sort" in
+  name) order='refname' ;;
+  *)    order='-committerdate' ;;
+esac
+
+current=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')
+
+# Build the rows array. `dot` tints the row's status glyph; `value` is the
+# payload handed to the row's action when it is clicked, which is what lets one
+# `checkout` action serve every row.
+rows=$(git -C "$repo" for-each-ref --format='%(refname:short)' \
+         --sort="$order" --count="$limit" refs/heads/ |
+  while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    if [ "$branch" = "$current" ]; then dot=working; else dot=idle; fi
+    # Escape the two characters that matter inside a JSON string.
+    esc=$(printf '%s' "$branch" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '{"text":"%s","dot":"%s","action":"checkout","value":"%s"},' \
+      "$esc" "$dot" "$esc"
+  done)
+
+# Trim the trailing comma and wrap.
+"$bohay" ui dock push --id branches --title BRANCHES \
+  --rows "[${rows%,}]"

--- a/examples/modules/scratch-pane/bohay-module.toml
+++ b/examples/modules/scratch-pane/bohay-module.toml
@@ -1,0 +1,34 @@
+id = "example.scratch-pane"
+name = "Scratch Pane"
+version = "0.1.0"
+min_bohay_version = "0.8.3"
+description = "Right-click a pane to open a scratch shell beside it, in that pane's directory."
+
+# A pane entrypoint: bohay spawns this argv as a real pane, so it can be a REPL,
+# a TUI, a log tail -- anything that runs in a terminal.
+[[panes]]
+id = "notes"
+title = "Notes"
+placement = "split"
+command = ["node", "notes.js"]
+
+# Right-click inside any pane to get these rows.
+[[actions]]
+id = "open-notes"
+title = "Open notes beside this"
+contexts = ["pane"]
+command = ["node", "open.js"]
+
+# Right-click a pane with text selected to stash the selection into the notes
+# file -- the selection travels in the invocation context.
+[[actions]]
+id = "stash-selection"
+title = "Send selection to notes"
+contexts = ["pane"]
+command = ["node", "stash.js"]
+
+[[settings]]
+key = "name-the-tab"
+title = "Rename the tab to Notes"
+type = "bool"
+default = true

--- a/examples/modules/scratch-pane/notes.js
+++ b/examples/modules/scratch-pane/notes.js
@@ -1,0 +1,38 @@
+// The `notes` pane entrypoint: a tiny scratch pad running in a real bohay pane.
+//
+// A pane command owns a terminal. Read stdin, write stdout, and exit when you
+// are done -- bohay closes the pane when the process exits.
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+
+const stateDir = process.env.BOHAY_MODULE_STATE_DIR ?? process.cwd();
+fs.mkdirSync(stateDir, { recursive: true });
+const file = path.join(stateDir, "notes.md");
+
+function show() {
+  const body = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
+  console.clear();
+  console.log("notes  ·  type a line to append  ·  :r reload  ·  :q quit");
+  console.log("─".repeat(56));
+  console.log(body.trim() || "(empty)");
+  console.log("─".repeat(56));
+}
+
+show();
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: "> " });
+rl.prompt();
+
+rl.on("line", (line) => {
+  const text = line.trim();
+  if (text === ":q") return rl.close();
+  if (text === ":r") {
+    show();
+  } else if (text) {
+    fs.appendFileSync(file, `${text}\n`);
+    show();
+  }
+  rl.prompt();
+});
+
+rl.on("close", () => process.exit(0));

--- a/examples/modules/scratch-pane/open.js
+++ b/examples/modules/scratch-pane/open.js
@@ -1,0 +1,33 @@
+// Open the module's `notes` pane next to the right-clicked pane, then
+// (optionally) name the tab.
+//
+// bohay hands every command its context twice: as flat BOHAY_* vars for quick
+// use, and as one BOHAY_MODULE_CONTEXT_JSON blob when you want the whole shape.
+const { spawnSync } = require("node:child_process");
+
+const bohay = process.env.BOHAY_BIN_PATH ?? "bohay";
+
+function run(...args) {
+  const r = spawnSync(bohay, args, { encoding: "utf8" });
+  if (r.status !== 0) {
+    // stderr shows up in `bohay module log`.
+    process.stderr.write(r.stderr ?? `${args[0]} failed\n`);
+  }
+  return r;
+}
+
+const moduleId = process.env.BOHAY_MODULE_ID;
+
+// `module pane open` spawns the manifest's `[[panes]]` entrypoint as a real
+// pane. It is a normal bohay pane afterwards, so pane.focus/close/split all
+// work on it like any other.
+run("module", "pane", "open", moduleId, "notes", "--placement", "split");
+
+if (process.env.BOHAY_SETTING_NAME_THE_TAB === "true") {
+  // Tab index comes from the context; renaming is the same label the
+  // tab-rename modal writes.
+  const tab = process.env.BOHAY_TAB_INDEX ?? "";
+  run("tab", "rename", "notes", ...(tab ? ["--tab", tab] : []));
+}
+
+run("ui", "toast", "notes opened");

--- a/examples/modules/scratch-pane/stash.js
+++ b/examples/modules/scratch-pane/stash.js
@@ -1,0 +1,30 @@
+// Append the pane's selected text to the notes file.
+//
+// Selecting text in a pane and right-clicking puts that selection in the
+// invocation context, so a module can act on what the user highlighted.
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const bohay = process.env.BOHAY_BIN_PATH ?? "bohay";
+const toast = (text) => spawnSync(bohay, ["ui", "toast", text], { encoding: "utf8" });
+
+const context = JSON.parse(process.env.BOHAY_MODULE_CONTEXT_JSON ?? "{}");
+const selection = (context.selection ?? "").trim();
+
+if (!selection) {
+  toast("select some text first");
+  process.exit(0);
+}
+
+// Durable, user-visible state belongs in the state dir. Never write it into
+// BOHAY_MODULE_ROOT: a git-installed module's root is a managed checkout that
+// a reinstall replaces.
+const stateDir = process.env.BOHAY_MODULE_STATE_DIR ?? process.cwd();
+fs.mkdirSync(stateDir, { recursive: true });
+
+const file = path.join(stateDir, "notes.md");
+const where = context.pane?.cwd || context.workspace?.cwd || "";
+fs.appendFileSync(file, `\n## from ${where}\n\n${selection}\n`);
+
+toast(`saved ${selection.split("\n").length} line(s) to notes`);

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -256,7 +256,7 @@ impl App {
         }
     }
 
-    fn dispatch(&mut self, method: &str, p: &Value) -> Result<Value, (String, String)> {
+    pub(crate) fn dispatch(&mut self, method: &str, p: &Value) -> Result<Value, (String, String)> {
         match method {
             "ping" => Ok(json!({"type":"pong","version": env!("CARGO_PKG_VERSION"),"protocol":1})),
             "server.stop" => {
@@ -432,8 +432,27 @@ impl App {
             // ── tabs ──
             "tab.list" => {
                 let ws = self.ws();
-                let arr: Vec<Value> = (0..ws.tabs.len())
-                    .map(|i| json!({"tab": (i + 1).to_string(), "active": i == ws.active_tab}))
+                let arr: Vec<Value> = ws
+                    .tabs
+                    .iter()
+                    .enumerate()
+                    .map(|(i, t)| {
+                        // `name` is what `tab.rename` writes; `kind` distinguishes
+                        // the dashboard tabs, which have no panes and can't be named.
+                        let kind = if t.git.is_some() {
+                            "git"
+                        } else if t.orch {
+                            "orch"
+                        } else {
+                            "panes"
+                        };
+                        json!({
+                            "tab": (i + 1).to_string(),
+                            "active": i == ws.active_tab,
+                            "name": t.name.clone(),
+                            "kind": kind,
+                        })
+                    })
                     .collect();
                 Ok(json!({"type":"tab_list","tabs":arr}))
             }
@@ -445,6 +464,28 @@ impl App {
                 if let Some(i) = param_usize(p, "tab") {
                     self.switch_tab(i.saturating_sub(1));
                 }
+                Ok(json!({"type":"ok"}))
+            }
+            // Name a tab from a module (docs/13 §3.9) — the same label the
+            // tab-rename modal writes. An empty name clears it back to a number.
+            "tab.rename" => {
+                let i = param_usize(p, "tab")
+                    .map(|i| i.saturating_sub(1))
+                    .unwrap_or(self.ws().active_tab);
+                let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("").trim();
+                let active = self.active_ws;
+                let tab = self.workspaces[active]
+                    .tabs
+                    .get_mut(i)
+                    .ok_or_else(not_found)?;
+                // Git/orch tabs keep their fixed labels (docs/28).
+                if tab.git.is_some() || tab.orch {
+                    return Err(module_err(
+                        "git and orch tabs cannot be renamed".to_string(),
+                    ));
+                }
+                tab.name = (!name.is_empty()).then(|| name.chars().take(40).collect());
+                self.session_dirty = true;
                 Ok(json!({"type":"ok"}))
             }
             "tab.close" => {
@@ -564,6 +605,12 @@ impl App {
                 }))
             }
             // A module pushes rows into its sidebar dock (docs/29, DOCK-4).
+            // A one-line confirmation, the same transient toast a copy shows.
+            "ui.toast" => {
+                let text = req_str(p, "text")?;
+                self.show_toast(text.chars().take(120).collect::<String>());
+                Ok(json!({"type":"ok"}))
+            }
             "ui.dock.push" => {
                 let id = p.get("id").and_then(|v| v.as_str()).unwrap_or("");
                 if id.is_empty() {
@@ -591,6 +638,10 @@ impl App {
                                 dot: r.get("dot").and_then(|v| v.as_str()).map(|s| s.to_string()),
                                 action: r
                                     .get("action")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string()),
+                                value: r
+                                    .get("value")
                                     .and_then(|v| v.as_str())
                                     .map(|s| s.to_string()),
                             })
@@ -757,6 +808,61 @@ impl App {
                     .module_open_pane(module, entrypoint, placement, "api")
                     .map_err(module_err)?;
                 Ok(json!({"type":"pane","pane": id.0.to_string()}))
+            }
+            // ── module settings (docs/13 §3.6) ──
+            "module.settings.list" => {
+                let id = req_str(p, "id")?.to_string();
+                let values = self.module_settings(&id).map_err(module_err)?;
+                let specs: Vec<Value> = self
+                    .modules
+                    .find(&id)
+                    .map(|m| {
+                        m.manifest
+                            .settings
+                            .iter()
+                            .map(|s| {
+                                let v = values.get(&s.key).cloned().unwrap_or(Value::Null);
+                                // A listing is the "show me everything" call and
+                                // usually lands in a terminal, so a secret reports
+                                // only whether it is set — same as the UI. Read the
+                                // exact value with `module.settings.get {key}`.
+                                let set = !matches!(&v, Value::Null)
+                                    && !v.as_str().is_some_and(|t| t.is_empty());
+                                json!({
+                                    "key": s.key, "title": s.title, "type": s.kind,
+                                    "options": s.options, "min": s.min, "max": s.max,
+                                    "secret": s.secret, "set": set,
+                                    "value": if s.secret { Value::Null } else { v },
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                Ok(json!({"type":"module_settings","id": id,"settings": specs}))
+            }
+            "module.settings.get" => {
+                let id = req_str(p, "id")?.to_string();
+                let values = self.module_settings(&id).map_err(module_err)?;
+                match p.get("key").and_then(|v| v.as_str()) {
+                    Some(k) => {
+                        let v = values
+                            .get(k)
+                            .cloned()
+                            .ok_or_else(|| module_err(format!("module {id} has no setting {k}")))?;
+                        Ok(json!({"type":"module_setting","id": id,"key": k,"value": v}))
+                    }
+                    None => Ok(json!({"type":"module_settings","id": id,"values": values})),
+                }
+            }
+            "module.settings.set" => {
+                let id = req_str(p, "id")?.to_string();
+                let key = req_str(p, "key")?.to_string();
+                // Accept a JSON value or a bare string (what the CLI sends).
+                let raw = p.get("value").cloned().unwrap_or(Value::Null);
+                let v = self
+                    .module_set_setting(&id, &key, raw)
+                    .map_err(module_err)?;
+                Ok(json!({"type":"module_setting","id": id,"key": key,"value": v}))
             }
             "module.pane.focus" => {
                 let id = self.resolve_pane(p).ok_or_else(not_found)?;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -128,6 +128,14 @@ impl App {
             }
             return;
         }
+        // A module-setting prompt sits on top of the Settings modal: a click
+        // anywhere cancels it rather than reaching the rows underneath.
+        if self.module_setting_edit.is_some() {
+            if let MouseEventKind::Down(MouseButton::Left) = m.kind {
+                self.module_setting_edit = None;
+            }
+            return;
+        }
         // While the Settings modal is open it owns the mouse: clicks hit the
         // modal (or dismiss it); everything else is swallowed.
         if self.settings.is_some() {
@@ -548,14 +556,27 @@ impl App {
             .find(|(_, _, rect)| hit(*rect))
             .cloned()
         {
-            if let Some(action) = self
+            if let Some(row) = self
                 .module_docks
                 .get(&dock_id)
                 .and_then(|d| d.rows.get(row_i))
-                .and_then(|r| r.action.clone())
+                .cloned()
             {
-                let owner = self.module_owning_dock(&dock_id);
-                let _ = self.module_invoke_action(&action, owner.as_deref(), "dock");
+                if let Some(action) = row.action {
+                    let owner = self.module_owning_dock(&dock_id);
+                    // Tell the action *which* row was clicked, so one action can
+                    // serve a whole list (docs/13 §3.10).
+                    let extra = vec![
+                        ("BOHAY_MODULE_DOCK_ID".to_string(), dock_id.clone()),
+                        ("BOHAY_MODULE_ROW_INDEX".to_string(), row_i.to_string()),
+                        ("BOHAY_MODULE_ROW_TEXT".to_string(), row.text.clone()),
+                        (
+                            "BOHAY_MODULE_ROW_VALUE".to_string(),
+                            row.value.unwrap_or(row.text),
+                        ),
+                    ];
+                    let _ = self.module_invoke_dock_action(&action, owner.as_deref(), extra);
+                }
             }
             return;
         }
@@ -804,7 +825,7 @@ impl App {
 
     /// Extract the current selection's text from the pane's grid (linear, with
     /// trailing blanks trimmed). `None` for a click without a drag or empty text.
-    fn selection_text(&self) -> Option<String> {
+    pub(crate) fn selection_text(&self) -> Option<String> {
         let sel = self.selection?;
         if !sel.has_range() {
             return None;
@@ -947,6 +968,12 @@ impl App {
         // The help cheat-sheet overlay swallows the next key press and closes.
         if self.help_open {
             self.help_open = false;
+            return true;
+        }
+        // A module-setting prompt sits *inside* the Settings modal, so it must
+        // take keys first (docs/13 §3.6).
+        if self.module_setting_edit.is_some() {
+            self.handle_module_setting_key(key);
             return true;
         }
         // The Settings modal captures all input while open.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,6 +17,7 @@ use crate::event::AppEvent;
 use crate::ids::PaneId;
 use crate::ipc::api::{self, ApiRequest, EventBus};
 use crate::layout::{Axis, Dir, TileLayout};
+use crate::module::context::Target;
 use crate::persist::{self, SessionSnapshot};
 use crate::terminal::pty::Pane;
 use crate::ui::theme::{State, Theme};
@@ -32,8 +33,9 @@ mod picker;
 mod settings;
 
 pub use keys::Cmd;
+pub use modules::ModuleMenuAction;
 pub use picker::{FolderPicker, Row};
-pub use settings::{LayoutRow, SettingsTab, SettingsUi};
+pub use settings::{LayoutRow, ModuleRow, SettingsTab, SettingsUi};
 
 /// How recently a pane must have produced PTY output to read as *raw* Working.
 const ACTIVITY_WINDOW: Duration = Duration::from_millis(700);
@@ -99,7 +101,11 @@ pub enum Side {
 pub struct DockRow {
     pub text: String,
     pub dot: Option<String>,
+    /// Action id to invoke when this row is clicked.
     pub action: Option<String>,
+    /// Opaque per-row payload handed to that action as `BOHAY_MODULE_ROW_VALUE`
+    /// — what turns a list of branches into a list of *buttons* (docs/13 §3.10).
+    pub value: Option<String>,
 }
 
 /// A module-contributed dock's cached content (title + rows). bohay owns the
@@ -269,10 +275,15 @@ pub struct WsMenu {
     pub anchor: (u16, u16),
     /// Each visible item + its clickable rect, filled in by the renderer.
     pub items: Vec<(WsMenuItem, Rect)>,
+    /// Module actions offered here, snapshotted when the menu opened (docs/13
+    /// §3.8) so a registry change mid-menu can't shift what a click runs.
+    pub module_actions: Vec<ModuleMenuAction>,
 }
 
 /// An action offered by the workspace context menu. Worktree / git actions only
 /// appear for nodes inside a git repo. `Divider` is a non-interactive separator.
+/// `Module(i)` is the `i`-th module action declaring `contexts = ["workspace"]`
+/// (docs/13 §3.8), resolved against the live registry when clicked.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum WsMenuItem {
     Close,
@@ -282,6 +293,7 @@ pub enum WsMenuItem {
     Divider,
     OpenGit,
     OpenOrch,
+    Module(usize),
 }
 
 /// A right-click context menu **inside a pane**: split or close it. Opened by
@@ -293,6 +305,8 @@ pub struct PaneMenu {
     pub anchor: (u16, u16),
     /// Each visible item + its clickable rect, filled in by the renderer.
     pub items: Vec<(PaneMenuItem, Rect)>,
+    /// Module actions offered here, snapshotted when the menu opened (docs/13 §3.8).
+    pub module_actions: Vec<ModuleMenuAction>,
 }
 
 /// An action offered by the pane context menu. `SplitVertical` puts the new pane
@@ -306,9 +320,13 @@ pub enum PaneMenuItem {
     RunningCmd,
     Divider,
     Close,
+    /// The `i`-th module action declaring `contexts = ["pane"]` (docs/13 §3.8).
+    Module(usize),
 }
 
 impl PaneMenuItem {
+    /// The built-in rows, in render order. Module actions are appended after a
+    /// divider by [`App::pane_menu_items`].
     pub const ALL: &'static [PaneMenuItem] = &[
         PaneMenuItem::SplitVertical,
         PaneMenuItem::SplitHorizontal,
@@ -333,16 +351,21 @@ pub struct AgentMenu {
     pub target: AgentTarget,
     pub anchor: (u16, u16),
     pub items: Vec<(AgentMenuItem, Rect)>,
+    /// Module actions offered here, snapshotted when the menu opened (docs/13 §3.8).
+    pub module_actions: Vec<ModuleMenuAction>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum AgentMenuItem {
     Resume,
     Close,
+    Divider,
+    /// The `i`-th module action declaring `contexts = ["agent"]` (docs/13 §3.8).
+    Module(usize),
 }
 
 impl AgentMenu {
-    /// The items shown for a given target, in render order.
+    /// The built-in items for a given target, in render order.
     pub fn items_for(target: AgentTarget) -> Vec<AgentMenuItem> {
         match target {
             AgentTarget::Session(_) => vec![AgentMenuItem::Resume, AgentMenuItem::Close],
@@ -743,6 +766,21 @@ pub struct App {
     pub module_logs: Vec<crate::module::ModuleCommandLog>,
     /// Live module panes by pane id, untracked automatically on close (MOD-2).
     pub module_panes: HashMap<PaneId, crate::module::ModulePaneRecord>,
+    /// Modules whose `[[startup]]` hooks have already run this process, so a
+    /// re-entrant call (link, enable, socket-ready) can't run them twice.
+    pub module_startup_done: std::collections::HashSet<String>,
+    /// The module-settings row being edited in Settings → Modules, if any.
+    pub module_setting_edit: Option<ModuleSettingEdit>,
+}
+
+/// The inline text prompt for a `type = "string"` module setting (docs/13 §3.6).
+/// Number/bool/enum settings are stepped with the `‹ ›` arrows instead.
+pub struct ModuleSettingEdit {
+    pub module_id: String,
+    pub key: String,
+    pub title: String,
+    pub buffer: String,
+    pub secret: bool,
 }
 
 impl App {
@@ -885,6 +923,8 @@ impl App {
             modules: crate::module::registry::load(),
             module_logs: Vec::new(),
             module_panes: HashMap::new(),
+            module_startup_done: std::collections::HashSet::new(),
+            module_setting_edit: None,
         };
         // A fresh start still loads `orch.json` — its pane bindings belong to a
         // previous server run, so rebind/clear them (same as `from_snapshot`).
@@ -1178,6 +1218,8 @@ impl App {
             modules,
             module_logs: Vec::new(),
             module_panes,
+            module_startup_done: std::collections::HashSet::new(),
+            module_setting_edit: None,
         };
         // Pane ids are reallocated every run, so the ledger's pane bindings from
         // the previous server are stale — rebind them to the restored panes (by
@@ -1612,6 +1654,7 @@ impl App {
                 index,
                 anchor: (col, row),
                 items: Vec::new(),
+                module_actions: self.module_menu_actions("workspace"),
             });
         }
     }
@@ -1634,6 +1677,42 @@ impl App {
             items.push(WsMenuItem::OpenGit);
         }
         items.push(WsMenuItem::OpenOrch);
+        // Module actions declaring `contexts = ["workspace"]`, below a divider.
+        let extras = self.ws_menu.as_ref().map_or(0, |m| m.module_actions.len());
+        if extras > 0 {
+            items.push(WsMenuItem::Divider);
+            items.extend((0..extras).map(WsMenuItem::Module));
+        }
+        items
+    }
+
+    /// The pane context-menu items: the built-ins, then any module actions
+    /// declaring `contexts = ["pane"]` below a divider.
+    pub fn pane_menu_items(&self) -> Vec<PaneMenuItem> {
+        let mut items = PaneMenuItem::ALL.to_vec();
+        let extras = self
+            .pane_menu
+            .as_ref()
+            .map_or(0, |m| m.module_actions.len());
+        if extras > 0 {
+            items.push(PaneMenuItem::Divider);
+            items.extend((0..extras).map(PaneMenuItem::Module));
+        }
+        items
+    }
+
+    /// The AGENTS-list context-menu items for `target`, plus module actions
+    /// declaring `contexts = ["agent"]`.
+    pub fn agent_menu_items(&self, target: AgentTarget) -> Vec<AgentMenuItem> {
+        let mut items = AgentMenu::items_for(target);
+        let extras = self
+            .agent_menu
+            .as_ref()
+            .map_or(0, |m| m.module_actions.len());
+        if extras > 0 {
+            items.push(AgentMenuItem::Divider);
+            items.extend((0..extras).map(AgentMenuItem::Module));
+        }
         items
     }
 
@@ -1654,13 +1733,23 @@ impl App {
 
     /// Run a context-menu action for the menu's target, then close the menu.
     pub fn ws_menu_action(&mut self, item: WsMenuItem) {
-        let Some(index) = self.ws_menu.as_ref().map(|m| m.index) else {
+        let Some((index, actions)) = self
+            .ws_menu
+            .as_ref()
+            .map(|m| (m.index, m.module_actions.clone()))
+        else {
             return;
         };
         self.ws_menu = None;
         let cwd = self.workspaces.get(index).map(|w| w.cwd.clone());
         match item {
             WsMenuItem::Divider => {}
+            // The right-clicked node, which needn't be the focused one.
+            WsMenuItem::Module(i) => {
+                if let Some(a) = actions.get(i).cloned() {
+                    self.run_module_menu_action("workspace", a, Target::workspace(index));
+                }
+            }
             WsMenuItem::Rename => self.open_ws_rename(index),
             WsMenuItem::Close => self.close_workspace(index),
             WsMenuItem::NewWorktree => {
@@ -1749,6 +1838,7 @@ impl App {
             pane,
             anchor: (col, row),
             items: Vec::new(),
+            module_actions: self.module_menu_actions("pane"),
         });
     }
 
@@ -1769,7 +1859,11 @@ impl App {
 
     /// Run a pane context-menu action on its target pane, then close the menu.
     pub fn pane_menu_action(&mut self, item: PaneMenuItem) {
-        let Some(pane) = self.pane_menu.as_ref().map(|m| m.pane) else {
+        let Some((pane, actions)) = self
+            .pane_menu
+            .as_ref()
+            .map(|m| (m.pane, m.module_actions.clone()))
+        else {
             return;
         };
         self.pane_menu = None;
@@ -1777,6 +1871,13 @@ impl App {
         self.layout_mut().focus = pane;
         match item {
             PaneMenuItem::Divider => {}
+            PaneMenuItem::Module(i) => {
+                if let Some(a) = actions.get(i).cloned() {
+                    let mut target = Target::pane(pane);
+                    target.selection = self.selection_text();
+                    self.run_module_menu_action("pane", a, target);
+                }
+            }
             PaneMenuItem::SplitVertical => self.split(Axis::Col), // side by side
             PaneMenuItem::SplitHorizontal => self.split(Axis::Row), // stacked
             PaneMenuItem::RunningCmd => self.open_cmd_inspect(pane),
@@ -1794,10 +1895,16 @@ impl App {
     /// Open the AGENTS-list context menu for `target` (a resumable session or a
     /// live agent), anchored at the click.
     pub fn open_agent_menu(&mut self, target: AgentTarget, col: u16, row: u16) {
+        // Only a live agent has a pane for an action to act on.
+        let module_actions = match target {
+            AgentTarget::Live(_) => self.module_menu_actions("agent"),
+            AgentTarget::Session(_) => Vec::new(),
+        };
         self.agent_menu = Some(AgentMenu {
             target,
             anchor: (col, row),
             items: Vec::new(),
+            module_actions,
         });
     }
 
@@ -1810,6 +1917,7 @@ impl App {
                 .map(|(it, _)| *it)
         });
         match hit {
+            Some(AgentMenuItem::Divider) => {} // non-interactive; keep the menu open
             Some(it) => self.agent_menu_action(it),
             None => self.agent_menu = None, // click outside dismisses
         }
@@ -1818,7 +1926,11 @@ impl App {
     /// Run an AGENTS-menu action, then close the menu. Resume/Close act on a
     /// session; Close on a live agent jumps to and closes its pane.
     pub fn agent_menu_action(&mut self, item: AgentMenuItem) {
-        let Some(target) = self.agent_menu.as_ref().map(|m| m.target) else {
+        let Some((target, actions)) = self
+            .agent_menu
+            .as_ref()
+            .map(|m| (m.target, m.module_actions.clone()))
+        else {
             return;
         };
         self.agent_menu = None;
@@ -1830,6 +1942,13 @@ impl App {
                 self.close_pane(id);
             }
             (AgentMenuItem::Resume, AgentTarget::Live(_)) => {} // n/a for a live agent
+            (AgentMenuItem::Module(i), AgentTarget::Live(id)) => {
+                if let Some(a) = actions.get(i).cloned() {
+                    self.run_module_menu_action("agent", a, Target::pane(id));
+                }
+            }
+            (AgentMenuItem::Module(_), AgentTarget::Session(_)) => {} // no live pane
+            (AgentMenuItem::Divider, _) => {}
         }
     }
 
@@ -4156,6 +4275,7 @@ mod tests {
                 text: "build ok".into(),
                 dot: Some("done".into()),
                 action: None,
+                value: None,
             }],
         );
         assert_eq!(app.sidebars.side_of(&k), Some(Side::Right));

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -6,9 +6,22 @@
 use std::path::Path;
 
 use super::*;
+use crate::module::context::Target;
 use crate::module::manifest::ModuleManifest;
 use crate::module::runtime::{ModuleCommandLog, ModuleStatus};
-use crate::module::{context, paths, registry, runtime, InstalledModule, ModulePaneRecord};
+use crate::module::{
+    context, paths, registry, runtime, settings, InstalledModule, ModulePaneRecord,
+};
+
+/// One module action offered in a right-click menu (docs/13 §3.8). A menu
+/// snapshots these when it opens, so the rows it draws and the action a click
+/// runs are the same list even if the registry changes underneath.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ModuleMenuAction {
+    pub module_id: String,
+    pub action_id: String,
+    pub title: String,
+}
 
 impl App {
     /// Register a module dir, recording its install `source` (a git install
@@ -36,6 +49,9 @@ impl App {
             warning: None,
         });
         registry::save(&self.modules);
+        // A freshly linked module gets its startup hooks now rather than at the
+        // next restart, so its docks appear immediately.
+        self.run_module_startup_hooks();
         Ok(id)
     }
 
@@ -80,11 +96,14 @@ impl App {
             .ok_or_else(|| format!("no module {id}"))?;
         m.enabled = on;
         registry::save(&self.modules);
-        // Disabling a module retires its docks; re-enabling re-mounts them on the
-        // module's next `ui.dock.push` (docs/29, DOCK-4).
+        // Disabling a module retires its docks; re-enabling re-runs its startup
+        // hooks so it can repaint them (docs/29, DOCK-4).
         if !on {
             let dock_ids = self.module_dock_ids(id);
             self.remove_module_docks(&dock_ids);
+            self.module_startup_done.remove(id);
+        } else {
+            self.run_module_startup_hooks();
         }
         Ok(())
     }
@@ -117,6 +136,112 @@ impl App {
         Ok(dir)
     }
 
+    // ── right-click menus (docs/13 §3.8) ─────────────────────────────────────
+
+    /// The module actions offered in right-click menu `context` (`pane`,
+    /// `workspace`, `agent`, `tab`), in registry order. Called when a menu opens,
+    /// not per frame.
+    pub fn module_menu_actions(&self, context: &str) -> Vec<ModuleMenuAction> {
+        self.modules
+            .modules
+            .iter()
+            .filter(|m| m.is_runnable())
+            .flat_map(|m| {
+                m.manifest
+                    .actions_for_context(context)
+                    .into_iter()
+                    .map(move |a| ModuleMenuAction {
+                        module_id: m.id.clone(),
+                        action_id: a.id.clone(),
+                        title: a.title.clone(),
+                    })
+            })
+            .collect()
+    }
+
+    /// Run a module action picked from a right-click menu, against `target`.
+    ///
+    /// `a` comes from the menu's own snapshot rather than a fresh lookup, so a
+    /// module enabled or disabled while the menu was open can't shift which
+    /// action a click runs. The module is re-resolved here, so one that went
+    /// away in the meantime is a no-op with a toast instead of a wrong action.
+    pub fn run_module_menu_action(&mut self, context: &str, a: ModuleMenuAction, target: Target) {
+        let argv = self
+            .modules
+            .find(&a.module_id)
+            .filter(|m| m.is_runnable())
+            .and_then(|m| m.manifest.action(&a.action_id).map(|x| x.command.clone()));
+        let Some(argv) = argv else {
+            self.show_toast(format!("{} is unavailable", a.module_id));
+            return;
+        };
+        let extra = vec![("BOHAY_MODULE_ACTION_ID".to_string(), a.action_id.clone())];
+        let label = format!("action:{}", a.action_id);
+        let source = format!("menu:{context}");
+        if let Err(e) =
+            self.run_module_command_for(&a.module_id, argv, label, extra, &source, target)
+        {
+            self.show_toast(e);
+        } else {
+            self.show_toast(a.title);
+        }
+    }
+
+    // ── settings (docs/13 §3.6) ──────────────────────────────────────────────
+
+    /// A module's effective settings (manifest defaults under stored values).
+    pub fn module_settings(&self, id: &str) -> Result<serde_json::Map<String, Value>, String> {
+        let m = self
+            .modules
+            .find(id)
+            .ok_or_else(|| format!("no module {id}"))?;
+        Ok(settings::effective(&m.manifest, id))
+    }
+
+    /// Set one declared setting, validated against its spec.
+    pub fn module_set_setting(&mut self, id: &str, key: &str, v: Value) -> Result<Value, String> {
+        let m = self
+            .modules
+            .find(id)
+            .ok_or_else(|| format!("no module {id}"))?;
+        settings::set(&m.manifest, id, key, v)
+    }
+
+    // ── startup hooks (docs/13 §3.7) ─────────────────────────────────────────
+
+    /// Run every enabled module's `[[startup]]` commands once per process.
+    ///
+    /// Called when the session is up and the API socket is listening, and again
+    /// when a module is linked or re-enabled mid-session — a module that paints
+    /// a dock needs somewhere to repaint it after a restart, and `ui.dock.push`
+    /// state is deliberately not persisted.
+    pub fn run_module_startup_hooks(&mut self) {
+        let pending: Vec<(String, Vec<Vec<String>>)> = self
+            .modules
+            .modules
+            .iter()
+            .filter(|m| m.is_runnable() && !self.module_startup_done.contains(&m.id))
+            .map(|m| {
+                let cmds = m
+                    .manifest
+                    .startup
+                    .iter()
+                    .filter(|s| crate::module::manifest::allowed_on(s.platforms.as_ref()))
+                    .map(|s| s.command.clone())
+                    .collect();
+                (m.id.clone(), cmds)
+            })
+            .collect();
+        for (id, cmds) in pending {
+            // Mark done even with no commands, so the scan stays cheap.
+            self.module_startup_done.insert(id.clone());
+            for argv in cmds {
+                let extra = vec![("BOHAY_MODULE_EVENT".to_string(), "startup".to_string())];
+                let _ = self.run_module_command(&id, argv, "startup".to_string(), extra, "startup");
+            }
+        }
+    }
+
     /// Invoke an action by id, optionally constrained to one module. Resolves by
     /// action id when unambiguous, else requires `module`. Returns the log id.
     pub fn module_invoke_action(
@@ -124,6 +249,28 @@ impl App {
         action_id: &str,
         module_filter: Option<&str>,
         source: &str,
+    ) -> Result<u64, String> {
+        self.module_invoke_action_with(action_id, module_filter, source, Vec::new())
+    }
+
+    /// Invoke a dock row's action, carrying that row's identity in the env so a
+    /// single action can back a whole list of rows (docs/13 §3.10).
+    pub fn module_invoke_dock_action(
+        &mut self,
+        action_id: &str,
+        module_filter: Option<&str>,
+        row_env: Vec<(String, String)>,
+    ) -> Result<u64, String> {
+        self.module_invoke_action_with(action_id, module_filter, "dock", row_env)
+    }
+
+    /// Invoke an action, appending `extra_env` to the usual injected environment.
+    pub fn module_invoke_action_with(
+        &mut self,
+        action_id: &str,
+        module_filter: Option<&str>,
+        source: &str,
+        extra_env: Vec<(String, String)>,
     ) -> Result<u64, String> {
         // When a specific module is named, validate it up front for a clear
         // error (e.g. "disabled") instead of a generic "no runnable module …".
@@ -163,7 +310,8 @@ impl App {
                 ))
             }
         };
-        let extra = vec![("BOHAY_MODULE_ACTION_ID".to_string(), action_id.to_string())];
+        let mut extra = vec![("BOHAY_MODULE_ACTION_ID".to_string(), action_id.to_string())];
+        extra.extend(extra_env);
         self.run_module_command(
             &module_id,
             argv,
@@ -188,7 +336,13 @@ impl App {
                 continue;
             }
             for e in &m.manifest.events {
-                if e.on == name {
+                // `workspace.*` also answers to the legacy `node.*` spelling, so
+                // a module written against the old names keeps working.
+                let matches = e.on == name
+                    || e.on
+                        .strip_prefix("node.")
+                        .is_some_and(|suffix| name.strip_prefix("workspace.") == Some(suffix));
+                if matches && crate::module::manifest::allowed_on(e.platforms.as_ref()) {
                     targets.push((m.id.clone(), e.command.clone()));
                 }
             }
@@ -227,7 +381,9 @@ impl App {
             m.manifest
                 .panes
                 .iter()
-                .find(|p| p.id == entrypoint)
+                .find(|p| {
+                    p.id == entrypoint && crate::module::manifest::allowed_on(p.platforms.as_ref())
+                })
                 .map(|p| p.command.clone())
                 .ok_or_else(|| format!("module {module_id} has no pane {entrypoint}"))?
         };
@@ -293,8 +449,7 @@ impl App {
         Ok(id)
     }
 
-    /// Run an argv command for a module: build env + context, enforce the
-    /// in-flight cap, push a `Running` log, and spawn the subprocess.
+    /// Run an argv command for a module against the focused workspace/pane.
     pub fn run_module_command(
         &mut self,
         module_id: &str,
@@ -302,6 +457,21 @@ impl App {
         label: String,
         extra_env: Vec<(String, String)>,
         source: &str,
+    ) -> Result<u64, String> {
+        self.run_module_command_for(module_id, argv, label, extra_env, source, Target::default())
+    }
+
+    /// Run an argv command for a module against an explicit `target`: build the
+    /// env and context, enforce the in-flight cap, push a `Running` log, and
+    /// spawn the subprocess.
+    pub fn run_module_command_for(
+        &mut self,
+        module_id: &str,
+        argv: Vec<String>,
+        label: String,
+        extra_env: Vec<(String, String)>,
+        source: &str,
+        target: Target,
     ) -> Result<u64, String> {
         {
             let module = self
@@ -326,7 +496,7 @@ impl App {
                 runtime::MAX_IN_FLIGHT
             ));
         }
-        let ctx = context::build(self, source);
+        let ctx = context::build_for(self, source, &target);
         let (root, mut env) = {
             let module = self.modules.find(module_id).unwrap();
             (module.root.clone(), runtime::base_env(module, &ctx))
@@ -712,6 +882,568 @@ command = ["sh", "-c", "sleep 5"]
                 .enabled,
             !before
         );
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// Link a module whose manifest is `toml`, in a scratch home.
+    fn link(app: &mut App, home: &Path, name: &str, toml: &str) -> String {
+        let dir = home.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bohay-module.toml"), toml).unwrap();
+        app.module_link_with(&dir, true, None).unwrap()
+    }
+
+    /// Pump the loop until `log_id` resolves (or we give up).
+    fn settle(app: &mut App, rx: &std::sync::mpsc::Receiver<AppEvent>, log_id: u64) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(ev) = rx.recv_timeout(Duration::from_millis(100)) {
+                app.handle_event(ev);
+            }
+            let done = app
+                .module_logs
+                .iter()
+                .find(|l| l.id == log_id)
+                .is_some_and(|l| l.status != ModuleStatus::Running);
+            if done || Instant::now() > deadline {
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn module_actions_appear_in_the_right_click_menus() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modmenu-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+
+        // Before any module, the menus are exactly the built-ins.
+        let pane_builtins = app.pane_menu_items().len();
+        let ws_builtins = app.ws_menu_items(0).len();
+
+        let id = link(
+            &mut app,
+            &home,
+            "ctx-mod",
+            r#"
+id = "you.ctx"
+name = "Ctx"
+version = "0.1.0"
+min_bohay_version = "0.1.0"
+
+[[actions]]
+id = "on-pane"
+title = "Do pane thing"
+contexts = ["pane"]
+command = ["sh", "-c", "echo pane=$BOHAY_PANE_ID src=$BOHAY_MODULE_CONTEXT_JSON"]
+
+[[actions]]
+id = "on-node"
+title = "Do node thing"
+contexts = ["node"]
+command = ["sh", "-c", "echo ws=$BOHAY_WORKSPACE_ID"]
+
+[[actions]]
+id = "headless"
+title = "Never in a menu"
+command = ["true"]
+"#,
+        );
+
+        // Each menu offers only the actions declaring its context.
+        assert_eq!(app.module_menu_actions("pane").len(), 1);
+        assert_eq!(app.module_menu_actions("workspace").len(), 1, "node alias");
+        assert_eq!(app.module_menu_actions("agent").len(), 0);
+
+        // Opening a menu snapshots them, and adds a divider above the rows.
+        let target = app.layout().focus;
+        app.open_pane_menu(target, 1, 1);
+        assert_eq!(app.pane_menu_items().len(), pane_builtins + 2);
+        app.open_ws_menu(0, 1, 1);
+        assert_eq!(app.ws_menu_items(0).len(), ws_builtins + 2);
+        app.ws_menu = None;
+
+        // The rows actually render, with the module's own title (never translated).
+        {
+            use ratatui::backend::TestBackend;
+            use ratatui::Terminal;
+            let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+            term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+            let text: String = term
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|c| c.symbol())
+                .collect();
+            assert!(text.contains("Do pane thing"), "the module row is drawn");
+            assert!(
+                !text.contains("Never in a menu"),
+                "an action with no contexts stays out of the menu"
+            );
+            // Every row got a clickable rect, module rows included.
+            let rects = app.pane_menu.as_ref().unwrap().items.len();
+            assert_eq!(rects, app.pane_menu_items().len());
+        }
+
+        // Clicking the pane entry runs it against the right-clicked pane, and the
+        // injected context names that pane rather than whatever had focus.
+        app.pane_menu_action(PaneMenuItem::Module(0));
+        assert!(app.pane_menu.is_none(), "the menu closed");
+        let log_id = app
+            .module_logs
+            .iter()
+            .find(|l| l.label == "action:on-pane")
+            .map(|l| l.id)
+            .expect("the action was queued");
+        settle(&mut app, &rx, log_id);
+        let log = app.module_logs.iter().find(|l| l.id == log_id).unwrap();
+        assert_eq!(log.status, ModuleStatus::Succeeded, "stderr: {}", log.err);
+        assert!(
+            log.out.contains(&format!("pane={}", target.0)),
+            "flat BOHAY_PANE_ID points at the clicked pane: {:?}",
+            log.out
+        );
+        assert!(
+            log.out.contains("\"invocation_source\":\"menu:pane\""),
+            "the context records where it came from: {:?}",
+            log.out
+        );
+
+        // Disabling the module retires its menu rows immediately.
+        app.module_set_enabled(&id, false).unwrap();
+        assert_eq!(app.module_menu_actions("pane").len(), 0);
+        app.open_pane_menu(target, 1, 1);
+        assert_eq!(app.pane_menu_items().len(), pane_builtins, "no module rows");
+
+        // A module disabled *while its menu is open* must not shift what a click
+        // runs: the snapshot still names the action, but it no longer resolves,
+        // so the click is a no-op with a toast rather than a wrong action.
+        app.module_set_enabled(&id, true).unwrap();
+        app.open_pane_menu(target, 1, 1);
+        assert_eq!(app.pane_menu.as_ref().unwrap().module_actions.len(), 1);
+        app.module_set_enabled(&id, false).unwrap();
+        let before = app.module_logs.len();
+        app.pane_menu_action(PaneMenuItem::Module(0));
+        assert_eq!(app.module_logs.len(), before, "nothing was run");
+        assert!(app.toast.is_some(), "and the user was told why");
+
+        // An index past the snapshot is ignored rather than panicking.
+        app.open_pane_menu(target, 1, 1);
+        app.pane_menu_action(PaneMenuItem::Module(99));
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn startup_hooks_run_once_and_again_after_re_enable() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modboot-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let id = link(
+            &mut app,
+            &home,
+            "boot-mod",
+            r#"
+id = "you.boot"
+name = "Boot"
+version = "0.1.0"
+min_bohay_version = "0.1.0"
+
+[[startup]]
+command = ["sh", "-c", "echo booted event=$BOHAY_MODULE_EVENT"]
+"#,
+        );
+
+        // Linking already ran it, so the module's dock can paint straight away.
+        let count = |a: &App| {
+            a.module_logs
+                .iter()
+                .filter(|l| l.label == "startup")
+                .count()
+        };
+        assert_eq!(count(&app), 1, "linking runs the hook");
+        let log_id = app
+            .module_logs
+            .iter()
+            .find(|l| l.label == "startup")
+            .unwrap()
+            .id;
+        settle(&mut app, &rx, log_id);
+        let log = app.module_logs.iter().find(|l| l.id == log_id).unwrap();
+        assert_eq!(log.status, ModuleStatus::Succeeded, "stderr: {}", log.err);
+        assert!(log.out.contains("event=startup"), "got: {:?}", log.out);
+
+        // Re-running the sweep (a second server tick) must not double-fire it.
+        app.run_module_startup_hooks();
+        app.run_module_startup_hooks();
+        assert_eq!(count(&app), 1, "once per process");
+
+        // Disable then re-enable: the module gets a fresh chance to repaint.
+        app.module_set_enabled(&id, false).unwrap();
+        assert_eq!(count(&app), 1, "disabling runs nothing");
+        app.module_set_enabled(&id, true).unwrap();
+        assert_eq!(count(&app), 2, "re-enabling re-runs it");
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn declared_settings_reach_a_command_as_env() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modsetenv-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        link(
+            &mut app,
+            &home,
+            "cfg-mod",
+            r#"
+id = "you.cfg"
+name = "Cfg"
+version = "0.1.0"
+min_bohay_version = "0.1.0"
+
+[[settings]]
+key = "token"
+title = "Token"
+type = "string"
+secret = true
+
+[[settings]]
+key = "limit"
+title = "Limit"
+type = "number"
+default = 5
+min = 1
+max = 10
+
+[[actions]]
+id = "show"
+title = "Show"
+command = ["sh", "-c", "echo t=$BOHAY_SETTING_TOKEN l=$BOHAY_SETTING_LIMIT"]
+"#,
+        );
+
+        // Defaults apply before the user touches anything.
+        let vals = app.module_settings("you.cfg").unwrap();
+        assert_eq!(vals.get("limit").unwrap(), 5);
+        assert_eq!(vals.get("token").unwrap(), "");
+
+        app.module_set_setting("you.cfg", "token", "abc123".into())
+            .unwrap();
+        // Over-max clamps instead of failing the whole write.
+        assert_eq!(
+            app.module_set_setting("you.cfg", "limit", 99.into())
+                .unwrap(),
+            10
+        );
+
+        let log_id = app.module_invoke_action("show", None, "test").unwrap();
+        settle(&mut app, &rx, log_id);
+        let log = app.module_logs.iter().find(|l| l.id == log_id).unwrap();
+        assert_eq!(log.status, ModuleStatus::Succeeded, "stderr: {}", log.err);
+        assert!(
+            log.out.contains("t=abc123 l=10"),
+            "settings reached the command: {:?}",
+            log.out
+        );
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn listing_settings_masks_secrets_but_get_returns_them() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modsec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        link(
+            &mut app,
+            &home,
+            "sec-mod",
+            r#"
+id = "you.sec"
+name = "Sec"
+version = "0.1.0"
+min_bohay_version = "0.1.0"
+
+[[settings]]
+key = "token"
+title = "Token"
+type = "string"
+secret = true
+
+[[settings]]
+key = "host"
+title = "Host"
+type = "string"
+default = "example.com"
+"#,
+        );
+        app.module_set_setting("you.sec", "token", "s3cret".into())
+            .unwrap();
+
+        let list = app
+            .dispatch("module.settings.list", &json!({"id": "you.sec"}))
+            .unwrap();
+        let text = list.to_string();
+        assert!(
+            !text.contains("s3cret"),
+            "a listing must not print a secret: {text}"
+        );
+        let entries = list["settings"].as_array().unwrap();
+        let token = entries.iter().find(|e| e["key"] == "token").unwrap();
+        assert_eq!(token["value"], Value::Null, "masked");
+        assert_eq!(token["set"], true, "but reported as configured");
+        // A non-secret is unaffected.
+        let host = entries.iter().find(|e| e["key"] == "host").unwrap();
+        assert_eq!(host["value"], "example.com");
+
+        // Asking for the one key by name still returns it, for scripting.
+        let got = app
+            .dispatch(
+                "module.settings.get",
+                &json!({"id": "you.sec", "key": "token"}),
+            )
+            .unwrap();
+        assert_eq!(got["value"], "s3cret");
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn item_platforms_gate_panes_and_events() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modplat-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        link(
+            &mut app,
+            &home,
+            "plat-mod",
+            r#"
+id = "you.plat"
+name = "Plat"
+version = "0.1.0"
+min_bohay_version = "0.1.0"
+
+[[panes]]
+id = "nope"
+title = "Elsewhere only"
+platforms = ["plan9"]
+command = ["sh", "-c", "sleep 5"]
+
+[[events]]
+on = "tab.created"
+platforms = ["plan9"]
+command = ["sh", "-c", "echo should-not-run"]
+
+# A module written against the old event spelling still fires.
+[[events]]
+on = "node.created"
+command = ["sh", "-c", "echo legacy-alias-fired"]
+"#,
+        );
+
+        // A pane entrypoint gated to another OS is simply not there.
+        let err = app
+            .module_open_pane("you.plat", "nope", None, "test")
+            .unwrap_err();
+        assert!(err.contains("no pane nope"), "got: {err}");
+
+        // Nor does a gated event hook run.
+        app.emit_event("tab.created", json!({"tab": "1"}));
+        assert!(
+            !app.module_logs
+                .iter()
+                .any(|l| l.label == "event:tab.created"),
+            "a platform-gated hook stays out of the queue"
+        );
+
+        // `workspace.created` still reaches a hook declared as `node.created`.
+        app.emit_event("workspace.created", json!({"workspace": "0"}));
+        assert!(
+            app.module_logs
+                .iter()
+                .any(|l| l.label == "event:workspace.created"),
+            "the legacy node.* alias still fires"
+        );
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn settings_tab_renders_and_edits_module_settings() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modsettab-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(100, 30, tx).unwrap();
+        link(
+            &mut app,
+            &home,
+            "ui-mod",
+            r#"
+id = "you.ui"
+name = "Ui"
+version = "0.1.0"
+min_bohay_version = "0.1.0"
+
+[[settings]]
+key = "loud"
+title = "Play a sound"
+type = "bool"
+
+[[settings]]
+key = "mode"
+title = "Mode"
+type = "enum"
+options = ["fast", "slow"]
+
+[[settings]]
+key = "token"
+title = "API token"
+type = "string"
+secret = true
+"#,
+        );
+
+        let mut term = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        app.open_settings();
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('5'),
+            KeyModifiers::NONE,
+        ))); // Modules
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+
+        let screen = |t: &Terminal<TestBackend>| -> String {
+            t.backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|c| c.symbol())
+                .collect()
+        };
+        let text = screen(&term);
+        assert!(text.contains("you.ui"), "the module row renders");
+        assert!(
+            text.contains("Play a sound"),
+            "its settings render under it"
+        );
+        assert!(text.contains("Mode"));
+        // 1 module row + 3 settings rows.
+        assert_eq!(app.module_rows().len(), 4);
+        assert_eq!(app.settings_ctl_rects.len(), 4);
+
+        // Row 2 is the enum: `›` steps it to the next option.
+        assert_eq!(
+            app.module_rows()[2],
+            crate::app::ModuleRow::Setting(0, 1),
+            "row 2 is the enum setting"
+        );
+        for _ in 0..2 {
+            app.handle_event(AppEvent::Key(KeyEvent::new(
+                KeyCode::Down,
+                KeyModifiers::NONE,
+            )));
+        }
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Right,
+            KeyModifiers::NONE,
+        )));
+        assert_eq!(
+            app.module_settings("you.ui").unwrap().get("mode").unwrap(),
+            "slow"
+        );
+
+        // Row 3 is the secret string: Enter opens the prompt, typed text saves,
+        // and the screen shows bullets rather than the value.
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::NONE,
+        )));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )));
+        assert!(app.module_setting_edit.is_some(), "the prompt opened");
+        for c in "hunter2".chars() {
+            app.handle_event(AppEvent::Key(KeyEvent::new(
+                KeyCode::Char(c),
+                KeyModifiers::NONE,
+            )));
+        }
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let typed = screen(&term);
+        assert!(typed.contains("•••••••"), "a secret echoes as bullets");
+        assert!(!typed.contains("hunter2"), "and never in the clear");
+
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )));
+        assert!(app.module_setting_edit.is_none(), "the prompt closed");
+        assert_eq!(
+            app.module_settings("you.ui").unwrap().get("token").unwrap(),
+            "hunter2"
+        );
+
+        // Disabling the module collapses its settings rows back to one.
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Up,
+            KeyModifiers::NONE,
+        )));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Up,
+            KeyModifiers::NONE,
+        )));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Up,
+            KeyModifiers::NONE,
+        )));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        )));
+        assert!(!app.modules.find("you.ui").unwrap().enabled);
+        assert_eq!(
+            app.module_rows().len(),
+            1,
+            "settings collapse when disabled"
+        );
+        // The cursor came back inside the shrunken list.
+        assert!(app.settings.as_ref().unwrap().cursor < app.module_rows().len());
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
 
         std::env::remove_var("BOHAY_HOME");
         let _ = std::fs::remove_dir_all(&home);

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -89,6 +89,18 @@ pub enum LayoutRow {
     Dock(DockKind),
 }
 
+/// A selectable row in the Modules tab (docs/13 §3.6): a module, or one of the
+/// settings it declares (indented beneath it while the module is enabled).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ModuleRow {
+    Module(usize),
+    Setting(usize, usize),
+}
+
+/// Cap a module setting's typed value, so a pathological paste can't bloat the
+/// module's `settings.json`.
+const MODULE_SETTING_MAX: usize = 512;
+
 impl App {
     /// The Layout tab's ordered selectable rows (docs/29). The first index of the
     /// dock section (used to draw the `── Docks ──` divider) is `dock_section_start`.
@@ -137,6 +149,7 @@ impl App {
 
     pub fn close_settings(&mut self) {
         self.settings = None;
+        self.module_setting_edit = None;
     }
 
     /// Number of selectable control rows in `tab` (for cursor clamping + render).
@@ -146,7 +159,7 @@ impl App {
             SettingsTab::Layout => self.layout_rows().len(),
             SettingsTab::Notifications => 3,
             SettingsTab::Keys => crate::app::Cmd::ALL.len(),
-            SettingsTab::Modules => self.modules.modules.len(),
+            SettingsTab::Modules => self.module_rows().len(),
             SettingsTab::Integrations => crate::integration::AGENTS.len(),
             SettingsTab::Language => crate::i18n::LANGS.len(),
         }
@@ -253,6 +266,8 @@ impl App {
                         | Some(LayoutRow::RightWidth)
                         | Some(LayoutRow::Dock(_))
                 ),
+                // Number/enum module settings likewise only move via `‹ ›`.
+                Some(SettingsTab::Modules) => self.module_row_is_slider(i),
                 _ => false,
             };
             if !is_slider {
@@ -305,7 +320,7 @@ impl App {
             SettingsTab::Notifications => {} // the Test row only reacts to Enter/click
             SettingsTab::Keys => {}          // rebind is Enter (capture), not ‹ ›
             SettingsTab::Integrations => self.settings_activate(cursor),
-            SettingsTab::Modules => self.toggle_module(cursor),
+            SettingsTab::Modules => self.toggle_module(cursor, Some(delta)),
         }
     }
 
@@ -330,7 +345,7 @@ impl App {
                 }
             }
             SettingsTab::Integrations => self.install_integration(cursor),
-            SettingsTab::Modules => self.toggle_module(cursor),
+            SettingsTab::Modules => self.toggle_module(cursor, None),
         }
     }
 
@@ -340,11 +355,133 @@ impl App {
         all[cursor.min(all.len() - 1)]
     }
 
-    /// Enable/disable the module at `cursor` in the Modules tab.
-    fn toggle_module(&mut self, cursor: usize) {
-        if let Some(m) = self.modules.modules.get(cursor) {
-            let (id, on) = (m.id.clone(), !m.enabled);
-            let _ = self.module_set_enabled(&id, on);
+    /// The Modules tab's dynamic row model: one row per installed module,
+    /// followed by an indented row per setting it declares while it is enabled.
+    /// Disabled modules collapse, so the list stays short.
+    pub fn module_rows(&self) -> Vec<ModuleRow> {
+        let mut v = Vec::new();
+        for (mi, m) in self.modules.modules.iter().enumerate() {
+            v.push(ModuleRow::Module(mi));
+            if m.enabled && m.warning.is_none() {
+                v.extend((0..m.manifest.settings.len()).map(|si| ModuleRow::Setting(mi, si)));
+            }
+        }
+        v
+    }
+
+    /// Whether Modules row `i` is a `‹ ›` stepper (number/enum), which a click on
+    /// the row body should only select, not change.
+    fn module_row_is_slider(&self, i: usize) -> bool {
+        use crate::module::manifest::SettingKind;
+        let Some(ModuleRow::Setting(mi, si)) = self.module_rows().get(i).copied() else {
+            return false;
+        };
+        self.modules
+            .modules
+            .get(mi)
+            .and_then(|m| m.manifest.settings.get(si))
+            .is_some_and(|s| matches!(s.kind, SettingKind::Number | SettingKind::Enum))
+    }
+
+    /// Enable/disable the module at `cursor`, or step its setting. `delta` is
+    /// the direction for a `‹ ›` press; `None` means "activate" (Enter/click),
+    /// which toggles a bool and opens the prompt for a string.
+    fn toggle_module(&mut self, cursor: usize, delta: Option<i32>) {
+        match self.module_rows().get(cursor).copied() {
+            Some(ModuleRow::Module(mi)) => {
+                if let Some(m) = self.modules.modules.get(mi) {
+                    let (id, on) = (m.id.clone(), !m.enabled);
+                    let _ = self.module_set_enabled(&id, on);
+                    // Collapsing a module can leave the cursor past the end.
+                    self.clamp_settings_cursor();
+                }
+            }
+            Some(ModuleRow::Setting(mi, si)) => self.adjust_module_setting(mi, si, delta),
+            None => {}
+        }
+    }
+
+    /// Apply a step (or an activation) to one declared module setting.
+    fn adjust_module_setting(&mut self, mi: usize, si: usize, delta: Option<i32>) {
+        use crate::module::manifest::SettingKind;
+        let Some((id, spec)) = self.modules.modules.get(mi).and_then(|m| {
+            m.manifest
+                .settings
+                .get(si)
+                .map(|s| (m.id.clone(), s.clone()))
+        }) else {
+            return;
+        };
+        let current = crate::module::settings::get(
+            &self.modules.find(&id).unwrap().manifest.clone(),
+            &id,
+            &spec.key,
+        )
+        .unwrap_or_else(|| spec.default_value());
+
+        // A string setting has nothing to step — Enter (and either arrow) opens
+        // the inline prompt instead.
+        if spec.kind == SettingKind::String {
+            self.module_setting_edit = Some(ModuleSettingEdit {
+                module_id: id,
+                key: spec.key.clone(),
+                title: spec.title.clone(),
+                // A secret starts empty rather than revealing the stored value.
+                buffer: if spec.secret {
+                    String::new()
+                } else {
+                    current.as_str().unwrap_or_default().to_string()
+                },
+                secret: spec.secret,
+            });
+            return;
+        }
+        // Enter on a bool flips it; on a number/enum it advances one step.
+        let step = delta.unwrap_or(1) as i64;
+        let next = crate::module::settings::stepped(&spec, &current, step);
+        if let Err(e) = self.module_set_setting(&id, &spec.key, next) {
+            self.show_toast(e);
+        }
+    }
+
+    /// Key handling for the inline module-setting prompt (docs/13 §3.6).
+    /// `Enter` saves, `Esc` cancels — the same contract as the rename modals.
+    pub fn handle_module_setting_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => self.module_setting_edit = None,
+            KeyCode::Enter => {
+                if let Some(e) = self.module_setting_edit.take() {
+                    let v = Value::String(e.buffer);
+                    if let Err(err) = self.module_set_setting(&e.module_id, &e.key, v) {
+                        self.show_toast(err);
+                    }
+                }
+            }
+            KeyCode::Backspace => {
+                if let Some(e) = self.module_setting_edit.as_mut() {
+                    e.buffer.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if let Some(e) = self.module_setting_edit.as_mut() {
+                    if e.buffer.chars().count() < MODULE_SETTING_MAX {
+                        e.buffer.push(c);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Keep the settings cursor inside the current tab's row count (rows can
+    /// shrink under it when a module collapses).
+    fn clamp_settings_cursor(&mut self) {
+        let Some(tab) = self.settings.as_ref().map(|u| u.tab) else {
+            return;
+        };
+        let max = self.settings_rows(tab).saturating_sub(1);
+        if let Some(ui) = self.settings.as_mut() {
+            ui.cursor = ui.cursor.min(max);
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,7 @@ tabs:
   tab list                   list tabs in the current workspace
   tab new                    new tab
   tab focus <n>              focus tab n (1-based)
+  tab rename <name>          name a tab (--tab N to target one; empty clears it)
   tab close [<n>]            close a tab (default: active)
 
 panes / agents:
@@ -80,6 +81,7 @@ appearance:
   ui dock push --id <id> [--title <t>] [--side left|right] [--rows <json>]
                              feed a module's sidebar dock its rows (JSON array,
                              or piped on stdin). See docs/29 + the website
+  ui toast <text>            flash a one-line message in the UI
 
 modules (extensions):
   module search [<query>]    find modules published to the `bohay-module` GitHub topic
@@ -96,6 +98,8 @@ modules (extensions):
   module pane focus <pane> | close <pane>
   module log [<id>]          tail module command logs (--limit N)
   module config-dir <id>     print/create a module's config dir
+  module settings <id>       list a module's declared settings and values
+  module settings <id> <key> [<value>]   read / write one setting
 
 git:
   git status                 branch, ahead/behind, working tree of the current workspace
@@ -634,6 +638,25 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
 
     // First positional arg after the verb (for workspace/tab indices).
     let arg0 = || rest.first().cloned();
+    // Everything after the verb, joined, minus flags and their values — for free
+    // text like a tab name, where `bohay tab rename my tab --tab 2` must not
+    // fold the flag into the name.
+    let rest_text = || {
+        let mut out: Vec<&str> = Vec::new();
+        let mut skip = false;
+        for a in rest {
+            if skip {
+                skip = false;
+                continue;
+            }
+            if a.starts_with("--") {
+                skip = true; // assume `--flag value`; a bare flag just eats the next word
+                continue;
+            }
+            out.push(a);
+        }
+        out.join(" ")
+    };
     let one = |key: &str, val: Option<String>| {
         let mut obj = serde_json::Map::new();
         if let Some(v) = val {
@@ -667,6 +690,7 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
 
         // Sidebar docks for module/plugin authors (docs/29). `push` feeds rows to
         // a dock: `--rows '<json array>'`, or pipe the JSON array on stdin.
+        ("ui", "toast") => ("ui.toast".into(), one("text", Some(rest_text()))),
         ("ui", "dock") => {
             let sub = rest.first().map(String::as_str).unwrap_or("list");
             match sub {
@@ -722,6 +746,15 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
         ("tab", "new") => ("tab.new".into(), json!({})),
         ("tab", "focus") => ("tab.focus".into(), one("tab", arg0())),
         ("tab", "close") => ("tab.close".into(), one("tab", arg0())),
+        // `tab rename <name>` names the active tab; `--tab N` targets another.
+        ("tab", "rename") => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("name".to_string(), json!(rest_text()));
+            if let Some(n) = flag(args, "--tab") {
+                obj.insert("tab".to_string(), json!(n));
+            }
+            ("tab.rename".into(), Value::Object(obj))
+        }
         ("tab", _) => ("tab.list".into(), json!({})),
 
         ("pane", "split") => {
@@ -821,6 +854,30 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
         }
         ("module", "info") => ("module.info".into(), one("id", arg0())),
         ("module", "config-dir") => ("module.config_dir".into(), one("id", arg0())),
+        // `module settings <id>` lists; `… <id> <key>` reads; `… <id> <key> <value>` writes.
+        ("module", "settings") => {
+            let mut obj = serde_json::Map::new();
+            let Some(id) = rest.first() else {
+                return Err(anyhow!(
+                    "usage: bohay module settings <id> [<key> [<value>]]"
+                ));
+            };
+            obj.insert("id".to_string(), json!(id));
+            match (rest.get(1), rest.get(2)) {
+                (Some(k), Some(v)) => {
+                    obj.insert("key".to_string(), json!(k));
+                    // A bare word is sent as-is; the server coerces it to the
+                    // declared type, so `--json` is only needed for arrays.
+                    obj.insert("value".to_string(), parse_setting_value(v));
+                    ("module.settings.set".into(), Value::Object(obj))
+                }
+                (Some(k), None) => {
+                    obj.insert("key".to_string(), json!(k));
+                    ("module.settings.get".into(), Value::Object(obj))
+                }
+                _ => ("module.settings.list".into(), Value::Object(obj)),
+            }
+        }
         ("module", "pane") => {
             let sub = rest.first().map(String::as_str).unwrap_or("");
             match sub {
@@ -999,6 +1056,21 @@ fn flag(args: &[String], name: &str) -> Option<String> {
     args.iter()
         .position(|a| a == name)
         .and_then(|i| args.get(i + 1).cloned())
+}
+
+/// A module-setting value typed on the command line. `true`/`false` and whole
+/// numbers become JSON scalars so a bool/number setting takes them directly;
+/// everything else stays a string (the server coerces against the declared
+/// type either way).
+fn parse_setting_value(s: &str) -> Value {
+    match s {
+        "true" => Value::Bool(true),
+        "false" => Value::Bool(false),
+        _ => match s.parse::<i64>() {
+            Ok(n) => Value::from(n),
+            Err(_) => Value::String(s.to_string()),
+        },
+    }
 }
 
 #[cfg(test)]

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -42,6 +42,10 @@ pub fn run() -> Result<()> {
     let (api_tx, api_rx) = mpsc::channel::<api::ApiRequest>();
     api::start_server(sock, api_tx, app.events.clone());
     start_client_listener(persist::client_socket_path(), tx.clone());
+    // The session is restored and the API socket is listening, so a module's
+    // `[[startup]]` hooks can now call back in — this is where a module
+    // repaints the docks it owns (docs/13 §3.7).
+    app.run_module_startup_hooks();
 
     let mut clients: Clients = HashMap::new();
     let mut foreground: Option<u64> = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,6 +636,7 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
     app.set_color_mode(ipc::protocol::truecolor_supported());
     let (api_tx, api_rx) = mpsc::channel::<ipc::api::ApiRequest>();
     ipc::api::start_server(sock, api_tx, app.events.clone());
+    app.run_module_startup_hooks(); // docs/13 §3.7 — same point as the server role
 
     terminal.draw(|f| ui::render(f, &mut app))?;
     let mut last_draw = Instant::now();

--- a/src/module/context.rs
+++ b/src/module/context.rs
@@ -1,25 +1,75 @@
-//! The `BOHAY_MODULE_CONTEXT_JSON` blob: a snapshot of the focused workspace / tab /
-//! pane handed to every module command (docs/13 §3.4).
+//! The `BOHAY_MODULE_CONTEXT_JSON` blob: a snapshot of the workspace / tab /
+//! pane a module command was invoked against (docs/13 §3.4).
+//!
+//! Most invocations (CLI, socket, event hooks) target whatever is focused. A
+//! right-click menu instead targets the row or pane that was clicked, which may
+//! not be the focused one — hence [`Target`].
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::{json, Value};
 
 use crate::app::App;
+use crate::ids::PaneId;
 use crate::ui::theme::State;
 
 static CORRELATION: AtomicU64 = AtomicU64::new(1);
 
-/// Build the context for a command invoked from `source` (cli|api|keybind|event).
+/// What a module command should act on. All-`None` means "whatever is focused",
+/// which is the right answer for CLI, socket, startup, and event invocations.
+#[derive(Default, Clone)]
+pub struct Target {
+    pub workspace: Option<usize>,
+    pub pane: Option<PaneId>,
+    /// The current mouse selection, when a menu was opened over one.
+    pub selection: Option<String>,
+}
+
+impl Target {
+    pub fn workspace(index: usize) -> Self {
+        Target {
+            workspace: Some(index),
+            ..Default::default()
+        }
+    }
+
+    pub fn pane(id: PaneId) -> Self {
+        Target {
+            pane: Some(id),
+            ..Default::default()
+        }
+    }
+}
+
+/// Build the context for a command invoked from `source` (cli|api|event|menu:*)
+/// against the focused workspace/pane.
 pub fn build(app: &App, source: &str) -> Value {
+    build_for(app, source, &Target::default())
+}
+
+/// Build the context for a command invoked against an explicit `target`.
+pub fn build_for(app: &App, source: &str, target: &Target) -> Value {
     let cid = format!("c{}", CORRELATION.fetch_add(1, Ordering::Relaxed));
-    let ws_id = app.active_ws;
+    let ws_id = target
+        .workspace
+        .filter(|i| *i < app.workspaces.len())
+        .unwrap_or(app.active_ws);
     let ws = app.workspaces.get(ws_id);
     let name = ws.map(|w| w.name.clone()).unwrap_or_default();
     let ws_cwd = ws.map(|w| w.cwd.display().to_string()).unwrap_or_default();
+    let branch = ws.and_then(|w| w.branch.clone()).unwrap_or_default();
     let tab_index = ws.map(|w| w.active_tab + 1).unwrap_or(1);
+    let tab_name = ws
+        .and_then(|w| w.tabs.get(w.active_tab))
+        .and_then(|t| t.name.clone())
+        .unwrap_or_default();
 
-    let focus = app.layout().focus;
+    // A targeted pane wins, but only while it still exists (a menu can outlive
+    // its pane if the process exits between the right-click and the click).
+    let focus = target
+        .pane
+        .filter(|id| app.panes.contains_key(id))
+        .unwrap_or_else(|| app.layout().focus);
     let pane_cwd = app
         .panes
         .get(&focus)
@@ -32,14 +82,40 @@ pub fn build(app: &App, source: &str) -> Value {
         .unwrap_or_default();
 
     json!({
-        "workspace": { "id": ws_id.to_string(), "name": name.clone(), "cwd": ws_cwd.clone() },
+        "workspace": {
+            "id": ws_id.to_string(), "name": name.clone(),
+            "cwd": ws_cwd.clone(), "branch": branch.clone(),
+        },
         // Legacy alias for modules written against the old "node" key.
-        "node": { "id": ws_id.to_string(), "name": name, "cwd": ws_cwd },
-        "tab": { "index": tab_index.to_string() },
+        "node": { "id": ws_id.to_string(), "name": name, "cwd": ws_cwd, "branch": branch },
+        "tab": { "index": tab_index.to_string(), "name": tab_name },
         "pane": { "id": focus.0.to_string(), "cwd": pane_cwd, "agent": agent, "status": status },
+        "selection": target.selection.clone().unwrap_or_default(),
         "invocation_source": source,
         "correlation_id": cid,
     })
+}
+
+/// The flat `BOHAY_*` vars mirroring the ids in `ctx`, so a shell script can use
+/// them without parsing JSON. `BOHAY_PANE_ID` is only advisory here — for a
+/// module *pane* bohay's own identity var always wins (see `Pane::build`).
+pub fn env_from(ctx: &Value) -> Vec<(String, String)> {
+    let s = |a: &str, b: &str| -> String {
+        ctx.get(a)
+            .and_then(|v| v.get(b))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+    vec![
+        ("BOHAY_WORKSPACE_ID".to_string(), s("workspace", "id")),
+        ("BOHAY_WORKSPACE_CWD".to_string(), s("workspace", "cwd")),
+        ("BOHAY_TAB_INDEX".to_string(), s("tab", "index")),
+        ("BOHAY_PANE_ID".to_string(), s("pane", "id")),
+        ("BOHAY_PANE_CWD".to_string(), s("pane", "cwd")),
+        ("BOHAY_PANE_AGENT".to_string(), s("pane", "agent")),
+        ("BOHAY_PANE_STATUS".to_string(), s("pane", "status")),
+    ]
 }
 
 fn state_str(s: State) -> &'static str {

--- a/src/module/install.rs
+++ b/src/module/install.rs
@@ -88,7 +88,12 @@ fn install_inner(
     }
 
     // 4. Run [[build]] with a scrubbed environment (no BOHAY_*/socket access).
+    // A step gated to other platforms is skipped, so one manifest can carry
+    // both a `npm.cmd` step for Windows and a `make` step for Unix.
     for b in &manifest.build {
+        if !super::manifest::allowed_on(b.platforms.as_ref()) {
+            continue;
+        }
         run_build(&module_root, &b.command)
             .with_context(|| format!("build step {:?} failed", b.command))?;
     }

--- a/src/module/manifest.rs
+++ b/src/module/manifest.rs
@@ -1,11 +1,12 @@
 //! `bohay-module.toml` — the module manifest: identity + declared argv commands
-//! (actions, event hooks, panes, build steps). Parsed with serde; validated to
-//! mirror the spec in docs/13 §3.1.
+//! (actions, event hooks, panes, docks, settings, startup + build steps). Parsed
+//! with serde; validated to mirror the spec in docs/13 §3.1.
 
 use std::collections::HashSet;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 pub const MANIFEST_FILE: &str = "bohay-module.toml";
 const HOST_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -22,6 +23,11 @@ pub struct ModuleManifest {
     pub platforms: Option<Vec<String>>,
     #[serde(default)]
     pub build: Vec<Build>,
+    /// One-shot commands run for each enabled module once the session is
+    /// restored and the API socket is up (docs/13 §3.7). This is how a module
+    /// repopulates its docks after a restart.
+    #[serde(default)]
+    pub startup: Vec<StartupHook>,
     #[serde(default)]
     pub actions: Vec<Action>,
     #[serde(default)]
@@ -32,25 +38,44 @@ pub struct ModuleManifest {
     /// content over the socket (`ui.dock.push`); bohay owns rendering.
     #[serde(default)]
     pub docks: Vec<DockEntry>,
+    /// User-editable settings rendered in Settings → Modules (docs/13 §3.6).
+    #[serde(default)]
+    pub settings: Vec<SettingSpec>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Build {
     pub command: Vec<String>,
+    #[serde(default)]
+    pub platforms: Option<Vec<String>>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct StartupHook {
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub platforms: Option<Vec<String>>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Action {
     pub id: String,
     pub title: String,
+    /// Right-click menus this action is offered in: `pane`, `workspace`
+    /// (alias `node`), `agent`, `tab`. Omit for an action that is only ever
+    /// invoked from the CLI, socket, or another module.
     #[serde(default)]
     pub contexts: Option<Vec<String>>,
+    #[serde(default)]
+    pub platforms: Option<Vec<String>>,
     pub command: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct EventHook {
     pub on: String,
+    #[serde(default)]
+    pub platforms: Option<Vec<String>>,
     pub command: Vec<String>,
 }
 
@@ -60,6 +85,8 @@ pub struct PaneEntry {
     pub title: String,
     #[serde(default = "default_placement")]
     pub placement: String,
+    #[serde(default)]
+    pub platforms: Option<Vec<String>>,
     pub command: Vec<String>,
 }
 
@@ -80,6 +107,65 @@ pub struct DockEntry {
 fn default_dock_placement() -> String {
     "sidebar.left".to_string()
 }
+
+/// The type of a declared setting, which picks its Settings-tab control.
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum SettingKind {
+    /// An on/off toggle, like the built-in notification switches.
+    Bool,
+    /// A free-text value, edited in a small inline prompt.
+    #[default]
+    String,
+    /// A whole number stepped with `‹ ›`, bounded by `min`/`max`.
+    Number,
+    /// One of `options`, cycled with `‹ ›`.
+    Enum,
+}
+
+/// One user-editable setting a module declares. Values live in the module's
+/// config dir (`settings.json`) and reach every command as
+/// `BOHAY_MODULE_SETTINGS_JSON` plus `BOHAY_SETTING_<KEY>`.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SettingSpec {
+    pub key: String,
+    pub title: String,
+    #[serde(rename = "type", default)]
+    pub kind: SettingKind,
+    #[serde(default)]
+    pub default: Option<Value>,
+    /// Choices for `type = "enum"`.
+    #[serde(default)]
+    pub options: Vec<String>,
+    #[serde(default)]
+    pub min: Option<i64>,
+    #[serde(default)]
+    pub max: Option<i64>,
+    #[serde(default)]
+    pub step: Option<i64>,
+    /// Hide the value in the UI (shown as `••••`) — for tokens and keys.
+    #[serde(default)]
+    pub secret: bool,
+}
+
+impl SettingSpec {
+    /// The value used when the user has not set one.
+    pub fn default_value(&self) -> Value {
+        if let Some(v) = &self.default {
+            return v.clone();
+        }
+        match self.kind {
+            SettingKind::Bool => Value::Bool(false),
+            SettingKind::Number => Value::from(self.min.unwrap_or(0)),
+            SettingKind::Enum => Value::String(self.options.first().cloned().unwrap_or_default()),
+            SettingKind::String => Value::String(String::new()),
+        }
+    }
+}
+
+/// Right-click menus an action can be attached to. `node` is accepted as a
+/// legacy alias of `workspace`.
+pub const KNOWN_CONTEXTS: &[&str] = &["pane", "workspace", "node", "agent", "tab"];
 
 impl ModuleManifest {
     /// Read + validate the manifest at `<root>/bohay-module.toml`.
@@ -121,6 +207,11 @@ impl ModuleManifest {
         }
         for b in &self.build {
             check_argv(&b.command, "build")?;
+            check_platforms(b.platforms.as_ref(), "build")?;
+        }
+        for (i, s) in self.startup.iter().enumerate() {
+            check_argv(&s.command, &format!("startup {i}"))?;
+            check_platforms(s.platforms.as_ref(), &format!("startup {i}"))?;
         }
         let mut action_ids = HashSet::new();
         for a in &self.actions {
@@ -134,6 +225,16 @@ impl ModuleManifest {
                 return Err(format!("duplicate action id: {}", a.id));
             }
             check_argv(&a.command, &format!("action {}", a.id))?;
+            check_platforms(a.platforms.as_ref(), &format!("action {}", a.id))?;
+            for c in a.contexts.iter().flatten() {
+                if !KNOWN_CONTEXTS.contains(&c.as_str()) {
+                    return Err(format!(
+                        "action {}: unknown context {c:?} (use {})",
+                        a.id,
+                        KNOWN_CONTEXTS.join(" | ")
+                    ));
+                }
+            }
         }
         let mut pane_ids = HashSet::new();
         for pe in &self.panes {
@@ -147,9 +248,34 @@ impl ModuleManifest {
                 return Err(format!("duplicate pane id: {}", pe.id));
             }
             check_argv(&pe.command, &format!("pane {}", pe.id))?;
+            check_platforms(pe.platforms.as_ref(), &format!("pane {}", pe.id))?;
         }
         for e in &self.events {
             check_argv(&e.command, &format!("event {}", e.on))?;
+            check_platforms(e.platforms.as_ref(), &format!("event {}", e.on))?;
+        }
+        let mut setting_keys = HashSet::new();
+        for s in &self.settings {
+            if !valid_local_id(&s.key) {
+                return Err(format!(
+                    "invalid setting key {:?} (use [a-z0-9:_-], no dots)",
+                    s.key
+                ));
+            }
+            if !setting_keys.insert(s.key.as_str()) {
+                return Err(format!("duplicate setting key: {}", s.key));
+            }
+            if s.title.trim().is_empty() {
+                return Err(format!("setting {}: title is required", s.key));
+            }
+            if s.kind == SettingKind::Enum && s.options.is_empty() {
+                return Err(format!("setting {}: enum needs a non-empty options", s.key));
+            }
+            if let (Some(lo), Some(hi)) = (s.min, s.max) {
+                if lo > hi {
+                    return Err(format!("setting {}: min is greater than max", s.key));
+                }
+            }
         }
         let mut dock_ids = HashSet::new();
         for d in &self.docks {
@@ -168,15 +294,33 @@ impl ModuleManifest {
 
     /// Whether this module is allowed to run on the current OS.
     pub fn allowed_on_platform(&self) -> bool {
-        match &self.platforms {
-            None => true,
-            Some(list) => list.iter().any(|p| p == current_platform()),
-        }
+        allowed_on(self.platforms.as_ref())
     }
 
-    /// Find an action by its local id.
+    /// Find an action by its local id, ignoring ones gated off this platform.
     pub fn action(&self, id: &str) -> Option<&Action> {
-        self.actions.iter().find(|a| a.id == id)
+        self.actions
+            .iter()
+            .find(|a| a.id == id && allowed_on(a.platforms.as_ref()))
+    }
+
+    /// Actions offered in right-click menu `context` on this platform.
+    pub fn actions_for_context(&self, context: &str) -> Vec<&Action> {
+        self.actions
+            .iter()
+            .filter(|a| allowed_on(a.platforms.as_ref()))
+            .filter(|a| {
+                a.contexts
+                    .iter()
+                    .flatten()
+                    .any(|c| c == context || (c == "node" && context == "workspace"))
+            })
+            .collect()
+    }
+
+    /// Find a setting spec by key.
+    pub fn setting(&self, key: &str) -> Option<&SettingSpec> {
+        self.settings.iter().find(|s| s.key == key)
     }
 
     /// Event `on` names that aren't known bohay events (non-fatal warnings).
@@ -191,9 +335,12 @@ impl ModuleManifest {
     }
 }
 
-/// Events a module may hook (docs/13 §3.5). Consumed by the hook runner (MOD-3).
-#[allow(dead_code)]
+/// Events a module may hook (docs/13 §3.5). Consumed by the hook runner (MOD-3)
+/// and by `module doctor` to flag typos. Kept in step with the `emit_event`
+/// call sites — `workspace.*` also answers to the legacy `node.*` spelling.
 pub const KNOWN_EVENTS: &[&str] = &[
+    "workspace.created",
+    "workspace.closed",
     "node.created",
     "node.closed",
     "tab.created",
@@ -201,7 +348,41 @@ pub const KNOWN_EVENTS: &[&str] = &[
     "pane.created",
     "pane.closed",
     "pane.agent_status_changed",
+    "agent.hook",
+    "task.added",
+    "task.claimed",
+    "task.started",
+    "task.updated",
+    "task.ready",
+    "task.done",
+    "task.released",
+    "task.deleted",
+    "task.merged",
+    "task.merge_conflict",
+    "task.needs_compaction",
+    "task.gate_running",
+    "task.gate_passed",
+    "task.gate_failed",
+    "lease.acquired",
+    "lease.released",
 ];
+
+/// Whether an item-level `platforms` list (or its absence) allows this OS.
+pub fn allowed_on(platforms: Option<&Vec<String>>) -> bool {
+    match platforms {
+        None => true,
+        Some(list) => list.iter().any(|p| p == current_platform()),
+    }
+}
+
+fn check_platforms(platforms: Option<&Vec<String>>, what: &str) -> Result<(), String> {
+    if platforms.is_some_and(|p| p.is_empty()) {
+        return Err(format!(
+            "{what}: platforms = [] is invalid (omit it for all platforms)"
+        ));
+    }
+    Ok(())
+}
 
 fn check_argv(argv: &[String], what: &str) -> Result<(), String> {
     if argv.is_empty() {
@@ -282,22 +463,29 @@ mod tests {
             description: None,
             platforms: None,
             build: vec![],
+            startup: vec![],
             actions: vec![],
             events: vec![],
             panes: vec![],
             docks: vec![],
+            settings: vec![],
+        }
+    }
+
+    fn action(id: &str) -> Action {
+        Action {
+            id: id.into(),
+            title: id.into(),
+            contexts: None,
+            platforms: None,
+            command: vec!["echo".into(), "hi".into()],
         }
     }
 
     #[test]
     fn valid_manifest_passes() {
         let mut m = base();
-        m.actions.push(Action {
-            id: "refresh".into(),
-            title: "Refresh".into(),
-            contexts: None,
-            command: vec!["echo".into(), "hi".into()],
-        });
+        m.actions.push(action("refresh"));
         assert!(m.validate().is_ok());
     }
 
@@ -308,22 +496,146 @@ mod tests {
         assert!(m.validate().is_err());
 
         let mut m = base();
-        m.actions.push(Action {
-            id: "has.dot".into(), // dots not allowed in local ids
-            title: "x".into(),
-            contexts: None,
-            command: vec!["echo".into()],
-        });
+        m.actions.push(action("has.dot")); // dots not allowed in local ids
         assert!(m.validate().is_err());
 
         let mut m = base();
-        m.actions.push(Action {
-            id: "ok".into(),
-            title: "x".into(),
-            contexts: None,
-            command: vec![], // empty argv
-        });
+        let mut a = action("ok");
+        a.command = vec![]; // empty argv
+        m.actions.push(a);
         assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn action_contexts_gate_the_right_click_menus() {
+        let mut m = base();
+        let mut a = action("apply");
+        a.contexts = Some(vec!["pane".into(), "node".into()]);
+        m.actions.push(a);
+        assert!(m.validate().is_ok());
+
+        assert_eq!(m.actions_for_context("pane").len(), 1);
+        // `node` is accepted as a legacy alias for `workspace`.
+        assert_eq!(m.actions_for_context("workspace").len(), 1);
+        assert_eq!(m.actions_for_context("agent").len(), 0);
+
+        // A typo'd context is a manifest error, not a silently dead menu entry.
+        let mut m = base();
+        let mut a = action("apply");
+        a.contexts = Some(vec!["sidebar".into()]);
+        m.actions.push(a);
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn item_platforms_gate_actions() {
+        let mut m = base();
+        let mut a = action("only-here");
+        a.platforms = Some(vec![current_platform().to_string()]);
+        a.contexts = Some(vec!["pane".into()]);
+        m.actions.push(a);
+        let mut b = action("never-here");
+        b.platforms = Some(vec!["plan9".into()]);
+        b.contexts = Some(vec!["pane".into()]);
+        m.actions.push(b);
+        assert!(m.validate().is_ok());
+
+        assert!(m.action("only-here").is_some());
+        assert!(m.action("never-here").is_none(), "gated off this platform");
+        assert_eq!(m.actions_for_context("pane").len(), 1);
+    }
+
+    #[test]
+    fn settings_validate_and_default() {
+        let mut m = base();
+        m.settings.push(SettingSpec {
+            key: "mode".into(),
+            title: "Mode".into(),
+            kind: SettingKind::Enum,
+            default: None,
+            options: vec!["fast".into(), "slow".into()],
+            min: None,
+            max: None,
+            step: None,
+            secret: false,
+        });
+        assert!(m.validate().is_ok());
+        // An enum with no explicit default falls back to its first option.
+        assert_eq!(m.setting("mode").unwrap().default_value(), "fast");
+
+        // enum without options is refused
+        let mut bad = base();
+        bad.settings.push(SettingSpec {
+            key: "mode".into(),
+            title: "Mode".into(),
+            kind: SettingKind::Enum,
+            default: None,
+            options: vec![],
+            min: None,
+            max: None,
+            step: None,
+            secret: false,
+        });
+        assert!(bad.validate().is_err());
+
+        // duplicate keys are refused
+        let mut dup = base();
+        for _ in 0..2 {
+            dup.settings.push(SettingSpec {
+                key: "token".into(),
+                title: "Token".into(),
+                kind: SettingKind::String,
+                default: None,
+                options: vec![],
+                min: None,
+                max: None,
+                step: None,
+                secret: true,
+            });
+        }
+        assert!(dup.validate().is_err());
+    }
+
+    #[test]
+    fn parses_a_full_v2_manifest() {
+        let m: ModuleManifest = toml::from_str(
+            r#"
+id = "you.demo"
+name = "Demo"
+version = "0.1.0"
+min_bohay_version = "0.1.0"
+
+[[startup]]
+command = ["./restore.sh"]
+
+[[actions]]
+id = "apply"
+title = "Apply layout"
+contexts = ["pane", "workspace"]
+command = ["./apply.sh"]
+
+[[settings]]
+key = "token"
+title = "API token"
+type = "string"
+secret = true
+
+[[settings]]
+key = "limit"
+title = "Row limit"
+type = "number"
+default = 20
+min = 1
+max = 99
+step = 1
+"#,
+        )
+        .expect("parses");
+        m.validate().expect("validates");
+        assert_eq!(m.startup.len(), 1);
+        assert_eq!(m.actions_for_context("workspace").len(), 1);
+        assert!(m.setting("token").unwrap().secret);
+        assert_eq!(m.setting("limit").unwrap().default_value(), 20);
     }
 
     #[test]
@@ -341,12 +653,7 @@ mod tests {
     fn duplicate_action_ids_rejected() {
         let mut m = base();
         for _ in 0..2 {
-            m.actions.push(Action {
-                id: "dup".into(),
-                title: "x".into(),
-                contexts: None,
-                command: vec!["echo".into()],
-            });
+            m.actions.push(action("dup"));
         }
         assert!(m.validate().is_err());
     }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -14,6 +14,7 @@ pub mod manifest;
 pub mod paths;
 pub mod registry;
 pub mod runtime;
+pub mod settings;
 
 pub use registry::{InstalledModule, ModuleRegistry};
 pub use runtime::ModuleCommandLog;

--- a/src/module/paths.rs
+++ b/src/module/paths.rs
@@ -1,5 +1,5 @@
 //! Module filesystem layout under `~/.bohay/modules/` and the deterministic
-//! id→path-component sanitizer (docs/13 §3.6). Module ids may contain `:`/`.`
+//! id→path-component sanitizer (docs/13 §3.11). Module ids may contain `:`/`.`
 //! which aren't always safe filesystem components, so they're encoded.
 
 use std::collections::hash_map::DefaultHasher;

--- a/src/module/runtime.rs
+++ b/src/module/runtime.rs
@@ -49,8 +49,12 @@ pub fn next_log_id() -> u64 {
     NEXT.fetch_add(1, Ordering::Relaxed)
 }
 
-/// The always-injected identity + context environment (docs/13 §3.4). Ensures
-/// the module's config/state dirs exist.
+/// The always-injected identity + context + settings environment (docs/13 §3.4).
+/// Ensures the module's config/state dirs exist.
+///
+/// Alongside `BOHAY_MODULE_CONTEXT_JSON` this flattens the ids into plain
+/// `BOHAY_WORKSPACE_ID` / `BOHAY_PANE_ID` / … vars and each declared setting
+/// into `BOHAY_SETTING_<KEY>`, so a bash module never has to parse JSON.
 pub fn base_env(module: &InstalledModule, ctx: &Value) -> Vec<(String, String)> {
     let config = paths::config_dir(&module.id);
     let state = paths::state_dir(&module.id);
@@ -73,7 +77,13 @@ pub fn base_env(module: &InstalledModule, ctx: &Value) -> Vec<(String, String)> 
             state.display().to_string(),
         ),
         ("BOHAY_MODULE_CONTEXT_JSON".to_string(), ctx.to_string()),
+        (
+            "BOHAY_MODULE_VERSION".to_string(),
+            module.manifest.version.clone(),
+        ),
     ];
+    env.extend(super::context::env_from(ctx));
+    env.extend(super::settings::env(&module.manifest, &module.id));
     if let Some(sock) = crate::ipc::api::socket_path_env() {
         env.push(("BOHAY_SOCKET_PATH".to_string(), sock));
     }

--- a/src/module/settings.rs
+++ b/src/module/settings.rs
@@ -1,0 +1,353 @@
+//! Module settings values (docs/13 §3.6): the user-set half of a module's
+//! `[[settings]]` declaration.
+//!
+//! The manifest declares the *shape* (key, title, type, bounds); this file
+//! stores the *values*, as a flat JSON object in the module's own config dir
+//! (`~/.bohay/modules/config/<id>/settings.json`). That dir already belongs to
+//! the module and survives reinstalls, so a module can also read the file
+//! directly if it would rather not parse the injected env.
+//!
+//! Only keys the manifest still declares are surfaced; a value left over from
+//! an older manifest version stays on disk untouched but is ignored.
+
+use serde_json::{Map, Value};
+
+use super::manifest::ModuleManifest;
+use super::paths;
+
+pub const FILE: &str = "settings.json";
+
+fn path(id: &str) -> std::path::PathBuf {
+    paths::config_dir(id).join(FILE)
+}
+
+/// The raw stored values (missing/corrupt file reads as empty).
+pub fn stored(id: &str) -> Map<String, Value> {
+    std::fs::read_to_string(path(id))
+        .ok()
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+        .and_then(|v| match v {
+            Value::Object(m) => Some(m),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// Manifest defaults overlaid with the user's stored values, restricted to the
+/// keys the manifest still declares. This is what commands and the UI see.
+pub fn effective(manifest: &ModuleManifest, id: &str) -> Map<String, Value> {
+    let saved = stored(id);
+    manifest
+        .settings
+        .iter()
+        .map(|spec| {
+            let v = saved
+                .get(&spec.key)
+                .cloned()
+                .unwrap_or_else(|| spec.default_value());
+            (spec.key.clone(), coerce(spec, v))
+        })
+        .collect()
+}
+
+/// One effective value.
+pub fn get(manifest: &ModuleManifest, id: &str, key: &str) -> Option<Value> {
+    let spec = manifest.setting(key)?;
+    let v = stored(id)
+        .get(key)
+        .cloned()
+        .unwrap_or_else(|| spec.default_value());
+    Some(coerce(spec, v))
+}
+
+/// Validate `value` against the declared spec and persist it. Returns the value
+/// as stored (coerced + clamped).
+pub fn set(manifest: &ModuleManifest, id: &str, key: &str, value: Value) -> Result<Value, String> {
+    let spec = manifest
+        .setting(key)
+        .ok_or_else(|| format!("module {id} has no setting {key}"))?;
+    let value = validate(spec, value)?;
+    let mut all = stored(id);
+    all.insert(key.to_string(), value.clone());
+    let dir = paths::config_dir(id);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
+    let text = serde_json::to_string_pretty(&Value::Object(all))
+        .map_err(|e| format!("cannot encode settings: {e}"))?;
+    // Write via a temp file + rename so a crash mid-write can't truncate the
+    // module's settings (same discipline as the module registry).
+    let tmp = dir.join(format!("{FILE}.tmp"));
+    std::fs::write(&tmp, text).map_err(|e| format!("cannot write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, path(id)).map_err(|e| format!("cannot save settings: {e}"))?;
+    Ok(value)
+}
+
+/// Reject a value of the wrong type; clamp numbers into `min..=max` and refuse
+/// an enum choice that isn't offered.
+fn validate(spec: &super::manifest::SettingSpec, v: Value) -> Result<Value, String> {
+    use super::manifest::SettingKind as K;
+    match spec.kind {
+        K::Bool => match v {
+            Value::Bool(b) => Ok(Value::Bool(b)),
+            Value::String(s) if s == "true" || s == "false" => Ok(Value::Bool(s == "true")),
+            _ => Err(format!("setting {} expects true or false", spec.key)),
+        },
+        K::Number => {
+            let n = match &v {
+                Value::Number(n) => n.as_i64(),
+                Value::String(s) => s.trim().parse::<i64>().ok(),
+                _ => None,
+            }
+            .ok_or_else(|| format!("setting {} expects a whole number", spec.key))?;
+            Ok(Value::from(clamp(spec, n)))
+        }
+        K::Enum => {
+            let s = v
+                .as_str()
+                .ok_or_else(|| format!("setting {} expects one of its options", spec.key))?;
+            if !spec.options.iter().any(|o| o == s) {
+                return Err(format!(
+                    "setting {} must be one of: {}",
+                    spec.key,
+                    spec.options.join(", ")
+                ));
+            }
+            Ok(Value::String(s.to_string()))
+        }
+        K::String => match v {
+            Value::String(s) => Ok(Value::String(s)),
+            Value::Null => Ok(Value::String(String::new())),
+            other => Ok(Value::String(other.to_string())),
+        },
+    }
+}
+
+/// Best-effort repair of an on-disk value whose type drifted from the manifest
+/// (a module can change a setting's type between versions). Never fails — it
+/// falls back to the declared default.
+fn coerce(spec: &super::manifest::SettingSpec, v: Value) -> Value {
+    validate(spec, v).unwrap_or_else(|_| spec.default_value())
+}
+
+fn clamp(spec: &super::manifest::SettingSpec, n: i64) -> i64 {
+    let n = spec.min.map_or(n, |lo| n.max(lo));
+    spec.max.map_or(n, |hi| n.min(hi))
+}
+
+/// Step a number/bool/enum setting by `delta` (the `‹ ›` arrows in Settings).
+/// Strings are not steppable and come back unchanged.
+pub fn stepped(spec: &super::manifest::SettingSpec, current: &Value, delta: i64) -> Value {
+    use super::manifest::SettingKind as K;
+    match spec.kind {
+        K::Bool => Value::Bool(!current.as_bool().unwrap_or(false)),
+        K::Number => {
+            let step = spec.step.unwrap_or(1).max(1);
+            let now = current.as_i64().unwrap_or_else(|| spec.min.unwrap_or(0));
+            Value::from(clamp(spec, now + delta * step))
+        }
+        K::Enum if !spec.options.is_empty() => {
+            let n = spec.options.len() as i64;
+            let at = current
+                .as_str()
+                .and_then(|s| spec.options.iter().position(|o| o == s))
+                .unwrap_or(0) as i64;
+            // Wrap in both directions so `‹` off the front lands on the last option.
+            let next = ((at + delta) % n + n) % n;
+            Value::String(spec.options[next as usize].clone())
+        }
+        _ => current.clone(),
+    }
+}
+
+/// A one-line rendering of a value for the Settings row (secrets are masked).
+pub fn display(spec: &super::manifest::SettingSpec, v: &Value) -> String {
+    if spec.secret {
+        let empty = v.as_str().is_some_and(|s| s.is_empty());
+        return if empty {
+            "not set".into()
+        } else {
+            "••••••".into()
+        };
+    }
+    match v {
+        Value::Bool(b) => if *b { "on" } else { "off" }.to_string(),
+        Value::String(s) if s.is_empty() => "not set".to_string(),
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// The env a module command sees for its settings: the whole set as JSON plus
+/// one `BOHAY_SETTING_<KEY>` per entry, so a shell script needs no JSON parser.
+pub fn env(manifest: &ModuleManifest, id: &str) -> Vec<(String, String)> {
+    if manifest.settings.is_empty() {
+        return Vec::new();
+    }
+    let values = effective(manifest, id);
+    let mut env = vec![(
+        "BOHAY_MODULE_SETTINGS_JSON".to_string(),
+        Value::Object(values.clone()).to_string(),
+    )];
+    for (k, v) in &values {
+        let name = format!(
+            "BOHAY_SETTING_{}",
+            k.to_uppercase().replace(['-', ':', '.'], "_")
+        );
+        // Scalars go in bare (no JSON quotes) so `$BOHAY_SETTING_TOKEN` is usable.
+        let flat = match v {
+            Value::String(s) => s.clone(),
+            Value::Bool(b) => b.to_string(),
+            other => other.to_string(),
+        };
+        env.push((name, flat));
+    }
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::module::manifest::{SettingKind, SettingSpec};
+    use crate::persist::TEST_ENV_LOCK;
+
+    fn spec(key: &str, kind: SettingKind) -> SettingSpec {
+        SettingSpec {
+            key: key.into(),
+            title: key.into(),
+            kind,
+            default: None,
+            options: vec![],
+            min: None,
+            max: None,
+            step: None,
+            secret: false,
+        }
+    }
+
+    fn manifest(settings: Vec<SettingSpec>) -> ModuleManifest {
+        ModuleManifest {
+            id: "you.demo".into(),
+            name: "Demo".into(),
+            version: "0.1.0".into(),
+            min_bohay_version: "0.1.0".into(),
+            description: None,
+            platforms: None,
+            build: vec![],
+            startup: vec![],
+            actions: vec![],
+            events: vec![],
+            panes: vec![],
+            docks: vec![],
+            settings,
+        }
+    }
+
+    #[test]
+    fn set_get_roundtrip_with_clamping_and_env() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modset-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let mut limit = spec("limit", SettingKind::Number);
+        limit.min = Some(1);
+        limit.max = Some(10);
+        let mut mode = spec("mode", SettingKind::Enum);
+        mode.options = vec!["fast".into(), "slow".into()];
+        let mut token = spec("token", SettingKind::String);
+        token.secret = true;
+        let m = manifest(vec![limit, mode, token, spec("loud", SettingKind::Bool)]);
+
+        // Defaults before anything is set.
+        assert_eq!(
+            get(&m, "you.demo", "limit").unwrap(),
+            1,
+            "min is the default"
+        );
+        assert_eq!(get(&m, "you.demo", "mode").unwrap(), "fast");
+
+        // Out-of-range numbers clamp rather than erroring.
+        assert_eq!(set(&m, "you.demo", "limit", 99.into()).unwrap(), 10);
+        assert_eq!(get(&m, "you.demo", "limit").unwrap(), 10);
+
+        // A bad enum choice is refused, and the old value survives.
+        assert!(set(&m, "you.demo", "mode", "sideways".into()).is_err());
+        assert_eq!(get(&m, "you.demo", "mode").unwrap(), "fast");
+        assert!(set(&m, "you.demo", "mode", "slow".into()).is_ok());
+
+        // An unknown key is an error, not a silent write.
+        assert!(set(&m, "you.demo", "nope", 1.into()).is_err());
+
+        set(&m, "you.demo", "token", "s3cret".into()).unwrap();
+        set(&m, "you.demo", "loud", true.into()).unwrap();
+
+        // Env: whole-set JSON + flat per-key vars usable straight from a shell.
+        let env = env(&m, "you.demo");
+        let find = |k: &str| {
+            env.iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default()
+        };
+        assert_eq!(find("BOHAY_SETTING_LIMIT"), "10");
+        assert_eq!(find("BOHAY_SETTING_MODE"), "slow");
+        assert_eq!(find("BOHAY_SETTING_TOKEN"), "s3cret", "no JSON quoting");
+        assert_eq!(find("BOHAY_SETTING_LOUD"), "true");
+        assert!(find("BOHAY_MODULE_SETTINGS_JSON").contains("\"mode\":\"slow\""));
+
+        // Secrets are masked in the UI even though the env carries the value.
+        let masked = display(m.setting("token").unwrap(), &"s3cret".into());
+        assert_eq!(masked, "••••••");
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn stepping_wraps_enums_and_clamps_numbers() {
+        let mut n = spec("n", SettingKind::Number);
+        (n.min, n.max, n.step) = (Some(0), Some(4), Some(2));
+        assert_eq!(stepped(&n, &0.into(), 1), 2);
+        assert_eq!(stepped(&n, &4.into(), 1), 4, "clamped at max");
+        assert_eq!(stepped(&n, &0.into(), -1), 0, "clamped at min");
+
+        let mut e = spec("e", SettingKind::Enum);
+        e.options = vec!["a".into(), "b".into(), "c".into()];
+        assert_eq!(stepped(&e, &"c".into(), 1), "a", "wraps forward");
+        assert_eq!(stepped(&e, &"a".into(), -1), "c", "wraps backward");
+
+        let b = spec("b", SettingKind::Bool);
+        assert_eq!(stepped(&b, &false.into(), 1), true);
+
+        // Strings are not steppable — the arrows leave them alone.
+        let s = spec("s", SettingKind::String);
+        assert_eq!(stepped(&s, &"hi".into(), 1), "hi");
+    }
+
+    #[test]
+    fn stale_values_from_an_older_manifest_are_ignored() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("bohay-modstale-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("BOHAY_HOME", &home);
+
+        let m = manifest(vec![spec("kept", SettingKind::String)]);
+        set(&m, "you.demo", "kept", "yes".into()).unwrap();
+        // Hand-write a key the manifest no longer declares, plus a type mismatch.
+        let dir = paths::config_dir("you.demo");
+        std::fs::write(
+            dir.join(FILE),
+            r#"{"kept": 42, "dropped": "old", "gone": true}"#,
+        )
+        .unwrap();
+
+        let eff = effective(&m, "you.demo");
+        assert_eq!(eff.len(), 1, "only declared keys surface");
+        // The number coerces to the declared string type rather than blowing up.
+        assert_eq!(eff.get("kept").unwrap(), "42");
+        // The undeclared value stays on disk (a downgrade shouldn't lose it).
+        assert!(stored("you.demo").contains_key("dropped"));
+
+        std::env::remove_var("BOHAY_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+}

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -2,7 +2,7 @@
 //! at the click point.
 
 use super::*;
-use crate::app::{AgentMenu, AgentMenuItem, PaneMenuItem, WsMenuItem};
+use crate::app::{AgentMenuItem, ModuleMenuAction, PaneMenuItem, WsMenuItem};
 use crate::i18n::Catalog;
 use ratatui::widgets::{Borders, Clear};
 
@@ -94,10 +94,11 @@ pub(super) fn draw_ws_menu(
     };
     let anchor = menu.anchor;
     let items = app.ws_menu_items(menu.index);
+    let extras = menu.module_actions.clone();
     let rows: Vec<MenuRow> = items
         .iter()
         .map(|it| MenuRow {
-            text: ws_label(*it, cat),
+            text: ws_label(*it, cat, &extras),
             divider: matches!(it, WsMenuItem::Divider),
             destructive: matches!(it, WsMenuItem::Close),
         })
@@ -119,11 +120,12 @@ pub(super) fn draw_pane_menu(
         return;
     };
     let anchor = menu.anchor;
-    let items = PaneMenuItem::ALL.to_vec();
+    let items = app.pane_menu_items();
+    let extras = menu.module_actions.clone();
     let rows: Vec<MenuRow> = items
         .iter()
         .map(|it| MenuRow {
-            text: pane_label(*it, cat),
+            text: pane_label(*it, cat, &extras),
             divider: matches!(it, PaneMenuItem::Divider),
             destructive: matches!(it, PaneMenuItem::Close),
         })
@@ -145,12 +147,13 @@ pub(super) fn draw_agent_menu(
         return;
     };
     let anchor = menu.anchor;
-    let items = AgentMenu::items_for(menu.target);
+    let items = app.agent_menu_items(menu.target);
+    let extras = menu.module_actions.clone();
     let rows: Vec<MenuRow> = items
         .iter()
         .map(|it| MenuRow {
-            text: agent_label(*it, cat),
-            divider: false,
+            text: agent_label(*it, cat, &extras),
+            divider: matches!(it, AgentMenuItem::Divider),
             destructive: matches!(it, AgentMenuItem::Close),
         })
         .collect();
@@ -160,14 +163,16 @@ pub(super) fn draw_agent_menu(
     }
 }
 
-fn agent_label(it: AgentMenuItem, cat: &Catalog) -> String {
+fn agent_label(it: AgentMenuItem, cat: &Catalog, extras: &[ModuleMenuAction]) -> String {
     match it {
         AgentMenuItem::Resume => cat.menu_resume.to_string(),
         AgentMenuItem::Close => cap_first(cat.act_close),
+        AgentMenuItem::Divider => String::new(),
+        AgentMenuItem::Module(i) => module_label(extras, i),
     }
 }
 
-fn ws_label(it: WsMenuItem, cat: &Catalog) -> String {
+fn ws_label(it: WsMenuItem, cat: &Catalog, extras: &[ModuleMenuAction]) -> String {
     match it {
         WsMenuItem::Close => cap_first(cat.act_close),
         WsMenuItem::Rename => cat.menu_rename.to_string(),
@@ -176,17 +181,26 @@ fn ws_label(it: WsMenuItem, cat: &Catalog) -> String {
         WsMenuItem::Divider => String::new(),
         WsMenuItem::OpenGit => cat.cmd_open_git.to_string(),
         WsMenuItem::OpenOrch => cat.cmd_open_board.to_string(),
+        WsMenuItem::Module(i) => module_label(extras, i),
     }
 }
 
-fn pane_label(it: PaneMenuItem, cat: &Catalog) -> String {
+fn pane_label(it: PaneMenuItem, cat: &Catalog, extras: &[ModuleMenuAction]) -> String {
     match it {
         PaneMenuItem::SplitVertical => cat.menu_split_vertical.to_string(),
         PaneMenuItem::SplitHorizontal => cat.menu_split_horizontal.to_string(),
         PaneMenuItem::RunningCmd => cat.menu_running_cmd.to_string(),
         PaneMenuItem::Divider => String::new(),
         PaneMenuItem::Close => cap_first(cat.act_close),
+        PaneMenuItem::Module(i) => module_label(extras, i),
     }
+}
+
+/// A module action's row label. Module titles come from the module author, so
+/// they are never translated — and a stale index renders blank rather than
+/// panicking (the registry can change while a menu is open).
+fn module_label(extras: &[ModuleMenuAction], i: usize) -> String {
+    extras.get(i).map(|a| a.title.clone()).unwrap_or_default()
 }
 
 /// Uppercase the first character (no-op for scripts without case, e.g. CJK), so

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -282,6 +282,8 @@ pub fn render_into(f: &mut RenderTarget, app: &mut App) {
         app.settings_ctl_rects.clear();
         app.settings_arrow_rects.clear();
     }
+    // A module-setting prompt sits above the modal it was opened from.
+    settings::draw_module_setting_prompt(f, area, app, &t);
 
     // The folder picker also draws last (over everything) when open.
     let picker_open = app.picker.is_some();

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3,7 +3,8 @@
 //! when open; returns the hit-test rects `render()` stores on the `App`.
 
 use super::*;
-use crate::app::{LayoutRow, SettingsTab};
+use crate::app::{LayoutRow, ModuleRow, SettingsTab};
+use crate::module::manifest::SettingKind;
 use ratatui::widgets::{Borders, Clear};
 
 pub(super) struct SettingsHits {
@@ -502,7 +503,8 @@ fn draw_content(
             }
         }
         SettingsTab::Modules => {
-            if app.modules.modules.is_empty() {
+            let rows = app.module_rows();
+            if rows.is_empty() {
                 f.render_widget(
                     Paragraph::new(Span::styled(
                         "   No modules installed — `bohay module link <dir>`.",
@@ -511,41 +513,182 @@ fn draw_content(
                     Rect::new(area.x, area.y, area.width, 1),
                 );
             } else {
-                for (i, m) in app.modules.modules.iter().enumerate() {
-                    let row = Rect::new(area.x, area.y + i as u16, area.width, 1);
-                    if row.y >= area.bottom() {
+                // Scroll so the cursor stays visible once modules expand their
+                // settings past the modal height (same idea as the Layout tab).
+                let h = area.height.max(1) as usize;
+                let first = cursor.saturating_sub(h.saturating_sub(1));
+                for (i, r) in rows.iter().enumerate().skip(first) {
+                    let y = area.y + (i - first) as u16;
+                    if y >= area.bottom() {
                         break;
                     }
+                    let row = Rect::new(area.x, y, area.width, 1);
                     let sel = i == cursor;
                     if sel {
                         fill_bg(f, row, t.sel_bg);
                     }
-                    // name + a hint (action count, or a ⚠ for a load warning)
-                    let hint = if m.warning.is_some() {
-                        " ⚠ unavailable".to_string()
-                    } else {
-                        format!(" · {} action(s)", m.manifest.actions.len())
-                    };
-                    f.render_widget(
-                        Paragraph::new(Line::from(vec![
-                            Span::styled(
-                                format!("  {}", m.id),
-                                Style::new().fg(if sel { t.text } else { t.subtext1 }),
-                            ),
-                            Span::styled(hint, Style::new().fg(t.overlay0)),
-                        ])),
-                        row,
-                    );
-                    f.render_widget(
-                        Paragraph::new(toggle(m.enabled, t)).alignment(Alignment::Right),
-                        Rect::new(row.x, row.y, row.width.saturating_sub(2), 1),
-                    );
+                    match *r {
+                        ModuleRow::Module(mi) => {
+                            let Some(m) = app.modules.modules.get(mi) else {
+                                continue;
+                            };
+                            // name + a hint (surface count, or a ⚠ for a load warning)
+                            let hint = if m.warning.is_some() {
+                                " ⚠ unavailable".to_string()
+                            } else {
+                                module_hint(m)
+                            };
+                            f.render_widget(
+                                Paragraph::new(Line::from(vec![
+                                    Span::styled(
+                                        format!("  {}", m.id),
+                                        Style::new().fg(if sel { t.text } else { t.subtext1 }),
+                                    ),
+                                    Span::styled(hint, Style::new().fg(t.overlay0)),
+                                ])),
+                                row,
+                            );
+                            f.render_widget(
+                                Paragraph::new(toggle(m.enabled, t)).alignment(Alignment::Right),
+                                Rect::new(row.x, row.y, row.width.saturating_sub(2), 1),
+                            );
+                        }
+                        ModuleRow::Setting(mi, si) => {
+                            let Some((m, spec)) = app
+                                .modules
+                                .modules
+                                .get(mi)
+                                .and_then(|m| m.manifest.settings.get(si).map(|s| (m, s)))
+                            else {
+                                continue;
+                            };
+                            let value = crate::module::settings::get(&m.manifest, &m.id, &spec.key)
+                                .unwrap_or_else(|| spec.default_value());
+                            let shown = crate::module::settings::display(spec, &value);
+                            // Indented under its module, with a ╰ tie so a long
+                            // settings list still reads as belonging to it.
+                            let label = format!("  ╰ {}", spec.title);
+                            match spec.kind {
+                                // Number/enum step through `‹ ›`, like the Layout sliders.
+                                SettingKind::Number | SettingKind::Enum => {
+                                    slider_row(
+                                        f,
+                                        area,
+                                        row.y,
+                                        i,
+                                        sel,
+                                        &label,
+                                        shown,
+                                        t,
+                                        &mut arrows,
+                                    );
+                                }
+                                SettingKind::Bool | SettingKind::String => {
+                                    f.render_widget(
+                                        Paragraph::new(Span::styled(
+                                            format!("  {label}"),
+                                            Style::new().fg(if sel { t.text } else { t.subtext0 }),
+                                        )),
+                                        row,
+                                    );
+                                    if spec.kind == SettingKind::Bool {
+                                        let on = value.as_bool().unwrap_or(false);
+                                        f.render_widget(
+                                            Paragraph::new(toggle(on, t))
+                                                .alignment(Alignment::Right),
+                                            Rect::new(row.x, row.y, row.width.saturating_sub(2), 1),
+                                        );
+                                    } else {
+                                        f.render_widget(
+                                            Paragraph::new(Span::styled(
+                                                format!("{shown}  "),
+                                                Style::new().fg(t.accent),
+                                            ))
+                                            .alignment(Alignment::Right),
+                                            row,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
                     ctls.push((i, row));
                 }
             }
         }
     }
     (ctls, arrows)
+}
+
+/// The one-line summary of what a module contributes, e.g. `· 2 actions · 1 dock`.
+/// Only non-zero surfaces are listed, so a small module stays quiet.
+fn module_hint(m: &crate::module::InstalledModule) -> String {
+    let man = &m.manifest;
+    let parts = [
+        (man.actions.len(), "action"),
+        (man.panes.len(), "pane"),
+        (man.docks.len(), "dock"),
+        (man.settings.len(), "setting"),
+    ];
+    let mut out = String::new();
+    for (n, name) in parts {
+        if n > 0 {
+            let plural = if n == 1 { "" } else { "s" };
+            out.push_str(&format!(" · {n} {name}{plural}"));
+        }
+    }
+    out
+}
+
+/// The inline prompt for a `type = "string"` module setting, drawn over the
+/// Settings modal. Mirrors the tab/workspace rename modals (docs/28).
+pub(super) fn draw_module_setting_prompt(f: &mut RenderTarget, area: Rect, app: &App, t: &Theme) {
+    let Some(e) = app.module_setting_edit.as_ref() else {
+        return;
+    };
+    let w = 52.min(area.width.max(10));
+    let h = 5.min(area.height.max(3));
+    let rect = Rect::new(
+        area.x + (area.width.saturating_sub(w)) / 2,
+        area.y + (area.height.saturating_sub(h)) / 2,
+        w,
+        h,
+    );
+    f.render_widget(Clear, rect);
+    let block = Block::new()
+        .borders(Borders::ALL)
+        .border_style(Style::new().fg(t.border_focus).bg(t.surface0))
+        .style(Style::new().bg(t.surface0));
+    let inner = block.inner(rect);
+    f.render_widget(block, rect);
+
+    f.render_widget(
+        Paragraph::new(Span::styled(
+            format!(" {}", e.title),
+            Style::new().fg(t.subtext1),
+        )),
+        Rect::new(inner.x, inner.y, inner.width, 1),
+    );
+    // A secret is echoed as bullets, so a shoulder-surfer can't read a token.
+    let shown = if e.secret {
+        "•".repeat(e.buffer.chars().count())
+    } else {
+        e.buffer.clone()
+    };
+    f.render_widget(
+        Paragraph::new(Span::styled(
+            format!(" {shown}▏"),
+            Style::new().fg(t.text).bold(),
+        )),
+        Rect::new(inner.x, inner.y + 1, inner.width, 1),
+    );
+    f.render_widget(
+        Paragraph::new(Span::styled(
+            " ⏎ save · esc cancel",
+            Style::new().fg(t.overlay0),
+        )),
+        Rect::new(inner.x, inner.y + 2, inner.width, 1),
+    );
 }
 
 /// The `‹ value ›` slider row for control `idx`. Records the two arrow cells as

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -62,6 +62,8 @@ export default defineConfig({
           items: [
             { label: 'Using Modules', slug: 'docs/extend/using-modules' },
             { label: 'Writing a Module', slug: 'docs/extend/writing-modules' },
+            // The community index is a standalone page, not a docs entry.
+            { label: 'Module Index', link: '/modules/', attrs: { target: '_self' } },
           ],
         },
         {

--- a/website/src/content/docs/docs/extend/using-modules.mdx
+++ b/website/src/content/docs/docs/extend/using-modules.mdx
@@ -1,24 +1,188 @@
 ---
 title: Using Modules
-description: Discover, install, and manage bohay extensions, safely.
+description: Find, install, configure, and manage bohay modules, and the trust model behind them.
 ---
 
-A **module** extends bohay with new commands, panels, and automations. Modules
-are ordinary programs (any language) declared in a small manifest, with no SDK
-and no plugin runtime.
+A **module** extends bohay with sidebar panels, panes, right-click actions, and
+automations. Modules are ordinary programs in any language, declared in a small
+manifest. There's no SDK and no plugin runtime, so a module is just a repo with
+some scripts in it.
+
+If you want to *build* one, see [Writing a Module](/docs/extend/writing-modules/).
+This page is about running other people's.
+
+## Finding modules
+
+There is no registry and no marketplace account. A module is a public GitHub
+repo tagged with the **`bohay-module`** topic, and both the terminal and the
+website read that same topic:
 
 ```sh
-bohay module search            # community modules (GitHub topic: bohay-module)
-bohay module install owner/repo
-bohay module list · info <id> · run <id> <action> · log <id>
-bohay module enable <id> · disable <id> · uninstall <id>
+bohay module search              # most-starred first
+bohay module search git status   # narrow it with keywords
 ```
 
-**Trust model:** installing shows you **every command the module declares and
-asks for confirmation before anything runs**. Builds run with a scrubbed
-environment, and a module's declared manifest can't silently change after install.
-Modules you're just developing locally can be registered with
-`bohay module link <path>`.
+Or browse the [module index](/modules/) on the site.
 
-Modules can also open their own panes (split, overlay, or tab placement) and
-react to bohay events. Manage everything from **Settings → Modules** too.
+`module search` needs `curl` or `wget` and talks only to GitHub's search API. It
+is read-only and never touches your running session, so it's safe to run any
+time.
+
+## Installing
+
+```sh
+bohay module install owner/repo              # the whole repo is the module
+bohay module install owner/repo/path/to      # a module in a subdirectory
+bohay module install owner/repo --ref v1.2   # pin a branch, tag, or commit
+```
+
+Install is deliberately a conversation, not a one-shot. It:
+
+1. Shallow-clones the repo to a staging directory.
+2. **Prints every command the module declares** and asks you to confirm.
+3. Runs any `[[build]]` steps with a **scrubbed environment** (no `BOHAY_*`, no
+   socket access), so a build script can't drive your session.
+4. Verifies the manifest didn't change during the build.
+5. Moves the checkout into bohay-managed storage and records the exact commit.
+
+A real install looks like this:
+
+```
+Install module from RizRiyz/bohay-agent-ping
+  id:      example.agent-ping
+  name:    Agent Ping 0.1.0
+  commit:  5d3687f1528e
+Commands this module can run:
+  action ping-now: python3 ping.py --force
+  on pane.agent_status_changed: python3 ping.py
+installed example.agent-ping (RizRiyz/bohay-agent-ping@5d3687f1528e…)
+```
+
+Read that command list before you say yes. It is the whole security review, and
+it is short on purpose.
+
+Use `--yes` to skip the prompt in scripts and CI, and only for sources you
+already trust. There's no `module update`: reinstall from GitHub to refresh a
+managed module.
+
+## Configuring
+
+Modules can declare their own settings. Open **Settings → Modules**
+(`Ctrl+Space` then the Menu button, or click **Menu** in the sidebar) and you'll
+see each module with its settings indented beneath it:
+
+- **Toggles** flip with `⏎` or a click.
+- **Numbers and choices** step with the `‹ ›` arrows.
+- **Text** opens a small prompt on `⏎`. Values marked secret show as `••••••`
+  and are never echoed back.
+
+Settings are collapsed while a module is disabled, so the list stays short.
+
+The same values are reachable from the CLI, which is handy for setup scripts:
+
+```sh
+bohay module settings you.ci               # every key, its type, current value
+bohay module settings you.ci limit         # read one
+bohay module settings you.ci limit 30      # write one
+```
+
+A listing reports a secret only as `"set": true|false`, never its value, since
+that output usually lands in your scrollback. Ask for the key by name when a
+script genuinely needs it.
+
+Anything a module stores itself lives in its own directory:
+
+```sh
+bohay module config-dir you.ci   # prints (and creates) it
+```
+
+## Managing
+
+```sh
+bohay module list                # what's installed, and whether it's runnable
+bohay module info <id>           # its actions, panes, docks, events, source
+bohay module enable <id>
+bohay module disable <id>
+bohay module run <id> <action>   # invoke an action by hand
+bohay module log [<id>]          # captured stdout/stderr + exit status
+bohay module uninstall <id>      # unregister + delete a managed checkout
+bohay module unlink <id>         # unregister only, leave the files alone
+```
+
+Everything here also works from **Settings → Modules**, where a click toggles a
+module on or off.
+
+**Disabling is the off switch you want.** A disabled module runs nothing: no
+actions, no event hooks, no startup commands, and its docks and right-click
+entries disappear. Re-enabling it lets it repaint its docks immediately, without
+a restart.
+
+`uninstall` only deletes files for modules bohay manages (installed from
+GitHub). For a module you linked from your own working directory it refuses, and
+tells you to use `unlink` instead, so it can never delete your source.
+
+## Where a module can show up
+
+Once enabled, a module appears wherever its manifest said it should:
+
+| Surface | Where you'll see it |
+|---|---|
+| **Dock** | A panel in either sidebar. Move it, or turn it off, in Settings → Layout |
+| **Pane** | A real pane you open with `bohay module pane open <id> <entrypoint>` |
+| **Right-click** | Extra rows below the divider in the pane, workspace, or agent menus |
+| **Settings** | Its own section in Settings → Modules |
+| **Events** | Invisible: it just runs when agents, panes, tabs, or tasks change |
+
+Docks are placed by the user, not the module. From **Settings → Layout**, each
+dock has `[Left] [Right] [Off]` buttons, so a module can suggest a side but
+never keep it.
+
+## Developing locally
+
+While writing a module, register your working directory instead of installing:
+
+```sh
+bohay module link /path/to/my-module      # add --disabled to register it off
+bohay module unlink you.my-module         # deregister; your files are untouched
+```
+
+`link` does **not** run `[[build]]` steps: build your own tree. Linking also
+runs the module's startup hooks straight away, so a dock shows up without a
+restart.
+
+Try the three examples that ship in the repo:
+
+```sh
+bohay module link ./examples/modules/branch-dock
+```
+
+## Trust
+
+A module is ordinary code that runs on your machine, as you, with your
+environment and your full bohay CLI. That openness is the point. It's the same
+deal as an editor extension or a shell plugin, and the same judgment applies.
+
+What bohay does for you:
+
+- Shows every declared command before an install, and waits for confirmation.
+- Runs build steps with a scrubbed environment and no socket access.
+- Refuses an install if the manifest changed after you saw the preview.
+- Pins the installed commit, so a later force-push doesn't change what you ran.
+- Keeps each module's config and state in its own directory.
+- Refuses to delete files it doesn't manage.
+
+What it does not do: **sandbox**. bohay doesn't inspect or restrict what a
+module's code does once you approve it. Install from authors you trust, skim the
+manifest and the scripts, and pin `--ref` when you want a specific revision.
+
+## Troubleshooting
+
+| Symptom | What's happening |
+|---|---|
+| Listed but `runnable: false` | Disabled, gated to another OS by `platforms`, or its manifest failed to load. `module list` shows the warning. |
+| An action *is ambiguous* | Two modules use the same action id. Qualify it: `module run <module-id> <action>`. |
+| Nothing in the log | The entry stays `running` until the command exits. Output is capped at 64 KiB per stream. |
+| A dock is empty | It repaints from a startup hook. If the module has none, run its refresh action once. |
+| Right-click row missing | The module is disabled, or the action's `platforms` exclude your OS. |
+| `module search` fails | It needs `curl` or `wget`, and GitHub rate-limits anonymous search. Browse [the topic](https://github.com/topics/bohay-module) instead. |
+| Install refused | Installing over a locally linked module is blocked. `unlink` the local one first. |

--- a/website/src/content/docs/docs/extend/writing-modules.mdx
+++ b/website/src/content/docs/docs/extend/writing-modules.mdx
@@ -7,9 +7,23 @@ A **module** is the way you extend bohay. It's a plain directory with one
 manifest file (`bohay-module.toml`) that declares **commands**, the argv arrays
 bohay runs as subprocesses. There's no SDK, no scripting runtime, and no
 language requirement: if it can be executed and read environment variables, it
-can be a bohay module. A command does its work by reading the injected
-`BOHAY_*` context and, when it needs to change the workspace, by calling the
-same `bohay` CLI you use by hand. **The bohay CLI is the module API**.
+can be a bohay module: a Bash script, a Python file, a Lua or Rust binary, a
+Node app, anything your machine can run. A command does its work by reading the
+injected `BOHAY_*` context and, when it needs to change the workspace, by
+calling the same `bohay` CLI you use by hand. **The bohay CLI is the module
+API**.
+
+A module can reach every surface the app has:
+
+| Surface | Declared as | What you get |
+|---|---|---|
+| **Docks** | `[[docks]]` | A panel in either sidebar, with clickable rows |
+| **Panes** | `[[panes]]` | A real terminal pane running your program |
+| **Tabs** | any command | Create, focus, name, and close tabs |
+| **Right-click** | `contexts` on an action | Rows in the pane / workspace / agent menus |
+| **Settings** | `[[settings]]` | Typed controls in Settings → Modules, no UI code |
+| **Events** | `[[events]]` | Run when agents, panes, tabs, or tasks change |
+| **Startup** | `[[startup]]` | Restore your state when the session comes up |
 
 ## A module in five minutes
 
@@ -24,7 +38,7 @@ my-module/
 id = "you.hello"                 # required, globally unique-ish
 name = "Hello"                   # required
 version = "0.1.0"                # required
-min_bohay_version = "0.1.0"      # required
+min_bohay_version = "0.8.3"      # required
 
 [[actions]]
 id = "refresh"                   # local id (no dots)
@@ -60,9 +74,14 @@ with `module log`.
 | `id` | ✓ | `[a-z0-9:._-]`, ≤120 chars. Dots allowed (e.g. `you.git-status`). |
 | `name` | ✓ | Human-readable, non-empty. |
 | `version` | ✓ | Your module's version. |
-| `min_bohay_version` | ✓ | Install is refused if newer than the host. |
+| `min_bohay_version` | ✓ | Install is refused if newer than the host. Use `0.8.3` if you use right-click menus, settings, startup hooks, or dock row values. |
 | `description` |  | One-line summary. |
 | `platforms` |  | e.g. `["macos", "linux"]`. Omit for all. `[]` is an error. |
+
+Every entry below (`build`, `startup`, `actions`, `events`, `panes`) also
+accepts its own `platforms` list, which overrides the top-level one. That's how
+one manifest ships a `pbcopy` action on macOS and a `clip.exe` action on
+Windows without either showing up on the wrong machine.
 
 ### `[[actions]]`: on-demand commands
 
@@ -70,11 +89,135 @@ with `module log`.
 [[actions]]
 id = "commit"                    # local id: [a-z0-9:_-], ≤120, NO dots
 title = "Commit staged changes"
+contexts = ["pane"]              # optional: also offer it on right-click
+platforms = ["macos", "linux"]   # optional: narrower than the top level
 command = ["bun", "run", "commit.ts"]
 ```
 
 Invoke with `bohay module run <module-id> <action-id>`. The qualified id is
 `{module-id}.{action-id}`.
+
+### `contexts`: put an action in a right-click menu
+
+An action with `contexts` is offered in bohay's own context menus, below a
+divider under the built-in items. This is the shortest path from a shell script
+to something that feels native.
+
+| Context | Where it appears | What the action receives |
+|---|---|---|
+| `pane` | Right-click inside any pane | The clicked pane, plus its **selected text** |
+| `workspace` | Right-click a WORKSPACES row | The clicked node (`node` is a legacy alias) |
+| `agent` | Right-click a live agent in AGENTS | That agent's pane |
+| `tab` | Reserved for a future tab menu | — |
+
+```toml
+[[actions]]
+id = "blame"
+title = "Blame this selection"
+contexts = ["pane"]
+command = ["python3", "blame.py"]
+```
+
+The target is **what you clicked**, not what happened to be focused: right-click
+a background node and `BOHAY_WORKSPACE_CWD` is that node's folder. Actions
+without `contexts` never appear in a menu, which is right for anything meant
+only for the CLI, a dock row, or another module.
+
+`invocation_source` in the context tells you where a run came from
+(`menu:pane`, `menu:workspace`, `menu:agent`, `dock`, `startup`, `event`,
+`cli`, `api`), so one script can serve several entry points.
+
+### `[[settings]]`: user-editable configuration
+
+Declare settings and bohay renders them in **Settings → Modules**, indented
+under your module, and hands the resolved values to every command you run. You
+never write a settings UI, and you never parse a config file.
+
+```toml
+[[settings]]
+key = "token"                    # local id: [a-z0-9:_-], NO dots
+title = "API token"
+type = "string"
+secret = true                    # masked in the UI and in the edit prompt
+
+[[settings]]
+key = "limit"
+title = "Rows to show"
+type = "number"
+default = 20
+min = 1
+max = 99
+step = 1
+
+[[settings]]
+key = "mode"
+title = "Mode"
+type = "enum"
+options = ["fast", "thorough"]
+default = "fast"
+
+[[settings]]
+key = "loud"
+title = "Play a sound"
+type = "bool"
+default = false
+```
+
+| `type` | Control | Notes |
+|---|---|---|
+| `bool` | A toggle | `default` is `false` when omitted |
+| `string` | An inline prompt on `⏎` | `secret = true` echoes bullets |
+| `number` | `‹ ›` steppers | Clamped to `min`/`max`; `step` defaults to 1 |
+| `enum` | `‹ ›` through `options` | Wraps; defaults to the first option |
+
+Values reach your command two ways, so no language needs a JSON parser:
+
+```sh
+echo "$BOHAY_SETTING_TOKEN"          # one flat var per key, UPPER_SNAKE
+echo "$BOHAY_SETTING_MODE"
+echo "$BOHAY_MODULE_SETTINGS_JSON"   # {"token":"...","limit":20,...}
+```
+
+bohay validates on write: a number is clamped into range, an enum choice
+outside `options` is refused, and a type that drifted between module versions
+falls back to the declared default rather than erroring. Values live in
+`$BOHAY_MODULE_CONFIG_DIR/settings.json`, so they survive a reinstall and you
+can read the file directly if you prefer.
+
+Read and write them from a script or the CLI too:
+
+```sh
+bohay module settings you.ci                  # list keys, types, current values
+bohay module settings you.ci limit            # read one
+bohay module settings you.ci limit 30         # write one
+```
+
+:::caution
+A **listing** reports a `secret` setting only as `"set": true|false`, never its
+value, because that output usually lands in a terminal and its scrollback. Ask
+for the key by name (`module settings you.ci token`) when a script genuinely
+needs the value. Your own commands always get the real value in
+`$BOHAY_SETTING_TOKEN`, so a module never needs to read its own secrets back
+over the API.
+:::
+
+### `[[startup]]`: run once when the session is ready
+
+```toml
+[[startup]]
+command = ["sh", "refresh.sh"]
+```
+
+Startup commands run for each enabled module once the session has been restored
+and the API socket is listening. They also run when a module is **linked or
+re-enabled**, so a module never sits idle waiting for a restart.
+
+This is how a module with a dock survives a restart: dock contents are cached in
+memory and deliberately not persisted, so the startup hook is where you repaint
+them. Keep hooks one-shot: restore your state, call what you need, exit. They
+are not supervised daemons, and a failure is logged without stopping the server.
+
+Startup commands get the normal environment plus `BOHAY_MODULE_EVENT=startup`.
 
 ### `[[events]]`: react to lifecycle events
 
@@ -85,10 +228,27 @@ command = ["sh", "notify.sh"]
 ```
 
 Your command runs with `BOHAY_MODULE_EVENT` (the name) and
-`BOHAY_MODULE_EVENT_JSON` (the payload). Hookable events: `node.created` ·
-`node.closed` · `tab.created` · `tab.closed` · `pane.created` · `pane.closed`
-· `pane.agent_status_changed` (payload `{pane, status, agent}`, the
-highest-value hook: notify when `status` becomes `blocked` or `done`).
+`BOHAY_MODULE_EVENT_JSON` (the payload).
+
+| Group | Events |
+|---|---|
+| Workspaces | `workspace.created` · `workspace.closed` (legacy aliases `node.created` / `node.closed`) |
+| Tabs | `tab.created` · `tab.closed` |
+| Panes | `pane.created` · `pane.closed` · `pane.agent_status_changed` |
+| Agents | `agent.hook` |
+| Orchestration | `task.added` · `task.claimed` · `task.started` · `task.updated` · `task.ready` · `task.done` · `task.released` · `task.deleted` · `task.merged` · `task.merge_conflict` · `task.needs_compaction` · `task.gate_running` · `task.gate_passed` · `task.gate_failed` |
+| Leases | `lease.acquired` · `lease.released` |
+
+`pane.agent_status_changed` is the highest-value hook -- notify when `status`
+becomes `blocked` or `done`. Its payload is the richest one:
+
+```json
+{ "pane": "4", "status": "blocked", "agent": "claude",
+  "cwd": "/Users/you/code/app", "project": "app", "branch": "main" }
+```
+
+A hook declared on `node.created` / `node.closed` still fires for the
+`workspace.*` events, so older modules keep working.
 
 ### `[[panes]]`: long-lived UI in a real pane
 
@@ -114,7 +274,7 @@ list) into the chrome.
 
 ```toml
 [[docks]]
-id = "you.ci"                    # local id: [a-z0-9:_-], ≤120, NO dots
+id = "you:ci"                    # local id: [a-z0-9:_-], ≤120, NO dots
 title = "CI"                     # the dock header
 placement = "sidebar.right"      # default side: sidebar.left | sidebar.right
 ```
@@ -128,8 +288,8 @@ the right sidebar, or turn it **Off** with `[Left] [Right] [Off]` buttons.
 Push rows with the CLI:
 
 ```sh
-"$BOHAY_BIN_PATH" ui dock push --id you.ci --title CI --rows '[
-  {"text": "build passing", "dot": "done",    "action": "open-ci"},
+"$BOHAY_BIN_PATH" ui dock push --id you:ci --title CI --rows '[
+  {"text": "build passing", "dot": "done",    "action": "open-ci", "value": "1421"},
   {"text": "3 checks",      "dot": "working"}
 ]'
 ```
@@ -137,7 +297,7 @@ Push rows with the CLI:
 or pipe the JSON array on stdin (handy when you build it with `jq`):
 
 ```sh
-printf '%s' "$rows_json" | "$BOHAY_BIN_PATH" ui dock push --id you.ci --title CI
+printf '%s' "$rows_json" | "$BOHAY_BIN_PATH" ui dock push --id you:ci --title CI
 ```
 
 Each **row** is an object:
@@ -147,14 +307,26 @@ Each **row** is an object:
 | `text` | ✓ | The row label. |
 | `dot` |  | A status dot: `idle` / `working` / `blocked` / `done` (colored like the Agents list). |
 | `action` |  | A module **action id** run when the row is clicked. |
+| `value` |  | An opaque payload for that action, so one action can back every row. |
 
 The **first push mounts** the dock into its `placement` side automatically (or
 wherever the user has since moved it). Later pushes just refresh the rows. Clear
 a dock with an empty array: `--rows '[]'`.
 
-A row with an `action` is **clickable**: clicking it runs that action (exactly
-like `bohay module run <your-id> <action>`), so a dock can be interactive: click
-a failing check to open its page, click a branch to check it out.
+A row with an `action` is **clickable**: clicking it runs that action and tells
+it which row was hit, so a dock becomes a list of buttons rather than a static
+readout.
+
+| Variable | Meaning |
+|---|---|
+| `BOHAY_MODULE_ROW_VALUE` | The row's `value` (falls back to `text`). |
+| `BOHAY_MODULE_ROW_TEXT` | The row's visible label. |
+| `BOHAY_MODULE_ROW_INDEX` | Its position in the dock. |
+| `BOHAY_MODULE_DOCK_ID` | Which dock it came from. |
+
+That's the whole trick behind a clickable branch list: push one row per branch
+with `"action": "checkout"` and `"value": "<branch>"`, then have `checkout` read
+`$BOHAY_MODULE_ROW_VALUE`.
 
 Declared docks show up in the **registry** in Settings → Layout even before they
 push anything, so the user can place them straight away. Disabling or unlinking
@@ -169,7 +341,7 @@ changes:
 
 ```toml
 [[docks]]
-id = "you.git"
+id = "you:git"
 title = "Git"
 placement = "sidebar.right"
 
@@ -181,21 +353,23 @@ command = ["sh", "push-git.sh"]
 ```sh
 #!/bin/sh
 # push-git.sh: build the rows with jq and push them
-cwd=$(printf '%s' "$BOHAY_MODULE_CONTEXT_JSON" | jq -r .node.cwd)
+cwd="$BOHAY_WORKSPACE_CWD"        # no JSON parsing needed for the common ids
 branch=$(git -C "$cwd" branch --show-current)
 dirty=$(git -C "$cwd" status --porcelain | wc -l | tr -d ' ')
 rows=$(jq -n --arg b "$branch" --arg d "$dirty" '[
   {text: ("on " + $b),        dot: "idle"},
   {text: ($d + " changed"),   dot: (if $d == "0" then "done" else "working" end)}
 ]')
-printf '%s' "$rows" | "$BOHAY_BIN_PATH" ui dock push --id you.git --title Git
+printf '%s' "$rows" | "$BOHAY_BIN_PATH" ui dock push --id you:git --title Git
 ```
 
 That's a live git dock in the sidebar, kept current with zero per-frame cost.
 
 :::tip
-Namespace your dock id (e.g. `you.ci`, `acme:builds`) so it can't collide with
-another plugin's dock. Colons are allowed in a dock id, but dots are not.
+Namespace your dock id (e.g. `you:ci`, `acme:builds`) so it can't collide with
+another module's dock. Colons are allowed in a dock id, but **dots are not** --
+that rule applies to every local id (actions, panes, docks, setting keys). Only
+the top-level module `id` may contain dots.
 :::
 
 ### `[[build]]`: install-time setup
@@ -212,8 +386,13 @@ socket access). For local `link` you run your own setup.
 
 A manifest is rejected if: any `command` is empty (or contains an empty
 string) · `min_bohay_version` is newer than the host · an id uses characters
-outside its set, or a local id contains a dot · two actions/panes/docks share
-an id · `platforms = []`.
+outside its set, or a local id contains a dot · two actions/panes/docks/settings
+share an id · `platforms = []` at any level · an action names a `contexts` value
+that isn't `pane` / `workspace` / `node` / `agent` / `tab` · an `enum` setting
+has no `options`, or a setting's `min` is above its `max`.
+
+Failing loudly on a typo'd context matters: the alternative is a menu entry that
+silently never appears.
 
 :::note
 Commands run **without a shell**: `["git", "status"]`, not `"git status"`.
@@ -235,17 +414,39 @@ takes down bohay.
 
 ## Environment variables
 
+**Identity**
+
 | Variable | Meaning |
 |---|---|
 | `BOHAY_ENV` | Always `1`, meaning you're running under bohay. |
 | `BOHAY_MODULE_ID` | Your module's id. |
+| `BOHAY_MODULE_VERSION` | Your module's declared version. |
 | `BOHAY_MODULE_ROOT` | The module directory (also the cwd). Read-only by convention. |
 | `BOHAY_MODULE_CONFIG_DIR` | Durable, user-owned config/secrets dir (created for you). |
 | `BOHAY_MODULE_STATE_DIR` | Durable state/cache dir (created for you). |
-| `BOHAY_MODULE_CONTEXT_JSON` | JSON snapshot of the focused workspace/tab/pane. |
 | `BOHAY_SOCKET_PATH` | The control socket (the CLI finds it automatically). |
 | `BOHAY_BIN_PATH` | Absolute path to the `bohay` binary. Use this to call back. |
-| `BOHAY_MODULE_ACTION_ID` | The action id, for action commands. |
+
+**Context** — the same snapshot twice: flattened for shells, whole for everyone else.
+
+| Variable | Meaning |
+|---|---|
+| `BOHAY_MODULE_CONTEXT_JSON` | The full snapshot (below). |
+| `BOHAY_WORKSPACE_ID` / `BOHAY_WORKSPACE_CWD` | The target node. |
+| `BOHAY_TAB_INDEX` | Its active tab, 1-based. |
+| `BOHAY_PANE_ID` / `BOHAY_PANE_CWD` | The target pane. |
+| `BOHAY_PANE_AGENT` / `BOHAY_PANE_STATUS` | What's running there and its state. |
+
+**Per-invocation**
+
+| Variable | Set for |
+|---|---|
+| `BOHAY_MODULE_ACTION_ID` | Action commands. |
+| `BOHAY_MODULE_ENTRYPOINT_ID` | Pane commands. |
+| `BOHAY_MODULE_EVENT` | Event hooks (the name) and startup hooks (`startup`). |
+| `BOHAY_MODULE_EVENT_JSON` | Event hooks (the payload). |
+| `BOHAY_MODULE_ROW_*` | Actions run from a clicked dock row. |
+| `BOHAY_SETTING_<KEY>` / `BOHAY_MODULE_SETTINGS_JSON` | Every command, when you declare `[[settings]]`. |
 
 Persist data in the **state/config dirs**, never in the module root, because for
 git-installed modules it's a managed checkout.
@@ -254,20 +455,32 @@ git-installed modules it's a managed checkout.
 
 ```json
 {
-  "node": { "id": "0", "name": "sudos", "cwd": "/Users/you/code/sudos" },
-  "tab":  { "index": "1" },
-  "pane": { "id": "4", "cwd": "/Users/you/code/sudos", "agent": "claude", "status": "working" },
-  "invocation_source": "cli",
+  "workspace": { "id": "0", "name": "sudos", "cwd": "/Users/you/code/sudos", "branch": "main" },
+  "node":      { "id": "0", "name": "sudos", "cwd": "/Users/you/code/sudos", "branch": "main" },
+  "tab":       { "index": "1", "name": "core" },
+  "pane":      { "id": "4", "cwd": "/Users/you/code/sudos", "agent": "claude", "status": "working" },
+  "selection": "the text highlighted in the pane, when there is any",
+  "invocation_source": "menu:pane",
   "correlation_id": "c7"
 }
 ```
 
-`status` is `idle` / `working` / `blocked` / `done` / `unknown`. Quick `jq`
-example:
+`node` is a legacy alias of `workspace`; both are always present. `status` is
+`idle` / `working` / `blocked` / `done` / `unknown`. For a right-click the
+workspace and pane describe **what you clicked**; everywhere else they describe
+what's focused.
+
+Most scripts want the flat vars, which need no parser at all:
 
 ```sh
-node_cwd=$(printf '%s' "$BOHAY_MODULE_CONTEXT_JSON" | jq -r .node.cwd)
-cd "$node_cwd" && git status --short
+cd "$BOHAY_WORKSPACE_CWD" && git status --short
+```
+
+Reach for the blob when you want `selection`, `invocation_source`, or the tab
+name:
+
+```sh
+selected=$(printf '%s' "$BOHAY_MODULE_CONTEXT_JSON" | jq -r .selection)
 ```
 
 ## Calling back into bohay
@@ -276,11 +489,331 @@ cd "$node_cwd" && git status --short
 "$BOHAY_BIN_PATH" pane run "git pull"     # run a command in the focused pane
 "$BOHAY_BIN_PATH" pane split --down       # change the layout
 "$BOHAY_BIN_PATH" workspace list          # inspect (JSON to stdout)
-"$BOHAY_BIN_PATH" ui dock push --id you.ci --rows '[...]'   # feed your sidebar dock
+"$BOHAY_BIN_PATH" tab rename review        # name the current tab
+"$BOHAY_BIN_PATH" ui toast "build passing" # flash a one-line message
+"$BOHAY_BIN_PATH" ui dock push --id you:ci --rows '[...]'   # feed your sidebar dock
 ```
 
-Anything in `bohay help` is available. Your command reads context from the
-environment and effects change through the CLI.
+Anything in `bohay help` is available: panes, tabs, workspaces, worktrees, the
+git tab, the orchestration board, agents, and the UI chrome. Your command reads
+context from the environment and effects change through the CLI. There is no
+separate module API and no restricted command set.
+
+:::tip
+Always call through `$BOHAY_BIN_PATH` rather than a bare `bohay` on `PATH`. It
+points at the running binary, so your module keeps working across Unix sockets
+and Windows named pipes, and against a build that isn't first on the path.
+:::
+
+## Complete examples
+
+Three whole modules, one per language. Each is short enough to read in full and
+covers a different part of the surface. They also ship in the repo under
+[`examples/modules/`](https://github.com/RizRiyz/bohay/tree/main/examples/modules)
+if you'd rather link one directly:
+
+```sh
+bohay module link ./examples/modules/branch-dock
+```
+
+| Example | Language | Shows |
+|---|---|---|
+| [Branch dock](#example-1-a-clickable-branch-dock-bash) | Bash | A dock, clickable rows, a startup hook, number + enum settings |
+| [Agent ping](#example-2-notify-when-an-agent-needs-you-python) | Python | An event hook, a secret setting, an `agent` right-click action |
+| [Scratch pane](#example-3-a-scratch-pane-from-a-right-click-node) | Node | A pane entrypoint, the selection, tab renaming |
+
+### Example 1: a clickable branch dock (Bash)
+
+A sidebar dock listing the node's git branches. Click one to check it out. It
+repaints on startup, so it survives a restart.
+
+```
+branch-dock/
+├── bohay-module.toml
+├── refresh.sh
+└── checkout.sh
+```
+
+```toml
+# bohay-module.toml
+id = "example.branch-dock"
+name = "Branch Dock"
+version = "0.1.0"
+min_bohay_version = "0.8.3"
+description = "The active node's git branches, in the sidebar."
+platforms = ["macos", "linux"]
+
+[[docks]]
+id = "branches"                  # local id: no dots
+title = "BRANCHES"
+placement = "sidebar.left"
+
+[[startup]]                      # repaint the dock after a restart
+command = ["sh", "refresh.sh"]
+
+[[events]]                       # and keep it honest as the user moves around
+on = "workspace.created"
+command = ["sh", "refresh.sh"]
+
+[[actions]]                      # right-click a WORKSPACES row to refresh
+id = "refresh"
+title = "Refresh branches"
+contexts = ["workspace"]
+command = ["sh", "refresh.sh"]
+
+[[actions]]                      # invoked by clicking a dock row
+id = "checkout"
+title = "Check out branch"
+command = ["sh", "checkout.sh"]
+
+[[settings]]
+key = "limit"
+title = "Branches to show"
+type = "number"
+default = 8
+min = 1
+max = 30
+
+[[settings]]
+key = "sort"
+title = "Sort by"
+type = "enum"
+options = ["recent", "name"]
+default = "recent"
+```
+
+```sh
+#!/bin/sh
+# refresh.sh -- build the rows and push them.
+set -eu
+bohay="${BOHAY_BIN_PATH:-bohay}"
+repo="${BOHAY_WORKSPACE_CWD:-$PWD}"
+limit="${BOHAY_SETTING_LIMIT:-8}"
+sort="${BOHAY_SETTING_SORT:-recent}"
+
+if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+  "$bohay" ui dock push --id branches --title BRANCHES \
+    --rows '[{"text":"not a git repo"}]'
+  exit 0
+fi
+
+case "$sort" in
+  name) order='refname' ;;
+  *)    order='-committerdate' ;;
+esac
+current=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')
+
+# `value` is the payload the row hands to its action when clicked -- that is
+# what lets one `checkout` action serve every row.
+rows=$(git -C "$repo" for-each-ref --format='%(refname:short)' \
+         --sort="$order" --count="$limit" refs/heads/ |
+  while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    if [ "$branch" = "$current" ]; then dot=working; else dot=idle; fi
+    esc=$(printf '%s' "$branch" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '{"text":"%s","dot":"%s","action":"checkout","value":"%s"},' \
+      "$esc" "$dot" "$esc"
+  done)
+
+"$bohay" ui dock push --id branches --title BRANCHES --rows "[${rows%,}]"
+```
+
+```sh
+#!/bin/sh
+# checkout.sh -- the clicked row arrives in BOHAY_MODULE_ROW_VALUE.
+set -eu
+bohay="${BOHAY_BIN_PATH:-bohay}"
+repo="${BOHAY_WORKSPACE_CWD:-$PWD}"
+branch="${BOHAY_MODULE_ROW_VALUE:-}"
+
+if [ -z "$branch" ]; then
+  "$bohay" ui toast "no branch selected"
+  exit 1
+fi
+
+if git -C "$repo" checkout "$branch" >/dev/null 2>&1; then
+  "$bohay" ui toast "switched to $branch"
+  sh "$(dirname "$0")/refresh.sh"    # repaint so the current-branch dot moves
+else
+  "$bohay" ui toast "cannot switch to $branch (uncommitted changes?)"
+  exit 1
+fi
+```
+
+### Example 2: notify when an agent needs you (Python)
+
+Posts a webhook when an agent goes blocked or finishes, with the URL stored as
+a **secret** setting so it never renders in the clear.
+
+```toml
+# bohay-module.toml
+id = "example.agent-ping"
+name = "Agent Ping"
+version = "0.1.0"
+min_bohay_version = "0.8.3"
+
+[[events]]
+on = "pane.agent_status_changed"
+command = ["python3", "ping.py"]
+
+[[actions]]                      # right-click a live agent in the AGENTS list
+id = "ping-now"
+title = "Send a ping"
+contexts = ["agent"]
+command = ["python3", "ping.py", "--force"]
+
+[[settings]]
+key = "webhook"
+title = "Webhook URL"
+type = "string"
+secret = true                    # shown as bullets, never echoed
+
+[[settings]]
+key = "notify-on"
+title = "Notify on"
+type = "enum"
+options = ["blocked", "done", "both"]
+default = "blocked"
+```
+
+```python
+#!/usr/bin/env python3
+import json, os, subprocess, sys, urllib.request
+
+BOHAY = os.environ.get("BOHAY_BIN_PATH", "bohay")
+
+def bohay(*args):
+    """Call back into bohay, ignoring failures: a module must never wedge the UI."""
+    try:
+        subprocess.run([BOHAY, *args], check=False, capture_output=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+forced = "--force" in sys.argv
+webhook = os.environ.get("BOHAY_SETTING_WEBHOOK", "").strip()
+# `notify-on` becomes BOHAY_SETTING_NOTIFY_ON: upper-cased, dashes to underscores.
+notify_on = os.environ.get("BOHAY_SETTING_NOTIFY_ON", "blocked")
+
+agent = os.environ.get("BOHAY_PANE_AGENT") or "agent"
+status = os.environ.get("BOHAY_PANE_STATUS") or "unknown"
+
+# An event hook prefers the event payload: it describes the pane that actually
+# changed, not the one in focus.
+raw = os.environ.get("BOHAY_MODULE_EVENT_JSON")
+if raw:
+    event = json.loads(raw)
+    agent = event.get("agent") or agent
+    status = event.get("status") or status
+
+# A right-click always pings; an event only pings for the chosen states.
+if not forced:
+    wanted = {"both": {"blocked", "done"}}.get(notify_on, {notify_on})
+    if status not in wanted:
+        raise SystemExit(0)
+
+where = os.path.basename(os.environ.get("BOHAY_WORKSPACE_CWD", "")) or "bohay"
+message = f"{agent} is {status} in {where}"
+bohay("ui", "toast", message)
+
+if webhook:
+    req = urllib.request.Request(
+        webhook,
+        data=json.dumps({"text": message}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        urllib.request.urlopen(req, timeout=10).close()
+    except OSError as err:
+        # stderr lands in `bohay module log`, which is where you debug a module.
+        print(f"webhook failed: {err}", file=sys.stderr)
+        raise SystemExit(1)
+```
+
+### Example 3: a scratch pane from a right-click (Node)
+
+Opens a real pane running your own program, and stashes the pane's **selected
+text** into a notes file.
+
+```toml
+# bohay-module.toml
+id = "example.scratch-pane"
+name = "Scratch Pane"
+version = "0.1.0"
+min_bohay_version = "0.8.3"
+
+[[panes]]
+id = "notes"
+title = "Notes"
+placement = "split"
+command = ["node", "notes.js"]
+
+[[actions]]
+id = "open-notes"
+title = "Open notes beside this"
+contexts = ["pane"]
+command = ["node", "open.js"]
+
+[[actions]]
+id = "stash-selection"
+title = "Send selection to notes"
+contexts = ["pane"]
+command = ["node", "stash.js"]
+
+[[settings]]
+key = "name-the-tab"
+title = "Rename the tab to Notes"
+type = "bool"
+default = true
+```
+
+```js
+// open.js -- open the pane entrypoint, then name the tab.
+const { spawnSync } = require("node:child_process");
+const bohay = process.env.BOHAY_BIN_PATH ?? "bohay";
+const run = (...args) => spawnSync(bohay, args, { encoding: "utf8" });
+
+// A module pane is a normal bohay pane once it opens: focus, split, close,
+// and the layout APIs all work on it.
+run("module", "pane", "open", process.env.BOHAY_MODULE_ID, "notes",
+    "--placement", "split");
+
+if (process.env.BOHAY_SETTING_NAME_THE_TAB === "true") {
+  const tab = process.env.BOHAY_TAB_INDEX ?? "";
+  run("tab", "rename", "notes", ...(tab ? ["--tab", tab] : []));
+}
+run("ui", "toast", "notes opened");
+```
+
+```js
+// stash.js -- append the pane's selection to a notes file.
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const bohay = process.env.BOHAY_BIN_PATH ?? "bohay";
+const toast = (t) => spawnSync(bohay, ["ui", "toast", t], { encoding: "utf8" });
+
+// The selection is one of the fields only the context blob carries.
+const context = JSON.parse(process.env.BOHAY_MODULE_CONTEXT_JSON ?? "{}");
+const selection = (context.selection ?? "").trim();
+if (!selection) {
+  toast("select some text first");
+  process.exit(0);
+}
+
+// Durable state goes in the state dir, never the module root: for a
+// git-installed module that root is a managed checkout a reinstall replaces.
+const stateDir = process.env.BOHAY_MODULE_STATE_DIR ?? process.cwd();
+fs.mkdirSync(stateDir, { recursive: true });
+fs.appendFileSync(
+  path.join(stateDir, "notes.md"),
+  `\n## from ${context.pane?.cwd ?? ""}\n\n${selection}\n`,
+);
+toast(`saved ${selection.split("\n").length} line(s) to notes`);
+```
+
+The `notes` pane itself is any program that reads stdin and writes stdout --
+a REPL, a log tail, a TUI. bohay closes the pane when the process exits.
 
 ## Distribution & discovery
 
@@ -300,6 +833,16 @@ environment, verifies the manifest didn't change during the build, and pins
 the checkout to the installed commit. There's intentionally **no central
 registry**: publishing is pushing a public repo.
 
+Once the topic is on your repo, it shows up in `bohay module search` and on the
+[module index](/modules/) with no further submission. Two things make a listing
+land well, because they're what people see before they trust you:
+
+- **The repo description** is the card text on the index. One line, what it
+  adds, not how it works.
+- **The README** should show the thing: a screenshot of the dock or menu entry,
+  the tools it needs (`jq`, `node`, …), and a `min_bohay_version` you've
+  actually tested against.
+
 ## Troubleshooting
 
 | Symptom | Fix |
@@ -309,3 +852,7 @@ registry**: publishing is pushing a public repo.
 | Action *is ambiguous* | Two modules expose the id, so qualify it: `module run <module-id> <action>`. |
 | No output in the log | The entry stays `running` until the command exits. Output is capped at 64 KiB. |
 | Callbacks do nothing | `$BOHAY_BIN_PATH` needs the bohay server for your session to be running. |
+| Action missing from a menu | Check its `contexts`, that the module is enabled, and that no `platforms` gate excludes this OS. |
+| Dock is empty after a restart | Push its rows from a `[[startup]]` hook. Dock contents are cached, not persisted. |
+| Settings row not showing | Settings appear only under an **enabled** module. Disabled modules collapse. |
+| `$BOHAY_SETTING_*` is empty | The key is upper-cased with `-` and `:` turned into `_`: `notify-on` → `BOHAY_SETTING_NOTIFY_ON`. |

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -34,14 +34,14 @@ printf '%s\n' '{"id":"1","method":"ping","params":{}}' | nc -U ~/.bohay/bohay.so
 | Family | Methods |
 |---|---|
 | workspaces | `workspace.list` · `workspace.open` · `workspace.focus` · `workspace.close` |
-| tabs | `tab.list` · `tab.new` · `tab.focus` · `tab.close` |
+| tabs | `tab.list` · `tab.new` · `tab.focus` · `tab.rename` · `tab.close` |
 | panes | `pane.list` · `pane.split` · `pane.focus` · `pane.run` · `pane.send_input` · `pane.read` · `pane.status` · `pane.close` · `attach.pane` |
 | agents | `agent.list` · `agent.sessions` · `agent.resume` · `pane.report_session` · `pane.report_event` |
 | git | `git.status` · `git.branches` · `git.log` · `git.open` |
 | worktrees | `worktree.list` · `worktree.create` · `worktree.open` · `worktree.remove` |
 | orchestration | `task.add` · `task.list` · `task.get` · `task.claim` · `task.next` · `task.start` · `task.heartbeat` · `task.update` · `task.done` · `task.merge` · `task.release` · `lease.acquire` · `lease.list` · `lease.release` |
-| modules | `module.list` · `module.info` · `module.link` · `module.unlink` · `module.enable` · `module.disable` · `module.action.invoke` · `module.pane.open` · `module.log` |
-| ui / server | `ui.sidebar` · `ui.dock.push` · `ui.dock.list` · `ui.dock.move` · `ping` · `server.stop` · `events.subscribe` |
+| modules | `module.list` · `module.info` · `module.link` · `module.unlink` · `module.enable` · `module.disable` · `module.action.list` · `module.action.invoke` · `module.pane.open` · `module.pane.focus` · `module.pane.close` · `module.config_dir` · `module.settings.list` · `module.settings.get` · `module.settings.set` · `module.log.list` |
+| ui / server | `ui.sidebar` · `ui.dock.push` · `ui.dock.list` · `ui.dock.move` · `ui.toast` · `ping` · `server.stop` · `events.subscribe` |
 
 Parameter shapes mirror the CLI flags (`bohay task add --paths x` →
 `{"paths": ["x"]}`). When a method takes a pane and none is given, it defaults
@@ -80,7 +80,8 @@ exactly this.
 ```
 
 Event names: `pane.created` · `pane.closed` · `pane.agent_status_changed` ·
-`agent.hook` · `node.created` · `node.closed` · `tab.created` · `tab.closed`
+`agent.hook` · `workspace.created` · `workspace.closed` (a module hook may
+still spell these `node.created` / `node.closed`) · `tab.created` · `tab.closed`
 · `task.added` · `task.claimed` · `task.started` · `task.ready` ·
 `task.gate_running` · `task.gate_passed` · `task.gate_failed` ·
 `task.needs_compaction` · `task.done` · `task.merged` ·

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -30,6 +30,7 @@ tabs:
   tab list                   list tabs in the current workspace
   tab new                    new tab
   tab focus <n>              focus tab n (1-based)
+  tab rename <name>          name a tab (--tab N to target one; empty clears it)
   tab close [<n>]            close a tab (default: active)
 
 panes / agents:
@@ -56,6 +57,7 @@ appearance:
   ui dock push --id <id> [--title <t>] [--side left|right] [--rows <json>]
                              feed a module's sidebar dock its rows (JSON array,
                              or piped on stdin). See docs/29 + the website
+  ui toast <text>            flash a one-line message in the UI
 
 modules (extensions):
   module search [<query>]    find modules published to the `bohay-module` GitHub topic
@@ -72,6 +74,8 @@ modules (extensions):
   module pane focus <pane> | close <pane>
   module log [<id>]          tail module command logs (--limit N)
   module config-dir <id>     print/create a module's config dir
+  module settings <id>       list a module's declared settings and values
+  module settings <id> <key> [<value>]   read / write one setting
 
 git:
   git status                 branch, ahead/behind, working tree of the current workspace

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -100,6 +100,7 @@ const entries = await Promise.all(
         </a>
         <div class="nav-links">
           <a href="/docs/">Docs</a>
+          <a href="/modules/">Modules</a>
           <a href="/compare/">Compare</a>
           <a href="/changelog/" aria-current="page">Changelog</a>
           <a href={GITHUB} class="gh">
@@ -170,9 +171,6 @@ const entries = await Promise.all(
           <span class="dim">by Riz</span>
         </div>
         <div class="foot-links">
-          <a href="/docs/">Docs</a>
-          <a href="/compare/">Compare</a>
-          <a href="/changelog/">Changelog</a>
           <a href={GITHUB}>GitHub</a>
           <a href="https://crates.io/crates/bohay">crates.io</a>
         </div>
@@ -280,6 +278,7 @@ const entries = await Promise.all(
         box-shadow: 0 0 0 4px rgb(198 255 26 / 0.16);
       }
       .card {
+        min-width: 0;
         border: 1px solid var(--line); border-radius: 1rem;
         background: linear-gradient(180deg, #131318, #0d0d12);
         padding: 1.35rem 1.6rem 1.15rem; margin-bottom: 1.7rem;
@@ -304,7 +303,11 @@ const entries = await Promise.all(
       }
 
       /* rendered release notes */
-      .notes { color: var(--text); font-size: 0.95rem; }
+      .notes { color: var(--text); font-size: 0.95rem; min-width: 0; }
+      /* Long code lines scroll inside their block instead of widening the page. */
+      .notes pre { max-width: 100%; }
+      .notes code { overflow-wrap: break-word; }
+      .notes a { overflow-wrap: break-word; }
       .notes > :first-child { margin-top: 0.35rem; }
       .notes > :last-child { margin-bottom: 0; }
       .notes h1, .notes h2, .notes h3, .notes h4, .notes h5 {
@@ -359,6 +362,13 @@ const entries = await Promise.all(
         section, header.page-hero { padding: 3rem 1.25rem; }
         .card { padding: 1.15rem 1.2rem 1rem; }
         .nav-links { gap: 1rem; }
+      }
+
+      /* Four nav links + the GitHub pill no longer fit a phone in one row:
+         let them wrap rather than widen the page. */
+      @media (max-width: 560px) {
+        .nav-inner { flex-wrap: wrap; row-gap: 0.45rem; padding-top: 0.7rem; padding-bottom: 0.7rem; }
+        .nav-links { gap: 0.9rem; font-size: 0.78rem; flex-wrap: wrap; justify-content: flex-end; }
       }
     </style>
   </body>

--- a/website/src/pages/compare.astro
+++ b/website/src/pages/compare.astro
@@ -129,6 +129,7 @@ const LANDSCAPE = [
         </a>
         <div class="nav-links">
           <a href="/docs/">Docs</a>
+          <a href="/modules/">Modules</a>
           <a href="/compare/" aria-current="page">Compare</a>
           <a href="/changelog/">Changelog</a>
           <a href={GITHUB} class="gh">
@@ -264,9 +265,6 @@ const LANDSCAPE = [
           <span class="dim">by Riz</span>
         </div>
         <div class="foot-links">
-          <a href="/docs/">Docs</a>
-          <a href="/compare/">Compare</a>
-          <a href="/changelog/">Changelog</a>
           <a href={GITHUB}>GitHub</a>
           <a href="https://crates.io/crates/bohay">crates.io</a>
         </div>
@@ -433,6 +431,13 @@ const LANDSCAPE = [
       @media (max-width: 760px) {
         .wcards { grid-template-columns: 1fr; }
         section, header.page-hero { padding: 3rem 1.25rem; }
+      }
+
+      /* Four nav links + the GitHub pill no longer fit a phone in one row:
+         let them wrap rather than widen the page. */
+      @media (max-width: 560px) {
+        .nav-inner { flex-wrap: wrap; row-gap: 0.45rem; padding-top: 0.7rem; padding-bottom: 0.7rem; }
+        .nav-links { gap: 0.9rem; font-size: 0.78rem; flex-wrap: wrap; justify-content: flex-end; }
       }
     </style>
   </body>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -87,6 +87,7 @@ const ogImage = 'https://bohay.dev/og.png';
       </a>
       <div class="nav-links">
         <a href="/docs/">Docs</a>
+        <a href="/modules/">Modules</a>
         <a href="/compare/">Compare</a>
         <a href="/changelog/">Changelog</a>
         <a href={GITHUB} class="gh">
@@ -462,10 +463,8 @@ const ogImage = 'https://bohay.dev/og.png';
           <span class="dim">by Riz</span>
         </div>
         <div class="foot-links">
-          <a href="/changelog/">changelog</a>
+          <a href={GITHUB}>github</a>
           <a href="https://crates.io/crates/bohay">crates.io</a>
-          <a href={`${GITHUB}/releases`}>releases</a>
-          <a href={`${GITHUB}/blob/main/LICENSE`}>license</a>
         </div>
       </div>
     </footer>
@@ -1620,6 +1619,13 @@ const ogImage = 'https://bohay.dev/og.png';
       @media (max-width: 480px) {
         .agent-grid { grid-template-columns: repeat(2, 1fr); }
         .nav-links a[href$='orchestration/'] { display: none; }
+      }
+
+      /* Four nav links + the GitHub pill no longer fit a phone in one row:
+         let them wrap rather than widen the page. */
+      @media (max-width: 560px) {
+        .nav-inner { flex-wrap: wrap; row-gap: 0.45rem; padding-top: 0.7rem; padding-bottom: 0.7rem; }
+        .nav-links { gap: 0.9rem; font-size: 0.78rem; flex-wrap: wrap; justify-content: flex-end; }
       }
     </style>
   </body>

--- a/website/src/pages/modules.astro
+++ b/website/src/pages/modules.astro
@@ -1,0 +1,785 @@
+---
+// The /modules page: the community module index.
+//
+// There is deliberately **no registry and no backend**. A module is just a
+// public GitHub repo carrying the `bohay-module` topic, exactly what
+// `bohay module search` queries from the terminal. This page runs the same
+// search so the site and the CLI can never disagree about what exists.
+//
+// The list is fetched at build time (so it renders with JS off and is
+// indexable) and refreshed client-side on load (so it stays current between
+// deploys, since Cloudflare Pages only rebuilds on push). A failed build-time
+// fetch is not fatal: the page ships an honest empty state and the browser
+// refresh fills it in.
+import '@fontsource-variable/inter';
+import '@fontsource-variable/jetbrains-mono';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
+import '@fontsource/ibm-plex-mono/700.css';
+import Logo from '../assets/logo.svg';
+
+const GITHUB = 'https://github.com/RizRiyz/bohay';
+const TOPIC = 'bohay-module';
+const TOPIC_URL = `https://github.com/topics/${TOPIC}`;
+const SEARCH_API = `https://api.github.com/search/repositories?q=topic:${TOPIC}&sort=stars&order=desc&per_page=60`;
+
+const title = 'Modules — bohay';
+const description =
+  'Community modules for bohay: sidebar docks, panes, right-click actions and automations, published as ordinary GitHub repos.';
+const ogImage = 'https://bohay.dev/og.png';
+
+// Build-time fetch. Never throw: a rate-limited or offline build must still
+// produce a page.
+let repos = [];
+let fetchFailed = false;
+try {
+  const res = await fetch(SEARCH_API, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'bohay.dev' },
+  });
+  if (!res.ok) throw new Error(`GitHub returned ${res.status}`);
+  const data = await res.json();
+  repos = (data.items ?? [])
+    .filter((r) => !r.archived)
+    .map((r) => ({
+      name: r.name,
+      full_name: r.full_name,
+      owner: r.owner?.login ?? '',
+      avatar: r.owner?.avatar_url ?? '',
+      description: r.description ?? '',
+      stars: r.stargazers_count ?? 0,
+      forks: r.forks_count ?? 0,
+      language: r.language ?? '',
+      topics: (r.topics ?? []).filter((t) => t !== TOPIC).slice(0, 3),
+      url: r.html_url,
+      pushed: r.pushed_at ?? '',
+      created: r.created_at ?? '',
+    }));
+} catch {
+  fetchFailed = true;
+}
+
+// "3 days ago" — short, so it fits the one-line meta row.
+const rel = (iso) => {
+  if (!iso) return '';
+  const s = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (s < 3600) return `${Math.max(1, Math.floor(s / 60))}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  const d = Math.floor(s / 86400);
+  if (d < 30) return `${d}d ago`;
+  if (d < 365) return `${Math.floor(d / 30)}mo ago`;
+  return `${Math.floor(d / 365)}y ago`;
+};
+
+// GitHub's language dot colours, for the handful a module is likely to be in.
+const LANG_COLOR = {
+  Shell: '#89e051',
+  Python: '#3572A5',
+  JavaScript: '#f1e05a',
+  TypeScript: '#3178c6',
+  Rust: '#dea584',
+  Go: '#00ADD8',
+  Lua: '#000080',
+  Ruby: '#701516',
+  Perl: '#0298c3',
+  C: '#555555',
+  'C++': '#f34b7d',
+};
+
+// Read the example modules off disk at build time so their stats are measured,
+// never guessed: a card claiming "3 files" has to stay true as the examples are
+// edited. Same trick the changelog page uses for `changelog/*.md`.
+const exampleFiles = import.meta.glob('../../../examples/modules/*/*', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+// → { 'branch-dock': { files: 3, lines: 129 }, … }
+const exampleStats = {};
+for (const [path, text] of Object.entries(exampleFiles)) {
+  const dir = path.split('/').at(-2);
+  if (!dir) continue;
+  const s = (exampleStats[dir] ??= { files: 0, lines: 0 });
+  s.files += 1;
+  s.lines += String(text).split('\n').length;
+}
+
+// The three examples that ship in the repo. Same card shape as a community
+// module, so the two grids read as one system.
+const examples = [
+  {
+    name: 'branch-dock',
+    owner: 'bohay/examples',
+    lang: 'Shell',
+    description:
+      "A sidebar dock listing the active node's git branches. Click one to check it out.",
+    topics: ['dock', 'startup', 'settings'],
+    install: 'bohay module link ./examples/modules/branch-dock',
+    path: 'examples/modules/branch-dock',
+  },
+  {
+    name: 'agent-ping',
+    owner: 'bohay/examples',
+    lang: 'Python',
+    description:
+      'Posts a webhook when an agent goes blocked, so you know without watching it.',
+    topics: ['events', 'secrets', 'right-click'],
+    install: 'bohay module link ./examples/modules/agent-ping',
+    path: 'examples/modules/agent-ping',
+  },
+  {
+    name: 'scratch-pane',
+    owner: 'bohay/examples',
+    lang: 'JavaScript',
+    description:
+      'Right-click a pane to open a scratch notepad beside it, and stash the selected text into it.',
+    topics: ['panes', 'selection', 'tabs'],
+    install: 'bohay module link ./examples/modules/scratch-pane',
+    path: 'examples/modules/scratch-pane',
+  },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="canonical" href="https://bohay.dev/modules/" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://bohay.dev/modules/" />
+    <meta property="og:site_name" content="bohay" />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+  </head>
+  <body>
+    <nav>
+      <div class="nav-inner">
+        <a class="brand" href="/">
+          <Logo width={28} height={28} class="mark" aria-hidden="true" />
+          <span>bohay</span>
+        </a>
+        <div class="nav-links">
+          <a href="/docs/">Docs</a>
+          <a href="/modules/" aria-current="page">Modules</a>
+          <a href="/compare/">Compare</a>
+          <a href="/changelog/">Changelog</a>
+          <a href={GITHUB} class="gh">
+            <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"
+              ><path
+                fill="currentColor"
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+              ></path></svg
+            >
+            <span id="stars">GitHub</span>
+          </a>
+        </div>
+      </div>
+    </nav>
+
+    <header class="page-hero">
+      <div class="glow" aria-hidden="true"></div>
+      <span class="eyebrow">Modules</span>
+      <h1>Extend bohay in any language</h1>
+      <p>
+        A module is a plain GitHub repo with a manifest and some commands. Bash, Python, Lua,
+        Rust, Node, anything your machine can run. No SDK, no plugin runtime, no registry to
+        sign up for.
+      </p>
+      <div class="hero-cta">
+        <a class="btn primary" href="/docs/extend/writing-modules/">Write a module →</a>
+        <a class="btn" href="/docs/extend/using-modules/">How installing works</a>
+      </div>
+    </header>
+
+    <!-- three steps, so the mental model lands before the list -->
+    <section class="how">
+      <ol class="steps">
+        <li>
+          <span class="num">1</span>
+          <h3>Find one</h3>
+          <p>
+            Browse below, or search from the terminal. Both read the same
+            <a href={TOPIC_URL}><code>{TOPIC}</code></a> GitHub topic.
+          </p>
+          <pre class="cmd"><code>bohay module search</code></pre>
+        </li>
+        <li>
+          <span class="num">2</span>
+          <h3>Review, then install</h3>
+          <p>
+            Install prints <strong>every command the module declares</strong> and waits for your
+            confirmation before anything runs.
+          </p>
+          <pre class="cmd"><code>bohay module install owner/repo</code></pre>
+        </li>
+        <li>
+          <span class="num">3</span>
+          <h3>Use it</h3>
+          <p>
+            It shows up in <strong>Settings → Modules</strong> with its own settings, and wherever
+            it declared itself: a dock, a pane, a right-click.
+          </p>
+          <pre class="cmd"><code>bohay module list</code></pre>
+        </li>
+      </ol>
+    </section>
+
+    <section class="index">
+      <div class="shead">
+        <h2>Community modules</h2>
+        <div class="shead-right">
+          <label class="sort" hidden={repos.length < 2}>
+            <span>sort</span>
+            <select id="sort">
+              <option value="stars">Most stars</option>
+              <option value="pushed">Recently updated</option>
+              <option value="created">Newest</option>
+              <option value="name">Name</option>
+            </select>
+          </label>
+          <a class="topic-link" href={TOPIC_URL}>Browse the topic →</a>
+        </div>
+      </div>
+
+      <div id="grid" class="grid">
+        {
+          repos.map((r) => (
+            <a class="mod" href={r.url}>
+              <div class="mhead">
+                {r.avatar && (
+                  <img class="avatar" src={r.avatar} alt="" width="26" height="26" loading="lazy" />
+                )}
+                <span class="mname">{r.name}</span>
+                <span class="stars" title={`${r.stars} stars`}>
+                  ★ {r.stars}
+                </span>
+              </div>
+              <span class="mowner">{r.owner}</span>
+              <p class="mdesc">{r.description || 'No description provided.'}</p>
+              <div class="meta">
+                {r.language && (
+                  <span class="mi">
+                    <i class="dot" style={`background:${LANG_COLOR[r.language] ?? '#c6ff1a'}`} />
+                    {r.language}
+                  </span>
+                )}
+                {r.forks > 0 && <span class="mi">{r.forks} forks</span>}
+                {r.pushed && <span class="mi">updated {rel(r.pushed)}</span>}
+              </div>
+              {r.topics.length > 0 && (
+                <div class="mfoot">
+                  {r.topics.map((t) => (
+                    <span class="chip">{t}</span>
+                  ))}
+                </div>
+              )}
+              <code class="install">bohay module install {r.full_name}</code>
+            </a>
+          ))
+        }
+      </div>
+
+      <!-- Shown when the index is empty. Treat it as an invitation, not an error. -->
+      <div id="empty" class="empty" hidden={repos.length > 0}>
+        <div class="empty-mark" aria-hidden="true">◇</div>
+        <h3>{fetchFailed ? 'Could not reach GitHub' : 'No modules published yet'}</h3>
+        <p>
+          {
+            fetchFailed
+              ? 'The live index is fetched from the GitHub search API, which rate-limits anonymous requests. Browse the topic directly, or try again in a minute.'
+              : 'The topic is brand new, so this list is empty. That also means the first module published here is going to be very easy to find.'
+          }
+        </p>
+        <div class="empty-cta">
+          <a class="btn primary" href="/docs/extend/writing-modules/">Write the first one →</a>
+          <a class="btn" href={TOPIC_URL}>Check the topic</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="samples">
+      <div class="shead">
+        <h2>Start from a working example</h2>
+        <a class="topic-link" href={`${GITHUB}/tree/main/examples/modules`}>See all three →</a>
+      </div>
+      <p class="lede">
+        Three complete modules ship in the repo, one per language, each covering a different part
+        of the surface. Copy one, change its id, and you have a module.
+      </p>
+      <div class="grid">
+        {
+          examples.map((e) => (
+            <a class="mod" href={`${GITHUB}/tree/main/${e.path}`}>
+              <div class="mhead">
+                <span class="avatar ex" aria-hidden="true">
+                  ◇
+                </span>
+                <span class="mname">{e.name}</span>
+                <span class="tag">example</span>
+              </div>
+              <span class="mowner">{e.owner}</span>
+              <p class="mdesc">{e.description}</p>
+              <div class="meta">
+                <span class="mi">
+                  <i class="dot" style={`background:${LANG_COLOR[e.lang] ?? '#c6ff1a'}`} />
+                  {e.lang}
+                </span>
+                <span class="mi">{exampleStats[e.name]?.files ?? 0} files</span>
+                <span class="mi">{exampleStats[e.name]?.lines ?? 0} lines</span>
+              </div>
+              <div class="mfoot">
+                {e.topics.map((t) => (
+                  <span class="chip">{t}</span>
+                ))}
+              </div>
+              <code class="install">{e.install}</code>
+            </a>
+          ))
+        }
+      </div>
+    </section>
+
+    <section class="publish">
+      <div class="pub-card">
+        <div class="pub-copy">
+          <span class="eyebrow">Publishing</span>
+          <h2>Getting listed takes one click</h2>
+          <p>
+            There is no submission, no review queue, and no account. Push a public repo with a
+            <code>bohay-module.toml</code> at its root, then add the
+            <strong>{TOPIC}</strong> topic to it on GitHub. This page and
+            <code>bohay module search</code> both pick it up on their next run.
+          </p>
+          <ol class="pub-steps">
+            <li>Put <code>bohay-module.toml</code> in the repo root (or a subdirectory).</li>
+            <li>
+              On GitHub: <strong>About → ⚙︎ → Topics</strong>, add <code>{TOPIC}</code>.
+            </li>
+            <li>
+              Tell people to run <code>bohay module install you/your-module</code>.
+            </li>
+          </ol>
+        </div>
+        <div class="pub-side">
+          <div class="tip">
+            <h4>What makes a good listing</h4>
+            <ul>
+              <li>A one-line repo description: it is the card text here.</li>
+              <li>A README showing what it adds, with a screenshot.</li>
+              <li>Any tools it needs (<code>jq</code>, <code>node</code>, …) stated up front.</li>
+              <li>A <code>min_bohay_version</code> you have actually tested.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="trust">
+      <h2>A note on trust</h2>
+      <p>
+        A module is ordinary code that runs on your machine as you, with your environment and
+        your full bohay CLI. That openness is the point, and a little judgment keeps it safe.
+        Install from people you trust, and skim the manifest first:
+        <code>bohay module install</code> shows you every command a module declares and asks
+        before running anything. Builds run with a scrubbed environment, and a manifest cannot
+        change between the preview and the install. bohay validates and isolates, but it does not
+        sandbox: third-party modules come from their authors, not from bohay.
+      </p>
+      <a class="btn" href="/docs/extend/using-modules/">Read the full trust model →</a>
+    </section>
+
+    <footer>
+      <div class="foot-inner">
+        <div class="foot-brand">
+          <Logo width={22} height={22} class="mark" aria-hidden="true" />
+          <span>bohay</span>
+          <span class="dim">by Riz</span>
+        </div>
+        <div class="foot-links">
+          <a href={GITHUB}>GitHub</a>
+          <a href="https://crates.io/crates/bohay">crates.io</a>
+        </div>
+      </div>
+    </footer>
+
+    <script define:vars={{ SEARCH_API, TOPIC, LANG_COLOR }}>
+      // Live star count (graceful: stays "GitHub" on failure).
+      fetch('https://api.github.com/repos/RizRiyz/bohay')
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          const el = document.getElementById('stars');
+          if (el && d?.stargazers_count != null) el.textContent = `★ ${d.stargazers_count}`;
+        })
+        .catch(() => {});
+
+      const esc = (s) =>
+        String(s ?? '').replace(/[&<>"']/g, (c) =>
+          ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+        );
+      const rel = (iso) => {
+        if (!iso) return '';
+        const s = (Date.now() - new Date(iso).getTime()) / 1000;
+        if (s < 3600) return `${Math.max(1, Math.floor(s / 60))}m ago`;
+        if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+        const d = Math.floor(s / 86400);
+        if (d < 30) return `${d}d ago`;
+        if (d < 365) return `${Math.floor(d / 30)}mo ago`;
+        return `${Math.floor(d / 365)}y ago`;
+      };
+
+      let items = [];
+      const card = (r) => {
+        const topics = (r.topics || [])
+          .filter((t) => t !== TOPIC)
+          .slice(0, 3)
+          .map((t) => `<span class="chip">${esc(t)}</span>`)
+          .join('');
+        const lang = r.language
+          ? `<span class="mi"><i class="dot" style="background:${LANG_COLOR[r.language] ?? '#c6ff1a'}"></i>${esc(r.language)}</span>`
+          : '';
+        const forks = r.forks_count > 0 ? `<span class="mi">${r.forks_count} forks</span>` : '';
+        const upd = r.pushed_at ? `<span class="mi">updated ${rel(r.pushed_at)}</span>` : '';
+        const avatar = r.owner?.avatar_url
+          ? `<img class="avatar" src="${esc(r.owner.avatar_url)}" alt="" width="26" height="26" loading="lazy">`
+          : '';
+        return `<a class="mod" href="${esc(r.html_url)}">
+          <div class="mhead">${avatar}<span class="mname">${esc(r.name)}</span>
+            <span class="stars" title="${r.stargazers_count ?? 0} stars">★ ${r.stargazers_count ?? 0}</span>
+          </div>
+          <span class="mowner">${esc(r.owner?.login ?? '')}</span>
+          <p class="mdesc">${esc(r.description || 'No description provided.')}</p>
+          <div class="meta">${lang}${forks}${upd}</div>
+          ${topics ? `<div class="mfoot">${topics}</div>` : ''}
+          <code class="install">bohay module install ${esc(r.full_name)}</code>
+        </a>`;
+      };
+
+      const paint = () => {
+        const grid = document.getElementById('grid');
+        const empty = document.getElementById('empty');
+        const sortWrap = document.querySelector('.sort');
+        if (!grid || !empty) return;
+        if (items.length === 0) {
+          grid.innerHTML = '';
+          empty.hidden = false;
+          if (sortWrap) sortWrap.hidden = true;
+          return;
+        }
+        const by = document.getElementById('sort')?.value ?? 'stars';
+        const sorted = [...items].sort((a, b) => {
+          if (by === 'name') return a.name.localeCompare(b.name);
+          if (by === 'pushed') return new Date(b.pushed_at) - new Date(a.pushed_at);
+          if (by === 'created') return new Date(b.created_at) - new Date(a.created_at);
+          return (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0);
+        });
+        grid.innerHTML = sorted.map(card).join('');
+        empty.hidden = true;
+        if (sortWrap) sortWrap.hidden = items.length < 2;
+      };
+
+      document.getElementById('sort')?.addEventListener('change', paint);
+
+      // Refresh the index in the browser so it stays current between deploys.
+      // Purely additive: if this fails, the build-time markup stands.
+      fetch(SEARCH_API, { headers: { Accept: 'application/vnd.github+json' } })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (!d || !Array.isArray(d.items)) return;
+          items = d.items.filter((r) => !r.archived);
+          paint();
+        })
+        .catch(() => {});
+    </script>
+
+    <style is:global>
+      :root {
+        --bg: #070709;
+        --bg2: #111116;
+        --line: #25252d;
+        --text: #e7e7ed;
+        --sub: #93939f;
+        --accent: #c6ff1a;
+      }
+      * { box-sizing: border-box; margin: 0; }
+      html { scroll-behavior: smooth; }
+      body {
+        background: var(--bg); color: var(--text);
+        font: 16px/1.65 'Inter Variable', ui-sans-serif, system-ui, -apple-system, sans-serif;
+      }
+      a { color: inherit; text-decoration: none; }
+      h1, h2, h3, h4, .brand, .foot-brand {
+        font-family: 'IBM Plex Mono', ui-monospace, 'JetBrains Mono Variable', monospace;
+        line-height: 1.14; letter-spacing: -0.045em;
+      }
+      section, header.page-hero { max-width: 1060px; margin: 0 auto; padding: 4rem 1.5rem; }
+      .dim { color: var(--sub); }
+      ::selection { background: #33450e; color: #e7e7ed; }
+      code { font-family: 'JetBrains Mono Variable', ui-monospace, monospace; }
+
+      /* nav */
+      nav {
+        position: sticky; top: 0; z-index: 10; background: rgb(7 7 9 / 0.75);
+        backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
+        border-bottom: 1px solid rgb(37 37 45 / 0.6);
+      }
+      .nav-inner {
+        display: flex; justify-content: space-between; align-items: center;
+        max-width: 1060px; margin: 0 auto; padding: 0.85rem 1.5rem;
+      }
+      .brand { display: flex; align-items: center; gap: 0.55rem; font-weight: 700; font-size: 1.15rem; }
+      .mark { display: block; flex-shrink: 0; }
+      .nav-links {
+        display: flex; align-items: center; gap: 1.4rem; color: var(--sub); font-size: 0.88rem;
+        font-family: 'IBM Plex Mono', ui-monospace, monospace; letter-spacing: -0.01em;
+      }
+      .nav-links a:hover { color: var(--text); }
+      .nav-links a[aria-current='page'] { color: var(--accent); }
+      .gh { display: inline-flex; align-items: center; gap: 0.4rem; border: 1px solid var(--line); padding: 0.35rem 0.75rem; border-radius: 999px; }
+      .gh:hover { border-color: var(--accent); color: var(--accent); }
+
+      /* hero */
+      .page-hero { text-align: center; position: relative; padding-top: 4.5rem; padding-bottom: 1.5rem; }
+      .page-hero .glow {
+        position: absolute; inset: -20% 0 auto 0; height: 460px; pointer-events: none;
+        background: radial-gradient(ellipse 60% 55% at 50% 0%, rgb(198 255 26 / 0.09), transparent 70%);
+      }
+      .eyebrow { font-family: 'IBM Plex Mono', monospace; color: var(--accent); font-size: 0.78rem; letter-spacing: 0.14em; text-transform: uppercase; position: relative; }
+      .page-hero h1 { font-size: clamp(2rem, 5.4vw, 3.1rem); font-weight: 700; margin-top: 0.6rem; position: relative; }
+      .page-hero p { color: var(--sub); max-width: 42rem; margin: 1.2rem auto 0; font-size: 1.08rem; position: relative; }
+      .hero-cta { margin-top: 1.7rem; position: relative; display: flex; gap: 0.7rem; justify-content: center; flex-wrap: wrap; }
+
+      .btn {
+        display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.65rem 1.35rem;
+        border-radius: 0.6rem; border: 1px solid var(--line); font-weight: 600; font-size: 0.92rem;
+        font-family: 'IBM Plex Mono', monospace; transition: border-color 0.15s, transform 0.15s, filter 0.15s;
+      }
+      .btn:hover { transform: translateY(-2px); border-color: var(--accent); color: var(--accent); }
+      .btn.primary { background: var(--accent); color: #0b0b0f; border-color: var(--accent); }
+      .btn.primary:hover { filter: brightness(1.08); color: #0b0b0f; }
+
+      /* the three steps */
+      .how { padding-top: 2rem; padding-bottom: 1rem; }
+      .steps {
+        list-style: none; padding: 0; margin: 0;
+        display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.1rem;
+      }
+      .steps li {
+        min-width: 0;
+        border: 1px solid var(--line); border-radius: 1rem; padding: 1.4rem 1.5rem 1.5rem;
+        background: linear-gradient(180deg, #131318, #0d0d12); position: relative;
+      }
+      .num {
+        display: inline-flex; align-items: center; justify-content: center;
+        width: 26px; height: 26px; border-radius: 50%; background: rgb(198 255 26 / 0.12);
+        border: 1px solid rgb(198 255 26 / 0.3); color: var(--accent);
+        font-family: 'IBM Plex Mono', monospace; font-size: 0.8rem; font-weight: 700;
+      }
+      .steps h3 { font-size: 1.02rem; margin: 0.8rem 0 0.4rem; }
+      .steps p { color: var(--sub); font-size: 0.9rem; }
+      .steps a { color: var(--accent); border-bottom: 1px solid rgb(198 255 26 / 0.3); }
+      .cmd {
+        margin-top: 0.9rem; background: #0a0a0d; border: 1px solid var(--line);
+        border-radius: 0.5rem; padding: 0.55rem 0.7rem; overflow-x: auto;
+      }
+      .cmd code { color: #d7ffb0; font-size: 0.8rem; white-space: pre; }
+
+      /* section headers */
+      .shead {
+        display: flex; align-items: baseline; justify-content: space-between;
+        gap: 1rem; flex-wrap: wrap; margin-bottom: 1.3rem;
+      }
+      .shead h2 { font-size: clamp(1.4rem, 3vw, 1.85rem); font-weight: 700; }
+      .shead-right { display: flex; align-items: center; gap: 1.1rem; }
+      .topic-link { color: var(--accent); font-size: 0.86rem; font-family: 'IBM Plex Mono', monospace; }
+      .topic-link:hover { text-decoration: underline; }
+      .lede { color: var(--sub); max-width: 46rem; margin: -0.6rem 0 1.4rem; }
+
+      /* sort control */
+      .sort {
+        display: inline-flex; align-items: center; gap: 0.45rem;
+        font-family: 'IBM Plex Mono', monospace; font-size: 0.78rem; color: var(--sub);
+      }
+      .sort[hidden] { display: none; }
+      .sort select {
+        background: #0f0f14; color: var(--text); border: 1px solid var(--line);
+        border-radius: 0.45rem; padding: 0.3rem 0.5rem;
+        font-family: inherit; font-size: 0.78rem; cursor: pointer;
+      }
+      .sort select:hover { border-color: rgb(198 255 26 / 0.35); }
+
+      /* ── module card ─────────────────────────────────────────────────
+         Compact and fixed-rhythm: the description is clamped to two lines
+         and pushed by `flex: 1`, so every card in a row ends with its meta
+         row and install line at the same height. Both grids use this. */
+      .grid {
+        display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.85rem;
+        align-items: stretch;
+      }
+      /* `min-width: 0` is load-bearing: without it a grid item refuses to
+         shrink below its content's intrinsic width, and the nowrap install
+         line drags every column past the section's max-width. */
+      .mod {
+        display: flex; flex-direction: column; min-width: 0;
+        border: 1px solid var(--line); border-radius: 0.85rem;
+        padding: 0.95rem 1rem 0.85rem;
+        background: linear-gradient(180deg, #131318, #0d0d12);
+        transition: border-color 0.18s, transform 0.18s, box-shadow 0.18s;
+      }
+      .mod:hover {
+        border-color: rgb(198 255 26 / 0.34); transform: translateY(-2px);
+        box-shadow: 0 6px 22px -12px rgb(198 255 26 / 0.25);
+      }
+      .mhead { display: flex; align-items: center; gap: 0.5rem; min-width: 0; }
+      .mhead > * { min-width: 0; }
+      .avatar { border-radius: 50%; border: 1px solid var(--line); flex-shrink: 0; }
+      .avatar.ex {
+        width: 26px; height: 26px; display: inline-flex; align-items: center; justify-content: center;
+        color: var(--accent); font-size: 0.85rem; background: rgb(198 255 26 / 0.1);
+        border-color: rgb(198 255 26 / 0.28);
+      }
+      .mname {
+        font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-size: 0.95rem;
+        color: var(--accent); letter-spacing: -0.02em;
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+      }
+      .stars, .tag {
+        margin-left: auto; flex-shrink: 0; color: var(--sub); font-size: 0.76rem;
+        font-family: 'JetBrains Mono Variable', monospace;
+      }
+      .tag {
+        font-family: 'IBM Plex Mono', monospace; font-size: 0.58rem; text-transform: uppercase;
+        letter-spacing: 0.09em; padding: 0.18rem 0.45rem; border-radius: 999px;
+        border: 1px solid var(--line); line-height: 1;
+      }
+      .mowner {
+        color: var(--sub); font-size: 0.74rem; margin: 0.25rem 0 0 2.1rem;
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      }
+      .mdesc {
+        color: var(--sub); font-size: 0.855rem; line-height: 1.5;
+        margin: 0.55rem 0 0; flex: 1;
+        display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+        line-clamp: 2; overflow: hidden;
+      }
+      /* one-line stat strip: language dot, forks, last push */
+      .meta {
+        display: flex; align-items: center; flex-wrap: wrap; gap: 0.75rem;
+        margin-top: 0.7rem; color: var(--sub); font-size: 0.72rem;
+        font-family: 'IBM Plex Mono', monospace;
+      }
+      .mi { display: inline-flex; align-items: center; gap: 0.32rem; white-space: nowrap; }
+      .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+      .mfoot { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.55rem; }
+      .chip {
+        font-size: 0.66rem; padding: 0.12rem 0.44rem; border-radius: 999px;
+        border: 1px solid var(--line); color: var(--sub);
+        font-family: 'IBM Plex Mono', monospace; line-height: 1.5;
+      }
+      .install {
+        display: block; margin-top: 0.75rem; background: #0a0a0d;
+        border: 1px solid var(--line); border-radius: 0.45rem;
+        padding: 0.4rem 0.5rem; font-size: 0.68rem; color: #d7ffb0;
+        line-height: 1.5; min-width: 0;
+        /* Wrap rather than ellipsis: this is the line people copy, so losing
+           the tail of it defeats the point. Breaking at the spaces keeps the
+           command readable, and the card's `flex: 1` description absorbs the
+           extra row so every card in the row still ends level. */
+        white-space: normal; overflow-wrap: break-word;
+      }
+      .mod:hover .install { border-color: rgb(198 255 26 / 0.22); }
+
+      /* the two grids are one block: pull them together */
+      .index { padding-bottom: 1.5rem; }
+      .samples { padding-top: 2.5rem; }
+
+      /* empty state */
+      .empty {
+        text-align: center; border: 1px dashed var(--line); border-radius: 1.2rem;
+        padding: 3.2rem 1.5rem; background: radial-gradient(ellipse 70% 90% at 50% 0%, rgb(198 255 26 / 0.045), transparent 70%);
+      }
+      .empty[hidden] { display: none; }
+      .empty-mark { font-size: 2.2rem; color: var(--accent); opacity: 0.55; line-height: 1; }
+      .empty h3 { font-size: 1.25rem; margin: 0.9rem 0 0.5rem; }
+      .empty p { color: var(--sub); max-width: 34rem; margin: 0 auto; font-size: 0.95rem; }
+      .empty-cta { margin-top: 1.5rem; display: flex; gap: 0.7rem; justify-content: center; flex-wrap: wrap; }
+
+      /* publishing */
+      .pub-card {
+        border: 1px solid var(--line); border-radius: 1.2rem; overflow: hidden;
+        background: linear-gradient(180deg, #131318, #0d0d12);
+        display: grid; grid-template-columns: 1.35fr 1fr;
+      }
+      .pub-copy { padding: 2rem 2.1rem; }
+      .pub-copy h2 { font-size: clamp(1.35rem, 3vw, 1.7rem); margin: 0.55rem 0 0.7rem; }
+      .pub-copy p { color: var(--sub); font-size: 0.95rem; }
+      .pub-copy code, .tip code, .trust code {
+        font-size: 0.85em; color: #d7ffb0; background: rgb(198 255 26 / 0.07);
+        border: 1px solid rgb(198 255 26 / 0.14); padding: 0.05rem 0.35rem; border-radius: 0.35rem;
+      }
+      .pub-copy strong { color: var(--text); }
+      .pub-steps { margin: 1.2rem 0 0; padding-left: 1.1rem; color: var(--sub); font-size: 0.92rem; }
+      .pub-steps li { margin: 0.5rem 0; }
+      .pub-side { border-left: 1px solid var(--line); padding: 2rem 1.8rem; background: rgb(255 255 255 / 0.015); }
+      .tip h4 {
+        font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em;
+        color: var(--sub); margin-bottom: 0.9rem;
+      }
+      .tip ul { list-style: none; padding: 0; margin: 0; }
+      .tip li {
+        position: relative; padding-left: 1.15rem; margin: 0.6rem 0;
+        color: var(--sub); font-size: 0.88rem; line-height: 1.5;
+      }
+      .tip li::before {
+        content: ''; position: absolute; left: 0.15rem; top: 0.62em; width: 5px; height: 5px;
+        border-radius: 50%; background: var(--accent); opacity: 0.85;
+      }
+
+      /* trust */
+      .trust { max-width: 800px; text-align: center; padding-top: 2rem; }
+      .trust h2 { font-size: 1.5rem; margin-bottom: 0.9rem; }
+      .trust p { color: var(--sub); font-size: 0.97rem; margin-bottom: 1.4rem; }
+
+      /* footer */
+      footer { border-top: 1px solid var(--line); margin-top: 2rem; }
+      .foot-inner {
+        max-width: 1060px; margin: 0 auto; padding: 2rem 1.5rem;
+        display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap;
+      }
+      .foot-brand { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; }
+      .foot-brand .dim { font-weight: 400; font-size: 0.85rem; }
+      .foot-links { display: flex; gap: 1.3rem; color: var(--sub); font-size: 0.92rem; flex-wrap: wrap; }
+      .foot-links a:hover { color: var(--accent); }
+
+      @media (max-width: 900px) {
+        .steps, .grid { grid-template-columns: repeat(2, 1fr); }
+        .pub-card { grid-template-columns: 1fr; }
+        .pub-side { border-left: none; border-top: 1px solid var(--line); }
+      }
+      @media (max-width: 640px) {
+        section, header.page-hero { padding: 3rem 1.25rem; }
+        .steps, .grid { grid-template-columns: 1fr; }
+        .nav-links { gap: 1rem; font-size: 0.82rem; }
+        .pub-copy, .pub-side { padding: 1.5rem 1.4rem; }
+      }
+
+      /* Four nav links + the GitHub pill no longer fit a phone in one row:
+         let them wrap rather than widen the page. */
+      @media (max-width: 560px) {
+        .nav-inner { flex-wrap: wrap; row-gap: 0.45rem; padding-top: 0.7rem; padding-bottom: 0.7rem; }
+        .nav-links { gap: 0.9rem; font-size: 0.78rem; flex-wrap: wrap; justify-content: flex-end; }
+      }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
Modules could already run argv commands and push sidebar rows, but they couldn't reach most of the app. This opens up the rest of the surface, keeps the design (a manifest plus commands, no SDK), and publishes a community index so modules are findable.

## What modules can do now

| Surface | Declared as | Notes |
|---|---|---|
| Right-click | `contexts` on an action | Rows in the pane / workspace / agent menus |
| Settings | `[[settings]]` | Typed controls in Settings → Modules, no UI code |
| Startup | `[[startup]]` | Runs once when the socket is up |
| Docks | `[[docks]]` | Rows now carry a `value`, so one action backs a list |
| Tabs | any command | `tab.rename`, and `tab.list` returns `name`/`kind` |

New socket methods: `module.settings.list|get|set`, `tab.rename`, `ui.toast`.

A module also gets flat `BOHAY_WORKSPACE_*` / `BOHAY_PANE_*` context vars and one `BOHAY_SETTING_<KEY>` per declared setting, so a bash module never has to parse JSON.

## Notable fixes found along the way

- **`contexts` was declared in the manifest and wired to nothing.** It now drives the real menus, and an unknown value is a hard manifest error rather than a menu row that silently never appears.
- **Docks came back empty after a restart.** Dock rows are cached and not persisted, and nothing ever asked the module to repaint. That is what `[[startup]]` is for.
- **`node.*` event hooks had stopped firing.** The code emits `workspace.*` while `KNOWN_EVENTS` still listed the old names. Both spellings work again.
- **Item-level `platforms` was parsed but ignored** for build steps, event hooks and pane entrypoints.
- **A menu could run the wrong action.** The list was re-derived on every click, so a module disabled between frames shifted the indices. Menus now snapshot their actions on open, which also removes a per-frame allocation.
- **`module.settings.list` printed secrets in the clear.** It now reports `set: true|false`, and `get <key>` still returns the value for scripting.

## Distribution

`/modules` on the site runs the same `bohay-module` topic search the CLI does, so the two cannot disagree. It is fetched at build time (so it renders with JS off and is indexable) and refreshed client-side, since Pages only rebuilds on push.

Verified end to end against a real published repo: search, install with the commit pinned, settings surfaced with the secret masked, right-click action registered, action ran.

## Docs

`writing-modules` is rewritten with three complete inline examples. `using-modules` was 24 lines that explained little and is now a real guide covering finding, installing, configuring, managing and the trust model.

Three working examples ship in `examples/modules/` (Bash, Python, Node), each covering a different surface. They are excluded from the published crate.

## Testing

221 tests (10 new), clippy clean, fmt clean. `cargo publish --dry-run` and the Windows cross-check both pass. The website was verified in a headless browser at 1440, 1024, 820, 560, 390 and 320px with no horizontal overflow on any page.

## Before merging

Ships in **0.8.3**, which the examples declare as their `min_bohay_version`. `Cargo.toml` is still 0.8.2 because `release.sh` owns that bump, so the examples will not link from a branch build until the release is cut. That is the intended version gate, just worth knowing when trying the branch.
