### PR TITLE
fix: reopen on the workspace you were last using, not the launch folder

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -440,13 +440,26 @@ impl App {
                 // Open `path` as a workspace, or focus it if it's already one. Used
                 // when `bohay` attaches to a running server from a new folder, so the
                 // launch directory shows up as a workspace.
+                //
+                // `focus` (default true) governs the *already-open* case. The
+                // automatic attach-open (`open_cwd_workspace`) passes `false`: it
+                // ensures the launch folder is a workspace but must NOT steal focus
+                // from the workspace a restored session left you on — otherwise
+                // reopening `bohay` always snaps back to the launch folder (usually
+                // the first workspace), never the one you were last using. An
+                // explicit `bohay workspace open <path>` omits it and still focuses.
                 let path = PathBuf::from(req_str(p, "path")?);
+                let focus = p.get("focus").and_then(|v| v.as_bool()).unwrap_or(true);
                 match self
                     .workspaces
                     .iter()
                     .position(|w| crate::platform::same_path(&w.cwd, &path))
                 {
-                    Some(i) => self.active_ws = i,
+                    Some(i) => {
+                        if focus {
+                            self.active_ws = i;
+                        }
+                    }
                     // Report a failed open instead of answering with the
                     // *previously* active node, which read as success and left
                     // the caller (and the user) looking at the wrong folder.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5270,6 +5270,41 @@ mod tests {
     }
 
     #[test]
+    fn attach_open_does_not_steal_focus_from_the_active_workspace() {
+        // The automatic attach-open (`focus: false`) must add the launch folder if
+        // new, but never yank you off the workspace a restored session left you on.
+        // This is the "reopen snaps back to the first workspace" bug.
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let first = app.ws().cwd.clone();
+        // A second workspace, now the active one (like being on a non-first node).
+        let other = std::env::temp_dir();
+        let open = |app: &mut App, path: &std::path::Path, focus: bool| {
+            let (reply, _r) = mpsc::channel();
+            app.handle_api(&ApiRequest {
+                id: "1".into(),
+                method: "workspace.open".into(),
+                params: json!({ "path": path.display().to_string(), "focus": focus }),
+                reply,
+            });
+        };
+        open(&mut app, &other, true);
+        let active = app.active_ws;
+        assert!(active > 0, "on a non-first workspace");
+
+        // Attach-open of the launch (first) folder must NOT switch away from it.
+        open(&mut app, &first, false);
+        assert_eq!(
+            app.active_ws, active,
+            "focus:false kept the active workspace on reopen"
+        );
+
+        // An explicit open (focus:true) still focuses the folder.
+        open(&mut app, &first, true);
+        assert_eq!(app.ws().cwd, first, "explicit open still focuses");
+    }
+
+    #[test]
     fn resume_session_opens_pane() {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,10 +391,13 @@ fn open_cwd_workspace() {
     let Ok(mut s) = ipc::transport::connect(&persist::socket_path()) else {
         return;
     };
+    // `focus: false` — add the launch folder if it isn't already a workspace, but
+    // don't switch to it if it is: a restored session should reopen on the
+    // workspace you were last using, not snap back to the launch directory.
     let req = serde_json::json!({
         "id": "1",
         "method": "workspace.open",
-        "params": { "path": cwd.display().to_string() },
+        "params": { "path": cwd.display().to_string(), "focus": false },
     });
     let _ = writeln!(s, "{req}");
     let mut line = String::new();


### PR DESCRIPTION
## What

Reopening bohay now lands you back on the workspace you were last using, instead of snapping to the folder you launched from (usually the first workspace).

## Why

Every time `bohay` attaches, it auto-opens the launch directory as a workspace, so running bohay in a new folder shows up. But when that folder was already a workspace, it also *focused* it, overriding the active workspace the restored session had saved. Because switching workspaces inside bohay does not change your outer shell's directory, reopening always dragged you back to where you first started, never the node you were actually on.

## Fix

`workspace.open` now takes a `focus` flag (default `true`). The automatic attach-open passes `focus: false`: it still adds the launch folder if it is new, but no longer steals focus from the workspace you were last on. An explicit `bohay workspace open <path>` omits the flag and still focuses the folder, so that behavior is unchanged.

Covered by a new test (`focus: false` keeps the active workspace; an explicit open still switches); the existing `workspace.open` add-new / focus-on-explicit behavior is untouched.
