### PR TITLE
feat(sidebar): drag either sidebar's edge to resize it, persisting on release, ellipsize long node, agent, and branch names instead of hard-cutting

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -370,8 +370,9 @@ impl App {
             return;
         }
         // Track which divider (if any) the cursor is over, for the hover
-        // highlight (docs/27, RESIZE-4).
+        // highlight (docs/27, RESIZE-4), plus the sidebar edge seam (docs/29).
         self.update_hover_divider(m.column, m.row);
+        self.update_hover_sidebar(m.column, m.row);
         // Right-click a pane tab to rename it (docs/28), a WORKSPACES row for its
         // context menu (rename / worktree / close), or inside a pane for the pane
         // menu (split / close).
@@ -397,6 +398,13 @@ impl App {
         // ── pane text selection: drag to select, release auto-copies (OSC 52) ──
         match m.kind {
             MouseEventKind::Down(MouseButton::Left) => {
+                // A sidebar-edge drag (docs/29) claims the press first: its seam is
+                // the sidebar's own `│` column (never a pane), and its neighbour is
+                // only grabbed when it isn't pane content, so this can't swallow a
+                // click meant for a pane or a mouse-tracking agent.
+                if self.begin_sidebar_resize(m.column, m.row) {
+                    return;
+                }
                 // Pane resize (docs/27) takes priority over selection: a divider
                 // sits on borders/gaps, outside any content rect, so grabbing one
                 // never conflicts. RESIZE-2 = drag the divider directly;
@@ -436,6 +444,10 @@ impl App {
                 return;
             }
             MouseEventKind::Drag(MouseButton::Left) | MouseEventKind::Drag(MouseButton::Middle) => {
+                if self.sidebar_resize.is_some() {
+                    self.update_sidebar_resize(m.column, m.row);
+                    return;
+                }
                 if self.resize_drag.is_some() {
                     self.update_resize(m.column, m.row);
                     return;
@@ -459,6 +471,10 @@ impl App {
                 return;
             }
             MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Up(MouseButton::Middle) => {
+                if self.sidebar_resize.is_some() {
+                    self.end_sidebar_resize();
+                    return;
+                }
                 if self.resize_drag.is_some() {
                     self.end_resize();
                     return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -677,6 +677,11 @@ pub struct ResizeDrag {
 /// makes the seam comfortably grabbable without stealing clicks from content.
 const RESIZE_GRAB_TOL: u16 = 2;
 
+/// How many columns onto the content side of a sidebar's edge still grab it for a
+/// resize (docs/29). Widens the 1-column seam into a comfortable target without
+/// reaching into the sidebar body (where dock rows own the width).
+const SIDEBAR_GRAB_TOL: u16 = 2;
+
 impl Selection {
     /// (start, end) terminal cells in reading order (top-left → bottom-right).
     pub(crate) fn ordered(&self) -> ((u16, u16), (u16, u16)) {
@@ -953,6 +958,20 @@ pub struct App {
     pub resize_drag: Option<ResizeDrag>,
     /// Divider under the cursor, for the hover highlight (RESIZE-4).
     pub hover_divider: Option<crate::layout::Divider>,
+    /// Active sidebar-edge resize drag (docs/29) — which side is being dragged;
+    /// `None` when idle. Width updates live during the drag and is persisted once
+    /// on release, so no `config.json` write lands on the per-event path.
+    pub sidebar_resize: Option<Side>,
+    /// Sidebar whose edge seam is under the cursor, for the hover highlight.
+    pub hover_sidebar: Option<Side>,
+    /// The draggable edge seam (`│` column) of each shown sidebar, set every frame
+    /// in `render`; `None` when that sidebar is hidden. Hit-tested by
+    /// `sidebar_seam_at`.
+    pub left_seam: Option<Rect>,
+    pub right_seam: Option<Rect>,
+    /// The full content area (frame minus the status bar), stored so an in-flight
+    /// sidebar drag can turn a cursor column into a width off the correct edge.
+    pub last_main_area: Rect,
     pub tab_rects: Vec<(usize, Rect)>,
     pub tab_close_rects: Vec<(usize, Rect)>,
     pub ws_rects: Vec<(usize, Rect)>,
@@ -1172,6 +1191,11 @@ impl App {
             scroll_pane: None,
             resize_drag: None,
             hover_divider: None,
+            sidebar_resize: None,
+            hover_sidebar: None,
+            left_seam: None,
+            right_seam: None,
+            last_main_area: Rect::ZERO,
             tab_rects: Vec::new(),
             ws_rects: Vec::new(),
             workspace_branch_rects: Vec::new(),
@@ -1527,6 +1551,11 @@ impl App {
             scroll_pane: None,
             resize_drag: None,
             hover_divider: None,
+            sidebar_resize: None,
+            hover_sidebar: None,
+            left_seam: None,
+            right_seam: None,
+            last_main_area: Rect::ZERO,
             tab_rects: Vec::new(),
             ws_rects: Vec::new(),
             workspace_branch_rects: Vec::new(),
@@ -2956,6 +2985,99 @@ impl App {
             };
     }
 
+    /// The sidebar whose draggable edge seam is at `(c, r)`, if any (docs/29).
+    /// The seam `│` column always grabs; the grab band also reaches
+    /// `SIDEBAR_GRAB_TOL` columns onto the **content side** — but only over cells
+    /// that are *not* a mouse-tracking pane, so an agent's own edge clicks (Claude
+    /// Code expanding a tool result at its left edge) still forward, and a
+    /// split's border/gap stays grabbable. It never reaches into the sidebar body,
+    /// where dock rows own the width, so it can't steal a workspace/agent click.
+    fn sidebar_seam_at(&self, c: u16, r: u16) -> Option<Side> {
+        for (seam, side) in [(self.left_seam, Side::Left), (self.right_seam, Side::Right)] {
+            let Some(seam) = seam else { continue };
+            if r < seam.y || r >= seam.bottom() {
+                continue;
+            }
+            if c == seam.x {
+                return Some(side);
+            }
+            // Distance onto the content side (right of a left seam, left of a
+            // right seam); `None` when the cursor is on the sidebar side.
+            let dist = match side {
+                Side::Left => c.checked_sub(seam.x),
+                Side::Right => seam.x.checked_sub(c),
+            };
+            let Some(d) = dist else { continue };
+            let over_agent = self
+                .pane_content_at(c, r)
+                .and_then(|(id, _)| self.panes.get(&id))
+                .is_some_and(|p| p.mouse_mode().report);
+            if (1..=SIDEBAR_GRAB_TOL).contains(&d) && !over_agent {
+                return Some(side);
+            }
+        }
+        None
+    }
+
+    /// Start dragging a sidebar's edge to resize it (docs/29). Returns whether a
+    /// drag began, so the mouse handler can claim the press before selection.
+    pub fn begin_sidebar_resize(&mut self, c: u16, r: u16) -> bool {
+        match self.sidebar_seam_at(c, r) {
+            Some(side) => {
+                self.sidebar_resize = Some(side);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Drive the active sidebar resize from the cursor column. Updates the width
+    /// live but does **not** persist: `save_sidebars` (a disk write) runs once on
+    /// release, keeping the drag off the config-write path (the perf memory).
+    pub fn update_sidebar_resize(&mut self, c: u16, _r: u16) {
+        let Some(side) = self.sidebar_resize else {
+            return;
+        };
+        let main = self.last_main_area;
+        // The other sidebar's current rendered width, derived from its seam, so
+        // the drag can never push the panes below the 24-column content floor.
+        let other = match side {
+            Side::Left => self
+                .right_seam
+                .map_or(0, |s| main.right().saturating_sub(s.x)),
+            Side::Right => self
+                .left_seam
+                .map_or(0, |s| s.x.saturating_sub(main.x).saturating_add(1)),
+        };
+        // The left seam sits on the sidebar's *last* column (width-1), so its width
+        // is the cursor column plus one; the right seam is the sidebar's *first*
+        // column, so its width counts back from the right edge.
+        let want = match side {
+            Side::Left => c.saturating_sub(main.x).saturating_add(1),
+            Side::Right => main.right().saturating_sub(c),
+        };
+        // Clamp to the supported range and to whatever still leaves 24 columns of
+        // content; `.max(MIN)` guarantees a valid clamp range on a tiny terminal.
+        let cap = main
+            .width
+            .saturating_sub(24 + other)
+            .clamp(SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX);
+        self.sidebars.get_mut(side).width = want.clamp(SIDEBAR_WIDTH_MIN, cap);
+    }
+
+    /// Finish a sidebar resize and persist the new width once (docs/29).
+    pub fn end_sidebar_resize(&mut self) {
+        if self.sidebar_resize.take().is_some() {
+            self.save_sidebars();
+        }
+    }
+
+    /// Recompute which sidebar edge (if any) the cursor is over, for the hover
+    /// highlight (mirrors `update_hover_divider`).
+    pub fn update_hover_sidebar(&mut self, c: u16, r: u16) {
+        self.hover_sidebar = self.sidebar_seam_at(c, r);
+    }
+
     /// Enter keyboard resize mode (RESIZE-3) — a no-op with nothing to resize.
     fn enter_resize_mode(&mut self) {
         if self.active_is_git() || self.active_is_orch() || self.layout().len() < 2 {
@@ -4376,6 +4498,143 @@ mod tests {
         )));
         assert!(app.resize_drag.is_none(), "content press is not a resize");
         assert!(app.selection.is_some(), "content press starts a selection");
+    }
+
+    #[test]
+    fn dragging_the_left_sidebar_edge_resizes_and_persists() {
+        let _env = crate::persist::test_env("sidebar-edge-drag");
+        use crate::event::AppEvent;
+        use ratatui::backend::TestBackend;
+        use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use ratatui::Terminal;
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+
+        let seam = app
+            .left_seam
+            .expect("left sidebar is shown, so it has a seam");
+        let before = app.sidebars.left.width;
+
+        let mouse = |kind, col, row| MouseEvent {
+            kind,
+            column: col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        };
+        // Grab the seam and drag it 6 columns to the right (wider).
+        app.handle_event(AppEvent::Mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            seam.x,
+            seam.y + 3,
+        )));
+        assert_eq!(
+            app.sidebar_resize,
+            Some(Side::Left),
+            "grabbed the left sidebar edge"
+        );
+        app.handle_event(AppEvent::Mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            seam.x + 6,
+            seam.y + 3,
+        )));
+        app.handle_event(AppEvent::Mouse(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            seam.x + 6,
+            seam.y + 3,
+        )));
+        assert!(app.sidebar_resize.is_none(), "released the drag");
+        assert_eq!(
+            app.sidebars.left.width,
+            before + 6,
+            "the left sidebar widened by the drag distance"
+        );
+        // Released width is persisted for the next launch.
+        assert_eq!(
+            crate::config::load().sidebars.unwrap().left.width,
+            before + 6,
+            "the new width was written to config"
+        );
+    }
+
+    #[test]
+    fn sidebar_drag_clamps_and_never_crushes_the_content() {
+        let _env = crate::persist::test_env("sidebar-edge-clamp");
+        use crate::event::AppEvent;
+        use ratatui::backend::TestBackend;
+        use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use ratatui::Terminal;
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let seam = app.left_seam.unwrap();
+
+        let mouse = |kind, col, row| MouseEvent {
+            kind,
+            column: col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_event(AppEvent::Mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            seam.x,
+            seam.y + 3,
+        )));
+        // Drag far past the right edge: width caps at MAX, never eats the content.
+        app.handle_event(AppEvent::Mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            119,
+            seam.y + 3,
+        )));
+        assert!(
+            app.sidebars.left.width <= SIDEBAR_WIDTH_MAX,
+            "width never exceeds the max ({} > {SIDEBAR_WIDTH_MAX})",
+            app.sidebars.left.width
+        );
+        assert!(
+            120 - app.sidebars.left.width >= 24,
+            "the content keeps at least 24 columns"
+        );
+        // Drag hard left: width floors at MIN rather than collapsing to nothing.
+        app.handle_event(AppEvent::Mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            0,
+            seam.y + 3,
+        )));
+        assert_eq!(
+            app.sidebars.left.width, SIDEBAR_WIDTH_MIN,
+            "a leftward drag floors at the minimum, not zero (closing is the chevron's job)"
+        );
+    }
+
+    #[test]
+    fn a_pane_click_does_not_start_a_sidebar_resize() {
+        let _env = crate::persist::test_env("sidebar-edge-nopane");
+        use crate::event::AppEvent;
+        use ratatui::backend::TestBackend;
+        use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use ratatui::Terminal;
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let pane = app.last_pane_area;
+
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: pane.x + 5,
+            row: pane.y + 5,
+            modifiers: KeyModifiers::NONE,
+        }));
+        assert!(
+            app.sidebar_resize.is_none(),
+            "a click inside a pane never grabs the sidebar edge"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -137,6 +137,9 @@ pub fn render_into(f: &mut RenderTarget, app: &mut App) {
     let status_h = if app.compact { 0 } else { 1 };
     let [main, status] =
         Layout::vertical([Constraint::Min(0), Constraint::Length(status_h)]).areas(area);
+    // Stored so an in-flight sidebar-edge drag can map a cursor column to a width
+    // off the correct edge (docs/29).
+    app.last_main_area = main;
 
     // Two sidebars flank the content (docs/29). Each is shown only if visible,
     // non-empty, and it (with the other) leaves the panes at least 24 columns —
@@ -169,6 +172,12 @@ pub fn render_into(f: &mut RenderTarget, app: &mut App) {
     .areas(main);
     let sidebar_left = (lw > 0).then_some(left_area);
     let sidebar_right = (rw > 0).then_some(right_area);
+    // The draggable edge seam of each shown sidebar — the `│` column drawn by
+    // `draw_sidebar` (left sidebar's right edge, right sidebar's left edge).
+    // Recomputed every frame, so a hidden sidebar leaves `None` and its drag can
+    // never fire (docs/29).
+    app.left_seam = sidebar_left.map(|a| Rect::new(a.right().saturating_sub(1), a.y, 1, a.height));
+    app.right_seam = sidebar_right.map(|a| Rect::new(a.x, a.y, 1, a.height));
 
     let [tabbar, pane_area] =
         Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(content);
@@ -555,6 +564,33 @@ pub(super) fn hint_line(pairs: &[(&str, &str)], t: &Theme) -> Line<'static> {
 pub(super) fn display_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr;
     s.width()
+}
+
+/// Truncate `s` to at most `max` display columns, ending in a `…` when it does not
+/// fit. Width-aware like `display_width` (a CJK glyph counts as two, and is never
+/// split), so a narrowed sidebar clips long node/agent/branch names gracefully
+/// instead of hard-cutting mid-glyph (docs/29).
+pub(super) fn truncate(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    if display_width(s) <= max {
+        return s.to_string();
+    }
+    // Reserve one column for the ellipsis.
+    let budget = max - 1;
+    let mut out = String::new();
+    let mut used = 0;
+    for ch in s.chars() {
+        let cw = display_width(&ch.to_string());
+        if used + cw > budget {
+            break;
+        }
+        out.push(ch);
+        used += cw;
+    }
+    out.push('…');
+    out
 }
 
 /// A small centered toast box near the bottom (e.g. "✓ Copied"). Drawn last, so

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -131,16 +131,19 @@ pub(super) fn draw_sidebar(
     f.render_widget(Block::new().style(Style::new().bg(t.base)), area);
     {
         // Edge separator (standard vertical rule): the left sidebar carries it on
-        // its right edge, the right sidebar on its left edge.
+        // its right edge, the right sidebar on its left edge. It doubles as the
+        // draggable resize seam (docs/29) and brightens while hovered or dragged.
         let sep_x = match side {
             Side::Left => area.right().saturating_sub(1),
             Side::Right => area.x,
         };
+        let seam_active = app.hover_sidebar == Some(side) || app.sidebar_resize == Some(side);
+        let sep_fg = if seam_active { t.overlay0 } else { t.surface0 };
         let buf = f.buffer_mut();
         for y in area.top()..area.bottom() {
             buf[(sep_x, y)]
                 .set_symbol("│")
-                .set_style(Style::new().fg(t.surface0).bg(t.base));
+                .set_style(Style::new().fg(sep_fg).bg(t.base));
         }
     }
 
@@ -389,18 +392,40 @@ fn draw_workspaces_dock(
         // A linked worktree is nested under its parent checkout with a connector.
         let indent: u16 = if is_member { 2 } else { 0 };
         // Row 1: state dot + workspace name + git branch (dot aligned with "WORKSPACES").
+        // On a narrow sidebar the name keeps priority: it is ellipsized only when
+        // it can't share the row, and the branch is fitted (then ellipsized, then
+        // dropped) into whatever space is left, so the row never hard-cuts.
+        let avail = (cw as usize).saturating_sub(indent as usize + 2);
+        let name_w = crate::ui::display_width(&ws.name);
+        let (name_disp, branch_disp) = match &ws.branch {
+            Some(b) => {
+                let branch_seg = 2 + crate::ui::display_width(b); // "  branch"
+                if name_w + branch_seg <= avail {
+                    (ws.name.clone(), Some(b.clone()))
+                } else if name_w + 4 <= avail {
+                    (
+                        ws.name.clone(),
+                        Some(crate::ui::truncate(b, avail - name_w - 2)),
+                    )
+                } else {
+                    (crate::ui::truncate(&ws.name, avail), None)
+                }
+            }
+            None => (crate::ui::truncate(&ws.name, avail), None),
+        };
         let mut line1: Vec<Span> = Vec::new();
         if is_member {
             line1.push(Span::styled("└ ", Style::new().fg(t.overlay0)));
         }
         line1.push(Span::styled(st.dot(), Style::new().fg(st.color(t))));
         line1.push(Span::raw(" "));
-        line1.push(Span::styled(ws.name.clone(), name_style));
-        if let Some(b) = &ws.branch {
-            // Record the branch text as a clickable rect (opens the git tab).
-            let name_w = ws.name.chars().count() as u16;
-            let bx = cx + 2 + indent + name_w;
-            let bw = 2 + b.chars().count() as u16;
+        let name_dw = crate::ui::display_width(&name_disp) as u16;
+        line1.push(Span::styled(name_disp, name_style));
+        if let Some(b) = &branch_disp {
+            // Record the branch text as a clickable rect (opens the git tab),
+            // positioned by the *displayed* name width so a click still lands.
+            let bx = cx + 2 + indent + name_dw;
+            let bw = 2 + crate::ui::display_width(b) as u16;
             if bx < area.right() {
                 let bw = bw.min(area.right().saturating_sub(bx));
                 app.workspace_branch_rects
@@ -567,12 +592,15 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                 } else {
                     st.dot()
                 };
+                let label = format!(" {}  ", st.label());
+                let prefix_w = crate::ui::display_width(dot) + crate::ui::display_width(&label);
+                let agent = crate::ui::truncate(&agent, (cw as usize).saturating_sub(prefix_w));
                 line_at(
                     f,
                     y,
                     Line::from(vec![
                         Span::styled(dot, Style::new().fg(st.color(t))),
-                        Span::styled(format!(" {}  ", st.label()), Style::new().fg(st.color(t))),
+                        Span::styled(label, Style::new().fg(st.color(t))),
                         Span::styled(agent, name_style),
                     ]),
                 );
@@ -584,7 +612,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                     f,
                     y + 1,
                     Line::from(Span::styled(
-                        format!("  {wsname} · {tab_label}"),
+                        crate::ui::truncate(&format!("  {wsname} · {tab_label}"), cw as usize),
                         Style::new().fg(if focused { t.subtext0 } else { t.overlay0 }),
                     )),
                 );
@@ -607,20 +635,23 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                     .unwrap_or("project");
                 let row = Rect::new(area.x, y, area.width, 2);
                 session_rects.push((si, row));
+                let label = " resume  ";
+                let prefix_w = 1 + crate::ui::display_width(label);
+                let name = crate::ui::truncate(&s.agent, (cw as usize).saturating_sub(prefix_w));
                 line_at(
                     f,
                     y,
                     Line::from(vec![
                         Span::styled("○", Style::new().fg(t.overlay1)),
-                        Span::styled(" resume  ", Style::new().fg(t.overlay1)),
-                        Span::styled(s.agent.clone(), Style::new().fg(t.subtext0)),
+                        Span::styled(label, Style::new().fg(t.overlay1)),
+                        Span::styled(name, Style::new().fg(t.subtext0)),
                     ]),
                 );
                 line_at(
                     f,
                     y + 1,
                     Line::from(Span::styled(
-                        format!("  {proj}"),
+                        crate::ui::truncate(&format!("  {proj}"), cw as usize),
                         Style::new().fg(t.overlay0),
                     )),
                 );
@@ -663,12 +694,15 @@ fn draw_module_dock(f: &mut RenderTarget, area: Rect, id: &str, app: &mut App, t
     for (i, row) in rows.iter().take(cap).enumerate() {
         let y = list_top + i as u16;
         let mut spans: Vec<Span> = Vec::new();
+        let mut prefix_w = 0usize;
         if let Some(dot) = &row.dot {
             let st = state_from_name(dot);
             spans.push(Span::styled(st.dot(), Style::new().fg(st.color(t))));
             spans.push(Span::raw(" "));
+            prefix_w = 2;
         }
-        spans.push(Span::styled(row.text.clone(), Style::new().fg(t.subtext1)));
+        let text = crate::ui::truncate(&row.text, (cw as usize).saturating_sub(prefix_w));
+        spans.push(Span::styled(text, Style::new().fg(t.subtext1)));
         line_at(f, y, Line::from(spans));
         if row.action.is_some() {
             app.module_dock_rects
@@ -771,6 +805,31 @@ mod tests {
         assert!(
             !buffer_contains(&term, "· tab 1"),
             "and must not still show the old number"
+        );
+    }
+
+    // A node/branch name too long for the sidebar is ellipsized, never hard-cut
+    // mid-word (docs/29 — matters now that the sidebar can be dragged narrow).
+    #[test]
+    fn long_workspace_name_is_ellipsized_not_hard_cut() {
+        let _env = crate::persist::test_env("sidebar-truncate");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let long = "a-really-long-workspace-name-that-cannot-possibly-fit";
+        app.workspaces[0].name = long.into();
+        app.workspaces[0].branch = Some("feature/some-very-long-branch-name".into());
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        // Read just the sidebar columns (the default left sidebar is 26 wide); the
+        // full name can appear untruncated in the wider status/tab chrome.
+        let buf = term.backend().buffer();
+        let sidebar: String = (0..buf.area.height)
+            .flat_map(|r| (0..26).map(move |c| buf.cell((c, r)).map(|x| x.symbol()).unwrap_or(" ")))
+            .collect();
+        assert!(sidebar.contains('…'), "an over-long name shows an ellipsis");
+        assert!(
+            !sidebar.contains(long),
+            "the full over-long name is never rendered in the sidebar"
         );
     }
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -33,8 +33,13 @@ export default defineConfig({
         { icon: 'github', label: 'GitHub', href: 'https://github.com/RizRiyz/bohay' },
       ],
       customCss: [
-        // Mono throughout, like the landing page: JetBrains Mono for body and
-        // code, IBM Plex Mono for the wordmark, headings and labels.
+        // Inter for running prose, JetBrains Mono for code, IBM Plex Mono for
+        // the wordmark, headings and labels. The landing page is mono
+        // throughout, but documentation is long-form reading: setting body text
+        // in a monospace face hurts legibility over paragraphs, so the docs keep
+        // a proportional face for prose and stay mono everywhere it signifies
+        // something (code, headings, chrome).
+        '@fontsource-variable/inter',
         '@fontsource-variable/jetbrains-mono',
         '@fontsource/ibm-plex-mono/500.css',
         '@fontsource/ibm-plex-mono/600.css',

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -100,7 +100,7 @@
   /* Monospace throughout, like the landing page: this is a terminal program,
      and a single face across body, chrome and code is what makes the docs read
      as part of the same site rather than as a generic documentation theme. */
-  --sl-font: 'JetBrains Mono Variable', ui-monospace, 'SF Mono', Menlo, monospace;
+  --sl-font: 'Inter Variable', ui-sans-serif, system-ui, sans-serif;
   --sl-font-mono: 'JetBrains Mono Variable', ui-monospace, 'SF Mono', Menlo, monospace;
   /* Display face — the wordmark, headings and labels. Tight tracking is what
      keeps a monospace heading from looking like plain terminal output. */
@@ -158,7 +158,7 @@
    landing page's rhythm: ~13.5px body on 1.75, headings that stop well short of
    Starlight's 42px h1. */
 :root:root {
-  --sl-text-base: 0.875rem;
+  --sl-text-base: 1rem;
   --sl-text-body: 0.875rem;
   --sl-text-body-sm: 0.8rem;
   --sl-text-code: 0.82rem;
@@ -180,7 +180,7 @@
   }
 }
 .sl-markdown-content {
-  font-size: 0.875rem;
+  font-size: 0.975rem;
 }
 .sl-markdown-content h1,
 .sl-markdown-content h2,
@@ -192,8 +192,9 @@ h1[id='_top'],
   letter-spacing: -0.03em;
   font-weight: 600;
 }
-/* Body text: mono, antialiased, on the page background — the landing page's
-   `body` rule, restated for the pieces Starlight renders outside the article. */
+/* Antialiasing, restated for the pieces Starlight renders outside the article.
+   Prose itself is proportional (see `--sl-font`); mono is reserved for code,
+   headings and chrome. */
 body {
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Two sidebar improvements, plus a small docs-site fix that rode along on this branch.

## Resizable sidebars
Drag either sidebar's edge to resize it, the same gesture as the pane dividers. The edge line brightens when you hover it; click and drag to set the width, release to keep it. Width is clamped so the panes always keep at least 24 columns, and dragging inward floors at the minimum rather than collapsing the sidebar (closing stays the chevron's job). The new width is saved once on release, so nothing writes to the config file mid-drag. The grab zone reaches a couple of columns onto the pane side but never over a mouse-tracking agent, so Claude Code's own edge clicks still work.

## Graceful long text
Long node, agent, branch, and session names now end in an ellipsis instead of being hard-cut mid-word when the sidebar is narrow. Node names keep priority: if a name and its branch can't both fit, the branch is shrunk, then dropped, before the name itself is touched. Truncation is width-aware, so a CJK name never splits a glyph.

## Also on this branch
A small fix to the docs site's reading font and scale for prose.
