### PR TITLE
feat: Re-apply agent launch flags on session resume

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -279,6 +279,72 @@ pub fn resume_command(agent: &str, session_id: &str) -> Option<String> {
     Some((src.resume)(&q))
 }
 
+/// Strip the session-selection flags from a captured launch argv (docs/62) so
+/// replaying it cannot fight the fresh `--resume <id>` bohay injects or re-fork
+/// the pane. Every other flag is kept verbatim, so unknown future flags survive
+/// untouched. Value-taking selectors also swallow the following bareword value.
+fn filter_launch_flags(agent: &str, launch: &[String]) -> Vec<String> {
+    const TAKES_VALUE: &[&str] = &["--resume", "-r", "--session", "--session-id", "--fork"];
+    const STANDALONE: &[&str] = &["--continue", "--fork-session", "--print", "-p"];
+
+    let mut i = 0;
+    // Codex selects a session with a positional `resume <id>` subcommand rather
+    // than a flag, so drop it when it leads the captured argv.
+    if agent == "codex" && launch.first().map(String::as_str) == Some("resume") {
+        i = 1;
+        if launch.get(1).is_some_and(|v| !v.starts_with('-')) {
+            i = 2;
+        }
+    }
+    let mut out = Vec::new();
+    while i < launch.len() {
+        let t = launch[i].as_str();
+        let head = t.split('=').next().unwrap_or(t);
+        if t.contains('=') && TAKES_VALUE.contains(&head) {
+            i += 1; // glued form, e.g. --resume=<id>
+            continue;
+        }
+        if TAKES_VALUE.contains(&t) {
+            i += 1;
+            if launch.get(i).is_some_and(|v| !v.starts_with('-')) {
+                i += 1; // swallow the value
+            }
+            continue;
+        }
+        if STANDALONE.contains(&t) {
+            i += 1;
+            continue;
+        }
+        out.push(launch[i].clone());
+        i += 1;
+    }
+    out
+}
+
+/// Like [`resume_command`], but re-applies the flags the pane was launched with
+/// (docs/62). Session-selection flags are filtered first so they cannot conflict
+/// with the fresh session id, then each kept flag is shell-quoted and appended
+/// after the resume reference, where every supported agent accepts trailing
+/// flags. Falls back to the plain resume command when nothing survives the filter.
+pub fn resume_command_with_flags(
+    agent: &str,
+    session_id: &str,
+    launch: &[String],
+) -> Option<String> {
+    let base = resume_command(agent, session_id)?;
+    let extra = filter_launch_flags(agent, launch);
+    if extra.is_empty() {
+        return Some(base);
+    }
+    let quoted = extra
+        .iter()
+        .map(|a| format!("'{}'", a.replace('\'', "'\\''")))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let body = base.trim_end_matches(['\r', '\n']);
+    Some(format!("{body} {quoted}\r"))
+}
+
 /// The command that **forks** an agent's session: continue from the original's
 /// full context in a new, diverging session (the original is left untouched).
 /// `None` for agents without a native fork, unknown agents, or unsafe ids.
@@ -1322,6 +1388,78 @@ mod tests {
         assert!(recent
             .iter()
             .any(|s| s.cwd == Path::new("/very/long/path/to/api")));
+    }
+
+    #[test]
+    fn launch_flag_filter_drops_session_selection() {
+        let f = |a: &str, v: &[&str]| {
+            filter_launch_flags(a, &v.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+        };
+        // A stale `--resume <id>` (captured from a pane bohay itself resumed) is
+        // dropped with its value; the real flags survive.
+        assert_eq!(
+            f("claude", &["--resume", "old-id", "--model", "opus"]),
+            vec!["--model", "opus"]
+        );
+        // Glued form.
+        assert_eq!(
+            f("copilot", &["--resume=old", "--banner"]),
+            vec!["--banner"]
+        );
+        // Standalone selectors, a fork flag, and one-shot print mode all go.
+        assert_eq!(
+            f(
+                "claude",
+                &["--continue", "--fork-session", "-p", "--verbose"]
+            ),
+            vec!["--verbose"]
+        );
+        // Codex selects a session with a positional `resume <id>` subcommand.
+        assert_eq!(
+            f("codex", &["resume", "sess_9", "--model", "o3"]),
+            vec!["--model", "o3"]
+        );
+        // A kept flag keeps its value.
+        assert_eq!(
+            f("claude", &["--permission-mode", "bypassPermissions"]),
+            vec!["--permission-mode", "bypassPermissions"]
+        );
+        // Nothing worth keeping.
+        assert!(f("claude", &["--resume", "id"]).is_empty());
+        assert!(f("claude", &[]).is_empty());
+    }
+
+    #[test]
+    fn resume_command_with_flags_appends_kept_flags() {
+        let launch = ["--resume", "abc", "--model", "opus"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        let cmd = resume_command_with_flags("claude", "abc", &launch).unwrap();
+        // The id still comes from resume_command; kept flags follow, \r preserved.
+        assert!(cmd.starts_with("claude --resume 'abc'"));
+        assert!(cmd.contains("'--model' 'opus'"));
+        assert!(cmd.ends_with('\r'));
+        // The stale captured --resume was filtered: exactly one resume id remains.
+        assert_eq!(cmd.matches("--resume").count(), 1);
+
+        // All-filtered input and empty input both fall back to the plain command.
+        let base = resume_command("claude", "abc").unwrap();
+        let only_sel = ["--resume", "abc"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            resume_command_with_flags("claude", "abc", &only_sel).unwrap(),
+            base
+        );
+        assert_eq!(
+            resume_command_with_flags("claude", "abc", &[]).unwrap(),
+            base
+        );
+
+        // Unknown agent is None, exactly like resume_command.
+        assert!(resume_command_with_flags("nope", "x", &["--model".into()]).is_none());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1587,10 +1587,17 @@ impl App {
                     // the pane opens straight into the resuming agent (nothing
                     // visibly typed); an unrecognised shell family falls back
                     // to typing the command after spawn.
-                    let resume = ps
-                        .agent_session
-                        .as_ref()
-                        .and_then(|(agent, sid)| crate::agent::resume_command(agent, sid));
+                    let resume =
+                        ps.agent_session
+                            .as_ref()
+                            .and_then(|(agent, sid)| match &ps.agent_launch {
+                                // Re-apply the launch flags captured at save time
+                                // (docs/62); falls back to the plain resume command.
+                                Some(flags) => {
+                                    crate::agent::resume_command_with_flags(agent, sid, flags)
+                                }
+                                None => crate::agent::resume_command(agent, sid),
+                            });
                     let resume_argv = resume.as_deref().and_then(|r| {
                         crate::platform::shell_run_then_interactive(&shell, r.trim())
                     });
@@ -4481,6 +4488,54 @@ mod tests {
         // The pane came back under a new id, but its name followed it.
         let rid = restored.layout().focus;
         assert_eq!(restored.agent_name_for(rid), Some("backend"));
+    }
+
+    /// The flags an agent pane was launched with (docs/62) are pulled from the
+    /// captured process argv into the snapshot, and survive a JSON round-trip. An
+    /// older snapshot with no such field loads as `None` (serde default), so the
+    /// change is backward compatible.
+    #[test]
+    fn agent_launch_flags_are_captured_in_the_snapshot() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let focus = app.layout().focus;
+        // Stand in for the detection scan: a claude pane started with flags.
+        app.status.get_mut(&focus).unwrap().agent = "claude".into();
+        app.proc_commands.insert(
+            focus,
+            vec!["claude --model opus --permission-mode bypassPermissions".into()],
+        );
+
+        let launch_of = |snap: &SessionSnapshot| -> Option<Vec<String>> {
+            snap.workspaces
+                .iter()
+                .flat_map(|w| &w.tabs)
+                .flat_map(|t| &t.panes)
+                .find(|(id, _)| *id == focus.0)
+                .and_then(|(_, ps)| ps.agent_launch.clone())
+        };
+
+        let snap = persist::snapshot(&app);
+        assert_eq!(
+            launch_of(&snap),
+            Some(vec![
+                "--model".into(),
+                "opus".into(),
+                "--permission-mode".into(),
+                "bypassPermissions".into(),
+            ])
+        );
+
+        // Survives serialization.
+        let json = serde_json::to_string(&snap).unwrap();
+        let back: SessionSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(launch_of(&back).unwrap().len(), 4);
+
+        // A PaneSnap written before this field existed still loads (serde default
+        // -> None), so old sessions are unaffected.
+        let old: persist::PaneSnap =
+            serde_json::from_str(r#"{"cwd":"/tmp/x","command":"sh"}"#).unwrap();
+        assert_eq!(old.agent_launch, None);
     }
 
     /// Two agent panes in one folder must not both restore the *same* session.

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -763,6 +763,41 @@ impl Manifests {
         None
     }
 
+    /// The launch flags an agent pane was started with: the argv tokens **after**
+    /// the agent's own token in its command line, in original case (docs/62).
+    /// Mirrors `agent_in_processes` -- the same per-token binary match and the
+    /// same interpreter unwrap (`node .../cli.js --flag`) -- but returns the tail
+    /// for the requested agent instead of a name. `None` when no running command
+    /// line belongs to that agent, so a pane bohay cannot pin to it captures
+    /// nothing rather than guessing.
+    pub fn launch_args_for(&self, running: &[String], agent: &str) -> Option<Vec<String>> {
+        for cmd in running {
+            let tokens: Vec<&str> = cmd.split_whitespace().collect();
+            let Some((first, rest)) = tokens.split_first() else {
+                continue;
+            };
+            let first_low = first.to_lowercase();
+            if self.match_binary(binary_name(&first_low)).as_deref() == Some(agent) {
+                return Some(rest.iter().map(|s| s.to_string()).collect());
+            }
+            // Interpreter form: the agent token is the first non-flag argument,
+            // and nothing before it is a launch flag.
+            if is_interpreter(binary_name(&first_low)) {
+                for (i, t) in rest.iter().enumerate() {
+                    if t.starts_with('-') {
+                        continue;
+                    }
+                    let t_low = t.to_lowercase();
+                    if self.match_binary(binary_name(&t_low)).as_deref() == Some(agent) {
+                        return Some(rest[(i + 1)..].iter().map(|s| s.to_string()).collect());
+                    }
+                    break; // the first non-flag arg is the script slot; nothing later counts
+                }
+            }
+        }
+        None
+    }
+
     /// The agent whose patterns name exactly this binary.
     fn match_binary(&self, base: &str) -> Option<String> {
         self.agents
@@ -879,6 +914,46 @@ mod tests {
             &Manifests::builtin(),
         )
         .state
+    }
+
+    #[test]
+    fn launch_args_extracted_after_the_agent_token() {
+        let m = Manifests::builtin();
+        // Direct binary at an absolute path; original case is preserved.
+        assert_eq!(
+            m.launch_args_for(
+                &[
+                    "/opt/homebrew/bin/claude --model Opus --permission-mode bypassPermissions"
+                        .into()
+                ],
+                "claude",
+            ),
+            Some(vec![
+                "--model".into(),
+                "Opus".into(),
+                "--permission-mode".into(),
+                "bypassPermissions".into(),
+            ])
+        );
+        // Interpreter form: the tail starts after the script slot that names the
+        // agent, and the interpreter's own args before it are ignored.
+        assert_eq!(
+            m.launch_args_for(
+                &["python /usr/local/bin/aider --model gpt-4o --yes".into()],
+                "aider"
+            ),
+            Some(vec!["--model".into(), "gpt-4o".into(), "--yes".into()])
+        );
+        // A plain shell, and a different agent, both yield nothing for claude.
+        assert!(m.launch_args_for(&["zsh -l".into()], "claude").is_none());
+        assert!(m
+            .launch_args_for(&["codex --model o".into()], "claude")
+            .is_none());
+        // An agent launched with no flags yields an empty tail (Some, not None).
+        assert_eq!(
+            m.launch_args_for(&["claude".into()], "claude"),
+            Some(vec![])
+        );
     }
 
     #[test]

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -63,6 +63,11 @@ pub struct PaneSnap {
     /// (agent, session_id) for native resume, if reported.
     #[serde(default)]
     pub agent_session: Option<(String, String)>,
+    /// The launch flags the agent pane was started with (argv after the agent
+    /// token, docs/62), replayed after the resume reference on restore. Session
+    /// selection flags are filtered at replay, so the stored list stays faithful.
+    #[serde(default)]
+    pub agent_launch: Option<Vec<String>>,
     /// The visible screen as ANSI, replayed on restore.
     #[serde(default)]
     pub screen: Option<String>,
@@ -377,6 +382,7 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
                                 command: String::new(),
                                 name: app.agent_name_for(id).map(|s| s.to_string()),
                                 agent_session: None,
+                                agent_launch: None,
                                 screen: None,
                                 module: None,
                                 file: Some(v.path.clone()),
@@ -387,6 +393,21 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
                         // Resolved once for the whole snapshot so no two panes
                         // can claim the same session (see `resolve_pane_sessions`).
                         let agent_session = sessions.get(&id).cloned().flatten();
+                        // The flags the agent was launched with, pulled from the
+                        // live process argv the detection scan already captured
+                        // (docs/62). Only for a recognized agent; a plain shell's
+                        // argv never matches, so it stays None.
+                        let agent_launch = app
+                            .status
+                            .get(&id)
+                            .map(|s| s.agent.as_str())
+                            .filter(|k| app.manifests.is_agent(k))
+                            .and_then(|k| {
+                                app.proc_commands
+                                    .get(&id)
+                                    .and_then(|cmds| app.manifests.launch_args_for(cmds, k))
+                            })
+                            .filter(|v| !v.is_empty());
                         // Capture the visible screen (cap size to keep saves light).
                         let screen = p
                             .engine
@@ -405,6 +426,7 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
                                 command: p.command.clone(),
                                 name: app.agent_name_for(id).map(|s| s.to_string()),
                                 agent_session,
+                                agent_launch,
                                 screen,
                                 module,
                                 file: None,

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -70,7 +70,7 @@ impl Theme {
             overlay1: rgb(0x80, 0x87, 0xa2),
             subtext0: rgb(0xa5, 0xad, 0xcb),
             subtext1: rgb(0xb8, 0xc0, 0xe0),
-            text: rgb(0xca, 0xd3, 0xf5),   // white (Catppuccin Macchiato text)
+            text: rgb(0xca, 0xd3, 0xf5), // white (Catppuccin Macchiato text)
             accent: rgb(0xdb, 0xc6, 0x6f), // rally gold — brand, focus, selected
             sel_bg: rgb(0x3a, 0x34, 0x16), // dark gold selection
             border: rgb(0x49, 0x4d, 0x64),


### PR DESCRIPTION
Session resume now re-applies the flags a pane was launched with, instead of reverting to a bare `claude --resume <id>`.

When a pane is snapshotted, bohay records the agent's launch flags (`--model`, `--permission-mode`, and so on) from the process argv the detection scan already reads, so there is no new scanning cost. On restore, those flags are replayed after the resume reference, with session-selection flags (`--resume`, `--continue`, `--session`, `--fork-session`) filtered out so they cannot conflict with the fresh session id or re-fork the pane.

The change is additive and backward compatible: the new snapshot field is optional, old sessions load unchanged, and the existing resume path is untouched when no flags were captured. Covered by unit tests for the filter, the command builder, argv extraction, and a snapshot round-trip. Full suite green, clippy and fmt clean.