### PR TITLE
feat(detect): OTA detection-rule updates via 'bohay server update-manifest'

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -395,6 +395,14 @@ impl App {
     pub(crate) fn dispatch(&mut self, method: &str, p: &Value) -> Result<Value, (String, String)> {
         match method {
             "ping" => Ok(json!({"type":"pong","version": env!("CARGO_PKG_VERSION"),"protocol":1})),
+            // Re-read `~/.bohay/manifests/` (built-in + managed OTA + user) into
+            // the live engine, so `server update-manifest` applies without a
+            // restart. Detection uses the new rules on the next tick.
+            "manifest.reload" => {
+                self.manifests =
+                    crate::detect::Manifests::load(&crate::persist::ensure_manifests_dir());
+                Ok(json!({"type":"ok","rules": self.manifests.rule_count()}))
+            }
             "server.stop" => {
                 self.should_quit = true;
                 Ok(json!({"type":"ok"}))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,6 +169,8 @@ server:
   server start               start the background server if it isn't up
   server stop                stop the server (and all panes)
   server restart             stop + start (load a newly-installed binary)
+  server update-manifest     fetch the latest agent-detection rules from bohay.dev
+                             (applies live if the server is up; else on next start)
   integration install|uninstall <claude|copilot|codex|opencode|kimi|grok>
                              add/remove bohay's session-resume hook (uninstall
                              removes only bohay's hook, never the agent)
@@ -853,7 +855,7 @@ pub fn request_attach(pane: &str) -> Result<()> {
 }
 
 /// One request/response over the control socket.
-fn send_request(method: &str, params: Value) -> Result<Value> {
+pub(crate) fn send_request(method: &str, params: Value) -> Result<Value> {
     let path = crate::persist::cli_socket_path();
     let mut stream =
         crate::ipc::transport::connect(&path).map_err(|_| anyhow!("no bohay server running"))?;

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -250,17 +250,22 @@ impl Cond {
     }
 }
 
-/// A spinner glyph: a *non-blank* braille cell (the common animated spinner) or a
-/// moon phase (Kimi animates 🌑..🌘 for background agents).
+/// A spinner glyph: a *non-blank* braille cell (the common animated spinner), a
+/// moon phase (Kimi animates 🌑..🌘 for background agents), or a half-circle
+/// (◐◑◒◓) — the busy spinner newer Claude Code builds animate instead of braille.
 ///
-/// The range deliberately starts at `U+2801`, **excluding `U+2800`** (Braille
-/// Pattern Blank). That codepoint is an invisible cell many TUIs use for
+/// The braille range deliberately starts at `U+2801`, **excluding `U+2800`**
+/// (Braille Pattern Blank). That codepoint is an invisible cell many TUIs use for
 /// padding/indentation, and it is *not* Unicode whitespace, so `trim_start`
 /// leaves it at the start of a line — which used to make an idle agent whose UI
 /// pads a line with it read as a running spinner (stuck "working"). A real
-/// animated spinner only ever shows non-blank frames, so this loses nothing.
+/// animated spinner only ever shows non-blank frames, so this loses nothing. The
+/// half-circle range is safe here because Claude's *done* line begins with a
+/// different glyph (a star ✻), not a half-circle.
 fn is_spinner_glyph(c: char) -> bool {
-    ('\u{2801}'..='\u{28FF}').contains(&c) || ('\u{1F311}'..='\u{1F318}').contains(&c)
+    ('\u{2801}'..='\u{28FF}').contains(&c)
+        || ('\u{1F311}'..='\u{1F318}').contains(&c)
+        || ('\u{25D0}'..='\u{25D3}').contains(&c)
 }
 
 /// A detection rule: `state` is chosen when every `cond` holds in `region`.
@@ -296,11 +301,22 @@ impl Manifests {
     pub fn load(dir: &Path) -> Manifests {
         let mut rules = builtin_rules();
         let mut agents = builtin_agents();
-        for mf in load_dir(dir) {
+        // Official OTA manifests (`bohay server update-manifest`) live in a
+        // `managed/` subdir, kept apart from the user's own `*.toml` so an update
+        // never clobbers a hand-written rule. Load managed first, then the user's,
+        // so equal-priority user rules can still override.
+        let managed = load_dir(&dir.join("managed"));
+        for mf in managed.into_iter().chain(load_dir(dir)) {
             mf.apply_identity(&mut agents);
             rules.extend(mf.into_rules());
         }
         Manifests { rules, agents }
+    }
+
+    /// Total detection rules in effect (built-in + managed + user), for the
+    /// `manifest.reload` reply so a caller can confirm an update took.
+    pub fn rule_count(&self) -> usize {
+        self.rules.len()
     }
 
     /// True if `name` is a recognised agent (not a plain shell). Drives whether
@@ -411,6 +427,23 @@ fn builtin_rules() -> Vec<Rule> {
             Region::Screen,
             vec![any(&["ctrl+c to stop"])],
         ),
+        // Newer Claude Code dropped the "esc to interrupt" hint and animates a
+        // non-braille spinner (✢/✻/✳), so the generic working rules miss it and
+        // the pane read as idle while generating. Its live line is
+        // "✢ Inferring… (12s · ↓ 3.2k tokens)", the streaming token counter of
+        // its **built-in** spinner (not the user-customizable statusLine). Match
+        // `↓ ` AND `tokens)` together, so a custom statusLine that happens to
+        // contain one of them (e.g. `↓3` git state) can't false-trigger working.
+        // The done line ("✻ Cogitated for 18s") has neither, so it stays idle,
+        // and the glyph is deliberately *not* added to `is_spinner_glyph`: the
+        // same ✻ appears in the done state and would misread it as working.
+        per(
+            "claude",
+            State::Working,
+            115,
+            Region::Screen,
+            vec![all(&["↓ ", "tokens)"])],
+        ),
         // Kimi's approval panel (permission prompt) shows the footer
         // "↑/↓ select · N choose · ↵ confirm" while it waits — a very specific
         // three-word combination, so it can't be mistaken for the spinner that
@@ -513,6 +546,12 @@ fn default_generic() -> String {
 }
 fn default_screen() -> String {
     "screen".to_string()
+}
+
+/// Whether `s` parses as a detection manifest, so `server update-manifest` can
+/// reject a garbled download before writing it into the managed dir.
+pub(crate) fn manifest_parses(s: &str) -> bool {
+    toml::from_str::<ManifestFile>(s).is_ok()
 }
 
 fn load_dir(dir: &Path) -> Vec<ManifestFile> {
@@ -954,6 +993,76 @@ mod tests {
             m.launch_args_for(&["claude".into()], "claude"),
             Some(vec![])
         );
+    }
+
+    #[test]
+    fn newer_claude_token_counter_reads_working() {
+        // Recent Claude Code shows "✢ Inferring… (12s · ↓ 3.2k tokens)" with no
+        // "esc to interrupt" and a non-braille spinner, so only the streaming
+        // token counter proves it is working.
+        assert_eq!(
+            state("✢ Inferring… (12s · ↓ 3.2k tokens)", false, false),
+            State::Working
+        );
+        // The done line is past-tense with no counter and must stay idle, even
+        // though it starts with the same ✻ glyph.
+        assert_eq!(state("✻ Cogitated for 18s", false, false), State::Idle);
+        assert_eq!(state("✻ Worked for 47s", false, false), State::Idle);
+    }
+
+    #[test]
+    fn half_circle_busy_spinner_reads_working() {
+        // Some Claude Code builds animate a half-circle busy spinner (◐◑◒◓)
+        // instead of braille; a line beginning with one means work.
+        assert_eq!(state("◐ Thinking…", false, false), State::Working);
+        assert_eq!(state("◓ Doing the thing", false, false), State::Working);
+        // A star-led done line is still idle — stars are not spinner glyphs here.
+        assert_eq!(state("✻ Cogitated for 18s", false, false), State::Idle);
+    }
+
+    #[test]
+    fn managed_ota_manifests_load_from_the_managed_subdir() {
+        use std::fs;
+        let dir = std::env::temp_dir().join(format!("bohay-managed-mf-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let managed = dir.join("managed");
+        fs::create_dir_all(&managed).unwrap();
+        // An OTA-style manifest that teaches claude a custom working marker.
+        fs::write(
+            managed.join("claude.toml"),
+            "agent = \"claude\"\n\
+             [[rule]]\n\
+             state = \"working\"\n\
+             priority = 250\n\
+             region = \"screen\"\n\
+             all = [\"zzz-marker\"]\n",
+        )
+        .unwrap();
+        let m = Manifests::load(&dir);
+        let d = classify(
+            Some("claude"),
+            "zzz-marker showing",
+            false,
+            false,
+            "claude",
+            "claude",
+            &[],
+            &m,
+        );
+        assert_eq!(
+            d.state,
+            State::Working,
+            "a managed/ manifest rule took effect"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn manifest_parses_accepts_valid_and_rejects_garbage() {
+        assert!(manifest_parses(
+            "agent = \"claude\"\n[[rule]]\nstate = \"working\"\nregion = \"screen\"\nall = [\"x\"]\n"
+        ));
+        assert!(!manifest_parses("this is not toml ["));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,12 +522,93 @@ fn server_cmd(args: &[String]) -> Result<()> {
         Some("stop") => server_stop(),
         Some("restart") => server_restart(),
         Some("status") => server_status(),
+        Some("update-manifest") => update_manifest(),
         Some(other) => {
             eprintln!("unknown server command: {other}");
-            eprintln!("usage: bohay server <start|stop|restart|status>");
+            eprintln!("usage: bohay server <start|stop|restart|status|update-manifest>");
             std::process::exit(2);
         }
     }
+}
+
+/// The published agent-detection manifest index (`bohay.dev/manifests/index.json`).
+#[derive(serde::Deserialize)]
+struct ManifestIndex {
+    files: Vec<String>,
+}
+
+/// `bohay server update-manifest` — fetch the latest agent-detection manifests
+/// and merge them in, so detection keeps up with agent-CLI UI changes without a
+/// binary release. Files land in the **managed** manifest dir (never touching a
+/// user's own manifests) and apply live if a server is running, else on next
+/// start. The source is `https://bohay.dev/manifests` (override with
+/// `$BOHAY_MANIFEST_URL`, e.g. a `file://` dir for testing).
+fn update_manifest() -> Result<()> {
+    let base = std::env::var("BOHAY_MANIFEST_URL")
+        .unwrap_or_else(|_| "https://bohay.dev/manifests".to_string());
+    let index_url = format!("{base}/index.json");
+    let index_body = crate::module::discovery::http_get(&index_url)
+        .map_err(|e| anyhow!("could not fetch the manifest index ({index_url}): {e}"))?;
+    let index: ManifestIndex = serde_json::from_str(&index_body)
+        .map_err(|e| anyhow!("bad manifest index at {index_url}: {e}"))?;
+
+    let managed = persist::manifests_dir().join("managed");
+    std::fs::create_dir_all(&managed)
+        .map_err(|e| anyhow!("cannot create {}: {e}", managed.display()))?;
+
+    let (mut written, mut skipped) = (0usize, 0usize);
+    for name in &index.files {
+        // Only plain `<agent>.toml` names — never a path that could escape the dir.
+        let bad = !name.ends_with(".toml")
+            || name.contains('/')
+            || name.contains('\\')
+            || name.contains("..");
+        if bad {
+            eprintln!("skipping suspicious manifest name: {name}");
+            skipped += 1;
+            continue;
+        }
+        let body = match crate::module::discovery::http_get(&format!("{base}/{name}")) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping {name}: {e}");
+                skipped += 1;
+                continue;
+            }
+        };
+        // Reject a garbled download before it can land in the managed dir.
+        if !crate::detect::manifest_parses(&body) {
+            eprintln!("skipping {name}: not a valid detection manifest");
+            skipped += 1;
+            continue;
+        }
+        std::fs::write(managed.join(name), body.as_bytes())
+            .map_err(|e| anyhow!("cannot write {name}: {e}"))?;
+        written += 1;
+    }
+    println!(
+        "updated {written} detection manifest(s){} -> {}",
+        if skipped > 0 {
+            format!(", {skipped} skipped")
+        } else {
+            String::new()
+        },
+        managed.display()
+    );
+
+    // Apply live if a server is up; otherwise the new rules load on next start.
+    match crate::cli::send_request("manifest.reload", serde_json::json!({})) {
+        Ok(v) => {
+            let n = v
+                .get("result")
+                .and_then(|r| r.get("rules"))
+                .and_then(|x| x.as_u64())
+                .unwrap_or(0);
+            println!("reloaded into the running server ({n} rules active) - no restart needed");
+        }
+        Err(_) => println!("no server running - the update loads on next start"),
+    }
+    Ok(())
 }
 
 /// Spawn the detached server if one isn't already up.

--- a/src/module/discovery.rs
+++ b/src/module/discovery.rs
@@ -73,7 +73,7 @@ fn parse_results(body: &str) -> Result<Vec<RepoHit>> {
 }
 
 /// Fetch a URL with `curl`, then `wget` — whichever is installed.
-fn http_get(url: &str) -> Result<String> {
+pub(crate) fn http_get(url: &str) -> Result<String> {
     let curl = [
         "-sSL",
         "--max-time",

--- a/website/public/manifests/claude.toml
+++ b/website/public/manifests/claude.toml
@@ -1,0 +1,18 @@
+# Official bohay agent-detection manifest for Claude Code.
+# Served at https://bohay.dev/manifests/claude.toml and fetched by
+# `bohay server update-manifest`, so detection keeps up with Claude Code UI
+# changes without waiting for a bohay binary release. Merged on top of bohay's
+# built-in rules; a user's own ~/.bohay/manifests/*.toml still wins.
+agent = "claude"
+
+# Working. Newer Claude Code shows a line like:
+#   ✢ Inferring… (12s · ↓ 3.2k tokens)
+# It dropped the "esc to interrupt" hint and animates a non-braille spinner, so
+# match the streaming token counter. Require BOTH "↓ " and "tokens)" so a custom
+# statusline containing only one of them (e.g. "↓3" git state) can't false-trigger
+# working. The done line ("✻ Cogitated for 18s") has neither, so it stays idle.
+[[rule]]
+state = "working"
+priority = 200
+region = "screen"
+all = ["↓ ", "tokens)"]

--- a/website/public/manifests/index.json
+++ b/website/public/manifests/index.json
@@ -1,0 +1,3 @@
+{
+  "files": ["claude.toml"]
+}

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -94,6 +94,26 @@ and it is bounded by `--timeout` (default 300s, exit 2 on timeout; exit 0 on
 settle). So a broken worker never traps you — but since it blocks, reach for it
 only when you actually need to wait.
 
+## The `$` shorthand
+
+With the skill installed you rarely type the commands. Write `$name` at the start
+of a line and the rest of it goes to that agent:
+
+```
+$codex add tests to src/parse.rs
+$reviewer take a look at the diff
+$7 run the migration
+```
+
+`$codex` addresses the pane named codex. An agent name or a pane id work the same
+way, so `$reviewer` and `$7` both resolve. The same targets `agent send` takes.
+
+It is a hand-off, not a wait: the agent you typed into keeps working, and the
+answer comes back when the other one is done. Ask for it to wait and it will.
+
+If the name does not resolve, the agent runs `bohay agent list` to find it or
+asks you which pane you meant.
+
 ## It is automatic with the skill
 
 The commands above are the plumbing. What lets a coding agent do this on its own

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -142,6 +142,8 @@ server:
   server start               start the background server if it isn't up
   server stop                stop the server (and all panes)
   server restart             stop + start (load a newly-installed binary)
+  server update-manifest     fetch the latest agent-detection rules from bohay.dev
+                             (applies live if the server is up; else on next start)
   integration install|uninstall <claude|copilot|codex|opencode|kimi|grok>
                              add/remove bohay's session-resume hook (uninstall
                              removes only bohay's hook, never the agent)

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -462,6 +462,33 @@ const ogImage = 'https://bohay.dev/og.png';
         </article>
 
         <article class="frow">
+          <span class="fr-k">Talk</span>
+          <div class="fr-text">
+            <h3>Agents that hand work to each other</h3>
+            <p>Type <code>$</code> and a pane name to delegate the rest of the line. <code>$codex add tests to src/parse.rs</code> sends that instruction to the pane named codex. An agent name or a pane number works just as well. The sender does not wait: it carries on working and picks up the reply when it arrives.</p>
+            <a class="fc-go" href="/docs/guides/agent-messaging/">Agent messaging →</a>
+          </div>
+          <div class="fm bare talk" aria-hidden="true">
+            <div class="fm-panes">
+              <div class="fm-pane">
+                <div class="fm-pt"><span class="d run"></span>claude</div>
+                <div class="fm-ln" style="--i:0"><i>❯</i> <u>$codex</u> add tests to <b>src/parse.rs</b></div>
+                <div class="fm-ln sent" style="--i:1">→ sent · not waiting</div>
+                <div class="fm-ln dim" style="--i:4">⏺ meanwhile: profiling…</div>
+                <div class="fm-ln back" style="--i:7">← codex: 12 cases, 155 passed</div>
+              </div>
+              <div class="fm-pane">
+                <div class="fm-pt"><span class="d done"></span>codex</div>
+                <div class="fm-ln got" style="--i:2">⇄ from claude: add tests</div>
+                <div class="fm-ln dim" style="--i:3">⏺ reading src/parse.rs…</div>
+                <div class="fm-ln ok" style="--i:5">✓ added 12 cases</div>
+                <div class="fm-ln ok" style="--i:6">✓ cargo test: 155 passed</div>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="frow">
           <span class="fr-k">Ship</span>
           <div class="fr-text">
             <h3>Git without leaving</h3>
@@ -593,6 +620,37 @@ const ogImage = 'https://bohay.dev/og.png';
         <a href="/docs/guides/layout/">movable panels and themes</a>
       </p>
     </section>
+
+    <!-- The TALK mock types itself, but only while it is on screen: it sits far
+         down the page, and a timer ticking behind the viewport is work nobody
+         sees. The observer starts it, and stops it again on the way out so it is
+         fresh next time rather than mid-sentence. -->
+    <script>
+      (() => {
+        const mock = document.querySelector('.fm.bare.talk');
+        if (!mock) return;
+        const CYCLE = 8200; // the last line lands at ~4.1s; the rest is a beat to read it
+        let timer = 0;
+        const play = () => {
+          mock.classList.remove('on');
+          void mock.offsetWidth; // reflow, so re-adding the class restarts the animations
+          mock.classList.add('on');
+        };
+        const io = new IntersectionObserver(
+          ([e]) => {
+            clearInterval(timer);
+            if (e.isIntersecting) {
+              play();
+              timer = window.setInterval(play, CYCLE);
+            } else {
+              mock.classList.remove('on');
+            }
+          },
+          { threshold: 0.35 },
+        );
+        io.observe(mock);
+      })();
+    </script>
 
     <section class="orch">
       <div class="orch-text">
@@ -1983,6 +2041,68 @@ const ogImage = 'https://bohay.dev/og.png';
       .fm-row i { font-style: normal; }
       .fm-row i.ok { color: var(--accent); }
       .fm-row i.hot { color: var(--coral); }
+      /* Two panes side by side, framed like the real thing: every pane carries an
+         edge, and the divider between them is the seam bohay draws. */
+      .fm-panes { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; margin-top: 0.35rem; }
+      .fm-pane { border: 1px solid var(--line); padding: 0.4rem 0.5rem; min-width: 0; }
+      .fm-pt {
+        display: flex; align-items: center; gap: 0.35rem; color: var(--sub);
+        font-size: 0.66rem; letter-spacing: 0.04em; text-transform: uppercase;
+        padding-bottom: 0.3rem; margin-bottom: 0.3rem; border-bottom: 1px solid var(--line);
+      }
+      .fm-ln {
+        font-size: 0.68rem; line-height: 1.65; white-space: nowrap;
+        overflow: hidden; text-overflow: ellipsis; color: var(--sub);
+      }
+      .fm-ln i { font-style: normal; color: var(--overlay1); }
+      .fm-ln b { color: var(--text); font-weight: 500; }
+      .fm-ln.dim { color: var(--overlay1); }
+      .fm-ln.ok, .fm-ln.sent, .fm-ln.back { color: var(--mint); }
+      .fm-ln.got { color: var(--accent); }
+      /* The `$name` token: the one thing on the mock that should catch the eye. */
+      .fm-ln u {
+        text-decoration: none; color: var(--accent); font-weight: 600;
+        background: rgb(from var(--accent) r g b / 0.14); padding: 0 0.2rem;
+      }
+      /* No outer card on this one: the two panes *are* the mock. A frame around
+         framed panes is a box inside a box, and it costs the room the panes want.
+         So drop the chrome and let them run to the column's full width. */
+      .fm.bare {
+        background: none; border: 0; padding: 0;
+      }
+      .fm.bare .fm-panes { margin-top: 0; gap: 0.6rem; }
+      .fm.bare .fm-pane { padding: 0.7rem 0.85rem; }
+      .fm.bare .fm-pt { font-size: 0.72rem; padding-bottom: 0.45rem; margin-bottom: 0.45rem; }
+      .fm.bare .fm-ln { font-size: 0.78rem; line-height: 1.85; }
+      /* Typed on, in the order the exchange actually happens: `--i` on each line
+         is its place in the conversation across *both* panes, so the two sides
+         interleave instead of each pane filling itself top to bottom.
+
+         `clip-path` rather than `width`, so revealing a line composites instead
+         of relaying out the column on every frame. `steps()` gives the characters
+         their tick; the caret rides the clip edge. */
+      .fm.bare .fm-ln { position: relative; clip-path: inset(0 100% 0 0); }
+      .fm.bare.on .fm-ln {
+        animation: fm-type 0.62s steps(26, end) forwards;
+        animation-delay: calc(var(--i, 0) * 0.5s);
+      }
+      .fm.bare.on .fm-ln::after {
+        content: ''; position: absolute; top: 0.15em; right: -0.1ch;
+        width: 0.55ch; height: 1.05em; background: var(--accent);
+        opacity: 0; animation: fm-caret 0.62s steps(1) calc(var(--i, 0) * 0.5s);
+      }
+      @keyframes fm-type { to { clip-path: inset(0 0 0 0); } }
+      @keyframes fm-caret { 0%, 99% { opacity: 0.9; } 100% { opacity: 0; } }
+      /* Nothing types: every line is simply there. */
+      @media (prefers-reduced-motion: reduce) {
+        .fm.bare .fm-ln { clip-path: none; }
+        .fm.bare.on .fm-ln, .fm.bare.on .fm-ln::after { animation: none; }
+        .fm.bare.on .fm-ln::after { display: none; }
+      }
+      /* Two panes need the width, so they stack rather than shrink. */
+      @media (max-width: 900px) {
+        .fm-panes { grid-template-columns: 1fr; }
+      }
       .fm-row i.hd { color: var(--overlay1); font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.06em; }
       /* The Mission Control table needs real columns, not a flex run. */
       .fm-row.cols {


### PR DESCRIPTION
Agent CLIs change their working/idle UI often (Claude Code alone recently changed its spinner and dropped the "esc to interrupt" hint), which silently breaks bohay's screen-based detection until a new binary ships. This adds an over-the-air path to refresh detection rules without a release, plus fixes for newer Claude Code states.

## `bohay server update-manifest`

Fetches the latest agent-detection manifests from bohay.dev and merges them in live:

- Downloads `index.json` plus each `<agent>.toml` via the existing curl/wget helper (no new dependency), validates each parses as a real manifest, and guards filenames against path escapes.
- Writes them to `~/.bohay/manifests/managed/`, a separate dir so an update never clobbers a user's own `~/.bohay/manifests/*.toml`.
- Applies live through a new `manifest.reload` socket method, so detection updates with no restart. With no server running, they load on next start.
- Built-in rules stay the offline fallback. Merge order is built-in, then managed (OTA), then user, so a user's own rules still win. Manual and opt-in, so there is no silent startup network call. The source is overridable with `$BOHAY_MANIFEST_URL`.

## Newer Claude Code detection

Recent Claude Code shows a working line like `Inferring... (12s down 3.2k tokens)` with no "esc to interrupt" and a non-braille spinner, so every Claude pane read as idle while generating.

- Added a Claude working rule matching the streaming token counter, requiring both markers together so a custom statusline cannot false-trigger it.
- Added the half-circle busy spinner glyphs to the spinner set, covering builds that animate them instead of braille. The done line still reads idle.

## Hosting

Publishes `website/public/manifests/{index.json,claude.toml}`, served at bohay.dev/manifests/ (live after the next website deploy). Also carries some website landing-page and guide updates that were staged alongside.

Covered by tests (managed-dir loading, manifest validation, the new Claude states) and verified end to end against a local source. Full suite green, clippy and fmt clean.