### PR TITLE
Native file viewer: tree dock, file panes and tabs + docs

### DIFF
--- a/examples/modules/README.md
+++ b/examples/modules/README.md
@@ -9,6 +9,7 @@ edited**, not installed as-is.
 | [`branch-dock`](branch-dock) | Bash | A sidebar **dock**, clickable rows with a `value` payload, a **startup hook**, `number` + `enum` **settings**, a `workspace` right-click action |
 | [`agent-ping`](agent-ping) | Python | An **event hook** on agent status, a **secret** setting, an `agent` right-click action, toasts |
 | [`scratch-pane`](scratch-pane) | Node | A **pane** entrypoint, `pane` right-click actions, reading the **selection**, **renaming a tab**, the state dir |
+| [`file-tree`](file-tree) | Bash | A **collapsible file tree** dock (per-row `toggle`/`open` actions, on-disk expand state), opening a file into a split **pane** via `pane split` + `pane run` — a no-core-edits prototype of docs/38 |
 
 Nothing here needs a build step or a dependency beyond the language runtime
 itself (`sh`, `python3`, `node`).

--- a/examples/modules/file-tree/README.md
+++ b/examples/modules/file-tree/README.md
@@ -1,0 +1,52 @@
+# File Tree (prototype module)
+
+A collapsible file tree of the active node in the sidebar, and a file opener that
+runs a pager in a pane. Built entirely as a **module** — no changes to bohay
+core — to validate the UX of docs/38 fast.
+
+```sh
+bohay module link examples/modules/file-tree
+```
+
+A **FILES** dock appears in the left sidebar (move it in Settings → Layout).
+
+- **Click a folder** to expand or collapse it. Only expanded folders are read, so
+  a large repo costs what you open, not the whole tree.
+- **Click a file** to open it in a pager pane (`bat` if installed, else `less -N`).
+- **Click the `⟳` header row** to re-root the tree on the node you are on now.
+- **Right-click a WORKSPACES row → "Open file tree here"** does the same.
+
+Settings (Settings → Modules → File Tree):
+
+- **Open files in** — `pane` (split beside you) or `tab` (a new tab).
+- **Show dotfiles** — include entries beginning with `.` (`.git` is always hidden).
+- **Max rows** — cap the tree so a huge expanded repo can't push an enormous dock.
+
+## What this prototype proves, and where it stops
+
+This is the fast-validation path from docs/38. It is a real, working file browser
+with **zero core edits**, and it deliberately stops where a module must:
+
+- The tree is a **flat pushed list** (indentation is text). Every expand/collapse
+  re-pushes the whole dock, so it is fine for browsing but not as smooth as a
+  native tree on a very large repo.
+- A file opens in a **pager PTY**, not a native bohay view — no theme-aware
+  renderer, no shared scroll, no in-file search. A module can only open real PTY
+  panes; the native view pane (docs/38 FILE-3, shared with docs/30) is the
+  upgrade that makes "open a file" first-class.
+
+If the UX feels right here, docs/38 is the plan to make it native.
+
+## How it works (no SDK, just argv + the socket)
+
+`bohay-module.toml` reserves the dock and declares the actions. The scripts fill
+the dock over the same socket API the CLI uses:
+
+- `render.sh` — walks the expanded tree (explicit-stack DFS, since POSIX sh has
+  no locals) and `bohay ui dock push`es it. Folders get the `toggle` action,
+  files the `open` action.
+- `toggle.sh` — a clicked folder's path arrives in `BOHAY_MODULE_ROW_VALUE`; flip
+  it in the expanded set (kept in `BOHAY_MODULE_STATE_DIR`) and repaint.
+- `open.sh` — a clicked file: `bohay pane split` (or `tab new`), capture the new
+  pane id, `bohay pane run <id> <pager>`.
+- `lib.sh` — shared state helpers and JSON escaping.

--- a/examples/modules/file-tree/bohay-module.toml
+++ b/examples/modules/file-tree/bohay-module.toml
@@ -1,0 +1,76 @@
+id = "example.file-tree"
+name = "File Tree"
+version = "0.1.0"
+min_bohay_version = "0.8.3"
+description = "A collapsible file tree of the active node in the sidebar. Click a folder to expand, a file to open it in a pane. A no-core-edits prototype of docs/38."
+platforms = ["macos", "linux"]
+
+# The dock bohay reserves for this module. The scripts fill it over the socket
+# with `ui dock push`; bohay owns the rendering and the row geometry, and the
+# user can move it to the other sidebar from Settings -> Layout.
+[[docks]]
+id = "files"
+title = "FILES"
+placement = "sidebar.left"
+
+# Dock contents are deliberately not persisted, so this repaints after a restart.
+[[startup]]
+command = ["sh", "render.sh"]
+
+# Keep the tree pointed at wherever the user is working. There is no dedicated
+# "active node changed" event yet, so we repaint on the node/tab events that do
+# fire; the in-dock "⟳" row (and the workspace right-click item) cover the rest.
+[[events]]
+on = "workspace.created"
+command = ["sh", "render.sh"]
+
+[[events]]
+on = "tab.created"
+command = ["sh", "render.sh"]
+
+# Right-click a WORKSPACES row -> "Open file tree here" to re-root on demand.
+[[actions]]
+id = "reroot"
+title = "Open file tree here"
+contexts = ["workspace"]
+command = ["sh", "render.sh"]
+
+# Clicking a *folder* row invokes this (rows set action = "toggle").
+[[actions]]
+id = "toggle"
+title = "Expand or collapse a folder"
+command = ["sh", "toggle.sh"]
+
+# Clicking a *file* row invokes this (rows set action = "open").
+[[actions]]
+id = "open"
+title = "Open a file in a pane"
+command = ["sh", "open.sh"]
+
+# The top "⟳" row re-roots to the active node and repaints.
+[[actions]]
+id = "refresh"
+title = "Refresh the tree"
+command = ["sh", "render.sh"]
+
+[[settings]]
+key = "open_in"
+title = "Open files in"
+type = "enum"
+options = ["pane", "tab"]
+default = "pane"
+
+[[settings]]
+key = "show_hidden"
+title = "Show dotfiles"
+type = "bool"
+default = false
+
+[[settings]]
+key = "max_rows"
+title = "Max rows in the tree"
+type = "number"
+default = 400
+min = 50
+max = 2000
+step = 50

--- a/examples/modules/file-tree/lib.sh
+++ b/examples/modules/file-tree/lib.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Shared helpers for the File Tree module. Sourced by render/toggle/open.
+#
+# State the module keeps between invocations (dock content is not persisted, and
+# each click is a fresh subprocess, so anything that must survive lives on disk):
+#   $BOHAY_MODULE_STATE_DIR/root       the folder the tree is rooted at
+#   $BOHAY_MODULE_STATE_DIR/expanded   newline-separated absolute dir paths
+#
+# Everything else arrives in the environment, so there is no JSON to parse:
+#   BOHAY_BIN_PATH          the running bohay binary (use it, not PATH's `bohay`)
+#   BOHAY_WORKSPACE_CWD     the active node's folder
+#   BOHAY_MODULE_ROW_VALUE  a clicked row's payload (here: an absolute path)
+#   BOHAY_SETTING_*         this module's settings
+
+bohay="${BOHAY_BIN_PATH:-bohay}"
+state="${BOHAY_MODULE_STATE_DIR:-/tmp/bohay-file-tree}"
+mkdir -p "$state"
+root_file="$state/root"
+exp_file="$state/expanded"
+[ -f "$exp_file" ] || : >"$exp_file"
+
+# The folder the tree is rooted at. `render` (re)writes it from the active node;
+# `toggle`/`open` read it so a click acts on the tree the user is looking at,
+# not on whatever node happens to be active at click time.
+tree_root() {
+  if [ -s "$root_file" ]; then cat "$root_file"; else printf '%s' "${BOHAY_WORKSPACE_CWD:-$PWD}"; fi
+}
+
+is_expanded() { grep -Fxq "$1" "$exp_file" 2>/dev/null; }
+
+expand()   { is_expanded "$1" || printf '%s\n' "$1" >>"$exp_file"; }
+collapse() {
+  # Drop the path and anything nested under it, so collapsing a parent also
+  # forgets its opened children.
+  grep -Fxv "$1" "$exp_file" 2>/dev/null | grep -v "^$1/" >"$exp_file.tmp" 2>/dev/null || :
+  mv "$exp_file.tmp" "$exp_file" 2>/dev/null || : >"$exp_file"
+}
+
+# Escape the two characters that matter inside a JSON string. Command
+# substitution eats a trailing newline, which is exactly what we want here.
+json_esc() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }

--- a/examples/modules/file-tree/open.sh
+++ b/examples/modules/file-tree/open.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# A file row was clicked: open it in a pager, in a new pane (default) or a new
+# tab. This is the prototype's "view a file" -- a real PTY running a pager, which
+# is the most a module can do without core support for a native view pane
+# (docs/38). `bat` is used when present (syntax + line numbers), else `less -N`.
+set -eu
+. "$(dirname "$0")/lib.sh"
+
+path="${BOHAY_MODULE_ROW_VALUE:-}"
+[ -n "$path" ] || { "$bohay" ui toast "no file selected"; exit 1; }
+[ -f "$path" ] || { "$bohay" ui toast "not a file: ${path##*/}"; exit 1; }
+
+open_in="${BOHAY_SETTING_OPEN_IN:-pane}"
+
+# The first pane id in a JSON reply. `pane split` returns exactly the new pane;
+# after `tab new` the new tab has a single (focused) shell, so its first pane is
+# the one we want. Pretty-printed JSON, so match `"pane": "N"`.
+first_pane() { sed -n 's/.*"pane": *"\([0-9][0-9]*\)".*/\1/p' | head -1; }
+
+if [ "$open_in" = "tab" ]; then
+  "$bohay" tab new >/dev/null 2>&1 || true
+  pid=$("$bohay" pane list | first_pane)
+else
+  pid=$("$bohay" pane split | first_pane)
+fi
+
+[ -n "${pid:-}" ] || { "$bohay" ui toast "could not open a pane"; exit 1; }
+
+# Single-quote the path for the shell that will run the pager, escaping any
+# embedded single quotes so a spaced or quirky filename is safe.
+q=$(printf "%s" "$path" | sed "s/'/'\\\\''/g")
+if command -v bat >/dev/null 2>&1; then
+  cmd="bat --paging=always --style=numbers,header '$q'"
+else
+  cmd="less -N '$q'"
+fi
+
+"$bohay" pane run "$pid" "$cmd"
+"$bohay" pane focus "$pid" >/dev/null 2>&1 || true
+"$bohay" ui toast "opened ${path##*/}"

--- a/examples/modules/file-tree/render.sh
+++ b/examples/modules/file-tree/render.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Walk the (expanded parts of the) tree and push it into the FILES dock.
+#
+# Only expanded directories are ever descended, so a huge repo costs what you
+# open, not the whole thing. Rendering is a flat list: bohay's dock draws rows,
+# so depth is indentation baked into each row's text. Folders carry the "toggle"
+# action, files the "open" action -- one action per row is all bohay needs.
+#
+# The walk is an explicit-stack DFS rather than a recursive function: POSIX sh
+# has no local variables, so a recursive walk would clobber its own loop state.
+set -eu
+. "$(dirname "$0")/lib.sh"
+
+# Re-root to the node this was invoked against (startup, a node/tab event, the
+# workspace right-click item, or the in-dock refresh row).
+printf '%s' "${BOHAY_WORKSPACE_CWD:-$PWD}" >"$root_file"
+root=$(tree_root)
+
+show_hidden="${BOHAY_SETTING_SHOW_HIDDEN:-false}"
+max_rows="${BOHAY_SETTING_MAX_ROWS:-400}"
+TAB=$(printf '\t')
+stack="$state/stack.$$"
+: >"$stack"
+
+ROWS=""
+N=0
+
+add_row() { # text  action  value  [dot]
+  esc_t=$(json_esc "$1"); esc_v=$(json_esc "$3")
+  if [ -n "${4:-}" ]; then
+    ROWS="${ROWS}{\"text\":\"$esc_t\",\"action\":\"$2\",\"value\":\"$esc_v\",\"dot\":\"$4\"},"
+  else
+    ROWS="${ROWS}{\"text\":\"$esc_t\",\"action\":\"$2\",\"value\":\"$esc_v\"},"
+  fi
+  N=$((N + 1))
+}
+
+indent_for() { i=0; s=""; while [ "$i" -lt "$1" ]; do s="$s  "; i=$((i + 1)); done; printf '%s' "$s"; }
+
+# A directory's immediate children as `depth<TAB>path` lines, dirs before files,
+# each group alphabetical (glob expansion is sorted). Dotfiles only when asked;
+# `.git` is always hidden.
+list_children() { # dir  child-depth
+  cd_="$2"
+  for e in "$1"/*/ ; do
+    [ -d "$e" ] || continue
+    q=${e%/}; nm=${q##*/}
+    [ "$nm" = ".git" ] && continue
+    printf '%s%s%s\n' "$cd_" "$TAB" "$q"
+  done
+  if [ "$show_hidden" = "true" ]; then
+    for e in "$1"/.*/ ; do
+      [ -d "$e" ] || continue
+      q=${e%/}; nm=${q##*/}
+      case "$nm" in .|..) continue ;; esac
+      [ "$nm" = ".git" ] && continue
+      printf '%s%s%s\n' "$cd_" "$TAB" "$q"
+    done
+  fi
+  for e in "$1"/* ; do
+    [ -f "$e" ] || continue
+    printf '%s%s%s\n' "$cd_" "$TAB" "$e"
+  done
+  if [ "$show_hidden" = "true" ]; then
+    for e in "$1"/.* ; do
+      [ -f "$e" ] || continue
+      printf '%s%s%s\n' "$cd_" "$TAB" "$e"
+    done
+  fi
+}
+
+# Push a dir's children onto the LIFO stack in reverse, so they pop in emit order.
+push_children() {
+  list_children "$1" "$2" | awk '{ a[NR] = $0 } END { for (i = NR; i >= 1; i--) print a[i] }' >>"$stack"
+}
+
+# Header row: click to re-root to the active node and repaint.
+add_row "⟳  ${root##*/}" refresh "$root" done
+push_children "$root" 0
+
+while [ -s "$stack" ] && [ "$N" -lt "$max_rows" ]; do
+  line=$(tail -n 1 "$stack")
+  sed '$d' "$stack" >"$stack.t" && mv "$stack.t" "$stack"
+  depth=${line%%"$TAB"*}
+  path=${line#*"$TAB"}
+  name=${path##*/}
+  ind=$(indent_for "$depth")
+  if [ -d "$path" ]; then
+    if is_expanded "$path"; then
+      add_row "${ind}▾ $name" toggle "$path" working
+      push_children "$path" $((depth + 1))
+    else
+      add_row "${ind}▸ $name" toggle "$path"
+    fi
+  else
+    add_row "${ind}  $name" open "$path"
+  fi
+done
+[ "$N" -lt "$max_rows" ] || add_row "  … (truncated)" refresh "$root"
+rm -f "$stack" "$stack.t"
+
+"$bohay" ui dock push --id files --title FILES --rows "[${ROWS%,}]"

--- a/examples/modules/file-tree/toggle.sh
+++ b/examples/modules/file-tree/toggle.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# A folder row was clicked: flip its expanded state, then repaint the tree.
+set -eu
+. "$(dirname "$0")/lib.sh"
+
+path="${BOHAY_MODULE_ROW_VALUE:-}"
+[ -n "$path" ] || { "$bohay" ui toast "no folder selected"; exit 1; }
+
+if is_expanded "$path"; then collapse "$path"; else expand "$path"; fi
+
+# Repaint from the stored root, without re-rooting (this click's active node may
+# differ from the tree's root; keep the tree the user is looking at). We call
+# render's walk by re-running it with the root already pinned, so temporarily
+# point BOHAY_WORKSPACE_CWD at the stored root.
+BOHAY_WORKSPACE_CWD=$(tree_root) sh "$(dirname "$0")/render.sh"

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -19,9 +19,17 @@ impl App {
     /// silent agent's Working→Done transition even when no other event fires.
     pub fn detect_tick(&mut self, now: Instant) -> bool {
         // Refresh working directories ~once a second so spaces follow the user.
+        // The file-viewer upkeep rides the same 1s cadence — sub-second freshness
+        // buys nothing (a node switch or an on-disk edit showing within a second
+        // is fine) and 10x/s stats + allocs would be wasted work on the loop.
         if now.duration_since(self.last_cwd_at) >= Duration::from_secs(1) {
             self.last_cwd_at = now;
             self.refresh_cwds();
+            // Keep the FILES dock rooted at the active node and its open dirs
+            // read (docs/38). Off-loop: this only schedules reads, never blocks.
+            self.ensure_file_tree();
+            // Live-refresh open file views whose file changed on disk (FILE-5).
+            self.ensure_file_views();
         }
         // Rescan the agents' session stores a little less often. The scan is
         // filesystem work that grows with on-disk history, so it runs on a
@@ -915,6 +923,55 @@ impl App {
                     .unwrap_or(self.active_ws);
                 self.open_git_tab(i);
                 Ok(json!({"type":"ok","git": self.active_is_git()}))
+            }
+            // ── file viewer (docs/38) ──
+            "files.open" => {
+                let raw = p.get("path").and_then(|v| v.as_str()).unwrap_or("");
+                if raw.is_empty() {
+                    return Err(("bad_request".into(), "path required".into()));
+                }
+                let path = self.resolve_file_path(raw);
+                let target = match p.get("target").and_then(|v| v.as_str()) {
+                    Some("tab") => crate::app::files::OpenTarget::Tab,
+                    Some("pane") => crate::app::files::OpenTarget::Pane,
+                    _ => crate::app::files::OpenTarget::Preview,
+                };
+                self.open_file_view(path, target);
+                Ok(json!({"type":"ok"}))
+            }
+            "files.tree" => {
+                let rows: Vec<Value> = self
+                    .file_tree
+                    .visible_rows()
+                    .iter()
+                    .map(|r| {
+                        json!({
+                            "path": r.path.to_string_lossy(),
+                            "name": r.name,
+                            "depth": r.depth,
+                            "dir": r.is_dir,
+                            "expanded": r.expanded,
+                        })
+                    })
+                    .collect();
+                Ok(json!({
+                    "type": "file_tree",
+                    "root": self.file_tree.root().to_string_lossy(),
+                    "rows": rows,
+                }))
+            }
+            "files.reveal" => {
+                let raw = p.get("path").and_then(|v| v.as_str()).unwrap_or("");
+                if raw.is_empty() {
+                    return Err(("bad_request".into(), "path required".into()));
+                }
+                let path = self.resolve_file_path(raw);
+                self.file_tree.reveal(&path);
+                Ok(json!({"type":"ok"}))
+            }
+            "files.refresh" => {
+                self.file_tree.invalidate();
+                Ok(json!({"type":"ok"}))
             }
             // ── worktrees (docs/18 WT-3) ──
             "worktree.list" => {

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -1,0 +1,698 @@
+//! App-layer file-tree actions (docs/38 FILE-1): keeping the tree pointed at the
+//! active node, scheduling directory reads off the loop, and opening a file.
+
+use std::path::PathBuf;
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+
+use crate::app::{App, DockKind, Mode, Tab, ViewKind};
+use crate::event::AppEvent;
+use crate::files::FileView;
+use crate::ids::PaneId;
+use crate::layout::{Axis, TileLayout};
+
+/// Where a file opens.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum OpenTarget {
+    /// A reused single-click preview pane (replaced as you click around).
+    Preview,
+    /// A new, permanent pane split beside the focus.
+    Pane,
+    /// A whole new tab.
+    Tab,
+}
+
+impl App {
+    /// Keep the FILES dock honest, off the render path. Called from `detect_tick`:
+    /// re-roots the tree to the active node, then schedules a worker read for any
+    /// directory that should be on screen but has not been read yet. Cheap when
+    /// there is nothing to do (a few `HashSet` checks), and a no-op when the dock
+    /// isn't mounted.
+    pub fn ensure_file_tree(&mut self) {
+        if self.sidebars.side_of(&DockKind::Files).is_none() {
+            return;
+        }
+        let cwd = self.ws().cwd.clone();
+        self.file_tree.set_root(cwd);
+        self.load_pending_dirs();
+    }
+
+    /// Resolve a possibly-relative path (from the API/CLI) against the active
+    /// node's folder.
+    pub fn resolve_file_path(&self, raw: &str) -> PathBuf {
+        let p = PathBuf::from(raw);
+        if p.is_absolute() {
+            p
+        } else {
+            self.ws().cwd.join(p)
+        }
+    }
+
+    /// Live refresh (docs/38 FILE-5): re-read any open file view whose file
+    /// changed on disk since we last read it. One `stat` per open view, ~1s —
+    /// cheap (there are rarely more than a couple). Called from `detect_tick`.
+    pub fn ensure_file_views(&mut self) {
+        if self.views.is_empty() {
+            return;
+        }
+        let mut stale = Vec::new();
+        for (id, ViewKind::File(v)) in self.views.iter() {
+            let disk = std::fs::metadata(&v.path).and_then(|m| m.modified()).ok();
+            if disk.is_some() && disk != v.mtime {
+                stale.push((*id, v.path.clone(), disk));
+            }
+        }
+        for (id, path, mtime) in stale {
+            if let Some(ViewKind::File(v)) = self.views.get_mut(&id) {
+                v.mtime = mtime; // record now so we don't reschedule until it changes again
+            }
+            self.schedule_file_read(id, path);
+        }
+    }
+
+    /// `Ctrl+Space e`: mount the FILES dock on the left sidebar, or unmount it if
+    /// it is already shown. Mounting also makes sure the sidebar is visible.
+    pub fn toggle_files_dock(&mut self) {
+        if self.sidebars.side_of(&DockKind::Files).is_some() {
+            self.unmount_dock(&DockKind::Files);
+        } else {
+            self.sidebars.left.docks.push(DockKind::Files);
+            self.sidebars.left.visible = true;
+            self.save_sidebars();
+        }
+    }
+
+    /// A FILES row was clicked: expand/collapse a folder, or open a file in a
+    /// **preview** pane (VS Code style — one reused pane while browsing).
+    pub fn file_row_activate(&mut self, index: usize, target: OpenTarget) {
+        let Some(row) = self.file_tree.visible_rows().get(index).cloned() else {
+            return;
+        };
+        if row.is_dir {
+            self.file_tree.toggle(&row.path);
+            // Schedule the read *now* so an expand feels instant — don't wait for
+            // the 1 Hz `ensure_file_tree` tick (that cadence is for background
+            // re-root/refresh, not a user click).
+            self.load_pending_dirs();
+        } else {
+            self.open_file_view(row.path, target);
+        }
+    }
+
+    /// Schedule an off-loop `read_dir` for every directory that should be on
+    /// screen but hasn't been read yet. Shared by the periodic `ensure_file_tree`
+    /// and the immediate on-expand path so a click loads without a visible lag.
+    fn load_pending_dirs(&mut self) {
+        for path in self.file_tree.needs_load() {
+            self.file_tree.mark_pending(path.clone());
+            let tx = self.app_tx.clone();
+            std::thread::spawn(move || {
+                let entries = crate::files::read_dir_entries(&path);
+                let _ = tx.send(AppEvent::DirRead { path, entries });
+            });
+        }
+    }
+
+    /// The leaf id of an open view already showing `path`, if any.
+    fn view_showing(&self, path: &std::path::Path) -> Option<PaneId> {
+        self.views
+            .iter()
+            .find_map(|(id, ViewKind::File(v))| (v.path == path).then_some(*id))
+    }
+
+    /// Open `path` in a native file view (docs/38 FILE-3). `Preview` reuses the
+    /// one preview pane; `Pane` splits a fresh permanent pane; `Tab` opens a new
+    /// tab. The file is read on a worker thread and applied via `FileRead`.
+    pub fn open_file_view(&mut self, path: PathBuf, target: OpenTarget) {
+        // Already open? Focus that view instead of opening a duplicate.
+        if let Some(id) = self.view_showing(&path) {
+            self.focus_pane_global(id);
+            return;
+        }
+        // Reuse the live preview pane: just swap its content.
+        if target == OpenTarget::Preview {
+            if let Some(id) = self.preview_view.filter(|id| self.views.contains_key(id)) {
+                self.set_view_file(id, path);
+                self.focus_pane_global(id);
+                return;
+            }
+        }
+
+        let id = PaneId::alloc();
+        self.views
+            .insert(id, ViewKind::File(FileView::new(path.clone())));
+        match target {
+            OpenTarget::Tab => {
+                let ws = &mut self.workspaces[self.active_ws];
+                ws.tabs.push(Tab::panes(TileLayout::new(id)));
+                ws.active_tab = ws.tabs.len() - 1;
+            }
+            OpenTarget::Preview | OpenTarget::Pane => {
+                self.layout_mut().split_focused(Axis::Col, id);
+                self.layout_mut().focus = id;
+            }
+        }
+        if target == OpenTarget::Preview {
+            self.preview_view = Some(id);
+        }
+        self.schedule_file_read(id, path);
+        self.mode = Mode::Normal;
+    }
+
+    /// Point an existing view leaf at a different file and re-read it.
+    fn set_view_file(&mut self, id: PaneId, path: PathBuf) {
+        if let Some(ViewKind::File(v)) = self.views.get_mut(&id) {
+            *v = FileView::new(path.clone());
+        }
+        self.schedule_file_read(id, path);
+    }
+
+    fn schedule_file_read(&mut self, id: PaneId, path: PathBuf) {
+        // Record the mtime now so live refresh (FILE-5) only re-reads on a real
+        // change, not immediately after this read.
+        if let Some(ViewKind::File(v)) = self.views.get_mut(&id) {
+            v.mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+        }
+        let tx = self.app_tx.clone();
+        std::thread::spawn(move || {
+            let load = crate::files::read_file(&path);
+            let _ = tx.send(AppEvent::FileRead { id, load });
+        });
+    }
+
+    /// Copy the whole file to the clipboard, via the same mechanism as a pane
+    /// text selection: queue `pending_clipboard` (the loop broadcasts it, the
+    /// client writes the native clipboard + OSC 52) and flash a toast. Only
+    /// text files copy; binary / too-large / errored views toast a reason.
+    pub fn copy_file_view(&mut self, id: PaneId) {
+        let text = match self.views.get(&id) {
+            Some(ViewKind::File(v)) => match &v.load {
+                crate::files::FileLoad::Text(lines) => Some(lines.join("\n")),
+                _ => None,
+            },
+            None => return,
+        };
+        match text {
+            Some(t) => {
+                self.pending_clipboard = Some(t);
+                let msg = self.catalog.copied;
+                self.show_toast(msg);
+            }
+            None => self.show_toast("nothing to copy"),
+        }
+    }
+
+    /// Keys for a focused file view: scroll, wrap, close. Returns whether the
+    /// frame should repaint.
+    pub fn handle_file_key(&mut self, id: PaneId, key: KeyEvent) -> bool {
+        // Rows visible in the view = its pane content height minus the footer.
+        let viewport = self
+            .pane_content_rects
+            .iter()
+            .find(|(pid, _)| *pid == id)
+            .map(|(_, r)| r.height.saturating_sub(1) as usize)
+            .unwrap_or(20);
+        let Some(ViewKind::File(v)) = self.views.get_mut(&id) else {
+            return false;
+        };
+        // While typing a search query, keys edit the query.
+        if v.search.as_ref().is_some_and(|s| s.editing) {
+            match key.code {
+                KeyCode::Char(c) => v.search_push(c),
+                KeyCode::Backspace => v.search_backspace(),
+                KeyCode::Enter => {
+                    v.search_commit();
+                    v.search_step(true, viewport); // reveal the first hit
+                }
+                KeyCode::Esc => v.search_cancel(),
+                _ => return false,
+            }
+            return true;
+        }
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => v.scroll_by(1, viewport),
+            KeyCode::Char('k') | KeyCode::Up => v.scroll_by(-1, viewport),
+            KeyCode::Char('d') => v.scroll_by(viewport as i32 / 2, viewport),
+            KeyCode::Char('u') => v.scroll_by(-(viewport as i32) / 2, viewport),
+            KeyCode::PageDown | KeyCode::Char(' ') => v.scroll_by(viewport as i32, viewport),
+            KeyCode::PageUp => v.scroll_by(-(viewport as i32), viewport),
+            KeyCode::Char('g') | KeyCode::Home => v.goto_top(),
+            KeyCode::Char('G') | KeyCode::End => v.goto_bottom(viewport),
+            KeyCode::Char('h') | KeyCode::Left => v.scroll_right(-8),
+            KeyCode::Char('l') | KeyCode::Right => v.scroll_right(8),
+            KeyCode::Char('w') => v.wrap = !v.wrap,
+            KeyCode::Char('/') => v.search_begin(),
+            KeyCode::Char('n') => v.search_step(true, viewport),
+            KeyCode::Char('N') => v.search_step(false, viewport),
+            // `y` copies the whole file to the clipboard, through the same path
+            // as a pane text selection (native clipboard + OSC 52 + a toast).
+            KeyCode::Char('y') | KeyCode::Char('c') => {
+                self.copy_file_view(id);
+                return true;
+            }
+            KeyCode::Char('q') => self.close_pane(id),
+            KeyCode::Esc => {
+                // Esc clears a committed search first, else closes the view.
+                if v.search.is_some() {
+                    v.search_cancel();
+                } else {
+                    self.close_pane(id);
+                }
+            }
+            _ => return false,
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::DockKind;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn buffer_text(term: &Terminal<TestBackend>) -> String {
+        let buf = term.backend().buffer();
+        (0..buf.area.height)
+            .map(|r| {
+                (0..buf.area.width)
+                    .map(|c| buf.cell((c, r)).map(|x| x.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The dock renders the tree, and a click on a folder row expands it in place.
+    #[test]
+    fn files_dock_renders_and_a_click_expands() {
+        let _env = crate::persist::test_env("files-dock-render");
+        // A tiny real tree on disk.
+        let root = std::env::temp_dir().join(format!("bohay-ft-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/mod.rs"), b"// hi").unwrap();
+        std::fs::write(root.join("README.md"), b"# hi").unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.workspaces[app.active_ws].cwd = root.clone();
+        app.sidebars.left.docks.push(DockKind::Files);
+
+        // `ensure_file_tree` re-roots + schedules reads on worker threads; apply
+        // the root read synchronously so the test is deterministic.
+        app.ensure_file_tree();
+        app.file_tree
+            .apply_dir(root.clone(), crate::files::read_dir_entries(&root));
+
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let text = buffer_text(&term);
+        assert!(text.contains("FILES"), "header drawn");
+        assert!(text.contains("src"), "a folder row drawn");
+        assert!(text.contains("README.md"), "a file row drawn");
+        // Collapsed: src's child is not visible yet.
+        assert!(!text.contains("mod.rs"), "child hidden while collapsed");
+
+        // Click the `src` row (find its rect) and re-render.
+        let (idx, rect) = app
+            .file_tree_rects
+            .iter()
+            .find(|(i, _)| app.file_tree.visible_rows()[*i].name == "src")
+            .cloned()
+            .expect("src row has a rect");
+        assert!(app.file_tree.visible_rows()[idx].is_dir);
+        app.file_row_activate(idx, OpenTarget::Preview);
+        // The expand scheduled a read; apply it and re-render.
+        app.file_tree.apply_dir(
+            root.join("src"),
+            crate::files::read_dir_entries(&root.join("src")),
+        );
+        let _ = rect;
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let text = buffer_text(&term);
+        assert!(text.contains("mod.rs"), "child visible after expanding src");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Opening a file makes a native view leaf that renders the file's contents
+    /// and line numbers in a pane, scrolls, and closes with `q`.
+    #[test]
+    fn file_view_pane_renders_scrolls_and_closes() {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let _env = crate::persist::test_env("file-view-pane");
+
+        let dir = std::env::temp_dir().join(format!("bohay-fvp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("code.rs");
+        let body: String = (1..=80).map(|i| format!("line number {i}\n")).collect();
+        std::fs::write(&file, body).unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+
+        // Open it in a permanent pane; apply the read synchronously.
+        app.open_file_view(file.clone(), OpenTarget::Pane);
+        let vid = app.layout().focus;
+        assert!(
+            app.views.contains_key(&vid),
+            "a view leaf exists and is focused"
+        );
+        if let Some(ViewKind::File(v)) = app.views.get_mut(&vid) {
+            v.apply(crate::files::read_file(&file));
+        }
+
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let text = buffer_text(&term);
+        assert!(text.contains("code.rs"), "the pane title shows the file");
+        assert!(text.contains("line number 1"), "first line rendered");
+        assert!(text.contains("80 lines"), "footer line count");
+        assert!(!text.contains("line number 80"), "bottom not visible yet");
+
+        // Scroll to the bottom via the key path, then it shows.
+        app.handle_file_key(vid, KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE));
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert!(
+            buffer_text(&term).contains("line number 80"),
+            "scrolled to end"
+        );
+
+        // `q` closes the view leaf; the tile collapses back to the shell.
+        app.handle_file_key(vid, KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(!app.views.contains_key(&vid), "view leaf closed");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Live refresh: editing a file on disk re-reads the open view (FILE-5).
+    #[test]
+    fn open_view_live_refreshes_on_disk_change() {
+        let _env = crate::persist::test_env("file-live-refresh");
+        let dir = std::env::temp_dir().join(format!("bohay-lr-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("live.txt");
+        std::fs::write(&file, b"before\n").unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.open_file_view(file.clone(), OpenTarget::Pane);
+        let vid = app.layout().focus;
+        // Block for the initial read so the channel is empty and deterministic.
+        let ev = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("initial read");
+        app.handle_event(ev);
+        assert_eq!(
+            app.views.get(&vid).map(|ViewKind::File(v)| v.line_count()),
+            Some(1),
+            "initial content is one line"
+        );
+
+        // Change the file with a strictly newer mtime, then tick.
+        std::fs::write(&file, b"after edit\nsecond line\n").unwrap();
+        filetime_set(&file, std::time::SystemTime::now());
+        app.ensure_file_views();
+        // A re-read was scheduled; apply it.
+        let ev = rx.recv_timeout(std::time::Duration::from_secs(3)).unwrap();
+        app.handle_event(ev);
+        if let Some(ViewKind::File(v)) = app.views.get(&vid) {
+            assert_eq!(v.line_count(), 2, "the view reloaded the edited file");
+        } else {
+            panic!("view gone");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Set a file's mtime, portable enough for the test (via a fresh write's
+    /// natural mtime is unreliable at sub-second resolution, so bump explicitly).
+    fn filetime_set(path: &std::path::Path, _when: std::time::SystemTime) {
+        // Touch by rewriting; most filesystems give it a newer mtime than the
+        // view's recorded one. If equal, sleep briefly and rewrite once more.
+        let cur = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+        let data = std::fs::read(path).unwrap();
+        std::fs::write(path, &data).unwrap();
+        if std::fs::metadata(path).and_then(|m| m.modified()).ok() == cur {
+            std::thread::sleep(std::time::Duration::from_millis(1100));
+            std::fs::write(path, &data).unwrap();
+        }
+    }
+
+    /// Opening a file that is already open focuses the existing view instead of
+    /// making a duplicate; `y` copies the whole file to the clipboard.
+    #[test]
+    fn reopening_focuses_existing_and_copy_yanks_content() {
+        let _env = crate::persist::test_env("file-dedup-copy");
+        let dir = std::env::temp_dir().join(format!("bohay-dc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("a.txt");
+        std::fs::write(&file, b"line one\nline two\n").unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+
+        app.open_file_view(file.clone(), OpenTarget::Tab);
+        let first = app.layout().focus;
+        // Drain the read so content is present.
+        let ev = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
+        app.handle_event(ev);
+        let tabs_before = app.workspaces[app.active_ws].tabs.len();
+        let views_before = app.views.len();
+
+        // Re-open the same file: no new tab, no new view, and it is focused.
+        app.open_file_view(file.clone(), OpenTarget::Tab);
+        assert_eq!(
+            app.workspaces[app.active_ws].tabs.len(),
+            tabs_before,
+            "no duplicate tab"
+        );
+        assert_eq!(app.views.len(), views_before, "no duplicate view");
+        assert_eq!(app.layout().focus, first, "the existing view is focused");
+
+        // `y` copies the whole file through the clipboard path.
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        app.handle_file_key(first, KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        assert_eq!(
+            app.pending_clipboard.as_deref(),
+            Some("line one\nline two"),
+            "the file content is queued to the clipboard"
+        );
+        assert!(app.toast.is_some(), "a copy toast is shown");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Dragging the mouse across a file view selects text and copies it on
+    /// release — the same drag-to-clipboard as a pane (docs/38).
+    #[test]
+    fn mouse_drag_selects_and_copies_file_text() {
+        use crate::event::AppEvent;
+        use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        let _env = crate::persist::test_env("file-drag-copy");
+        let dir = std::env::temp_dir().join(format!("bohay-md-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("s.txt");
+        std::fs::write(&file, b"hello world\nsecond line\n").unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.open_file_view(file.clone(), OpenTarget::Tab);
+        let vid = app.layout().focus;
+        let ev = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
+        app.handle_event(ev);
+
+        // Render so `pane_content_rects` (needed for hit-testing the drag) is set.
+        let mut term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == vid)
+            .map(|(_, r)| *r)
+            .expect("the view has a content rect");
+
+        // Drag across the first text line: text starts after the gutter.
+        let gutter = crate::files::gutter_width(2);
+        let x0 = content.x + gutter + 1; // first text column
+        let y = content.y; // first visible line
+        let down = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: x0,
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        };
+        let drag = MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: x0 + 4, // select "hello"
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        };
+        let up = MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: x0 + 4,
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_event(AppEvent::Mouse(down));
+        app.handle_event(AppEvent::Mouse(drag));
+        assert!(
+            app.selection.is_some(),
+            "a selection is built over the view"
+        );
+        app.handle_event(AppEvent::Mouse(up));
+
+        assert_eq!(
+            app.pending_clipboard.as_deref(),
+            Some("hello"),
+            "the dragged text was copied to the clipboard"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A file view opened in a tab survives a save/restore round trip.
+    #[test]
+    fn file_tab_survives_restore() {
+        let _env = crate::persist::test_env("file-tab-restore");
+        let dir = std::env::temp_dir().join(format!("bohay-fvr-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("keep.txt");
+        std::fs::write(&file, b"persisted body\n").unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.open_file_view(file.clone(), OpenTarget::Tab);
+        let snap = crate::persist::snapshot(&app);
+
+        let (tx2, _rx2) = std::sync::mpsc::channel();
+        let restored = App::from_snapshot(snap, tx2).expect("restore");
+        // Exactly one file view came back, pointing at the same path.
+        let paths: Vec<_> = restored
+            .views
+            .values()
+            .map(|ViewKind::File(v)| v.path.clone())
+            .collect();
+        assert_eq!(paths, vec![file], "the file view was rebuilt on restore");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+    #[test]
+    fn file_view_frees_content_on_close() {
+        let _env = crate::persist::test_env("file-mem-free");
+        let dir = std::env::temp_dir().join(format!("bohay-mem-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("big.txt");
+        let body: String = (0..50_000).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(&file, body).unwrap();
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_file_view(file.clone(), OpenTarget::Tab);
+        let vid = app.layout().focus;
+        if let Some(ViewKind::File(v)) = app.views.get_mut(&vid) {
+            v.apply(crate::files::read_file(&file));
+            assert_eq!(v.line_count(), 50_000, "content held while open");
+        }
+        // Closing drops the view entirely — no lingering content.
+        app.close_pane(vid);
+        assert!(
+            !app.views.contains_key(&vid),
+            "view (and its 50k lines) freed on close"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+    #[test]
+    fn set_line_dock_no_stale_tail_when_row_shortens() {
+        use ratatui::{backend::TestBackend, Terminal};
+        let _env = crate::persist::test_env("stale-tail");
+        let root = std::env::temp_dir().join(format!("bohay-st-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("VERYLONGFILENAME_abcdefghij.rs"), b"x").unwrap();
+        std::fs::write(root.join("z_short.rs"), b"x").unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(60, 20, tx).unwrap();
+        app.workspaces[app.active_ws].cwd = root.clone();
+        app.sidebars.left.docks.push(crate::app::DockKind::Files);
+        app.ensure_file_tree();
+        app.file_tree
+            .apply_dir(root.clone(), crate::files::read_dir_entries(&root));
+
+        // The SAME Terminal reused across frames — this is where stale cells bite.
+        let mut term = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        // Now hide the long file (show_hidden trick won't help; instead re-root to
+        // an empty dir so the long row is replaced by nothing at that position).
+        let empty = root.join("sub");
+        std::fs::create_dir_all(&empty).unwrap();
+        std::fs::write(empty.join("z.rs"), b"x").unwrap();
+        app.workspaces[app.active_ws].cwd = empty.clone();
+        app.file_tree.set_root(empty.clone());
+        app.file_tree
+            .apply_dir(empty.clone(), crate::files::read_dir_entries(&empty));
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+
+        let buf = term.backend().buffer();
+        let full: String = (0..buf.area.height)
+            .map(|r| {
+                (0..buf.area.width)
+                    .map(|c| buf.cell((c, r)).map(|x| x.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !full.contains("VERYLONGFILENAME"),
+            "stale tail from the previous longer row leaked:\n{full}"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+    /// Clicking a folder schedules its read immediately (not on the next 1 Hz
+    /// tick), so it loads without a visible lag.
+    #[test]
+    fn expanding_a_folder_loads_it_immediately() {
+        let _env = crate::persist::test_env("file-expand-now");
+        let root = std::env::temp_dir().join(format!("bohay-ex-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("sub/inner.rs"), b"x").unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.workspaces[app.active_ws].cwd = root.clone();
+        app.sidebars.left.docks.push(DockKind::Files);
+        app.ensure_file_tree();
+        // Apply the root read so `sub` is a visible row.
+        let ev = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
+        app.handle_event(ev);
+
+        // Click `sub` to expand it — WITHOUT calling ensure_file_tree again.
+        let idx = app
+            .file_tree
+            .visible_rows()
+            .iter()
+            .position(|r| r.name == "sub")
+            .expect("sub row");
+        app.file_row_activate(idx, OpenTarget::Tab);
+
+        // A read for `sub` must already be in flight — arrives without any tick.
+        let ev = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("expand scheduled a read immediately");
+        app.handle_event(ev);
+        assert!(
+            app.file_tree
+                .visible_rows()
+                .iter()
+                .any(|r| r.name == "inner.rs"),
+            "the folder's contents loaded right after the click"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -61,6 +61,18 @@ impl App {
                 self.apply_proc_scan(found);
                 false
             }
+            AppEvent::DirRead { path, entries } => {
+                self.file_tree.apply_dir(path, entries);
+                true
+            }
+            AppEvent::FileRead { id, load } => {
+                if let Some(crate::app::ViewKind::File(v)) = self.views.get_mut(&id) {
+                    v.apply(load);
+                    true
+                } else {
+                    false // the view leaf was closed before its read landed
+                }
+            }
             AppEvent::GitData { view, payload } => {
                 self.git_data(view, payload);
                 true
@@ -392,6 +404,10 @@ impl App {
                 self.agents_scroll = step(self.agents_scroll);
                 return;
             }
+            if hit(self.files_area) {
+                self.file_tree.scroll = step(self.file_tree.scroll);
+                return;
+            }
             // Wheel over a git tab scrolls its active view (docs/17).
             if self.active_is_git() && hit(self.last_pane_area) {
                 self.git_scroll(scroll);
@@ -400,6 +416,19 @@ impl App {
             // Wheel over the orchestration board scrolls its list (docs/22).
             if self.active_is_orch() && hit(self.orch_area) {
                 self.orch_scroll_by(scroll);
+                return;
+            }
+            // Wheel over a file view (docs/38) scrolls its content.
+            if let Some((id, rect)) = self
+                .pane_content_rects
+                .iter()
+                .find(|(id, rect)| self.views.contains_key(id) && hit(*rect))
+                .map(|(id, rect)| (*id, *rect))
+            {
+                let viewport = rect.height.saturating_sub(1) as usize;
+                if let Some(crate::app::ViewKind::File(v)) = self.views.get_mut(&id) {
+                    v.scroll_by(scroll, viewport);
+                }
                 return;
             }
             // Otherwise the wheel scrolls the pane under the cursor.
@@ -547,6 +576,19 @@ impl App {
         if let Some((i, _)) = self.session_rects.iter().find(|(_, rect)| hit(*rect)) {
             let i = *i;
             self.resume_session(i);
+            return;
+        }
+        // Clicking a FILES row expands/collapses a folder or opens a file (docs/38).
+        // A plain click opens the file in a full tab (the native default); Shift
+        // opens it in a pane split beside the focus.
+        if let Some((i, _)) = self.file_tree_rects.iter().find(|(_, rect)| hit(*rect)) {
+            let i = *i;
+            let target = if m.modifiers.contains(KeyModifiers::SHIFT) {
+                crate::app::files::OpenTarget::Pane
+            } else {
+                crate::app::files::OpenTarget::Tab
+            };
+            self.file_row_activate(i, target);
             return;
         }
         // Clicking a module dock row with an action invokes it (docs/29, DOCK-4).
@@ -830,6 +872,11 @@ impl App {
         if !sel.has_range() {
             return None;
         }
+        // A file-view leaf (docs/38) has no VT grid — pull the selected text from
+        // its rendered lines instead, so drag-to-copy works just like a pane.
+        if let Some(crate::app::ViewKind::File(v)) = self.views.get(&sel.pane) {
+            return crate::files::selection_text(v, sel.content, sel.ordered());
+        }
         let rows = self
             .panes
             .get(&sel.pane)?
@@ -1104,6 +1151,12 @@ impl App {
                 if is_prefix(&key) {
                     self.mode = Mode::Prefix;
                     return true; // entered prefix mode → the status bar updates
+                }
+                // A focused file view (docs/38 FILE-3) consumes keys itself
+                // (scroll / wrap / close) — they never reach a PTY.
+                let focus = self.layout().focus;
+                if self.views.contains_key(&focus) {
+                    return self.handle_file_key(focus, key);
                 }
                 // `Shift+↑` / `Shift+PageUp` enter keyboard scroll mode (no prefix,
                 // works on a stock Mac keyboard). From there plain keys navigate.

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -35,6 +35,7 @@ pub enum Cmd {
     ToggleSidebar,
     ToggleRightSidebar,
     ToggleAgents,
+    ToggleFiles,
     Detach,
 }
 
@@ -64,6 +65,7 @@ impl Cmd {
         Cmd::ToggleSidebar,
         Cmd::ToggleRightSidebar,
         Cmd::ToggleAgents,
+        Cmd::ToggleFiles,
         Cmd::Detach,
     ];
 
@@ -93,6 +95,7 @@ impl Cmd {
             Cmd::ToggleSidebar => "toggle_sidebar",
             Cmd::ToggleRightSidebar => "toggle_right_sidebar",
             Cmd::ToggleAgents => "toggle_agents",
+            Cmd::ToggleFiles => "toggle_files",
             Cmd::Detach => "detach",
         }
     }
@@ -125,6 +128,7 @@ impl Cmd {
             Cmd::ToggleSidebar => cat.cmd_toggle_sidebar,
             Cmd::ToggleRightSidebar => cat.cmd_toggle_right_sidebar,
             Cmd::ToggleAgents => cat.cmd_toggle_agents,
+            Cmd::ToggleFiles => cat.cmd_toggle_files,
             Cmd::Detach => cat.cmd_detach,
         }
     }
@@ -155,6 +159,7 @@ impl Cmd {
             Cmd::ToggleSidebar => "b",
             Cmd::ToggleRightSidebar => "B",
             Cmd::ToggleAgents => "a",
+            Cmd::ToggleFiles => "e",
             Cmd::Detach => "d",
         }
     }
@@ -279,6 +284,7 @@ impl App {
             Cmd::ToggleSidebar => self.toggle_side(crate::app::Side::Left),
             Cmd::ToggleRightSidebar => self.toggle_side(crate::app::Side::Right),
             Cmd::ToggleAgents => self.agents_active_only = !self.agents_active_only,
+            Cmd::ToggleFiles => self.toggle_files_dock(),
             Cmd::Detach => self.detach_requested = true,
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,6 +25,7 @@ use crate::ui::theme::{State, Theme};
 mod board;
 pub use board::agent_choices;
 mod dispatch;
+pub(crate) mod files;
 mod git;
 mod input;
 mod keys;
@@ -63,6 +64,8 @@ pub const SIDEBAR_WIDTH_MAX: u16 = 44;
 pub enum DockKind {
     Workspaces,
     Agents,
+    /// The native file tree of the active node (docs/38).
+    Files,
     Module(String),
 }
 
@@ -72,6 +75,7 @@ impl DockKind {
         match self {
             DockKind::Workspaces => "workspaces",
             DockKind::Agents => "agents",
+            DockKind::Files => "files",
             DockKind::Module(id) => id,
         }
     }
@@ -82,9 +86,17 @@ impl DockKind {
         match id {
             "workspaces" => DockKind::Workspaces,
             "agents" => DockKind::Agents,
+            "files" => DockKind::Files,
             other => DockKind::Module(other.to_string()),
         }
     }
+}
+
+/// A non-PTY leaf renderer (docs/38 FILE-3). The tile tree holds the leaf id;
+/// this holds what to draw there. Deliberately an enum so the diff viewer
+/// (docs/30) can add its own variant later without another seam.
+pub enum ViewKind {
+    File(crate::files::FileView),
 }
 
 /// Which sidebar a dock lives in (docs/29).
@@ -529,7 +541,7 @@ const RESIZE_GRAB_TOL: u16 = 2;
 
 impl Selection {
     /// (start, end) terminal cells in reading order (top-left → bottom-right).
-    fn ordered(&self) -> ((u16, u16), (u16, u16)) {
+    pub(crate) fn ordered(&self) -> ((u16, u16), (u16, u16)) {
         let key = |p: (u16, u16)| (p.1, p.0);
         if key(self.anchor) <= key(self.cursor) {
             (self.anchor, self.cursor)
@@ -707,6 +719,18 @@ pub struct App {
     pub agents_scroll: usize,
     pub workspaces_area: Rect,
     pub agents_area: Rect,
+    /// The FILES dock (docs/38): the tree model, its scroll region, and the
+    /// clickable rect per visible row (`(row index, rect)`), re-set each frame.
+    pub file_tree: crate::files::FileTree,
+    pub files_area: Rect,
+    pub file_tree_rects: Vec<(usize, Rect)>,
+    /// Native **view panes** (docs/38 FILE-3): a leaf id maps to a non-PTY
+    /// renderer here instead of a `Pane` in `panes`. Invariant: a leaf is in
+    /// `panes` **xor** `views`.
+    pub views: HashMap<PaneId, ViewKind>,
+    /// The reused single-click **preview** file pane, if one is open — clicking
+    /// another file replaces its content instead of spawning a second pane.
+    pub preview_view: Option<PaneId>,
     /// AGENTS list filter: `true` (default) shows only live (active) agents;
     /// `false` also shows the resumable session history.
     pub agents_active_only: bool,
@@ -891,6 +915,13 @@ impl App {
             agents_active_only: true,
             workspaces_area: Rect::ZERO,
             agents_area: Rect::ZERO,
+            // Rooted at nothing; the first detect tick re-roots it to the active
+            // node (set_root is a no-op when already correct).
+            file_tree: crate::files::FileTree::new(std::path::PathBuf::new()),
+            files_area: Rect::ZERO,
+            file_tree_rects: Vec::new(),
+            views: HashMap::new(),
+            preview_view: None,
             last_active_ws_shown: 0,
             hover: None,
             app_tx,
@@ -953,6 +984,7 @@ impl App {
         let mut panes = HashMap::new();
         let mut status = HashMap::new();
         let mut module_panes: HashMap<PaneId, crate::module::ModulePaneRecord> = HashMap::new();
+        let mut views: HashMap<PaneId, ViewKind> = HashMap::new();
         let mut workspaces = Vec::new();
         for ws in snap.workspaces {
             let mut tabs = Vec::new();
@@ -988,6 +1020,22 @@ impl App {
                 let mut remap = HashMap::new();
                 for (raw, ps) in &tab.panes {
                     let id = PaneId::alloc();
+                    // A file-view leaf (docs/38 FILE-3): rebuild the view and
+                    // re-read the file off-loop; no PTY is spawned.
+                    if let Some(path) = &ps.file {
+                        views.insert(
+                            id,
+                            ViewKind::File(crate::files::FileView::new(path.clone())),
+                        );
+                        let tx = app_tx.clone();
+                        let p = path.clone();
+                        std::thread::spawn(move || {
+                            let load = crate::files::read_file(&p);
+                            let _ = tx.send(crate::event::AppEvent::FileRead { id, load });
+                        });
+                        remap.insert(*raw, id);
+                        continue;
+                    }
                     // Resume the native agent session captured at save time (a
                     // precise hook report, or one discovered from the agent's
                     // on-disk store keyed by cwd — see `persist::snapshot`).
@@ -1186,6 +1234,13 @@ impl App {
             agents_active_only: true,
             workspaces_area: Rect::ZERO,
             agents_area: Rect::ZERO,
+            // Rooted at nothing; the first detect tick re-roots it to the active
+            // node (set_root is a no-op when already correct).
+            file_tree: crate::files::FileTree::new(std::path::PathBuf::new()),
+            files_area: Rect::ZERO,
+            file_tree_rects: Vec::new(),
+            views,
+            preview_view: None,
             last_active_ws_shown: 0,
             hover: None,
             app_tx,
@@ -1293,6 +1348,7 @@ impl App {
         match kind {
             DockKind::Workspaces => self.catalog.workspaces.to_string(),
             DockKind::Agents => self.catalog.agents.to_string(),
+            DockKind::Files => self.catalog.files.to_string(),
             DockKind::Module(id) => self.module_dock_title(id),
         }
     }
@@ -1317,7 +1373,7 @@ impl App {
     /// entry). Deduplicated, built-ins first. Its current side is
     /// `sidebars.side_of(kind)` (`None` = not placed yet).
     pub fn available_docks(&self) -> Vec<DockKind> {
-        let mut v = vec![DockKind::Workspaces, DockKind::Agents];
+        let mut v = vec![DockKind::Workspaces, DockKind::Agents, DockKind::Files];
         for m in self.modules.modules.iter().filter(|m| m.is_runnable()) {
             for d in &m.manifest.docks {
                 let k = DockKind::Module(d.id.clone());
@@ -2313,6 +2369,12 @@ impl App {
     fn close_pane(&mut self, id: PaneId) {
         self.panes.remove(&id);
         self.status.remove(&id);
+        // A view leaf (docs/38) has no PTY; drop its renderer and forget it as
+        // the reused preview pane.
+        self.views.remove(&id);
+        if self.preview_view == Some(id) {
+            self.preview_view = None;
+        }
         if self.scroll_pane == Some(id) {
             self.scroll_pane = None; // don't leave scroll mode pointing at a dead pane
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,7 @@ pub fn is_cli(args: &[String]) -> bool {
                 | "events"
                 | "module"
                 | "git"
+                | "files"
                 | "worktree"
                 | "task"
                 | "lease"
@@ -107,6 +108,10 @@ git:
   git branches               local branches with tracking
   git log [--limit N]        recent commits
   git open [<workspace>]     open the git tab for a workspace
+  files tree                 print the FILES tree of the active node
+  files open <path> [--target pane|tab|preview]   open a file in a view
+  files reveal <path>        expand the tree to a path
+  files refresh              re-read the tree from disk
 
 worktrees:
   worktree list              list the current repo's worktrees
@@ -917,6 +922,18 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             ("git.log".into(), Value::Object(obj))
         }
         ("git", "open") => ("git.open".into(), one("workspace", arg0())),
+        ("files", "open") => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("path".to_string(), json!(arg0().unwrap_or_default()));
+            if let Some(tg) = flag(args, "--target") {
+                obj.insert("target".to_string(), json!(tg));
+            }
+            ("files.open".into(), Value::Object(obj))
+        }
+        ("files", "tree") => ("files.tree".into(), json!({})),
+        ("files", "reveal") => ("files.reveal".into(), one("path", arg0())),
+        ("files", "refresh") => ("files.refresh".into(), json!({})),
+        ("files", _) => ("files.tree".into(), json!({})),
         ("git", _) => ("git.status".into(), json!({})),
 
         ("worktree", "create") => ("worktree.create".into(), one("branch", arg0())),

--- a/src/event.rs
+++ b/src/event.rs
@@ -39,6 +39,17 @@ pub enum AppEvent {
     /// thread — the scan walks agent session stores and must never block the
     /// event loop).
     SessionsScanned(Vec<crate::agent::SessionInfo>),
+    /// A FILES-dock directory read finished (docs/38): its sorted entries, run
+    /// on a worker thread so the tree never blocks a frame on `read_dir`.
+    DirRead {
+        path: std::path::PathBuf,
+        entries: Vec<crate::files::Entry>,
+    },
+    /// A file-view read finished (docs/38 FILE-3): applied to the view leaf `id`.
+    FileRead {
+        id: PaneId,
+        load: crate::files::FileLoad,
+    },
     /// The periodic process scan finished: command lines running under each
     /// pane's child pid, from one `ps`. `None` means the platform cannot tell
     /// (Windows) or `ps` failed — detection then falls back to text heuristics

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -1,0 +1,361 @@
+//! The file-tree model (docs/38 FILE-1): a lazy, flat-indexed view of a folder
+//! for the FILES sidebar dock.
+//!
+//! Two performance rules, both load-bearing:
+//!
+//! - **Only expanded directories are ever read.** Collapsing forgets nothing
+//!   (the listing stays cached); expanding a never-seen dir asks the app to
+//!   schedule an off-loop `read_dir`. A 100k-file repo costs what you expand.
+//! - **Rendering is O(visible rows).** [`FileTree::visible_rows`] flattens only
+//!   the *expanded* tree into a `Vec`, the same flat-index trick the git and
+//!   orch lists use — no recursion per frame beyond the open depth, no hidden
+//!   subtree cost.
+//!
+//! The model is pure: it never touches the filesystem itself. The app reads
+//! directories on a worker thread and feeds them back via [`FileTree::apply_dir`].
+
+mod view;
+pub use view::{gutter_width, read_file, selection_text, FileLoad, FileView, SIZE_CAP};
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// One entry in a directory listing. Directories sort before files; within each
+/// group, case-insensitive by name.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Entry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+/// A cached directory listing.
+#[derive(Clone, Default)]
+struct Dir {
+    entries: Vec<Entry>,
+    /// False until an `apply_dir` has filled it — distinguishes "empty dir" from
+    /// "not read yet", which drives lazy loading and the "loading…" affordance.
+    loaded: bool,
+}
+
+/// One row of the flattened, on-screen tree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VisibleRow {
+    pub path: PathBuf,
+    pub name: String,
+    pub depth: u16,
+    pub is_dir: bool,
+    /// A directory that is currently expanded (drives the `▾` vs `▸` chevron).
+    pub expanded: bool,
+    /// An expanded directory whose listing has not arrived yet.
+    pub loading: bool,
+}
+
+/// The FILES dock's state: which folder, which dirs are open, and the cursor.
+pub struct FileTree {
+    root: PathBuf,
+    dirs: HashMap<PathBuf, Dir>,
+    expanded: HashSet<PathBuf>,
+    /// Directories whose read has been scheduled but not yet applied — so the
+    /// app never schedules the same read twice.
+    pending: HashSet<PathBuf>,
+    /// Cursor + scroll into [`visible_rows`], clamped by the renderer.
+    pub cursor: usize,
+    pub scroll: usize,
+    /// Show entries beginning with `.` (a display filter; `.git` is always
+    /// hidden). Toggling it never re-reads — it only changes what is flattened.
+    pub show_hidden: bool,
+    /// Memoized flattened rows (perf): the renderer asks for these every frame,
+    /// but the tree only changes on expand/collapse/read/re-root. `dirty` marks
+    /// the cache stale; `cache_hidden` catches a `show_hidden` toggle. Rebuilt
+    /// lazily on the next `visible_rows`, so an unchanged tree costs zero
+    /// per-frame allocation.
+    cache: Vec<VisibleRow>,
+    dirty: bool,
+    cache_hidden: bool,
+}
+
+impl FileTree {
+    pub fn new(root: PathBuf) -> Self {
+        FileTree {
+            root,
+            dirs: HashMap::new(),
+            expanded: HashSet::new(),
+            pending: HashSet::new(),
+            cursor: 0,
+            scroll: 0,
+            show_hidden: false,
+            cache: Vec::new(),
+            dirty: true,
+            cache_hidden: false,
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Point the tree at a new folder (the active node changed). Keeps nothing
+    /// open and resets the cursor; the dir cache is harmless to keep but the
+    /// expanded set must reset or a stale path could show under the wrong root.
+    pub fn set_root(&mut self, root: PathBuf) {
+        if root == self.root {
+            return;
+        }
+        self.root = root;
+        self.expanded.clear();
+        self.pending.clear();
+        self.cursor = 0;
+        self.scroll = 0;
+        self.dirty = true;
+    }
+
+    /// Directories that should be on screen but have not been read yet: the root
+    /// plus every expanded dir, minus anything already loaded or in flight. The
+    /// caller schedules an off-loop read for each and calls [`mark_pending`].
+    pub fn needs_load(&self) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        let consider = |p: &Path, out: &mut Vec<PathBuf>| {
+            if !self.is_loaded(p) && !self.pending.contains(p) {
+                out.push(p.to_path_buf());
+            }
+        };
+        consider(&self.root, &mut out);
+        for p in &self.expanded {
+            consider(p, &mut out);
+        }
+        out
+    }
+
+    pub fn mark_pending(&mut self, path: PathBuf) {
+        self.pending.insert(path);
+    }
+
+    fn is_loaded(&self, path: &Path) -> bool {
+        self.dirs.get(path).is_some_and(|d| d.loaded)
+    }
+
+    /// Fold a finished directory read into the cache. `entries` is stored as
+    /// given, so the reader is responsible for the sort order (dirs first).
+    pub fn apply_dir(&mut self, path: PathBuf, entries: Vec<Entry>) {
+        self.pending.remove(&path);
+        self.dirty = true;
+        self.dirs.insert(
+            path,
+            Dir {
+                entries,
+                loaded: true,
+            },
+        );
+    }
+
+    /// Expand or collapse a directory. Collapsing also forgets its open
+    /// descendants, so re-expanding a parent doesn't restore a deep open state
+    /// the user can no longer see.
+    pub fn toggle(&mut self, path: &Path) {
+        self.dirty = true;
+        if self.expanded.contains(path) {
+            self.expanded.retain(|p| p != path && !p.starts_with(path));
+        } else {
+            self.expanded.insert(path.to_path_buf());
+        }
+    }
+
+    /// Expand every ancestor directory of `path` so it becomes visible (docs/38
+    /// `files.reveal`). The ancestors that are not yet read are picked up by the
+    /// next `needs_load` sweep.
+    pub fn reveal(&mut self, path: &Path) {
+        let mut cur = path.parent();
+        while let Some(dir) = cur {
+            if !dir.starts_with(&self.root) && dir != self.root {
+                break;
+            }
+            if dir != self.root {
+                self.expanded.insert(dir.to_path_buf());
+                self.dirty = true;
+            }
+            if dir == self.root {
+                break;
+            }
+            cur = dir.parent();
+        }
+    }
+
+    /// Forget every cached directory listing so the next sweep re-reads them —
+    /// the `files.refresh` action. Expanded state is kept.
+    pub fn invalidate(&mut self) {
+        self.dirs.clear();
+        self.pending.clear();
+        self.dirty = true;
+    }
+
+    /// The flattened, on-screen tree — only expanded directories are descended.
+    /// **Memoized**: the renderer calls this every frame, but it only rebuilds
+    /// when the tree actually changed (expand/collapse/read/re-root) or
+    /// `show_hidden` flipped. An unchanged tree returns the cached slice with no
+    /// walk and no allocation.
+    pub fn visible_rows(&mut self) -> &[VisibleRow] {
+        if self.dirty || self.cache_hidden != self.show_hidden {
+            self.cache = self.compute_rows();
+            self.dirty = false;
+            self.cache_hidden = self.show_hidden;
+        }
+        &self.cache
+    }
+
+    fn compute_rows(&self) -> Vec<VisibleRow> {
+        let mut out = Vec::new();
+        self.flatten(&self.root, 0, &mut out);
+        out
+    }
+
+    fn flatten(&self, dir: &Path, depth: u16, out: &mut Vec<VisibleRow>) {
+        let Some(d) = self.dirs.get(dir) else {
+            return;
+        };
+        for e in &d.entries {
+            if e.name == ".git" {
+                continue;
+            }
+            if !self.show_hidden && e.name.starts_with('.') {
+                continue;
+            }
+            let path = dir.join(&e.name);
+            let expanded = e.is_dir && self.expanded.contains(&path);
+            out.push(VisibleRow {
+                path: path.clone(),
+                name: e.name.clone(),
+                depth,
+                is_dir: e.is_dir,
+                expanded,
+                loading: expanded && !self.is_loaded(&path),
+            });
+            if expanded {
+                self.flatten(&path, depth + 1, out);
+            }
+        }
+    }
+}
+
+/// Read one directory into sorted [`Entry`]s: directories first, then files,
+/// each case-insensitive by name. Runs on a worker thread (never the loop). An
+/// unreadable directory yields an empty listing rather than an error, so a
+/// permission-denied folder is simply empty instead of breaking the tree.
+pub fn read_dir_entries(path: &Path) -> Vec<Entry> {
+    let mut entries: Vec<Entry> = match std::fs::read_dir(path) {
+        Ok(rd) => rd
+            .flatten()
+            .map(|de| {
+                let name = de.file_name().to_string_lossy().into_owned();
+                // `file_type` avoids a stat when the OS already knows; fall back
+                // to `is_dir` via metadata only if the type is unknown.
+                let is_dir = de
+                    .file_type()
+                    .map(|ft| ft.is_dir())
+                    .unwrap_or_else(|_| de.path().is_dir());
+                Entry { name, is_dir }
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    };
+    entries.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn e(name: &str, is_dir: bool) -> Entry {
+        Entry {
+            name: name.into(),
+            is_dir,
+        }
+    }
+
+    #[test]
+    fn only_expanded_dirs_are_flattened() {
+        let root = PathBuf::from("/r");
+        let mut t = FileTree::new(root.clone());
+        t.apply_dir(root.clone(), vec![e("src", true), e("README.md", false)]);
+
+        // Collapsed: src shows, its children do not.
+        let rows = t.visible_rows();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "src");
+        assert!(rows[0].is_dir && !rows[0].expanded);
+        assert_eq!(rows[1].name, "README.md");
+
+        // Expanding src asks for a load; until it arrives the row reads "loading".
+        t.toggle(&root.join("src"));
+        assert_eq!(t.needs_load(), vec![root.join("src")]);
+        let rows = t.visible_rows();
+        assert!(rows[0].expanded && rows[0].loading);
+
+        // Once the child listing arrives, its entries appear indented.
+        t.apply_dir(root.join("src"), vec![e("mod.rs", false)]);
+        let rows = t.visible_rows();
+        assert_eq!(rows.len(), 3);
+        assert_eq!((rows[1].name.as_str(), rows[1].depth), ("mod.rs", 1));
+        assert!(!rows[0].loading);
+    }
+
+    #[test]
+    fn collapsing_forgets_open_descendants() {
+        let root = PathBuf::from("/r");
+        let mut t = FileTree::new(root.clone());
+        t.apply_dir(root.clone(), vec![e("a", true)]);
+        t.apply_dir(root.join("a"), vec![e("b", true)]);
+        t.toggle(&root.join("a"));
+        t.toggle(&root.join("a/b"));
+        // a expanded -> shows a, then b (expanded).
+        assert_eq!(t.visible_rows().iter().filter(|r| r.expanded).count(), 2);
+
+        t.toggle(&root.join("a")); // collapse the parent
+        let rows = t.visible_rows();
+        assert_eq!(rows.len(), 1, "only a shows, collapsed");
+        assert!(!rows[0].expanded, "a is collapsed");
+        // Re-expanding a must not restore b's open state (it was forgotten).
+        t.toggle(&root.join("a"));
+        let b = t
+            .visible_rows()
+            .iter()
+            .find(|r| r.name == "b")
+            .cloned()
+            .unwrap();
+        assert!(!b.expanded, "descendant open state forgotten");
+    }
+
+    #[test]
+    fn hidden_filter_and_git_are_display_only() {
+        let root = PathBuf::from("/r");
+        let mut t = FileTree::new(root.clone());
+        t.apply_dir(
+            root.clone(),
+            vec![e(".git", true), e(".env", false), e("main.rs", false)],
+        );
+        // .git is always hidden; dotfiles hidden by default.
+        let names: Vec<_> = t.visible_rows().iter().map(|r| r.name.clone()).collect();
+        assert_eq!(names, vec!["main.rs"]);
+        // Toggling show_hidden reveals dotfiles without a re-read, but never .git.
+        t.show_hidden = true;
+        let names: Vec<_> = t.visible_rows().iter().map(|r| r.name.clone()).collect();
+        assert_eq!(names, vec![".env", "main.rs"]);
+    }
+
+    #[test]
+    fn set_root_resets_open_state_but_reader_sorts() {
+        let mut t = FileTree::new(PathBuf::from("/r"));
+        t.apply_dir(PathBuf::from("/r"), vec![e("x", true)]);
+        t.toggle(&PathBuf::from("/r/x"));
+        t.cursor = 5;
+        t.set_root(PathBuf::from("/other"));
+        assert_eq!(t.root(), Path::new("/other"));
+        // Nothing from the old root is expanded any more, and the cursor resets.
+        assert!(t.needs_load().contains(&PathBuf::from("/other")));
+        assert_eq!(t.cursor, 0);
+    }
+}

--- a/src/files/view.rs
+++ b/src/files/view.rs
@@ -1,0 +1,399 @@
+//! The file-view model (docs/38 FILE-3): one open file rendered natively inside
+//! a pane or a tab. Pure state; the bytes are read on a worker thread and folded
+//! in via [`FileView::apply`]. Rendering is O(visible rows) — the renderer slices
+//! `lines` to the viewport.
+
+use std::path::{Path, PathBuf};
+
+/// Files larger than this are not read into memory — a viewer is not an excuse
+/// to allocate hundreds of MB on a whim.
+pub const SIZE_CAP: u64 = 5 * 1024 * 1024;
+
+/// How many leading bytes decide "binary": a NUL in here means don't try to
+/// render it as text.
+const SNIFF: usize = 8192;
+
+/// The outcome of reading a file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FileLoad {
+    /// The read is in flight.
+    Loading,
+    /// Decoded text, one entry per line (tabs already expanded).
+    Text(Vec<String>),
+    /// Binary content (a NUL byte was found); carries the byte size.
+    Binary(u64),
+    /// Over [`SIZE_CAP`]; carries the byte size.
+    TooLarge(u64),
+    /// The read failed; carries a human-readable reason.
+    Error(String),
+}
+
+/// A live in-file search over the loaded text.
+#[derive(Clone, Debug, Default)]
+pub struct Search {
+    /// The query being typed / active (lowercased match is case-insensitive).
+    pub query: String,
+    /// True while the user is still typing the query (before Enter).
+    pub editing: bool,
+    /// `(line, start_col)` of every match, in document order.
+    pub matches: Vec<(usize, usize)>,
+    /// Index into `matches` of the current hit.
+    pub current: usize,
+}
+
+/// One open file: what it is, and where the viewport sits.
+pub struct FileView {
+    pub path: PathBuf,
+    pub load: FileLoad,
+    /// First visible line.
+    pub scroll: usize,
+    /// Horizontal scroll (columns), ignored when `wrap`.
+    pub hscroll: u16,
+    /// Soft-wrap long lines instead of clipping + horizontal scroll.
+    pub wrap: bool,
+    /// The file's mtime at the last read — drives live refresh (docs/38 FILE-5).
+    pub mtime: Option<std::time::SystemTime>,
+    /// In-file search state (docs/38 FILE-6), `None` when not searching.
+    pub search: Option<Search>,
+}
+
+impl FileView {
+    pub fn new(path: PathBuf) -> Self {
+        FileView {
+            path,
+            load: FileLoad::Loading,
+            scroll: 0,
+            hscroll: 0,
+            wrap: false,
+            mtime: None,
+            search: None,
+        }
+    }
+
+    /// Fold a finished read in. Scroll is **kept** (clamped to the new content),
+    /// so a live refresh (docs/38 FILE-5) doesn't yank the reader back to the
+    /// top; a fresh open already has scroll at 0. An active search is
+    /// re-evaluated against the new text.
+    pub fn apply(&mut self, load: FileLoad) {
+        self.load = load;
+        let max = self.line_count().saturating_sub(1);
+        self.scroll = self.scroll.min(max);
+        self.hscroll = 0;
+        if let Some(s) = self.search.take() {
+            if !s.query.is_empty() {
+                self.run_search(&s.query);
+            }
+        }
+    }
+
+    pub fn line_count(&self) -> usize {
+        match &self.load {
+            FileLoad::Text(lines) => lines.len(),
+            _ => 0,
+        }
+    }
+
+    /// Scroll vertically by `delta` lines, clamped so at least one line stays on
+    /// screen. `viewport` is the number of text rows currently visible.
+    pub fn scroll_by(&mut self, delta: i32, viewport: usize) {
+        let max = self.line_count().saturating_sub(1);
+        let next = (self.scroll as i32 + delta).clamp(0, max as i32) as usize;
+        self.scroll = next;
+        // Also clamp so the last page doesn't scroll into empty space.
+        let last_top = self.line_count().saturating_sub(viewport.max(1));
+        if self.scroll > last_top {
+            self.scroll = last_top;
+        }
+    }
+
+    pub fn goto_top(&mut self) {
+        self.scroll = 0;
+    }
+
+    pub fn goto_bottom(&mut self, viewport: usize) {
+        self.scroll = self.line_count().saturating_sub(viewport.max(1));
+    }
+
+    pub fn scroll_right(&mut self, delta: i16) {
+        if self.wrap {
+            return;
+        }
+        self.hscroll = (self.hscroll as i16 + delta).max(0) as u16;
+    }
+
+    // ── search (docs/38 FILE-6) ──────────────────────────────────────────────
+
+    /// Begin typing a query.
+    pub fn search_begin(&mut self) {
+        self.search = Some(Search {
+            editing: true,
+            ..Default::default()
+        });
+    }
+
+    /// A char typed into the active query.
+    pub fn search_push(&mut self, c: char) {
+        if let Some(s) = self.search.as_mut().filter(|s| s.editing) {
+            s.query.push(c);
+        }
+    }
+
+    /// Backspace in the active query.
+    pub fn search_backspace(&mut self) {
+        if let Some(s) = self.search.as_mut().filter(|s| s.editing) {
+            s.query.pop();
+        }
+    }
+
+    /// Commit the query: compute matches and jump to the first at/after the
+    /// current scroll position.
+    pub fn search_commit(&mut self) {
+        let Some(query) = self.search.as_ref().map(|s| s.query.clone()) else {
+            return;
+        };
+        if query.is_empty() {
+            self.search = None;
+            return;
+        }
+        self.run_search(&query);
+    }
+
+    /// Cancel search entirely.
+    pub fn search_cancel(&mut self) {
+        self.search = None;
+    }
+
+    /// Step to the next (`forward`) / previous match, wrapping, and scroll it
+    /// into view.
+    pub fn search_step(&mut self, forward: bool, viewport: usize) {
+        let (len, next) = match self.search.as_ref() {
+            Some(s) if !s.matches.is_empty() => {
+                let n = s.matches.len();
+                let cur = s.current;
+                (
+                    n,
+                    if forward {
+                        (cur + 1) % n
+                    } else {
+                        (cur + n - 1) % n
+                    },
+                )
+            }
+            _ => return,
+        };
+        if let Some(s) = self.search.as_mut() {
+            s.current = next;
+        }
+        let _ = len;
+        self.reveal_current_match(viewport);
+    }
+
+    fn run_search(&mut self, query: &str) {
+        let needle = query.to_lowercase();
+        let mut matches = Vec::new();
+        if let FileLoad::Text(lines) = &self.load {
+            for (li, line) in lines.iter().enumerate() {
+                let hay = line.to_lowercase();
+                let mut from = 0;
+                while let Some(rel) = hay[from..].find(&needle) {
+                    let col = from + rel;
+                    matches.push((li, col));
+                    from = col + needle.len().max(1);
+                }
+            }
+        }
+        // Jump to the first match at/after the current viewport top.
+        let current = matches
+            .iter()
+            .position(|(l, _)| *l >= self.scroll)
+            .unwrap_or(0);
+        self.search = Some(Search {
+            query: query.to_string(),
+            editing: false,
+            matches,
+            current,
+        });
+    }
+
+    fn reveal_current_match(&mut self, viewport: usize) {
+        if let Some(s) = &self.search {
+            if let Some((line, _)) = s.matches.get(s.current).copied() {
+                // Center-ish: keep the match on screen.
+                if line < self.scroll || line >= self.scroll + viewport.max(1) {
+                    self.scroll = line.saturating_sub(viewport / 2);
+                }
+            }
+        }
+    }
+}
+
+/// The line-number gutter width for a file of `line_count` lines. Shared by the
+/// renderer and mouse-selection extraction so their column math agrees.
+pub fn gutter_width(line_count: usize) -> u16 {
+    (line_count.max(1).to_string().len() as u16 + 1).max(4)
+}
+
+/// Extract the text under a mouse selection over a file view (docs/38), so
+/// drag-to-copy works like a pane. `content` is the view's content rect and
+/// `((sx,sy),(ex,ey))` the selection in reading order (terminal cells).
+///
+/// Maps each selected screen row to a file line (via `scroll`) and each column
+/// past the line-number gutter to a text column (via `hscroll`). Soft-wrap makes
+/// the row→line mapping non-linear, so a wrapped view copies whole lines in the
+/// row range rather than a precise sub-range.
+pub fn selection_text(
+    v: &FileView,
+    content: ratatui::layout::Rect,
+    ordered: ((u16, u16), (u16, u16)),
+) -> Option<String> {
+    let FileLoad::Text(lines) = &v.load else {
+        return None;
+    };
+    let ((sx, sy), (ex, ey)) = ordered;
+    let gutter = gutter_width(lines.len());
+    let text_x = content.x + gutter + 1;
+    let mut out = String::new();
+    for ty in sy..=ey {
+        let li = v.scroll + (ty.saturating_sub(content.y)) as usize;
+        let chars: Vec<char> = lines
+            .get(li)
+            .map(|l| l.chars().collect())
+            .unwrap_or_default();
+        // Column range in the file line. In wrap mode the on-screen column does
+        // not map to a text column, so take the whole line.
+        let (start, end) = if v.wrap {
+            (0, chars.len())
+        } else {
+            let to_col =
+                |screen_x: u16| (screen_x.saturating_sub(text_x)) as usize + v.hscroll as usize;
+            let s = if ty == sy { to_col(sx) } else { 0 };
+            let e = if ty == ey {
+                to_col(ex) + 1
+            } else {
+                chars.len()
+            };
+            (s.min(chars.len()), e.min(chars.len()))
+        };
+        let seg: String = if start < end {
+            chars[start..end].iter().collect()
+        } else {
+            String::new()
+        };
+        if ty != sy {
+            out.push('\n');
+        }
+        out.push_str(seg.trim_end());
+    }
+    let out = out.trim_end_matches('\n').to_string();
+    (!out.is_empty()).then_some(out)
+}
+
+/// Read `path` off the loop into a [`FileLoad`]. Never panics: a missing file,
+/// permission error, oversize file, or binary content each becomes a variant.
+pub fn read_file(path: &Path) -> FileLoad {
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) => return FileLoad::Error(e.to_string()),
+    };
+    if meta.len() > SIZE_CAP {
+        return FileLoad::TooLarge(meta.len());
+    }
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => return FileLoad::Error(e.to_string()),
+    };
+    if bytes.iter().take(SNIFF).any(|&b| b == 0) {
+        return FileLoad::Binary(meta.len());
+    }
+    // Lossy UTF-8, split on \n, strip a trailing \r, expand tabs to 4 columns so
+    // horizontal scroll and width math stay simple.
+    let text = String::from_utf8_lossy(&bytes);
+    let lines: Vec<String> = text
+        .split('\n')
+        .map(|l| l.strip_suffix('\r').unwrap_or(l).replace('\t', "    "))
+        .collect();
+    // A trailing newline yields a final empty element; drop it so the line count
+    // matches what an editor shows.
+    let lines = if lines.len() > 1 && lines.last().is_some_and(|l| l.is_empty()) {
+        lines[..lines.len() - 1].to_vec()
+    } else {
+        lines
+    };
+    FileLoad::Text(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_text_binary_and_oversize() {
+        let dir = std::env::temp_dir().join(format!("bohay-fv-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(dir.join("t.txt"), b"a\nb\tc\n").unwrap();
+        assert_eq!(
+            read_file(&dir.join("t.txt")),
+            FileLoad::Text(vec!["a".into(), "b    c".into()]),
+            "tabs expanded, trailing newline dropped"
+        );
+
+        std::fs::write(dir.join("b.bin"), [0u8, 1, 2, 3]).unwrap();
+        assert!(matches!(read_file(&dir.join("b.bin")), FileLoad::Binary(4)));
+
+        assert!(matches!(
+            read_file(&dir.join("missing")),
+            FileLoad::Error(_)
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scroll_clamps_to_content() {
+        let mut v = FileView::new(PathBuf::from("/x"));
+        v.apply(FileLoad::Text((0..10).map(|i| i.to_string()).collect()));
+        v.scroll_by(100, 4); // viewport 4 rows, 10 lines → last top is 6
+        assert_eq!(v.scroll, 6);
+        v.scroll_by(-100, 4);
+        assert_eq!(v.scroll, 0);
+    }
+
+    #[test]
+    fn search_finds_navigates_and_reveals() {
+        let mut v = FileView::new(PathBuf::from("/x"));
+        v.apply(FileLoad::Text(vec![
+            "let foo = 1;".into(),
+            "// nothing here".into(),
+            "foo(foo, FOO);".into(), // 3 hits (case-insensitive) on line 2
+        ]));
+        v.search_begin();
+        for c in "foo".chars() {
+            v.search_push(c);
+        }
+        v.search_commit();
+        let s = v.search.as_ref().unwrap();
+        // 1 on line 0, 3 on line 2 (foo, foo, FOO) = 4 total.
+        assert_eq!(s.matches.len(), 4);
+        assert_eq!(s.current, 0);
+
+        // Next wraps through all four; N goes back.
+        v.search_step(true, 2);
+        assert_eq!(v.search.as_ref().unwrap().current, 1);
+        v.search_step(false, 2);
+        assert_eq!(v.search.as_ref().unwrap().current, 0);
+
+        // Stepping to a match far down scrolls it into view.
+        v.goto_top();
+        v.search_step(true, 1); // current -> 1, which is on line 2
+        assert!(v.scroll >= 1, "the match line was revealed");
+
+        // A refreshed read re-evaluates the query against new text.
+        v.apply(FileLoad::Text(vec!["only foo".into()]));
+        assert_eq!(v.search.as_ref().unwrap().matches.len(), 1);
+
+        v.search_cancel();
+        assert!(v.search.is_none());
+    }
+}

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -15,6 +15,8 @@
 pub struct Catalog {
     // ── sidebar ──
     pub workspaces: &'static str,
+    /// FILES dock header (docs/38).
+    pub files: &'static str,
     pub agents: &'static str,
     pub no_active_agents: &'static str,
     pub no_agents_or_sessions: &'static str,
@@ -229,6 +231,7 @@ pub struct Catalog {
     pub cmd_toggle_sidebar: &'static str,
     pub cmd_toggle_right_sidebar: &'static str,
     pub cmd_toggle_agents: &'static str,
+    pub cmd_toggle_files: &'static str,
     pub cmd_detach: &'static str,
     pub menu_resume: &'static str,
     pub menu_split_vertical: &'static str,
@@ -250,6 +253,7 @@ pub struct Catalog {
 pub static EN: Catalog = Catalog {
     workspaces: "WORKSPACES",
     agents: "AGENTS",
+    files: "FILES",
     no_active_agents: "no active agents",
     no_agents_or_sessions: "no agents or sessions",
     all: "All",
@@ -450,6 +454,7 @@ pub static EN: Catalog = Catalog {
     cmd_toggle_sidebar: "Toggle sidebar",
     cmd_toggle_right_sidebar: "Toggle right sidebar",
     cmd_toggle_agents: "Agents: all / active",
+    cmd_toggle_files: "Files: show / hide",
     cmd_detach: "Detach (leave server running)",
     menu_resume: "Resume",
     menu_split_vertical: "Split vertical",
@@ -470,6 +475,7 @@ pub static EN: Catalog = Catalog {
 static ES: Catalog = Catalog {
     workspaces: "ESPACIOS",
     agents: "AGENTES",
+    files: "ARCHIVOS",
     no_active_agents: "sin agentes activos",
     no_agents_or_sessions: "sin agentes ni sesiones",
     all: "Todos",
@@ -670,6 +676,7 @@ static ES: Catalog = Catalog {
     cmd_toggle_sidebar: "Alternar barra lateral",
     cmd_toggle_right_sidebar: "Alternar barra derecha",
     cmd_toggle_agents: "Agentes: todos / activos",
+    cmd_toggle_files: "Archivos: mostrar / ocultar",
     cmd_detach: "Desacoplar (servidor sigue activo)",
     menu_resume: "Reanudar",
     menu_split_vertical: "Dividir vertical",
@@ -690,6 +697,7 @@ static ES: Catalog = Catalog {
 static PT: Catalog = Catalog {
     workspaces: "ESPAÇOS",
     agents: "AGENTES",
+    files: "ARQUIVOS",
     no_active_agents: "nenhum agente ativo",
     no_agents_or_sessions: "nenhum agente ou sessão",
     all: "Todos",
@@ -890,6 +898,7 @@ static PT: Catalog = Catalog {
     cmd_toggle_sidebar: "Alternar barra lateral",
     cmd_toggle_right_sidebar: "Alternar barra direita",
     cmd_toggle_agents: "Agentes: todos / ativos",
+    cmd_toggle_files: "Arquivos: mostrar / ocultar",
     cmd_detach: "Desacoplar (servidor continua)",
     menu_resume: "Retomar",
     menu_split_vertical: "Dividir vertical",
@@ -910,6 +919,7 @@ static PT: Catalog = Catalog {
 static FR: Catalog = Catalog {
     workspaces: "ESPACES",
     agents: "AGENTS",
+    files: "FICHIERS",
     no_active_agents: "aucun agent actif",
     no_agents_or_sessions: "aucun agent ni session",
     all: "Tous",
@@ -1110,6 +1120,7 @@ static FR: Catalog = Catalog {
     cmd_toggle_sidebar: "Basculer la barre latérale",
     cmd_toggle_right_sidebar: "Basculer la barre de droite",
     cmd_toggle_agents: "Agents : tous / actifs",
+    cmd_toggle_files: "Fichiers : afficher / masquer",
     cmd_detach: "Détacher (serveur actif)",
     menu_resume: "Reprendre",
     menu_split_vertical: "Diviser verticalement",
@@ -1130,6 +1141,7 @@ static FR: Catalog = Catalog {
 static DE: Catalog = Catalog {
     workspaces: "BEREICHE",
     agents: "AGENTEN",
+    files: "DATEIEN",
     no_active_agents: "keine aktiven Agenten",
     no_agents_or_sessions: "keine Agenten oder Sitzungen",
     all: "Alle",
@@ -1330,6 +1342,7 @@ static DE: Catalog = Catalog {
     cmd_toggle_sidebar: "Seitenleiste umschalten",
     cmd_toggle_right_sidebar: "Rechte Seitenleiste umschalten",
     cmd_toggle_agents: "Agenten: alle / aktiv",
+    cmd_toggle_files: "Dateien: ein / aus",
     cmd_detach: "Abkoppeln (Server läuft weiter)",
     menu_resume: "Fortsetzen",
     menu_split_vertical: "Vertikal teilen",
@@ -1350,6 +1363,7 @@ static DE: Catalog = Catalog {
 static ID: Catalog = Catalog {
     workspaces: "RUANG KERJA",
     agents: "AGEN",
+    files: "BERKAS",
     no_active_agents: "tidak ada agen aktif",
     no_agents_or_sessions: "tidak ada agen atau sesi",
     all: "Semua",
@@ -1550,6 +1564,7 @@ static ID: Catalog = Catalog {
     cmd_toggle_sidebar: "Alihkan bilah sisi",
     cmd_toggle_right_sidebar: "Alihkan bilah kanan",
     cmd_toggle_agents: "Agen: semua / aktif",
+    cmd_toggle_files: "Berkas: tampil / sembunyi",
     cmd_detach: "Lepas (server tetap jalan)",
     menu_resume: "Lanjutkan",
     menu_split_vertical: "Bagi vertikal",
@@ -1570,6 +1585,7 @@ static ID: Catalog = Catalog {
 static ZH: Catalog = Catalog {
     workspaces: "工作区",
     agents: "代理",
+    files: "文件",
     no_active_agents: "无活动代理",
     no_agents_or_sessions: "无代理或会话",
     all: "全部",
@@ -1770,6 +1786,7 @@ static ZH: Catalog = Catalog {
     cmd_toggle_sidebar: "切换侧栏",
     cmd_toggle_right_sidebar: "切换右侧栏",
     cmd_toggle_agents: "代理：全部 / 活动",
+    cmd_toggle_files: "文件：显示 / 隐藏",
     cmd_detach: "分离（服务器继续运行）",
     menu_resume: "恢复",
     menu_split_vertical: "垂直拆分",
@@ -1790,6 +1807,7 @@ static ZH: Catalog = Catalog {
 static JA: Catalog = Catalog {
     workspaces: "ワークスペース",
     agents: "エージェント",
+    files: "ファイル",
     no_active_agents: "アクティブなエージェントなし",
     no_agents_or_sessions: "エージェント・セッションなし",
     all: "すべて",
@@ -1990,6 +2008,7 @@ static JA: Catalog = Catalog {
     cmd_toggle_sidebar: "サイドバー切替",
     cmd_toggle_right_sidebar: "右サイドバー切替",
     cmd_toggle_agents: "エージェント: 全部 / アクティブ",
+    cmd_toggle_files: "ファイル：表示 / 非表示",
     cmd_detach: "デタッチ（サーバーは継続）",
     menu_resume: "再開",
     menu_split_vertical: "垂直分割",

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod config;
 mod detect;
 mod event;
+mod files;
 mod git;
 mod i18n;
 mod ids;
@@ -1192,6 +1193,9 @@ mod tests {
     /// row, and the leases section into the off-screen buffer without panicking.
     #[test]
     fn renders_orch_board() {
+        // Isolate $BOHAY_HOME: orch mutations call `orch.save()`, so without this
+        // parallel orch tests race on a shared `orch.json`.
+        let _env = crate::persist::test_env("renders-orch-board");
         let (tx, _rx) = mpsc::channel::<AppEvent>();
         let mut app = App::new(80, 24, tx).expect("spawn pane");
         app.orch
@@ -1229,6 +1233,7 @@ mod tests {
     /// state, the start-worker picker, and the task detail overlay.
     #[test]
     fn renders_board_live_state_picker_and_detail() {
+        let _env = crate::persist::test_env("renders-board-live");
         let (tx, _rx) = mpsc::channel::<AppEvent>();
         let mut app = App::new(80, 24, tx).expect("spawn pane");
         let pane = *app.panes.keys().next().unwrap();
@@ -1540,5 +1545,79 @@ span{{white-space:pre}}</style><pre>{body}</pre>"
             let v = 8 + 10 * (i - 232);
             (v, v, v)
         }
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_file_viewer_render() {
+        use ratatui::{backend::TestBackend, Terminal};
+        use std::time::Instant;
+        let dir = std::env::temp_dir().join("bohay-perf-fv");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src/app")).unwrap();
+        std::fs::create_dir_all(dir.join("src/ui")).unwrap();
+        for i in 0..40 {
+            std::fs::write(dir.join(format!("src/f{i}.rs")), b"x").unwrap();
+        }
+        for i in 0..20 {
+            std::fs::write(dir.join(format!("src/app/a{i}.rs")), b"x").unwrap();
+        }
+        let big: String = (1..=400)
+            .map(|i| format!("line {i} of a source file with some length to it\n"))
+            .collect();
+        let file = dir.join("code.rs");
+        std::fs::write(&file, big).unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(160, 50, tx).unwrap();
+        app.workspaces[app.active_ws].cwd = dir.clone();
+        app.sidebars.left.docks.push(crate::app::DockKind::Files);
+        app.ensure_file_tree();
+        app.file_tree
+            .apply_dir(dir.clone(), crate::files::read_dir_entries(&dir));
+        app.file_tree.toggle(&dir.join("src"));
+        app.file_tree.apply_dir(
+            dir.join("src"),
+            crate::files::read_dir_entries(&dir.join("src")),
+        );
+        app.file_tree.toggle(&dir.join("src/app"));
+        app.file_tree.apply_dir(
+            dir.join("src/app"),
+            crate::files::read_dir_entries(&dir.join("src/app")),
+        );
+        app.open_file_view(file.clone(), crate::app::files::OpenTarget::Pane);
+        let vid = app.layout().focus;
+        if let Some(crate::app::ViewKind::File(v)) = app.views.get_mut(&vid) {
+            v.apply(crate::files::read_file(&file));
+        }
+
+        let rows = app.file_tree.visible_rows().len();
+        let mut term = Terminal::new(TestBackend::new(160, 50)).unwrap();
+        // warmup
+        for _ in 0..20 {
+            term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        }
+        let n = 2000;
+        let t = Instant::now();
+        for _ in 0..n {
+            term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        }
+        let per = t.elapsed().as_nanos() as f64 / n as f64 / 1000.0;
+        println!(
+            "FVBENCH: {:.1}µs/frame  (files dock {} rows + 400-line view)",
+            per, rows
+        );
+
+        // isolate visible_rows() cost
+        let t = Instant::now();
+        for _ in 0..n {
+            let _ = app.file_tree.visible_rows();
+        }
+        let vr = t.elapsed().as_nanos() as f64 / n as f64 / 1000.0;
+        println!(
+            "FVBENCH: visible_rows() alone: {:.2}µs ({} rows, allocs a Vec+clones/call)",
+            vr, rows
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -59,6 +59,10 @@ pub struct PaneSnap {
     /// (module_id, entrypoint) for a module pane (MOD-2), re-spawned on restore.
     #[serde(default)]
     pub module: Option<(String, String)>,
+    /// A native file **view** leaf (docs/38 FILE-3): the file it shows. When set,
+    /// restore rebuilds the view (re-reads the file) instead of spawning a shell.
+    #[serde(default)]
+    pub file: Option<PathBuf>,
 }
 
 /// Serializes tests that mutate the global `$BOHAY_HOME` env + config files, so
@@ -257,6 +261,21 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
                 .leaves()
                 .into_iter()
                 .filter_map(|id| {
+                    // A file-view leaf (docs/38 FILE-3) is saved by its path and
+                    // rebuilt on restore; it has no PTY.
+                    if let Some(crate::app::ViewKind::File(v)) = app.views.get(&id) {
+                        return Some((
+                            id.0,
+                            PaneSnap {
+                                cwd: PathBuf::new(),
+                                command: String::new(),
+                                agent_session: None,
+                                screen: None,
+                                module: None,
+                                file: Some(v.path.clone()),
+                            },
+                        ));
+                    }
                     app.panes.get(&id).map(|p| {
                         let agent_session = app.status.get(&id).and_then(|s| {
                             // A hook-reported session is precise; otherwise
@@ -289,6 +308,7 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
                                 agent_session,
                                 screen,
                                 module,
+                                file: None,
                             },
                         )
                     })

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -1,0 +1,293 @@
+//! The FILES dock renderer (docs/38 FILE-1). Draws the flattened file tree; the
+//! model in `crate::files` owns the state, this only paints it and records the
+//! clickable rect per row. O(visible rows): it slices the flattened list to the
+//! viewport and draws that, nothing more.
+
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use crate::app::App;
+use crate::files::{FileLoad, FileView, SIZE_CAP};
+use crate::ui::theme::Theme;
+use crate::ui::RenderTarget;
+
+pub(super) fn draw_files_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) {
+    app.files_area = area;
+    app.file_tree_rects.clear();
+
+    let cx = area.x + 2;
+    let cw = area.width.saturating_sub(3);
+    // Write the row straight into the buffer with `set_line` (width + unicode
+    // handled) instead of a `Paragraph` widget per row — cheaper on the docks'
+    // hot path, which draw one styled line per row every frame.
+    let line_at = |f: &mut RenderTarget, y: u16, line: Line| {
+        if y < area.bottom() {
+            f.buffer_mut().set_line(cx, y, &line, cw);
+        }
+    };
+
+    // Header: "FILES · <node>". The root follows the active node (re-rooted off
+    // the loop in `ensure_file_tree`); show its basename, or a dash before the
+    // first read lands.
+    let name = app
+        .file_tree
+        .root()
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "—".into());
+    let title = format!("{} · {name}", app.catalog.files);
+    line_at(
+        f,
+        area.y,
+        Line::from(Span::styled(title, Style::new().fg(t.overlay1).bold())),
+    );
+
+    let list_top = area.y + 1;
+    let cap = area.height.saturating_sub(1) as usize;
+    // Clamp scroll first (mutates `file_tree`), *then* borrow the memoized rows —
+    // `visible_rows` returns a slice borrowing `file_tree`, so it must come after
+    // the scroll write.
+    let n = app.file_tree.visible_rows().len();
+    let max_scroll = n.saturating_sub(cap);
+    if app.file_tree.scroll > max_scroll {
+        app.file_tree.scroll = max_scroll;
+    }
+    let scroll = app.file_tree.scroll;
+    let hover = app.hover;
+
+    let rows = app.file_tree.visible_rows();
+    for (i, row) in rows.iter().enumerate().skip(scroll).take(cap) {
+        let y = list_top + (i - scroll) as u16;
+        let rect = Rect::new(area.x, y, area.width, 1);
+        let hovered = hover.is_some_and(|(hc, hr)| {
+            hc >= rect.x && hc < rect.right() && hr >= rect.y && hr < rect.bottom()
+        });
+
+        // Indentation, then a chevron for a dir / two spaces for a file so names
+        // line up under a chevron.
+        let indent = "  ".repeat(row.depth as usize);
+        let glyph = if row.is_dir {
+            if row.expanded {
+                "▾ "
+            } else {
+                "▸ "
+            }
+        } else {
+            "  "
+        };
+        let mut label = format!("{indent}{glyph}{}", row.name);
+        if row.loading {
+            label.push_str(" …");
+        }
+
+        let fg = if row.is_dir { t.subtext1 } else { t.subtext0 };
+        let mut style = Style::new().fg(fg);
+        if row.is_dir {
+            style = style.bold();
+        }
+        if hovered {
+            style = style.fg(t.accent);
+        }
+        line_at(f, y, Line::from(Span::styled(label, style)));
+        app.file_tree_rects.push((i, rect));
+    }
+}
+
+/// Draw a native file view (docs/38 FILE-3) into `area`, the pane's content
+/// rect. O(visible rows): only the on-screen slice of `lines` is rendered. The
+/// bottom row is a dim status footer.
+pub(super) fn draw_file_view(
+    f: &mut RenderTarget,
+    area: Rect,
+    v: &FileView,
+    sel: Option<&crate::app::Selection>,
+    t: &Theme,
+) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    let body = Rect::new(area.x, area.y, area.width, area.height.saturating_sub(1));
+    let footer_y = area.bottom().saturating_sub(1);
+
+    match &v.load {
+        FileLoad::Loading => center(f, body, "loading…", t.overlay0),
+        FileLoad::Binary(n) => center(f, body, &format!("binary file · {}", human(*n)), t.overlay1),
+        FileLoad::TooLarge(n) => center(
+            f,
+            body,
+            &format!(
+                "too large to preview · {} (cap {})",
+                human(*n),
+                human(SIZE_CAP)
+            ),
+            t.overlay1,
+        ),
+        FileLoad::Error(e) => center(f, body, &format!("cannot open: {e}"), t.coral),
+        FileLoad::Text(lines) => draw_text(f, body, v, lines, t),
+    }
+
+    // Mouse selection highlight (docs/38): overlay the selection background on
+    // the selected cells, after the text so it tints whatever is under it. A
+    // buffer post-pass keeps it independent of the text/search spans.
+    if let Some(sel) = sel {
+        let buf = f.buffer_mut();
+        for y in body.y..body.bottom() {
+            for x in body.x..body.right() {
+                if sel.contains(x, y) {
+                    if let Some(cell) = buf.cell_mut((x, y)) {
+                        cell.set_bg(t.sel_bg);
+                    }
+                }
+            }
+        }
+    }
+
+    // Footer: path · lines · encoding, or the state.
+    let name = v
+        .path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    // A search overrides the footer with the query + hit position.
+    let foot = if let Some(s) = &v.search {
+        if s.editing {
+            format!(" /{}", s.query)
+        } else if s.matches.is_empty() {
+            format!(" /{} · no matches", s.query)
+        } else {
+            format!(" /{} · {}/{}", s.query, s.current + 1, s.matches.len())
+        }
+    } else {
+        match &v.load {
+            FileLoad::Text(lines) => format!(" {name} · {} lines · UTF-8", lines.len()),
+            FileLoad::Binary(_) => format!(" {name} · binary"),
+            FileLoad::TooLarge(_) => format!(" {name} · too large"),
+            FileLoad::Loading => format!(" {name} · loading…"),
+            FileLoad::Error(_) => format!(" {name} · error"),
+        }
+    };
+    let wrap_hint = if v.wrap { " wrap " } else { "" };
+    let foot = clip(&foot, area.width.saturating_sub(wrap_hint.len() as u16));
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(foot, Style::new().fg(t.overlay0)))),
+        Rect::new(area.x, footer_y, area.width, 1),
+    );
+    if v.wrap {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                wrap_hint,
+                Style::new().fg(t.base).bg(t.overlay0),
+            ))),
+            Rect::new(area.right().saturating_sub(6), footer_y, 6, 1),
+        );
+    }
+}
+
+fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t: &Theme) {
+    let rows = body.height as usize;
+    // Shared with mouse-selection extraction so their columns agree.
+    let gutter = crate::files::gutter_width(lines.len());
+    let text_x = body.x + gutter + 1;
+    let text_w = body.width.saturating_sub(gutter + 1);
+
+    for (i, line) in lines.iter().enumerate().skip(v.scroll).take(rows) {
+        let y = body.y + (i - v.scroll) as u16;
+        // Line-number gutter.
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!("{:>w$} ", i + 1, w = gutter as usize),
+                Style::new().fg(t.overlay0),
+            ))),
+            Rect::new(body.x, y, gutter + 1, 1),
+        );
+        if text_w == 0 {
+            continue;
+        }
+        if v.wrap {
+            f.render_widget(
+                Paragraph::new(line.clone())
+                    .wrap(ratatui::widgets::Wrap { trim: false })
+                    .style(Style::new().fg(t.text)),
+                Rect::new(text_x, y, text_w, 1),
+            );
+        } else {
+            let line_ui = search_line(v, i, line, t);
+            f.render_widget(
+                Paragraph::new(line_ui).scroll((0, v.hscroll)),
+                Rect::new(text_x, y, text_w, 1),
+            );
+        }
+    }
+}
+
+fn center(f: &mut RenderTarget, area: Rect, msg: &str, fg: ratatui::style::Color) {
+    if area.height == 0 {
+        return;
+    }
+    let y = area.y + area.height / 2;
+    let msg = clip(msg, area.width);
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(msg, Style::new().fg(fg))))
+            .alignment(ratatui::layout::Alignment::Center),
+        Rect::new(area.x, y, area.width, 1),
+    );
+}
+
+/// Clip a string to `w` display columns (char count; ASCII-dominated source).
+fn clip(s: &str, w: u16) -> String {
+    s.chars().take(w as usize).collect()
+}
+
+fn human(n: u64) -> String {
+    if n >= 1 << 20 {
+        format!("{:.1} MB", n as f64 / (1 << 20) as f64)
+    } else if n >= 1 << 10 {
+        format!("{:.1} KB", n as f64 / (1 << 10) as f64)
+    } else {
+        format!("{n} B")
+    }
+}
+
+/// Build a line's spans, highlighting any search matches on it (the current
+/// match brighter). No match → one plain span.
+fn search_line<'a>(v: &FileView, line_idx: usize, line: &'a str, t: &Theme) -> Line<'a> {
+    let Some(s) = &v.search else {
+        return Line::from(Span::styled(line, Style::new().fg(t.text)));
+    };
+    let hits: Vec<(usize, usize)> = s
+        .matches
+        .iter()
+        .enumerate()
+        .filter(|(_, (l, _))| *l == line_idx)
+        .map(|(i, (_, c))| (i, *c))
+        .collect();
+    if hits.is_empty() || s.query.is_empty() {
+        return Line::from(Span::styled(line, Style::new().fg(t.text)));
+    }
+    let qlen = s.query.chars().count();
+    let mut spans: Vec<Span> = Vec::new();
+    let mut cursor = 0usize; // char index
+    let chars: Vec<char> = line.chars().collect();
+    for (mi, col) in hits {
+        if col > cursor {
+            let seg: String = chars[cursor..col.min(chars.len())].iter().collect();
+            spans.push(Span::styled(seg, Style::new().fg(t.text)));
+        }
+        let end = (col + qlen).min(chars.len());
+        let seg: String = chars[col..end].iter().collect();
+        let hl = if mi == s.current {
+            Style::new().fg(t.base).bg(t.accent).bold()
+        } else {
+            Style::new().fg(t.base).bg(t.amber)
+        };
+        spans.push(Span::styled(seg, hl));
+        cursor = end;
+    }
+    if cursor < chars.len() {
+        let seg: String = chars[cursor..].iter().collect();
+        spans.push(Span::styled(seg, Style::new().fg(t.text)));
+    }
+    Line::from(spans)
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -55,6 +55,7 @@ impl<'a> RenderTarget<'a> {
 mod board;
 mod borders;
 mod cmdinfo;
+mod files;
 mod git;
 mod help;
 mod menu;

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -17,6 +17,46 @@ pub(super) fn draw_pane_titles(
         if rect.width < 8 || rect.height < 2 {
             continue;
         }
+        // A view leaf's title is its file path + a state dot placeholder.
+        if let Some(crate::app::ViewKind::File(v)) = app.views.get(id) {
+            let focused = *id == focus;
+            let bg = t.mantle;
+            let inner_w = rect.width - 2;
+            let close_w: u16 = if focused { 3 } else { 0 };
+            let title_w = inner_w.saturating_sub(close_w);
+            let name = v
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let path_fg = if focused { t.accent } else { t.subtext0 };
+            // A plain small-square glyph (no emoji), neutral marker.
+            let dot = Span::styled(" ■ ", Style::new().fg(t.overlay1).bg(bg));
+            let label: String = name
+                .chars()
+                .take(title_w.saturating_sub(3) as usize)
+                .collect();
+            let text_w = (3 + label.chars().count() as u16).min(title_w);
+            let title_rect = Rect::new(rect.x + 1, rect.y, text_w, 1);
+            f.render_widget(
+                Paragraph::new(Line::from(vec![
+                    dot,
+                    Span::styled(label, Style::new().fg(path_fg).bg(bg)),
+                ])),
+                title_rect,
+            );
+            title_rects.push((*id, title_rect));
+            if focused {
+                f.render_widget(
+                    Paragraph::new(Span::styled(
+                        " × ",
+                        Style::new().fg(t.subtext1).bg(bg).bold(),
+                    )),
+                    Rect::new(rect.x + 1 + title_w, rect.y, close_w, 1),
+                );
+            }
+            continue;
+        }
         let Some(pane) = app.panes.get(id) else {
             continue;
         };
@@ -84,6 +124,13 @@ fn draw_one_pane(
     app: &App,
     t: &Theme,
 ) -> Option<(u16, u16)> {
+    // A view leaf (docs/38 FILE-3) renders natively, not from a PTY.
+    if let Some(crate::app::ViewKind::File(v)) = app.views.get(&id) {
+        let content = pane_content(area, bordered)?;
+        let sel = app.selection.filter(|s| s.pane == id);
+        super::files::draw_file_view(f, content, v, sel.as_ref(), t);
+        return None; // views own no terminal cursor
+    }
     let pane = app.panes.get(&id)?;
     let st = pane_state(app, id);
     let content = pane_content(area, bordered)?;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -187,6 +187,7 @@ pub(super) fn draw_sidebar(
                 agent_rects = a;
                 session_rects = s;
             }
+            DockKind::Files => super::files::draw_files_dock(f, slot, app, t),
             DockKind::Module(id) => draw_module_dock(f, slot, id, app, t),
         }
     }
@@ -207,7 +208,7 @@ fn draw_left_chrome(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
     let cw = area.width.saturating_sub(3);
     let line_at = |f: &mut RenderTarget, y: u16, line: Line| {
         if y < area.bottom() {
-            f.render_widget(Paragraph::new(line), Rect::new(cx, y, cw, 1));
+            f.buffer_mut().set_line(cx, y, &line, cw);
         }
     };
 
@@ -316,7 +317,7 @@ fn draw_workspaces_dock(
     let bar_col = area.right().saturating_sub(2);
     let line_at = |f: &mut RenderTarget, y: u16, line: Line| {
         if y < area.bottom() {
-            f.render_widget(Paragraph::new(line), Rect::new(cx, y, cw, 1));
+            f.buffer_mut().set_line(cx, y, &line, cw);
         }
     };
     let mut ws_rects = Vec::new();
@@ -440,7 +441,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
     let bar_col = area.right().saturating_sub(2);
     let line_at = |f: &mut RenderTarget, y: u16, line: Line| {
         if y < area.bottom() {
-            f.render_widget(Paragraph::new(line), Rect::new(cx, y, cw, 1));
+            f.buffer_mut().set_line(cx, y, &line, cw);
         }
     };
     let mut agent_rects = Vec::new();
@@ -634,7 +635,7 @@ fn draw_module_dock(f: &mut RenderTarget, area: Rect, id: &str, app: &mut App, t
     let cw = area.width.saturating_sub(3);
     let line_at = |f: &mut RenderTarget, y: u16, line: Line| {
         if y < area.bottom() {
-            f.render_widget(Paragraph::new(line), Rect::new(cx, y, cw, 1));
+            f.buffer_mut().set_line(cx, y, &line, cw);
         }
     };
     let (title, rows) = match app.module_docks.get(id) {

--- a/src/ui/tabbar.rs
+++ b/src/ui/tabbar.rs
@@ -114,16 +114,27 @@ pub(super) fn draw_tabbar(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
         // A user-named pane tab (docs/28) shows its name; git/orch tabs are never
         // named, so they keep their fixed label.
         let name = ws.tabs.get(i).and_then(|tb| tb.name.as_deref());
+        // A tab that is a single file-view leaf (docs/38) is labeled `■ name`.
+        let file_name = ws.tabs.get(i).and_then(|tb| file_tab_name(tb, app));
         let title = |w: usize| {
+            let fit = |s: &str, w: usize| -> String {
+                if s.chars().count() > w {
+                    s.chars().take(w.saturating_sub(1)).chain(['…']).collect()
+                } else {
+                    s.to_string()
+                }
+            };
             if let Some(nm) = name {
                 // Truncate with an ellipsis to fit the cell, then center it (like
                 // the number) so the name has even padding instead of hugging the
                 // left edge.
-                let label: String = if nm.chars().count() > w {
-                    nm.chars().take(w.saturating_sub(1)).chain(['…']).collect()
-                } else {
-                    nm.to_string()
-                };
+                let label = fit(nm, w);
+                format!("{label:^w$}")
+            } else if let Some(fl) = &file_name {
+                // Cap to `w-2` so centering always leaves at least one space on
+                // each side — the `■` glyph never touches the tab's edge, the
+                // way the short git/orch labels never do.
+                let label = fit(fl, w.saturating_sub(2));
                 format!("{label:^w$}")
             } else if is_git {
                 format!("{:^w$}", "⎇ git", w = w)
@@ -187,4 +198,17 @@ pub(super) fn draw_tabbar(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
         tab_rects.push((n, rect));
     }
     (tab_rects, close_rects, prev_rect, next_rect)
+}
+
+/// If `tab` is a single file-view leaf (docs/38), its `■ name` label (a plain
+/// square glyph, no emoji).
+fn file_tab_name(tab: &crate::app::Tab, app: &App) -> Option<String> {
+    let leaves = tab.layout.leaves();
+    if leaves.len() == 1 {
+        if let Some(crate::app::ViewKind::File(v)) = app.views.get(&leaves[0]) {
+            let name = v.path.file_name()?.to_string_lossy().into_owned();
+            return Some(format!("■ {name}"));
+        }
+    }
+    None
 }

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -83,6 +83,10 @@ git:
   git branches               local branches with tracking
   git log [--limit N]        recent commits
   git open [<workspace>]     open the git tab for a workspace
+  files tree                 print the FILES tree of the active node
+  files open <path> [--target pane|tab|preview]   open a file in a view
+  files reveal <path>        expand the tree to a path
+  files refresh              re-read the tree from disk
 
 worktrees:
   worktree list              list the current repo's worktrees


### PR DESCRIPTION
## What

A native file viewer built into bohay, so you can browse a project and read files without leaving the multiplexer or shelling out to a pager.

- **FILES dock** (sidebar): a lazy, collapsible tree of the active node. Off by default; enable with `Ctrl+Space e` or in Settings then Layout. Only expanded folders are read, off the loop, so a big repo or a slow mount never blocks a frame. Expanding a folder loads instantly.
- **Open a file**: click for a full tab, `Shift+click` for a pane beside your agent. Re-opening a file focuses the existing view instead of duplicating it.
- **The view**: native renderer (not a pager) with line numbers, scroll, soft-wrap, a 5 MB cap, and binary / too-large detection. It live-refreshes when an agent edits the file underneath you.
- **Search**: `/` to query, `n` / `N` to step matches, highlighted hits.
- **Copy**: works exactly like a pane. Drag to select and release, or `y` / `c` for the whole file. Goes through the native clipboard, OSC 52, and a toast.
- **Persistence**: a file tab survives a restart.
- **API / CLI**: `files.open` / `files.tree` / `files.reveal` / `files.refresh` and `bohay files ...`, guard-tested against the CLI reference. Fully localized.

## How it works

The load-bearing new primitive is a **view pane**: `App.views` with a `ViewKind::File` variant lets a tile-tree leaf render from a native renderer instead of a PTY, with the invariant that a leaf is in `panes` xor `views`. This is shared foundation for the planned diff viewer. File tabs and file panes both render through the normal pane path, so there is no separate tab kind.

## Performance

- The dock memoizes its flattened rows, so an unchanged tree costs no per-frame walk or allocation.
- Every dock now draws rows with `Buffer::set_line` instead of a `Paragraph` per row (safe because bohay resets the render buffer each frame). Files-dock frame 246 to 228 microseconds, standard chrome 86.5 to 84.6.
- Directory reads fire on the click, not on a background tick.

## Testing

- `cargo fmt`, `cargo clippy --all-targets`, and the full suite are green (244 tests, plus new coverage for the tree, view render/scroll/close, search, live refresh, drag-copy, dedup-on-open, restore, and a no-stale-tail render guard).
- Bench: `cargo test --release bench_file_viewer_render -- --ignored --nocapture`.

## Not included (follow-ups, tracked)

- Syntax coloring (wants a real highlighter, weighed against the single static binary goal).
- Git-status tint and per-type glyphs in the tree.
- `.gitignore` filtering (`.git/` and dotfiles are hidden by default today).
