### PR TITLE
feat: hook-driven blocked state + session freshness for agent integration

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -3,6 +3,13 @@
 
 use super::*;
 
+/// IR-1 (docs/48): backstop expiry for a hook state hint. The hint is normally
+/// cleared the moment the agent resumes (a visible Working reading) or a `Stop`
+/// hook arrives; this TTL is only a safety net so a missed clear-event can never
+/// pin a pane as Blocked forever. Long, because a real permission prompt can sit
+/// unanswered while the user is away.
+const HINT_TTL: Duration = Duration::from_secs(6 * 3600);
+
 /// Debounce dwell for committing a newly-desired agent state (hysteresis).
 /// Active states publish instantly (responsive sidebar); the fall back to a
 /// quiet state waits `QUIET_DWELL` so streaming pauses don't flap the status.
@@ -173,11 +180,27 @@ impl App {
                     agent_appeared = true;
                 }
                 // The state the raw reading wants right now.
-                let desired = if s.done && det.state == State::Idle {
+                let mut desired = if s.done && det.state == State::Idle {
                     State::Done
                 } else {
                     det.state
                 };
+                // IR-1 (docs/48): arbitrate the hook state hint against the screen
+                // reading. Display-only — never touches the session (Law 1). The
+                // screen always vetoes (Law 2): a visible Working reading clears it
+                // (the agent resumed), a non-agent pane (the agent exited to a
+                // shell) clears it, and a backstop TTL clears it. Only then may a
+                // fresh Notification hint PROMOTE an otherwise non-Blocked reading
+                // to Blocked — the missed-prompt case this whole feature exists for.
+                if let Some((hint, when)) = s.hook_hint {
+                    let is_agent = self.manifests.is_agent(&s.agent) || s.agent_session.is_some();
+                    if !is_agent || desired == State::Working || now.duration_since(when) > HINT_TTL
+                    {
+                        s.hook_hint = None;
+                    } else if hint == State::Blocked && desired != State::Blocked {
+                        desired = State::Blocked;
+                    }
+                }
                 // Debounce with asymmetric hysteresis: a fresh `desired` only
                 // becomes the published `state` once it has held for its dwell.
                 // Active states (Working/Blocked) commit instantly so the sidebar
@@ -413,10 +436,32 @@ impl App {
                 let kind = p.get("kind").and_then(|v| v.as_str()).unwrap_or("");
                 let message = p.get("message").and_then(|v| v.as_str()).unwrap_or("");
                 let tool = p.get("tool").and_then(|v| v.as_str()).unwrap_or("");
+                let state = p.get("state").and_then(|v| v.as_str());
                 self.emit_event(
                     "agent.hook",
                     json!({ "pane": id.0.to_string(), "agent": agent, "kind": kind, "message": message, "tool": tool }),
                 );
+                // IR-1 (docs/48): drive a Blocked *hint* from lifecycle events —
+                // display-only, arbitrated by `detect_tick`, never touching the
+                // session. Prefer the hook's explicit `state` (schema-driven, from
+                // the verified per-agent event→state map); fall back to deriving it
+                // from the event kind so older installed hooks keep working. Only
+                // Blocked is hook-driven (the state the screen can miss); "idle"
+                // (turn ended) clears the hint and lets the screen decide;
+                // working/idle otherwise stay screen-led. A visible Working screen
+                // still vetoes a stale Blocked hint (see `detect_tick`).
+                let resolved = state.or(match kind {
+                    "Notification" | "PermissionRequest" => Some("blocked"),
+                    "Stop" | "Interrupt" => Some("idle"),
+                    _ => None,
+                });
+                if let Some(s) = self.status.get_mut(&id) {
+                    match resolved {
+                        Some("blocked") => s.hook_hint = Some((State::Blocked, Instant::now())),
+                        Some("idle") => s.hook_hint = None,
+                        _ => {}
+                    }
+                }
                 Ok(json!({"type":"ok"}))
             }
             // ── workspaces ── (`node.*` kept as a back-compat alias)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -631,6 +631,14 @@ pub struct PaneStatus {
     /// `candidate_since` this is the hysteresis gate (see `QUIET_DWELL`).
     candidate: State,
     candidate_since: Instant,
+    /// IR-1: a hook-driven state hint (docs/48). A `Notification` hook sets
+    /// `(Blocked, when)`; `detect_tick` arbitrates it against the screen reading
+    /// (display-only, never touches `agent_session`): it promotes to Blocked when
+    /// the screen isn't already Working and the pane is still an agent, a visible
+    /// Working reading vetoes and clears it, a `Stop` hook clears it, and it
+    /// expires after a backstop TTL. Makes "agent needs input" robust to prompt
+    /// wording the screen rules miss, without the hook ever writing `state`.
+    hook_hint: Option<(State, Instant)>,
 }
 
 impl PaneStatus {
@@ -651,6 +659,7 @@ impl PaneStatus {
             notify_armed: true,
             candidate: State::Idle,
             candidate_since: Instant::now(),
+            hook_hint: None,
         }
     }
 }
@@ -4295,6 +4304,79 @@ mod tests {
         // classify() falls back to the shell command — the exact trigger.
         app.detect_tick(Instant::now());
         assert_eq!(app.status.get(&focus).unwrap().agent, "claude");
+    }
+
+    #[test]
+    fn ir1_permission_hook_promotes_a_missed_prompt_to_blocked() {
+        use crate::ui::theme::State;
+        let _env = crate::persist::test_env("ir1-blocked");
+        let (tx, _rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let focus = app.layout().focus;
+
+        // Brand it as kimi with a live session (the hook path).
+        let (reply, _r) = mpsc::channel();
+        app.handle_api(&ApiRequest {
+            id: "1".into(),
+            method: "pane.report_session".into(),
+            params: json!({"pane": focus.0.to_string(), "agent": "kimi", "session_id": "s1"}),
+            reply,
+        });
+        // Kimi's real permission event fires with an explicit state (the verified
+        // schema, docs/48), but the on-screen prompt matches no detection rule —
+        // so screen scraping alone would read Idle.
+        let (reply2, _r2) = mpsc::channel();
+        app.handle_api(&ApiRequest {
+            id: "2".into(),
+            method: "pane.report_event".into(),
+            params: json!({"pane": focus.0.to_string(), "agent": "kimi", "kind": "PermissionRequest", "state": "blocked"}),
+            reply: reply2,
+        });
+
+        let t0 = app.last_detect_at;
+        app.detect_tick(t0 + std::time::Duration::from_millis(200));
+        let s = app.status.get(&focus).unwrap();
+        assert_eq!(
+            s.state,
+            State::Blocked,
+            "the permission hint promoted to blocked"
+        );
+        assert!(
+            s.agent_session.is_some(),
+            "the hint never touched the session (Law 1)"
+        );
+    }
+
+    #[test]
+    fn ir1_hint_never_blocks_a_shell_and_is_cleared_on_agent_exit() {
+        use crate::ui::theme::State;
+        let _env = crate::persist::test_env("ir1-veto");
+        let (tx, _rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let focus = app.layout().focus;
+
+        // A stale Blocked hint on a pane that is actually a plain, quiet shell
+        // (the agent has exited). The scan sees only `zsh`.
+        {
+            let s = app.status.get_mut(&focus).unwrap();
+            s.agent = "zsh".into();
+            s.last_activity = Instant::now() - Duration::from_secs(5);
+            s.hook_hint = Some((State::Blocked, Instant::now()));
+        }
+        app.proc_commands.insert(focus, vec!["zsh".to_string()]);
+
+        let t0 = app.last_detect_at;
+        app.detect_tick(t0 + std::time::Duration::from_millis(200));
+        let s = app.status.get(&focus).unwrap();
+        assert_ne!(
+            s.state,
+            State::Blocked,
+            "a shell is never forced Blocked by a stale hint"
+        );
+        assert!(
+            s.hook_hint.is_none(),
+            "the hint was cleared for a non-agent"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,7 @@ server:
   integration install|uninstall <claude|copilot|codex|opencode|kimi|grok>
                              add/remove bohay's session-resume hook (uninstall
                              removes only bohay's hook, never the agent)
+  integration status         which hooks are installed + each agent's version
 ";
 
 pub fn run(args: &[String]) -> Result<i32> {
@@ -828,6 +829,10 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             );
             if let Some(t) = flag(args, "--tool") {
                 obj.insert("tool".to_string(), json!(t));
+            }
+            // IR-1 (docs/48): an optional agent-reported state hint (blocked/idle).
+            if let Some(s) = flag(args, "--state") {
+                obj.insert("state".to_string(), json!(s));
             }
             ("pane.report_event".into(), with_pane(obj))
         }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -28,20 +28,33 @@ evt="$(printf '%s' "$input" | python3 -c 'import sys,json
 try:
     d=json.load(sys.stdin); print(d.get("hook_event_name") or d.get("event") or "")
 except Exception: print("")' 2>/dev/null)"
+# Session id for resume — re-report on EVERY event so an id an agent mints on
+# `--resume` stays fresh (IR-2), not only at SessionStart. Idempotent.
+sid="$(printf '%s' "$input" | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin); print(d.get("session_id") or d.get("sessionId") or d.get("id") or "")
+except Exception: print("")' 2>/dev/null)"
+[ -n "$sid" ] && bohay pane report --agent {agent} --session "$sid" >/dev/null 2>&1
+# Map the lifecycle event to a state hint (IR-1, docs/48). Only Blocked is
+# hook-driven — it is the state screen detection can miss; working/idle stay
+# screen-led. `Notification`/`PermissionRequest` = the agent is waiting on you;
+# `Stop`/`Interrupt` = the turn ended (clear the hint).
+state=""
 case "$evt" in
-  Notification|Stop|SubagentStop)
+  Notification|PermissionRequest) state="blocked" ;;
+  Stop|Interrupt) state="idle" ;;
+esac
+case "$evt" in
+  Notification|PermissionRequest|Stop|Interrupt|SubagentStop)
     msg="$(printf '%s' "$input" | python3 -c 'import sys,json
 try:
     d=json.load(sys.stdin); print((d.get("message") or "")[:200])
 except Exception: print("")' 2>/dev/null)"
-    bohay pane report-event --agent {agent} --kind "$evt" --message "$msg" >/dev/null 2>&1
-    ;;
-  *)
-    sid="$(printf '%s' "$input" | python3 -c 'import sys,json
-try:
-    d=json.load(sys.stdin); print(d.get("session_id") or d.get("sessionId") or d.get("id") or "")
-except Exception: print("")' 2>/dev/null)"
-    [ -n "$sid" ] && bohay pane report --agent {agent} --session "$sid" >/dev/null 2>&1
+    if [ -n "$state" ]; then
+      bohay pane report-event --agent {agent} --kind "$evt" --message "$msg" --state "$state" >/dev/null 2>&1
+    else
+      bohay pane report-event --agent {agent} --kind "$evt" --message "$msg" >/dev/null 2>&1
+    fi
     ;;
 esac
 exit 0
@@ -79,12 +92,84 @@ export const bohay = async () => {
 }
 "#;
 
+// ── IR-6: agent version probe + gating (docs/48) ─────────────────────────────
+
+/// How to read an agent's version, and the minimum it must meet for native
+/// resume. `min` is `None` by default: we surface the version for visibility but
+/// never block a valid install on a number we are not certain of. Fill in a real
+/// minimum here only when it is known.
+struct VersionSpec {
+    binary: &'static str,
+    args: &'static [&'static str],
+    min: Option<(u64, u64, u64)>,
+}
+
+fn version_spec(agent: &str) -> Option<VersionSpec> {
+    let binary = match agent {
+        "claude" => "claude",
+        "copilot" => "copilot",
+        "codex" => "codex",
+        "opencode" => "opencode",
+        "kimi" => "kimi",
+        "grok" => "grok",
+        _ => return None,
+    };
+    Some(VersionSpec {
+        binary,
+        args: &["--version"],
+        min: None,
+    })
+}
+
+/// Run `<binary> --version` and parse the first `major.minor.patch` it prints.
+/// `None` when the binary is absent, errors, or prints nothing parseable — the
+/// caller then proceeds, so a probe miss is never a hard failure.
+fn detect_agent_version(spec: &VersionSpec) -> Option<(u64, u64, u64)> {
+    let out = std::process::Command::new(spec.binary)
+        .args(spec.args)
+        .output()
+        .ok()?;
+    parse_version_triple(&String::from_utf8_lossy(&out.stdout))
+        .or_else(|| parse_version_triple(&String::from_utf8_lossy(&out.stderr)))
+}
+
+/// Extract the first `major.minor[.patch]` triple from free text (patch defaults
+/// to 0). Robust to a leading `v` and surrounding words.
+fn parse_version_triple(text: &str) -> Option<(u64, u64, u64)> {
+    text.split(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .find_map(|token| {
+            let mut parts = token.splitn(3, '.');
+            let major: u64 = parts.next()?.parse().ok()?;
+            let minor: u64 = parts.next()?.parse().ok()?;
+            let patch: u64 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+            Some((major, minor, patch))
+        })
+}
+
 pub fn run(args: &[String]) -> Result<i32> {
     match (
         args.get(2).map(String::as_str),
         args.get(3).map(String::as_str),
     ) {
         (Some("install"), Some(agent)) if AGENTS.contains(&agent) => {
+            // IR-6: surface the agent version, and refuse only if a *known*
+            // minimum is unmet. An unknown/unparseable version never blocks.
+            if let Some(spec) = version_spec(agent) {
+                match detect_agent_version(&spec) {
+                    Some(v) => {
+                        if let Some(min) = spec.min {
+                            if v < min {
+                                return Err(anyhow!(
+                                    "{agent} v{}.{}.{} is too old for native resume (need >= v{}.{}.{}); update {agent}, then re-run",
+                                    v.0, v.1, v.2, min.0, min.1, min.2
+                                ));
+                            }
+                        }
+                        println!("detected {agent} v{}.{}.{}", v.0, v.1, v.2);
+                    }
+                    None => println!("note: couldn't read `{agent} --version`; installing anyway"),
+                }
+            }
             install(agent)?;
             println!("installed bohay {agent} integration");
             Ok(0)
@@ -94,12 +179,38 @@ pub fn run(args: &[String]) -> Result<i32> {
             println!("removed bohay {agent} integration (the {agent} agent itself is untouched)");
             Ok(0)
         }
+        // IR-3: per-agent install + version visibility — "why isn't this working"
+        // becomes a command instead of guesswork.
+        (Some("status"), _) => {
+            for &agent in AGENTS {
+                let installed = is_installed(agent);
+                let ver = if installed {
+                    version_spec(agent).and_then(|s| detect_agent_version(&s))
+                } else {
+                    None
+                };
+                let vstr = ver
+                    .map(|v| format!("v{}.{}.{}", v.0, v.1, v.2))
+                    .unwrap_or_else(|| "-".into());
+                println!(
+                    "{:9} {:14} {}",
+                    agent,
+                    if installed {
+                        "installed"
+                    } else {
+                        "not installed"
+                    },
+                    vstr
+                );
+            }
+            Ok(0)
+        }
         (Some("install" | "uninstall"), Some(other)) => Err(anyhow!(
             "unsupported agent: {other} (supported: {})",
             AGENTS.join(", ")
         )),
         _ => Err(anyhow!(
-            "usage: bohay integration <install|uninstall> <{}>",
+            "usage: bohay integration <install|uninstall|status> [<{}>]",
             AGENTS.join("|")
         )),
     }
@@ -233,24 +344,37 @@ fn install_shell_hook(agent: &str) -> Result<PathBuf> {
     Ok(spec.dir)
 }
 
-pub fn install_claude() -> Result<PathBuf> {
-    let dir = install_shell_hook("claude")?;
-    // Also register the same (branching) script under lifecycle events so the
-    // notch companion gets precise permission/turn-end signals (docs/24 NOTCH-6).
+/// Register the shared branching script under lifecycle events (in the agent's
+/// `settings.json`), on top of its `SessionStart` registration. Two purposes:
+/// the notch companion gets precise permission/turn-end signals (docs/24
+/// NOTCH-6), and — since the script re-reports the session id (IR-2) and feeds
+/// the state hint (IR-1) on those events — the agent's session stays fresh and
+/// its blocked/idle state becomes hook-driven, not screen-guessed.
+fn register_lifecycle_events(dir: &Path, events: &[&str]) -> Result<()> {
     let cfg_path = dir.join("settings.json");
     let script = dir.join("bohay-agent-hook.sh");
     let mut cfg: Value = fs::read_to_string(&cfg_path)
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_else(|| json!({}));
-    for evt in ["Notification", "Stop"] {
+    for evt in events {
         register_hook(&mut cfg, evt, None, &script.to_string_lossy());
     }
     fs::write(&cfg_path, serde_json::to_string_pretty(&cfg)?)?;
+    Ok(())
+}
+
+pub fn install_claude() -> Result<PathBuf> {
+    let dir = install_shell_hook("claude")?;
+    register_lifecycle_events(&dir, &["Notification", "Stop"])?;
     Ok(dir)
 }
 
 pub fn install_copilot() -> Result<PathBuf> {
+    // SessionStart only, by design (docs/48). Copilot does not reliably fire
+    // turn-end lifecycle hooks — the reference tool tried them and removed them —
+    // so we take just the session id for resume and let screen detection drive
+    // state. Registering Notification/Stop here would be a no-op at best.
     install_shell_hook("copilot")
 }
 
@@ -272,6 +396,10 @@ pub fn install_opencode() -> Result<PathBuf> {
 /// accepts only `event`/`matcher`/`command`/`timeout`, so we write nothing else.
 const KIMI_HOOK_EVENTS: &[(&str, Option<&str>)] = &[
     ("SessionStart", Some("startup|resume")),
+    // Kimi signals a waiting permission prompt via `PermissionRequest` (not
+    // `Notification`, docs/48), so that is the event that must drive Blocked.
+    // `Notification` is kept as a harmless belt-and-suspenders.
+    ("PermissionRequest", None),
     ("Notification", None),
     ("Stop", None),
 ];
@@ -551,6 +679,31 @@ mod tests {
     use super::*;
 
     #[test]
+    fn ir6_parses_version_triples_from_free_text() {
+        assert_eq!(parse_version_triple("claude 1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_version_triple("v0.9.5 (build abc)"), Some((0, 9, 5)));
+        assert_eq!(parse_version_triple("copilot version 6.0"), Some((6, 0, 0)));
+        assert_eq!(parse_version_triple("1.88.0"), Some((1, 88, 0)));
+        // No usable triple.
+        assert_eq!(parse_version_triple("unknown"), None);
+        assert_eq!(parse_version_triple("v2"), None);
+    }
+
+    #[test]
+    fn ir1_ir2_hook_reports_session_freshness_and_blocked_state() {
+        let s = agent_hook_script("grok");
+        // IR-2: the session id is re-reported unconditionally, so it fires on
+        // every event (turn boundaries included), not just SessionStart.
+        assert!(s.contains("bohay pane report --agent grok --session"));
+        // IR-1: permission events map to an explicit Blocked state hint.
+        assert!(s.contains("PermissionRequest"));
+        assert!(s.contains("state=\"blocked\""));
+        assert!(s.contains("--state \"$state\""));
+        // Notch forwarding is still intact.
+        assert!(s.contains("bohay pane report-event --agent grok"));
+    }
+
+    #[test]
     fn install_writes_hook_and_settings() {
         let _env = crate::persist::TEST_ENV_LOCK
             .lock()
@@ -714,11 +867,14 @@ mod tests {
         assert!(after.contains("sk-secret-123"), "api key preserved");
         assert!(after.contains("# my kimi config"), "comment preserved");
         assert!(after.contains("echo mine"), "user's own hook kept");
-        // Our three events landed exactly once each despite installing twice.
+        // Our events land exactly once each despite installing twice.
         let doc: toml_edit::DocumentMut = after.parse().unwrap();
         let hooks = doc["hooks"].as_array_of_tables().unwrap();
         let bohay = hooks.iter().filter(|t| kimi_entry_is_bohay(t)).count();
-        assert_eq!(bohay, 3, "SessionStart + Notification + Stop, no dupes");
+        assert_eq!(
+            bohay, 4,
+            "SessionStart + PermissionRequest + Notification + Stop, no dupes"
+        );
         let sess = hooks
             .iter()
             .find(|t| t.get("event").and_then(|v| v.as_str()) == Some("SessionStart"))

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -128,4 +128,5 @@ server:
   integration install|uninstall <claude|copilot|codex|opencode|kimi|grok>
                              add/remove bohay's session-resume hook (uninstall
                              removes only bohay's hook, never the agent)
+  integration status         which hooks are installed + each agent's version
 ```


### PR DESCRIPTION
## What

Makes bohay's agent integration substantially more robust, layered **on top of** the existing screen + process detection (which is unchanged and still the fallback for every agent). Nothing is replaced; agents without hooks behave exactly as before.

## Why

The weak spot was **Blocked** detection: it came only from screen-scraping, so a change in an agent's permission-prompt wording made a waiting agent read as idle. And sessions could go stale on resume ("reopens an old conversation").

## Changes

- **Hook-driven Blocked state.** When an agent's integration hook fires its permission event, bohay now marks the pane Blocked directly, using each agent's *verified* event: Claude/grok `Notification`, kimi `PermissionRequest`. The hook reports an explicit state (schema-driven), with a fallback that derives it from the event kind so older installed hooks keep working. Only Blocked is hook-driven; working/idle stay screen-led (already reliable, and this avoids a "crashed agent stuck working" failure).
- **Safety by construction.** The hook only sets a display hint that `detect_tick` arbitrates: it never touches the session/resume, a visible working screen vetoes and clears it, it clears when the pane is no longer an agent, and a backstop TTL expires it.
- **Session freshness.** The hook re-reports the session id on every turn, not just at start, so a fork-on-resume id never goes stale.
- **`bohay integration status`.** Shows, per agent, whether the hook is installed and the agent's version.
- **Version probe at install.** Surfaces the agent version and refuses only on a known-unmet minimum.
- Copilot is kept SessionStart-only on purpose (it does not fire lifecycle hooks reliably).

## Coverage (honest)

- Hook-driven Blocked: Claude, grok, kimi.
- Session + screen (no reliable lifecycle hooks): copilot, codex, droid, cursor.
- Screen + disk only (no hook system): gemini, aider, qwen, amp.

## Testing

`cargo fmt` / `clippy -D warnings` clean, full suite passes (347), and live end-to-end verified for grok and kimi (idle -> permission event -> blocked -> stop -> idle). To pick up the new hook, re-run `bohay integration install <agent>`.
