### PR TITLE
fix(nodes): stop opening the wrong folder on launch and on session end

### DIFF
--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -96,19 +96,19 @@ impl App {
             let live = self
                 .panes
                 .iter()
-                .find(|(_, p)| p.cwd == path)
+                .find(|(_, p)| crate::platform::same_path(&p.cwd, &path))
                 .map(|(&pid, _)| pid);
             match live {
                 Some(pid) => self.focus_pane_global(pid),
-                None => {
-                    self.create_workspace_at(path.clone());
-                    if self.ws().cwd != path {
-                        return Err((
-                            "spawn_failed".to_string(),
-                            "the worker pane didn't start".to_string(),
-                        ));
-                    }
+                // `create_workspace_at` now reports this directly, so the old
+                // "did the active node's cwd change?" probe is gone.
+                None if !self.create_workspace_at(path.clone()) => {
+                    return Err((
+                        "spawn_failed".to_string(),
+                        "the worker pane didn't start".to_string(),
+                    ));
                 }
+                None => {}
             }
             path
         } else {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -18,6 +18,14 @@ impl App {
     /// Returns whether anything the sidebar shows changed, so the loop repaints a
     /// silent agent's Working→Done transition even when no other event fires.
     pub fn detect_tick(&mut self, now: Instant) -> bool {
+        // No node open (docs/43 §3.3 — the session was closed). Closing the last
+        // node also closed every pane, so there is nothing to classify, and
+        // `layout()` below would index an empty `workspaces`. The server keeps
+        // ticking here with no clients attached, so this is a live path, not a
+        // theoretical one.
+        if self.workspaces.is_empty() {
+            return false;
+        }
         // Refresh working directories ~once a second so spaces follow the user.
         // The file-viewer upkeep rides the same 1s cadence — sub-second freshness
         // buys nothing (a node switch or an on-disk edit showing within a second
@@ -251,9 +259,26 @@ impl App {
     // ── api dispatch ──────────────────────────────────────────────────────────
 
     pub fn handle_api(&mut self, req: &ApiRequest) -> String {
-        // No active session (the last workspace was closed and the app is quitting) —
-        // most methods reach `layout()`, which would index an empty `workspaces`.
-        if self.workspaces.is_empty() {
+        // No node open: most methods reach `layout()`, which would index an empty
+        // `workspaces`. This was written when an empty session only ever existed
+        // for the moment before the app quit; since docs/43 §3.3 a server *stays*
+        // empty after its last node closes, so the methods that open one — the
+        // only way back — must get through, or the server is a brick that only
+        // `server stop` can clear.
+        // Only methods that are safe with no node: they either take an explicit
+        // path or touch no node at all. Notably absent is `workspace.new`, which
+        // derives its folder from the focused pane and would fall back to the
+        // *server's* cwd — the very thing §3.3 removed.
+        const WITHOUT_NODE: &[&str] = &[
+            "ping",
+            "server.stop",
+            "workspace.open",
+            "node.open",
+            "workspace.list",
+            "node.list",
+            "worktree.open",
+        ];
+        if self.workspaces.is_empty() && !WITHOUT_NODE.contains(&req.method.as_str()) {
             return json!({ "id": req.id, "error": { "code": "no_session", "message": "no active session" } }).to_string();
         }
         match self.dispatch(&req.method, &req.params) {
@@ -416,9 +441,25 @@ impl App {
                 // when `bohay` attaches to a running server from a new folder, so the
                 // launch directory shows up as a workspace.
                 let path = PathBuf::from(req_str(p, "path")?);
-                match self.workspaces.iter().position(|w| w.cwd == path) {
+                match self
+                    .workspaces
+                    .iter()
+                    .position(|w| crate::platform::same_path(&w.cwd, &path))
+                {
                     Some(i) => self.active_ws = i,
-                    None => self.create_workspace_at(path),
+                    // Report a failed open instead of answering with the
+                    // *previously* active node, which read as success and left
+                    // the caller (and the user) looking at the wrong folder.
+                    None if !self.create_workspace_at(path.clone()) => {
+                        return Err((
+                            "spawn_failed".to_string(),
+                            format!(
+                                "couldn't open {} — the shell failed to start there",
+                                path.display()
+                            ),
+                        ));
+                    }
+                    None => {}
                 }
                 Ok(json!({"type":"workspace","workspace": self.active_ws.to_string()}))
             }
@@ -1000,7 +1041,15 @@ impl App {
             }
             "worktree.open" => {
                 let path = param_path(p)?;
-                self.create_workspace_at(path);
+                if !self.create_workspace_at(path.clone()) {
+                    return Err((
+                        "spawn_failed".to_string(),
+                        format!(
+                            "couldn't open {} — the shell failed to start there",
+                            path.display()
+                        ),
+                    ));
+                }
                 Ok(json!({"type":"ok"}))
             }
             "worktree.remove" => {
@@ -1020,7 +1069,11 @@ impl App {
                     }
                 }
                 // Close the workspace opened at this worktree, if any.
-                if let Some(i) = self.workspaces.iter().position(|w| w.cwd == path) {
+                if let Some(i) = self
+                    .workspaces
+                    .iter()
+                    .position(|w| crate::platform::same_path(&w.cwd, &path))
+                {
                     self.close_workspace(i);
                 }
                 Ok(json!({"type":"ok"}))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -825,6 +825,11 @@ pub struct App {
     pub last_cursor: Option<(u16, u16)>,
     /// Foreground client asked to detach (prefix+q). Distinct from quit.
     pub detach_requested: bool,
+    /// The last node was closed, ending the session (docs/43 §3.3). *Every*
+    /// client detaches, so the window closes, while the server stays up with no
+    /// nodes — distinct from `detach_requested` (one client leaves, session
+    /// continues) and from `should_quit` (the server itself exits).
+    pub end_session: bool,
     /// Force the next frame to be a **full** repaint (not a diff), so a terminal
     /// whose screen was damaged outside bohay's knowledge — a window move/resize,
     /// regaining focus, another program's output — repaints cleanly. The render
@@ -1101,6 +1106,7 @@ impl App {
             orch_area: Rect::ZERO,
             last_cursor: None,
             detach_requested: false,
+            end_session: false,
             force_redraw: false,
             pending_notify: Vec::new(),
             pending_sound: false,
@@ -1455,6 +1461,7 @@ impl App {
             orch_area: Rect::ZERO,
             last_cursor: None,
             detach_requested: false,
+            end_session: false,
             force_redraw: false,
             pending_notify: Vec::new(),
             pending_sound: false,
@@ -1936,26 +1943,36 @@ impl App {
 
     /// Open `cwd` as a new **static** workspace (a workspace) and focus it. The folder
     /// is fixed — its name/cwd won't change as the pane's process `cd`s around.
-    pub fn create_workspace_at(&mut self, cwd: PathBuf) {
+    ///
+    /// Returns whether the node was opened. Opening fails when the shell can't
+    /// spawn there (a folder that vanished, no permission, a bad `config.shell`).
+    /// That used to be swallowed: the caller carried on, `active_ws` still
+    /// pointed at whatever was focused before, and the user saw the *previous*
+    /// folder with no error anywhere — indistinguishable from bohay ignoring
+    /// them. A toast is raised here so every caller reports it the same way.
+    pub fn create_workspace_at(&mut self, cwd: PathBuf) -> bool {
         let name = ws_name(&cwd);
         let branch = git_branch(&cwd);
-        if let Some(id) = self.spawn_into(cwd.clone()) {
-            self.workspaces.push(Workspace {
-                name,
-                worktree: worktree_membership(&cwd),
-                cwd,
-                branch,
-                git_ahead_behind: None,
-                tabs: vec![Tab::panes(TileLayout::new(id))],
-                active_tab: 0,
-            });
-            self.active_ws = self.workspaces.len() - 1;
-            let ws = self.active_ws;
-            self.emit_event(
-                "workspace.created",
-                serde_json::json!({"workspace": ws.to_string()}),
-            );
-        }
+        let Some(id) = self.spawn_into(cwd.clone()) else {
+            self.show_toast(format!("couldn't open {} — shell failed to start", name));
+            return false;
+        };
+        self.workspaces.push(Workspace {
+            name,
+            worktree: worktree_membership(&cwd),
+            cwd,
+            branch,
+            git_ahead_behind: None,
+            tabs: vec![Tab::panes(TileLayout::new(id))],
+            active_tab: 0,
+        });
+        self.active_ws = self.workspaces.len() - 1;
+        let ws = self.active_ws;
+        self.emit_event(
+            "workspace.created",
+            serde_json::json!({"workspace": ws.to_string()}),
+        );
+        true
     }
 
     /// The order the WORKSPACES sidebar draws nodes in: each linked worktree is
@@ -2740,7 +2757,9 @@ impl App {
         // Per the Layout setting, reuse the session's own workspace (or the workspace at
         // its cwd); otherwise open it as a tab in the currently active workspace.
         let target = if self.config.layout.resume_in_new_workspace {
-            self.workspaces.iter().position(|w| w.cwd == s.cwd)
+            self.workspaces
+                .iter()
+                .position(|w| crate::platform::same_path(&w.cwd, &s.cwd))
         } else {
             Some(self.active_ws)
         };
@@ -3013,21 +3032,26 @@ impl App {
         }
     }
 
-    /// The last workspace just closed. In server mode the session keeps running
-    /// with a fresh workspace (detached clients can come back to a live server;
-    /// only `server stop` ends it); in `--local` this quits the app. If the
-    /// fresh spawn fails we still quit rather than serve an empty, unrenderable
-    /// state.
+    /// The last node just closed, so the **session** is over (docs/43 §3.3).
+    ///
+    /// This used to reset to a fresh node at `std::env::current_dir()` — the
+    /// *server's* cwd, i.e. the folder it was first launched from. Closing every
+    /// node therefore resurrected the folder you closed first, the window never
+    /// went away, and the snapshot kept that folder so it came back after a
+    /// restart too. It also made `persist::save`'s empty-snapshot branch — which
+    /// exists precisely because "the user deliberately closed everything" must
+    /// not resurrect anything — unreachable in server mode.
+    ///
+    /// Now the *window* ends and the *server* survives, which is what
+    /// `server_mode` was for: clients detach, no node is recreated, and the empty
+    /// snapshot clears `session.json`. `server stop` still ends the server, and a
+    /// later `bohay` attaches and opens its launch folder fresh. `--local` has no
+    /// server to outlive, so it quits like a normal terminal app.
     fn all_workspaces_closed(&mut self) {
+        self.session_dirty = true;
         if self.server_mode {
-            let cwd = std::env::current_dir()
-                .ok()
-                .or_else(crate::platform::home_dir)
-                .unwrap_or_else(|| PathBuf::from("/"));
-            self.create_workspace_at(cwd);
-            self.session_dirty = true;
-        }
-        if self.workspaces.is_empty() {
+            self.end_session = true;
+        } else {
             self.should_quit = true;
         }
     }
@@ -3654,23 +3678,143 @@ mod tests {
         assert!(app.toast.is_none());
     }
 
+    /// The reported bug (docs/43 §3.3): open projectA then projectB, close
+    /// projectA, then close projectB — and **projectA came back** while the app
+    /// refused to close. `all_workspaces_closed` reset to a fresh node at
+    /// `std::env::current_dir()`, which in the server is the folder it was
+    /// launched from, i.e. projectA.
+    ///
+    /// The server still outlives its windows (that part was always intended);
+    /// what ends now is the *session*.
     #[test]
-    fn server_mode_outlives_the_last_workspace() {
+    fn closing_the_last_node_ends_the_session_without_resurrecting_one() {
         let _env = crate::persist::test_env("server-outlives");
-        // A server session keeps running when its last workspace closes: it
-        // resets to a fresh workspace instead of setting `should_quit`, so a
-        // detached client always has a live server to come back to.
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         app.server_mode = true;
-        let id = app.layout().focus;
-        app.handle_event(AppEvent::PtyExit(id)); // the only pane's shell exits
-        assert!(!app.should_quit, "a server session outlives its windows");
-        assert_eq!(app.workspaces.len(), 1, "reset to a fresh workspace");
-        let fresh = app.layout().focus;
+
+        // A second node, so this mirrors the report (close one, then the other)
+        // rather than the single-node case.
+        let dir = std::env::temp_dir().join("bohay-lastnode-4b1c9f");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        assert!(app.create_workspace_at(dir.clone()));
+        assert_eq!(app.workspaces.len(), 2);
+
+        // Close them both, ending with the last one.
+        app.close_workspace(0);
+        assert_eq!(app.workspaces.len(), 1, "the other node stays open");
+        app.close_workspace(0);
+
         assert!(
-            app.panes.contains_key(&fresh),
-            "the fresh workspace has a live pane"
+            app.workspaces.is_empty(),
+            "no node is resurrected — least of all the server's launch folder"
+        );
+        assert!(
+            !app.should_quit,
+            "the server itself still outlives its windows; `server stop` ends it"
+        );
+        assert!(
+            app.end_session,
+            "every client is told to detach, so the window actually closes"
+        );
+
+        // The server keeps ticking after the session ends, with no clients
+        // attached. `detect_tick` reaches `layout()`, so an unguarded empty
+        // session panics the whole server here — which is exactly what happened,
+        // and what no assertion above would have caught.
+        for _ in 0..3 {
+            assert!(
+                !app.detect_tick(Instant::now()),
+                "an empty session has nothing to detect"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// With no node open, the socket API must answer with an error rather than
+    /// indexing an empty `workspaces` and taking the server down. `handle_api`
+    /// already guards this centrally; the session can now *stay* empty rather
+    /// than being a brief pre-quit window, so this pins that guard in place.
+    #[test]
+    fn node_scoped_api_reports_no_session_instead_of_panicking() {
+        let _env = crate::persist::test_env("api-no-node");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.server_mode = true;
+        app.close_workspace(0);
+        assert!(app.workspaces.is_empty());
+
+        let call = |app: &mut App, method: &str, params: serde_json::Value| {
+            let (reply, _r) = std::sync::mpsc::channel();
+            let resp = app.handle_api(&crate::ipc::api::ApiRequest {
+                id: "1".into(),
+                method: method.into(),
+                params,
+                reply,
+            });
+            serde_json::from_str::<serde_json::Value>(&resp).unwrap()
+        };
+
+        for method in ["tab.list", "tab.new", "tab.close", "tab.rename"] {
+            let res = call(&mut app, method, serde_json::json!({}));
+            assert_eq!(
+                res.pointer("/error/code").and_then(|v| v.as_str()),
+                Some("no_session"),
+                "{method} must report the empty session, not panic: {res}"
+            );
+        }
+
+        // ...but the methods that *open* a node have to get through, or an empty
+        // server is a brick only `server stop` can clear. This is the recovery
+        // path a client takes when it attaches after a session ended, and the
+        // blanket guard used to swallow it.
+        let res = call(&mut app, "workspace.list", serde_json::json!({}));
+        assert!(
+            res.get("error").is_none(),
+            "listing nodes with none open is not an error: {res}"
+        );
+
+        let dir = std::env::temp_dir().join("bohay-recover-4b1c9f");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let res = call(
+            &mut app,
+            "workspace.open",
+            serde_json::json!({ "path": dir.display().to_string() }),
+        );
+        assert!(
+            res.get("error").is_none(),
+            "an empty server must still be able to open a folder: {res}"
+        );
+        assert_eq!(app.workspaces.len(), 1, "the session is back");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The same empty session must render. A client can still be attached for the
+    /// frame or two before it detaches, and `bohay attach` / `--remote` can attach
+    /// before any folder is opened — every draw fn below `render` assumes a node.
+    #[test]
+    fn an_empty_session_still_renders() {
+        let _env = crate::persist::test_env("render-no-node");
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.server_mode = true;
+        app.close_workspace(0);
+        assert!(app.workspaces.is_empty());
+
+        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let text: String = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(
+            text.contains("no folders open"),
+            "the empty session says so instead of drawing a broken frame"
         );
     }
 
@@ -4580,6 +4724,101 @@ mod tests {
             app.resize_drag.is_none(),
             "body click did not start a resize"
         );
+    }
+
+    /// A node that can't be opened must say so. `create_workspace_at` used to
+    /// swallow a failed shell spawn: it returned normally, `active_ws` still
+    /// pointed at the previously focused node, and the user was left looking at
+    /// the *wrong folder* with no error anywhere.
+    ///
+    /// An unresolvable shell is the failure that actually reaches this branch,
+    /// and it is the plausible Windows one: `resolve_shell` tries `pwsh.exe`,
+    /// then `powershell.exe`, then `%COMSPEC%`, and a bad `config.shell` or
+    /// `BOHAY_SHELL` defeats all three. (A *missing directory*, by contrast,
+    /// still spawns — the child only fails once it execs — so it is deliberately
+    /// not what this asserts on.)
+    #[test]
+    fn failing_to_open_a_node_is_reported_not_swallowed() {
+        let _env = crate::persist::test_env("ws-open-failure");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).expect("spawn pane");
+        let before = app.workspaces.len();
+        let active_before = app.active_ws;
+
+        app.config.shell = "bohay-not-a-real-shell-4b1c9f".to_string();
+        assert!(
+            !app.create_workspace_at(std::env::temp_dir()),
+            "opening a node whose shell cannot start must report failure"
+        );
+        assert_eq!(app.workspaces.len(), before, "no half-built node is added");
+        assert_eq!(app.active_ws, active_before, "focus must not move");
+        // The socket API must not answer with the *previously* active node, which
+        // read as success to `bohay` itself and to any scripting agent.
+        let (reply, _r) = std::sync::mpsc::channel();
+        let resp = app.handle_api(&crate::ipc::api::ApiRequest {
+            id: "1".into(),
+            method: "workspace.open".into(),
+            params: serde_json::json!({ "path": std::env::temp_dir().display().to_string() }),
+            reply,
+        });
+        let res: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(
+            res.pointer("/error/code").and_then(|v| v.as_str()),
+            Some("spawn_failed"),
+            "a failed open is an API error, not a fake success: {res}"
+        );
+
+        assert!(
+            app.toast
+                .as_ref()
+                .is_some_and(|(t, _)| t.contains("couldn't open")),
+            "the user is told, rather than silently shown the previous folder"
+        );
+    }
+
+    /// docs/43 WIN-6: `workspace.open` matched nodes with raw `PathBuf` equality,
+    /// so a different *spelling* of an open folder added a duplicate node instead
+    /// of focusing it.
+    ///
+    /// The spelling used here is the `\\?\` verbatim prefix, because it is the
+    /// one that discriminates on *every* platform: `Path`'s own `==` already
+    /// normalizes trailing separators, and case-folding is Windows-only (both
+    /// are covered directly in `platform`'s tests). Without `same_path` this
+    /// test sees two nodes.
+    #[test]
+    fn opening_an_already_open_node_focuses_it_instead_of_duplicating() {
+        let _env = crate::persist::test_env("ws-open-dedupe");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).expect("spawn pane");
+
+        let dir = std::env::temp_dir().join("bohay-dedupe-4b1c9f");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        assert!(app.create_workspace_at(dir.clone()), "first open succeeds");
+        let count = app.workspaces.len();
+        let opened = app.active_ws;
+
+        // The same folder as `canonicalize` would hand it back on Windows.
+        let spelled = format!(r"\\?\{}", dir.display());
+        let (reply, _r) = std::sync::mpsc::channel();
+        let resp = app.handle_api(&crate::ipc::api::ApiRequest {
+            id: "1".into(),
+            method: "workspace.open".into(),
+            params: serde_json::json!({ "path": spelled }),
+            reply,
+        });
+        let res: serde_json::Value = serde_json::from_str(&resp).unwrap();
+
+        assert!(
+            res.get("error").is_none(),
+            "re-opening an open node is not an error: {res}"
+        );
+        assert_eq!(
+            app.workspaces.len(),
+            count,
+            "the existing node is focused, not duplicated"
+        );
+        assert_eq!(app.active_ws, opened, "focus lands on the existing node");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The reported bug: a relocated WORKSPACES dock's rows opened files instead

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -143,6 +143,23 @@ pub fn run() -> Result<()> {
             );
             break;
         }
+        // The last node closed (docs/43 §3.3): the *session* is over, so every
+        // window goes away — not just the foreground one, which would leave other
+        // clients staring at a session with nothing in it. The server stays up
+        // with no nodes; `server stop` is still what ends it.
+        if app.end_session {
+            app.end_session = false;
+            broadcast(&mut clients, ServerMessage::Detach);
+            clients.clear();
+            foreground = None;
+            // Persist immediately rather than waiting out the 2s debounce: the
+            // snapshot is now empty, which *removes* `session.json`, and a kill
+            // inside that window would otherwise leave the closed nodes on disk
+            // to be restored on the next start.
+            persist::save(&app);
+            app.session_dirty = false;
+            last_save = Instant::now();
+        }
         if app.detach_requested {
             app.detach_requested = false;
             if let Some(id) = foreground.take() {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -149,8 +149,21 @@ pub fn run() -> Result<()> {
         // with no nodes; `server stop` is still what ends it.
         if app.end_session {
             app.end_session = false;
-            broadcast(&mut clients, ServerMessage::Detach);
-            clients.clear();
+            // NOT `broadcast`: that uses `try_send` on a capacity-1 channel and
+            // drops the message when the slot is occupied — which is routine
+            // (see `behind`). A dropped frame is self-healing; a dropped Detach
+            // is not, and would strand the client on a session with no nodes.
+            // `ServerShutdown` survives the same hazard only because the process
+            // then exits and closes every socket; here the server keeps running.
+            //
+            // So block until the writer thread takes it — on a detached thread,
+            // never on this loop, since a wedged client (a stalled ssh link)
+            // would otherwise hang the whole server.
+            for (_, tx) in clients.drain() {
+                thread::spawn(move || {
+                    let _ = tx.send(ServerMessage::Detach);
+                });
+            }
             foreground = None;
             // Persist immediately rather than waiting out the 2s debounce: the
             // snapshot is now empty, which *removes* `session.json`, and a kill
@@ -529,6 +542,9 @@ mod shutdown {
 #[cfg(test)]
 mod tests {
     use super::needs_render;
+    use super::ServerMessage;
+    use std::sync::mpsc;
+    use std::thread;
 
     /// A client that dropped a diff must get its full-frame resync even when the
     /// screen goes quiet. The resync only ships from inside a render, so a
@@ -550,5 +566,42 @@ mod tests {
             !needs_render(false, false, false),
             "nothing to do means no frame"
         );
+    }
+
+    /// Ending a session must actually reach the client (docs/43 §3.3). The frame
+    /// channel is `sync_channel(1)`, and `broadcast` uses `try_send`, which drops
+    /// the message when that single slot is occupied — routine enough that the
+    /// loop tracks it as `behind`. A dropped *frame* is self-healing; a dropped
+    /// *Detach* strands the client on a session with no nodes, which is the
+    /// original "the app is not closing" symptom. `ServerShutdown` survives the
+    /// same hazard only because the process then exits and closes every socket.
+    #[test]
+    fn ending_a_session_delivers_detach_even_when_the_channel_is_full() {
+        use std::sync::mpsc::TrySendError;
+
+        let (tx, rx) = mpsc::sync_channel::<ServerMessage>(1);
+        // A queued frame occupies the only slot.
+        tx.try_send(ServerMessage::Sound).expect("slot is free");
+
+        // What the old path did: silently drop it.
+        assert!(
+            matches!(
+                tx.try_send(ServerMessage::Detach),
+                Err(TrySendError::Full(_))
+            ),
+            "a full channel is exactly the case that used to lose the Detach"
+        );
+
+        // What it does now: block until the writer drains — off-thread, so a
+        // wedged client can never hang the server loop.
+        let h = thread::spawn(move || {
+            let _ = tx.send(ServerMessage::Detach);
+        });
+        assert!(matches!(rx.recv().unwrap(), ServerMessage::Sound));
+        assert!(
+            matches!(rx.recv().unwrap(), ServerMessage::Detach),
+            "the client is told to detach even though the channel was full"
+        );
+        h.join().unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,9 +361,6 @@ fn autodetect_and_attach() -> Result<()> {
         spawn_server()?;
         wait_for_socket(&sock)?;
     }
-    // A fresh server already opened the launch folder (its `App::new` uses the cwd
-    // it inherited). When attaching to an *existing* server, ask it to open (or
-    // focus) the folder we launched in, so `bohay <in a new folder>` adds it.
     if !fresh {
         // An upgraded binary silently attaching to an older running server means
         // none of the new version shows up — tell the user how to load it (the
@@ -376,8 +373,12 @@ fn autodetect_and_attach() -> Result<()> {
             );
             thread::sleep(Duration::from_millis(2000));
         }
-        open_cwd_workspace();
     }
+    // Always ask the server to open the launch folder. A *fresh* server may have
+    // restored a saved session (`restore_or_new`), in which case it never saw
+    // this cwd — so this cannot be skipped on the fresh path. Idempotent: if the
+    // folder is already a workspace, the server just focuses it.
+    open_cwd_workspace();
     ipc::client::run(&sock)
 }
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,6 +1,44 @@
 //! OS-specific bits, isolated here so core modules stay portable (docs/03 §7).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Do two paths name the same folder? (docs/43 WIN-6.)
+///
+/// Node lookup used to compare `PathBuf`s with `==`, so any difference in
+/// *spelling* read as "not open" and bohay added a duplicate node instead of
+/// focusing the existing one. Windows has many spellings for one path — case
+/// (`C:\Proj` vs `c:\proj`, which the filesystem treats as equal), the `\\?\`
+/// verbatim prefix that `canonicalize` returns, `/` accepted in place of `\`,
+/// and trailing separators — and every one of them defeated `==`.
+///
+/// Deliberately **lexical only, no IO**: this runs on user actions that can
+/// repeat, and a `canonicalize` per candidate would put syscalls on that path
+/// for no gain (the client always sends `std::env::current_dir()`, which is
+/// already resolved). Consequence: two *different* spellings that only a
+/// symlink resolve would unify (`/tmp` vs `/private/tmp` on macOS) still
+/// compare unequal. That is the intended trade.
+pub fn same_path(a: &Path, b: &Path) -> bool {
+    path_key(a) == path_key(b)
+}
+
+/// The comparison key for [`same_path`] — normalized spelling, never displayed.
+/// The node keeps the user's original spelling for its label and pane cwd.
+fn path_key(p: &Path) -> String {
+    let s = p.to_string_lossy();
+    // `\\?\C:\proj` and `C:\proj` are the same folder.
+    let s = s.strip_prefix(r"\\?\").unwrap_or(&s);
+    #[cfg(windows)]
+    // Windows accepts `/` as a separator and is case-insensitive.
+    let s = s.replace('/', "\\").to_lowercase();
+    // Drop trailing separators so `proj\` == `proj`, but never eat a bare root
+    // (`/` or `C:\`), which would make every root compare equal to the empty path.
+    let sep: &[char] = &['/', '\\'];
+    let trimmed = s.trim_end_matches(sep);
+    if trimmed.is_empty() || trimmed.ends_with(':') {
+        return s.to_string();
+    }
+    trimmed.to_string()
+}
 
 /// The user's home directory, cross-platform (`$HOME`, else `%USERPROFILE%`).
 pub fn home_dir() -> Option<PathBuf> {
@@ -436,6 +474,63 @@ mod tests {
         assert_eq!(super::resolve_shell("default"), "/bin/sh");
         assert_eq!(super::resolve_shell("zsh"), "/bin/sh");
         std::env::remove_var("BOHAY_SHELL");
+    }
+
+    #[test]
+    fn same_path_ignores_verbatim_prefix_and_trailing_separator() {
+        use std::path::Path;
+        // The `\\?\` prefix `canonicalize` returns names the same folder.
+        assert!(super::same_path(
+            Path::new(r"\\?\C:\proj"),
+            Path::new(r"C:\proj")
+        ));
+        // A trailing separator is not a different folder.
+        assert!(super::same_path(
+            Path::new("/work/app/"),
+            Path::new("/work/app")
+        ));
+        // ...but a bare root must not collapse to the empty path.
+        assert!(!super::same_path(Path::new("/"), Path::new("")));
+        // Genuinely different folders still differ.
+        assert!(!super::same_path(
+            Path::new("/work/app"),
+            Path::new("/work/api")
+        ));
+        assert!(!super::same_path(
+            Path::new("/work/app"),
+            Path::new("/work/app2")
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn same_path_folds_case_and_separators_on_windows() {
+        use std::path::Path;
+        // Windows paths are case-insensitive; `PathBuf` comparison is not.
+        assert!(super::same_path(
+            Path::new(r"C:\Users\Riz\proj"),
+            Path::new(r"c:\users\riz\proj")
+        ));
+        // Windows accepts `/` as a separator.
+        assert!(super::same_path(
+            Path::new("C:/proj"),
+            Path::new(r"C:\proj")
+        ));
+        // A bare drive root keeps its separator rather than collapsing.
+        assert!(super::same_path(Path::new(r"C:\"), Path::new(r"c:\")));
+        assert!(!super::same_path(Path::new(r"C:\"), Path::new(r"D:\")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn same_path_stays_case_sensitive_on_unix() {
+        use std::path::Path;
+        // Unix filesystems can be case-sensitive, so folding case here would
+        // wrongly merge two real, distinct folders.
+        assert!(!super::same_path(
+            Path::new("/work/App"),
+            Path::new("/work/app")
+        ));
     }
 
     #[cfg(windows)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -111,6 +111,23 @@ pub fn render_into(f: &mut RenderTarget, app: &mut App) {
         return;
     }
 
+    // No nodes at all (docs/43 §3.3): the last one was closed, so the session is
+    // over and every client has been told to detach. A client can still be
+    // attached for the frame or two before it goes (or attach fresh via
+    // `bohay attach` / `--remote` before opening a folder), and every draw fn
+    // below assumes an active node — `app.ws()` indexes `workspaces[active_ws]`.
+    // One guard here covers the whole tree rather than each call site.
+    if app.workspaces.is_empty() {
+        let msg = "no folders open — run `bohay` in a folder";
+        let y = area.y + area.height / 2;
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(msg, Style::new().fg(t.overlay1))))
+                .alignment(ratatui::layout::Alignment::Center),
+            Rect::new(area.x, y, area.width, 1),
+        );
+        return;
+    }
+
     // Compact (touch) mode on a narrow phone screen (docs/18): no sidebars, one
     // full-screen pane, a `≡` switcher for navigation. A vertical split doesn't
     // change the width, so decide it from `area.width` here — early enough that


### PR DESCRIPTION
Four related bugs that all showed up to users as "bohay opened the wrong folder". All were reported on Windows, but every one reproduces on macOS too: none are platform specific. Design notes in `docs/43`.

## 1. Closing the last node reopened the folder you closed first

The reported bug: open projectA, then projectB. Close projectA, then close projectB. The app does not close, and **projectA comes back**.

`all_workspaces_closed` reset to a fresh node at `std::env::current_dir()`, which in the server process is the folder the *server* was launched from, i.e. projectA. The snapshot then kept it, so it also returned after a restart.

Half of this was intended. The server outliving its windows is deliberate (`d5a9138`: "only `server stop` ends it"). What was not intended is that it contradicted `persist::save`, whose empty snapshot branch exists precisely because "the user deliberately closed everything, and a leftover file would resurrect those panes". That branch was unreachable in server mode, because a node was always recreated first.

Now the *session* ends while the *server* survives. Every client is told to detach, no node is recreated, and the empty snapshot clears `session.json`. `server stop` still ends the server, and `--local` still quits like a normal app.

Delivering that detach needed care. `broadcast` uses `try_send` on a `sync_channel(1)`, so it drops the message whenever the single slot holds a queued frame, which is routine enough that the loop already tracks it as `behind`. A dropped frame is self healing; a dropped detach strands the client on a session with no nodes, which is the original "app is not closing" symptom. `ServerShutdown` survives the same hazard only because the process then exits and closes every socket. Ending a session therefore drains the client map and blocks on `send` from a detached thread, so delivery is guaranteed without a wedged client ever hanging the server loop.

## 2. The launch folder was ignored when the server started fresh

`autodetect_and_attach` only asked the server to open the launch folder on the *attach* path. The comment claimed a fresh server had already opened it, but that only holds when there is no session snapshot: both server entry points call `restore_or_new`, which prefers `from_snapshot` and never looks at the launch cwd.

So a fresh server plus an existing `session.json` silently ignored the folder you ran `bohay` in. Unix rarely hit this because the server survives and takes the attach path; Windows hits it constantly because the server dies on every logout (see `docs/43` WIN-2). The call is now unconditional, which is safe because `workspace.open` is idempotent.

## 3. A failed node open was swallowed

`create_workspace_at` returned `()` and did nothing when the shell failed to spawn. No node was added, focus stayed on the previous one, and `workspace.open` still answered with it as success. The user saw the previous folder with no error anywhere, which is indistinguishable from the bug above.

Measured rather than assumed: a **missing directory still spawns** (the child only fails once it execs), while an **unresolvable shell fails**. The failing case is the plausible Windows one, since `resolve_shell` tries `pwsh.exe`, then `powershell.exe`, then `%COMSPEC%`.

It now returns whether the node opened and raises a toast, so every caller reports it identically, and the API returns a `spawn_failed` error instead of a fake success.

## 4. Node lookup compared paths by spelling (`docs/43` WIN-6)

`workspace.open` matched nodes with raw `PathBuf` equality, so any respelling of an open folder added a duplicate instead of focusing it. On Windows every spelling of one path defeats `==`: case, the `\\?\` verbatim prefix that `canonicalize` returns, `/` in place of `\`, and trailing separators.

`platform::same_path` compares a normalized key. It is deliberately lexical with no IO, since a `canonicalize` per candidate would add syscalls to a repeatable user action for no gain. Case folding is Windows only, because Unix filesystems can be case sensitive and folding would wrongly merge two real folders. Applied at the four sites that match nodes by path.

## Living with zero nodes

The app could previously never hold zero nodes for more than the moment before quitting. Now it can, and three paths assumed otherwise:

| Path | Fix |
|---|---|
| `ui::render_into` | one guard covering the whole draw tree, draws "no folders open" |
| `detect_tick` | early return; it reaches `layout()` and keeps ticking with no clients |
| `handle_api` | its blanket `no_session` guard also blocked `workspace.open`, the only way back |

That last one made an empty server a brick only `server stop` could clear. `handle_api` now admits the methods that are safe without a node: `ping`, `server.stop`, `workspace.open`/`node.open`, `workspace.list`/`node.list`, `worktree.open`. `workspace.new` is deliberately excluded, since it derives its folder from the focused pane and would fall back to the server's cwd, reintroducing bug 1. Input was already guarded.

## Testing

334 tests pass, clippy clean, `cargo fmt --check` clean, and `cargo check --target x86_64-pc-windows-gnu --tests` clean.

Nine new tests. Each was confirmed to **fail with its fix reverted**, so none are vacuous:

- `closing_the_last_node_ends_the_session_without_resurrecting_one`
- `ending_a_session_delivers_detach_even_when_the_channel_is_full`
- `an_empty_session_still_renders`
- `node_scoped_api_reports_no_session_instead_of_panicking`
- `failing_to_open_a_node_is_reported_not_swallowed`
- `opening_an_already_open_node_focuses_it_instead_of_duplicating`
- `same_path_ignores_verbatim_prefix_and_trailing_separator`
- `same_path_folds_case_and_separators_on_windows`
- `same_path_stays_case_sensitive_on_unix`

End to end against a real server on the reported scenario: both nodes open, close projectA, projectB remains, close projectB, node list is empty and projectA does not return, server still running, `session.json` cleared, reopening a folder works, zero server panics.

Two testing notes worth keeping, both of which cost a round trip here:

- Unit tests passed while the real server still panicked in `detect_tick`, and passed again while `workspace.open` was being swallowed. Only driving the actual binary over the socket caught either. Run the server in the foreground when doing this, since `spawn_server` sends its stderr to `/dev/null` and a panic otherwise leaves no trace.
- A repro run from inside a bohay pane must clear `$BOHAY_SOCKET_PATH`, or the CLI queries the real server and a broken build looks like a pass.

## Known gaps

- **Not verified on Windows.** Everything above was validated on macOS. The bugs reproduce identically there and the Windows arms compile, but nothing here has been run on Windows. That is what `docs/43` WIN-1 exists to provide.
- **The client window closing was not observed directly.** It rests on the `Detach` path, which is the same one `Ctrl+Space d` already uses, plus the full channel test. A client could not be kept attached in a headless harness.
- **A missing directory still opens a node whose shell dies immediately**, because the spawn itself succeeds. Detecting that means noticing an instant child exit, which is a separate change. Noted in `docs/43` §3.2 so it is not mistaken for these bugs.
