### PR TITLE
perf(app): reduce redraws and preserve terminal state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,12 @@ exclude = [
 name = "bohay"
 path = "src/main.rs"
 
+[features]
+default = []
+# Opt-in benchmark and artifact generators. Keeping these out of the default
+# test registry avoids reporting deliberate developer commands as ignored tests.
+dev-tools = []
+
 [dependencies]
 ratatui = "0.30"
 crossterm = { version = "0.29", features = ["serde"] }

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -1029,7 +1029,7 @@ mod tests {
         // `FileRead`, then `FileChanges` once `git diff` returns — so simply
         // taking the next event races: whichever the worker happens to have
         // queued first wins. Pump until the one we need arrives.
-        pump_until_read(&rx, &mut app);
+        pump_until_file_read(&rx, &mut app, vid);
         assert_eq!(
             app.views.get(&vid).map(|ViewKind::File(v)| v.line_count()),
             Some(1),
@@ -1042,7 +1042,7 @@ mod tests {
         app.ensure_file_views();
         // A re-read was scheduled; apply events until its text arrives — the
         // first read's trailing `FileChanges` may still be queued ahead of it.
-        pump_until_read(&rx, &mut app);
+        pump_until_file_read(&rx, &mut app, vid);
         if let Some(ViewKind::File(v)) = app.views.get(&vid) {
             assert_eq!(v.line_count(), 2, "the view reloaded the edited file");
         } else {
@@ -1051,7 +1051,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Apply events until a `FileRead` has been handled, or the deadline passes.
+    /// Apply events until the requested view's `FileRead` has been handled, or
+    /// the deadline passes.
     ///
     /// A scheduled read emits `FileRead` **and** `FileChanges`; the two arrive in
     /// whatever order the worker gets to them, and a previous read's
@@ -1059,19 +1060,48 @@ mod tests {
     /// makes the test independent of that timing (it was a CI-only flake: on a
     /// faster `git diff` the stale `FileChanges` was consumed instead of the
     /// re-read, so the view kept its old contents).
-    fn pump_until_read(rx: &std::sync::mpsc::Receiver<AppEvent>, app: &mut App) {
+    fn pump_until_file_read(
+        rx: &std::sync::mpsc::Receiver<AppEvent>,
+        app: &mut App,
+        expected: PaneId,
+    ) {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         while std::time::Instant::now() < deadline {
             let Ok(ev) = rx.recv_timeout(std::time::Duration::from_millis(250)) else {
                 continue;
             };
-            let was_read = matches!(ev, AppEvent::FileRead { .. });
+            let was_read = matches!(&ev, AppEvent::FileRead { id, .. } if *id == expected);
             app.handle_event(ev);
             if was_read {
                 return;
             }
         }
-        panic!("no FileRead arrived within the deadline");
+        panic!("no FileRead for {expected:?} arrived within the deadline");
+    }
+
+    /// Apply events until the requested directory's listing has been handled.
+    /// A newly-created app also produces PTY and background-scan events, so
+    /// consuming only the next event makes directory tests race those workers.
+    fn pump_until_dir_read(
+        rx: &std::sync::mpsc::Receiver<AppEvent>,
+        app: &mut App,
+        expected: &std::path::Path,
+    ) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            let Ok(ev) = rx.recv_timeout(std::time::Duration::from_millis(250)) else {
+                continue;
+            };
+            let was_read = matches!(&ev, AppEvent::DirRead { path, .. } if path == expected);
+            app.handle_event(ev);
+            if was_read {
+                return;
+            }
+        }
+        panic!(
+            "no DirRead for {} arrived within the deadline",
+            expected.display()
+        );
     }
 
     /// Set a file's mtime, portable enough for the test (via a fresh write's
@@ -1105,8 +1135,7 @@ mod tests {
         app.open_file_view(file.clone(), OpenTarget::Tab);
         let first = app.layout().focus;
         // Drain the read so content is present.
-        let ev = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
-        app.handle_event(ev);
+        pump_until_file_read(&rx, &mut app, first);
         let tabs_before = app.workspaces[app.active_ws].tabs.len();
         let views_before = app.views.len();
 
@@ -1150,8 +1179,7 @@ mod tests {
         let mut app = App::new(120, 40, tx).unwrap();
         app.open_file_view(file.clone(), OpenTarget::Tab);
         let vid = app.layout().focus;
-        let ev = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
-        app.handle_event(ev);
+        pump_until_file_read(&rx, &mut app, vid);
 
         // Render so `pane_content_rects` (needed for hit-testing the drag) is set.
         let mut term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 40)).unwrap();
@@ -1316,8 +1344,7 @@ mod tests {
         app.sidebars.left.docks.push(DockKind::Files);
         app.ensure_file_tree();
         // Apply the root read so `sub` is a visible row.
-        let ev = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
-        app.handle_event(ev);
+        pump_until_dir_read(&rx, &mut app, &root);
 
         // Click `sub` to expand it — WITHOUT calling ensure_file_tree again.
         let idx = app
@@ -1329,10 +1356,7 @@ mod tests {
         app.file_row_activate(idx, OpenTarget::Tab);
 
         // A read for `sub` must already be in flight — arrives without any tick.
-        let ev = rx
-            .recv_timeout(std::time::Duration::from_secs(2))
-            .expect("expand scheduled a read immediately");
-        app.handle_event(ev);
+        pump_until_dir_read(&rx, &mut app, &root.join("sub"));
         assert!(
             app.file_tree
                 .visible_rows()
@@ -1460,8 +1484,7 @@ mod tests {
         let mut app = App::new(40, 20, tx).unwrap();
         app.open_file_view(file.clone(), OpenTarget::Tab);
         let vid = app.layout().focus;
-        let ev = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
-        app.handle_event(ev);
+        pump_until_file_read(&rx, &mut app, vid);
         assert!(
             matches!(
                 app.views.get(&vid),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -19,10 +19,7 @@ impl App {
         }
         match ev {
             AppEvent::Key(k) => self.handle_key(k),
-            AppEvent::Mouse(m) => {
-                self.handle_mouse(m);
-                true // conservative: hover/selection/clicks can change the UI
-            }
+            AppEvent::Mouse(m) => self.handle_mouse(m),
             AppEvent::Paste(s) => {
                 // A paste while a text-input modal is open (a Settings field, a
                 // rename prompt, …) fills that field, not the pane underneath.
@@ -211,7 +208,121 @@ impl App {
         true
     }
 
-    fn handle_mouse(&mut self, m: ratatui::crossterm::event::MouseEvent) {
+    /// Apply a mouse event and report whether it changed anything Bohay draws.
+    ///
+    /// Button, drag, release, and wheel events stay conservative because they
+    /// are low-frequency interactions and can change state through many modal
+    /// handlers. Motion is the hot path: compare only the hover state the
+    /// renderer consumes, so moving across ordinary pane cells does not request
+    /// frames while links, menus, FILES rows, and resize seams still repaint.
+    fn handle_mouse(&mut self, m: ratatui::crossterm::event::MouseEvent) -> bool {
+        use ratatui::crossterm::event::MouseEventKind;
+
+        let kind = m.kind;
+        let hover_before = self.rendered_hover_rect(self.hover);
+        let divider_before = self
+            .hover_divider
+            .as_ref()
+            .map(|d| (d.path.clone(), d.axis, d.line, d.span));
+        let sidebar_before = self.hover_sidebar;
+        let link_before = self.hover_link.clone();
+
+        self.apply_mouse(m);
+
+        if !matches!(kind, MouseEventKind::Moved) {
+            return true;
+        }
+
+        let divider_after = self
+            .hover_divider
+            .as_ref()
+            .map(|d| (d.path.clone(), d.axis, d.line, d.span));
+        hover_before != self.rendered_hover_rect(self.hover)
+            || divider_before != divider_after
+            || sidebar_before != self.hover_sidebar
+            || link_before != self.hover_link
+    }
+
+    /// The hover-highlighted rectangle containing `at`, if any. Moving within
+    /// one rectangle does not alter the rendered frame; entering, leaving, or
+    /// crossing into another one does. Keep this list aligned with renderers
+    /// that consume `App.hover`.
+    fn rendered_hover_rect(&self, at: Option<(u16, u16)>) -> Option<Rect> {
+        let (c, r) = at?;
+        let hit = |rect: Rect| c >= rect.x && c < rect.right() && r >= rect.y && r < rect.bottom();
+        let first = |rects: &[Rect]| rects.iter().copied().find(|rect| hit(*rect));
+
+        if self.changelog_open {
+            return self.changelog_check_rect.filter(|rect| hit(*rect));
+        }
+        if let Some(menu) = &self.pane_menu {
+            return menu
+                .items
+                .iter()
+                .map(|(_, rect)| *rect)
+                .chain(menu.tab_rects.iter().map(|(_, rect)| *rect))
+                .find(|rect| hit(*rect));
+        }
+        if let Some(menu) = &self.agent_menu {
+            return menu
+                .items
+                .iter()
+                .map(|(_, rect)| *rect)
+                .find(|rect| hit(*rect));
+        }
+        if let Some(menu) = &self.ws_menu {
+            return menu
+                .items
+                .iter()
+                .map(|(_, rect)| *rect)
+                .find(|rect| hit(*rect));
+        }
+        if let Some(menu) = &self.file_menu {
+            return menu
+                .items
+                .iter()
+                .map(|(_, rect)| *rect)
+                .find(|rect| hit(*rect));
+        }
+        if let Some(menu) = &self.dock_menu {
+            return first(&menu.rects);
+        }
+
+        let modal = [self.modal_commit_rect, self.modal_cancel_rect]
+            .into_iter()
+            .flatten()
+            .find(|rect| hit(*rect));
+        if modal.is_some() {
+            return modal;
+        }
+
+        if self.switcher {
+            return self
+                .switcher_rects
+                .iter()
+                .map(|(_, rect)| *rect)
+                .chain(self.switcher_scope_rects.iter().map(|(_, rect)| *rect))
+                .find(|rect| hit(*rect));
+        }
+
+        self.file_tree_rects
+            .iter()
+            .map(|(_, rect)| *rect)
+            .chain(
+                [
+                    self.switcher_button_rect,
+                    self.sidebar_toggle_rect,
+                    self.right_sidebar_toggle_rect,
+                    self.version_rect,
+                    self.settings_icon_rect,
+                ]
+                .into_iter()
+                .flatten(),
+            )
+            .find(|rect| hit(*rect))
+    }
+
+    fn apply_mouse(&mut self, m: ratatui::crossterm::event::MouseEvent) {
         use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
         // Track the cursor for hover affordances (e.g. the session delete ✕).
         self.hover = Some((m.column, m.row));
@@ -649,18 +760,8 @@ impl App {
                 if self.mouse_grab.is_none() {
                     if let Some((id, content)) = self.pane_content_at(m.column, m.row) {
                         if let Some(pane) = self.panes.get(&id) {
-                            let mm = pane.mouse_mode();
-                            if mm.motion {
-                                let col = m.column - content.x + 1;
-                                let row = m.row - content.y + 1;
-                                // No button held = code 3, with the motion flag.
-                                pane.send(&mouse_button_seq(
-                                    3 + mouse_mod_bits(m.modifiers),
-                                    MouseSeq::Drag,
-                                    col,
-                                    row,
-                                    mm.sgr,
-                                ));
+                            if let Some(seq) = hover_motion_seq(&m, content, pane.mouse_mode()) {
+                                pane.send(&seq);
                             }
                         }
                     }
@@ -1744,6 +1845,28 @@ fn mouse_button_seq(btn: u16, kind: MouseSeq, col: u16, row: u16, sgr: bool) -> 
     }
 }
 
+/// Encode an any-motion (DECSET 1003) hover report for a pane. The caller owns
+/// hit-testing and delivery; keeping the encoding pure pins the exact bytes in
+/// a unit test while the dirty-result path remains independent of forwarding.
+fn hover_motion_seq(
+    m: &ratatui::crossterm::event::MouseEvent,
+    content: Rect,
+    mode: crate::terminal::pty::MouseModes,
+) -> Option<Vec<u8>> {
+    if !mode.motion {
+        return None;
+    }
+    let col = m.column.saturating_sub(content.x) + 1;
+    let row = m.row.saturating_sub(content.y) + 1;
+    Some(mouse_button_seq(
+        3 + mouse_mod_bits(m.modifiers),
+        MouseSeq::Drag,
+        col,
+        row,
+        mode.sgr,
+    ))
+}
+
 fn mouse_wheel_seq(up: bool, col: u16, row: u16, sgr: bool) -> Vec<u8> {
     let btn: u16 = if up { 64 } else { 65 };
     if sgr {
@@ -1939,6 +2062,44 @@ mod tests {
         assert_eq!(
             mouse_button_seq(3, MouseSeq::Drag, 2, 2, true),
             b"\x1b[<35;2;2M".to_vec()
+        );
+    }
+
+    #[test]
+    fn any_motion_hover_keeps_its_exact_forwarded_bytes() {
+        use crate::terminal::pty::MouseModes;
+        use ratatui::crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+
+        let event = MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: 14,
+            row: 9,
+            modifiers: KeyModifiers::CONTROL,
+        };
+        let content = Rect::new(10, 5, 40, 20);
+        let mode = MouseModes {
+            report: true,
+            drag: true,
+            motion: true,
+            sgr: true,
+        };
+
+        assert_eq!(
+            hover_motion_seq(&event, content, mode),
+            Some(b"\x1b[<51;5;5M".to_vec()),
+            "1003 hover keeps code 3, Ctrl +16, motion +32, and pane-local coordinates"
+        );
+        assert_eq!(
+            hover_motion_seq(
+                &event,
+                content,
+                MouseModes {
+                    motion: false,
+                    ..mode
+                }
+            ),
+            None,
+            "1002 drag tracking alone does not receive buttonless hover"
         );
     }
 
@@ -2145,12 +2306,29 @@ mod link_click_tests {
             ..
         } = fixture();
 
-        app.handle_event(mouse(MouseEventKind::Moved, on_link, KeyModifiers::NONE));
+        for i in 0..10_000 {
+            let at = if i % 2 == 0 {
+                off_link
+            } else {
+                (off_link.0 + 1, off_link.1 + 1)
+            };
+            assert!(
+                !app.handle_event(mouse(MouseEventKind::Moved, at, KeyModifiers::NONE)),
+                "ordinary pane motion {i} stays clean"
+            );
+        }
         assert!(app.hover_link.is_none(), "plain hover scans nothing");
 
-        app.handle_event(mouse(MouseEventKind::Moved, on_link, KeyModifiers::CONTROL));
+        assert!(
+            app.handle_event(mouse(MouseEventKind::Moved, on_link, KeyModifiers::CONTROL)),
+            "entering a link changes its underline"
+        );
         let hl = app.hover_link.as_ref().expect("ctrl hover found the link");
         assert_eq!(hl.target, LinkTarget::Url(URL.to_string()));
+        assert!(
+            !app.handle_event(mouse(MouseEventKind::Moved, on_link, KeyModifiers::CONTROL)),
+            "resting inside the same link does not repaint"
+        );
 
         // It is actually drawn underlined, not merely recorded.
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
@@ -2161,12 +2339,84 @@ mod link_click_tests {
         );
 
         // Moving off the link, still holding Ctrl, drops it.
-        app.handle_event(mouse(
-            MouseEventKind::Moved,
-            off_link,
-            KeyModifiers::CONTROL,
-        ));
+        assert!(
+            app.handle_event(mouse(
+                MouseEventKind::Moved,
+                off_link,
+                KeyModifiers::CONTROL,
+            )),
+            "leaving a link removes its underline"
+        );
         assert!(app.hover_link.is_none());
+    }
+
+    #[test]
+    fn any_motion_forwarding_does_not_mark_bohay_dirty() {
+        let _env = crate::persist::test_env("mouse-any-motion-dirty");
+        let Fixture {
+            mut app,
+            pane,
+            off_link,
+            ..
+        } = fixture();
+
+        app.panes
+            .get(&pane)
+            .unwrap()
+            .engine
+            .lock()
+            .unwrap()
+            .advance(b"\x1b[?1003h\x1b[?1006h");
+        let mode = app.panes.get(&pane).unwrap().mouse_mode();
+        assert!(mode.motion && mode.sgr, "the pane requested 1003 + 1006");
+
+        assert!(
+            !app.handle_event(mouse(MouseEventKind::Moved, off_link, KeyModifiers::NONE,)),
+            "forwarding hover waits for the child's PtyData instead of rendering early"
+        );
+    }
+
+    #[test]
+    fn context_menu_hover_dirties_only_when_the_highlight_changes() {
+        let _env = crate::persist::test_env("menu-hover-dirty");
+        let Fixture {
+            mut app,
+            mut term,
+            off_link,
+            ..
+        } = fixture();
+
+        assert!(app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Right),
+            off_link,
+            KeyModifiers::NONE,
+        )));
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let rows: Vec<Rect> = app
+            .pane_menu
+            .as_ref()
+            .expect("pane menu opened")
+            .items
+            .iter()
+            .map(|(_, rect)| *rect)
+            .take(2)
+            .collect();
+        assert_eq!(rows.len(), 2, "the menu has multiple hoverable rows");
+        let first = (rows[0].x + 1, rows[0].y);
+        let second = (rows[1].x + 1, rows[1].y);
+
+        assert!(
+            app.handle_event(mouse(MouseEventKind::Moved, first, KeyModifiers::NONE)),
+            "entering a menu row paints its highlight"
+        );
+        assert!(
+            !app.handle_event(mouse(MouseEventKind::Moved, first, KeyModifiers::NONE)),
+            "motion inside the same row leaves the frame unchanged"
+        );
+        assert!(
+            app.handle_event(mouse(MouseEventKind::Moved, second, KeyModifiers::NONE)),
+            "crossing rows moves the highlight"
+        );
     }
 
     /// A fixture whose pane grid holds `text`, plus the screen cell sitting on

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1107,6 +1107,11 @@ impl App {
         }
         if let Some((id, _)) = self.pane_rects.iter().find(|(_, rect)| hit(*rect)) {
             let id = *id;
+            if self.layout().focus != id {
+                // Leave the old pane's viewport exactly where it is. Only drop
+                // keyboard ownership so subsequent input follows the new focus.
+                self.scroll_pane = None;
+            }
             self.layout_mut().focus = id;
             self.mode = Mode::Normal;
         }
@@ -1272,6 +1277,7 @@ impl App {
             return false;
         }
         pane.scroll_to_bottom(); // the app's coordinates are the live screen's
+        self.scroll_pane = None;
         self.layout_mut().focus = id;
         self.mode = Mode::Normal;
         let g = crate::app::MouseGrab {
@@ -1535,6 +1541,16 @@ impl App {
     fn handle_key(&mut self, key: KeyEvent) -> bool {
         if key.kind == KeyEventKind::Release {
             return false; // ignored — nothing changed
+        }
+        // Scroll mode belongs to one pane, not to the whole tab. A focus change
+        // must never let the next key snap and type into the previously scrolled
+        // pane. Pointer focus clears this eagerly below; this guard also covers
+        // focus changes made by tabs, workspaces, the switcher, or API actions.
+        if self
+            .scroll_pane
+            .is_some_and(|scrolling| scrolling != self.layout().focus)
+        {
+            self.scroll_pane = None;
         }
         // The running-command overlay: scroll it, refresh it, or dismiss.
         if self.cmd_inspect.is_some() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3472,6 +3472,7 @@ impl App {
     }
 
     fn focus_pane_global(&mut self, id: PaneId) {
+        let changed = self.layout().focus != id;
         let mut found = None;
         for (wi, ws) in self.workspaces.iter().enumerate() {
             for (ti, tab) in ws.tabs.iter().enumerate() {
@@ -3484,6 +3485,9 @@ impl App {
             self.active_ws = wi;
             self.workspaces[wi].active_tab = ti;
             self.workspaces[wi].tabs[ti].layout.focus = id;
+            if changed {
+                self.scroll_pane = None;
+            }
             self.mode = Mode::Normal;
         }
     }
@@ -5477,6 +5481,90 @@ mod tests {
             content.x + 7,
             content.y + 3,
         ))));
+    }
+
+    #[test]
+    fn clicking_another_pane_keeps_the_scrolled_pane_at_its_position() {
+        let _env = crate::persist::test_env("scroll-focus-keeps-position");
+        use crate::event::AppEvent;
+        use ratatui::backend::TestBackend;
+        use ratatui::crossterm::event::{
+            KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+        };
+        use ratatui::Terminal;
+        use std::sync::{Arc, Mutex};
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.run_cmd(crate::app::keys::Cmd::SplitRight);
+        let leaves = app.layout().leaves();
+        let (left, right) = (leaves[0], leaves[1]);
+
+        // Give the left pane deterministic history. Its real shell reader keeps
+        // its old engine, so it cannot race this viewport assertion.
+        let (response_tx, _response_rx) = std::sync::mpsc::channel();
+        app.panes.get_mut(&left).unwrap().engine = Arc::new(Mutex::new(
+            crate::terminal::vt::alacritty::AlacrittyEngine::new(60, 38, response_tx, 2_000),
+        ));
+        if let Some(pane) = app.panes.get(&left) {
+            let mut engine = pane.engine.lock().unwrap();
+            for i in 0..200 {
+                engine.advance(format!("history {i}\r\n").as_bytes());
+            }
+        }
+
+        app.layout_mut().focus = left;
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let rect = |app: &App, id| {
+            app.pane_content_rects
+                .iter()
+                .find(|(pane, _)| *pane == id)
+                .map(|(_, rect)| *rect)
+                .unwrap()
+        };
+        let left_rect = rect(&app, left);
+        let right_rect = rect(&app, right);
+        let mouse = |kind, rect: Rect| {
+            AppEvent::Mouse(MouseEvent {
+                kind,
+                column: rect.x + 2,
+                row: rect.y + 2,
+                modifiers: KeyModifiers::NONE,
+            })
+        };
+
+        assert!(app.handle_event(mouse(MouseEventKind::ScrollUp, left_rect)));
+        let stopped_at = app.panes.get(&left).unwrap().scroll_state().0;
+        assert!(stopped_at > 0, "the left pane is stopped in its history");
+        assert_eq!(app.scroll_pane, Some(left));
+
+        assert!(app.handle_event(mouse(MouseEventKind::Down(MouseButton::Left), right_rect,)));
+        assert_eq!(
+            app.layout().focus,
+            right,
+            "the click focuses the right pane"
+        );
+        assert!(
+            app.scroll_pane.is_none(),
+            "the old pane no longer owns keyboard scroll mode"
+        );
+        assert_eq!(
+            app.panes.get(&left).unwrap().scroll_state().0,
+            stopped_at,
+            "focus leaves the left viewport exactly where the user stopped"
+        );
+
+        assert!(!app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+        ))));
+        assert_eq!(app.layout().focus, right);
+        assert_eq!(
+            app.panes.get(&left).unwrap().scroll_state().0,
+            stopped_at,
+            "typing in the right pane cannot snap the left pane to live"
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -806,6 +806,11 @@ pub struct PaneStatus {
     pub last_input: Instant,
     pub seen: bool,
     pub agent_session: Option<AgentSession>,
+    /// Consecutive successful process scans that saw this pane's shell/process
+    /// tree but not the agent bound in `agent_session`. Two confirmations mean
+    /// the agent really returned to the shell, rather than briefly disappearing
+    /// during startup/re-exec; see `apply_proc_scan`.
+    agent_absent_scans: u8,
     prev_working: bool,
     done: bool,
     /// Whether a blocked/done bell may fire. Set false after one fires; re-armed
@@ -844,6 +849,7 @@ impl PaneStatus {
                 .unwrap_or_else(Instant::now),
             seen: true,
             agent_session: None,
+            agent_absent_scans: 0,
             prev_working: false,
             done: false,
             notify_armed: true,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -879,7 +879,7 @@ pub enum LinkTarget {
 /// `link.spans` are **grid** coordinates, the same space
 /// `VtEngine::for_each_cell` reports, so the renderer tests a cell directly with
 /// no arithmetic per frame.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HoverLink {
     pub pane: PaneId,
     pub link: crate::links::Link,
@@ -3317,8 +3317,52 @@ impl App {
                 next.insert(*id, cmds.clone());
             }
         }
-        let changed = next != self.proc_commands;
+        let mut lifecycle_changed = false;
+        for (id, cmds) in &next {
+            // A successful Unix scan includes at least the pane's shell. Empty
+            // means the process table could not see this root, so it is not
+            // evidence that an agent exited.
+            if cmds.is_empty() {
+                continue;
+            }
+            let base = self
+                .panes
+                .get(id)
+                .map(|p| p.command.clone())
+                .unwrap_or_default();
+            let Some(st) = self.status.get_mut(id) else {
+                continue;
+            };
+            let Some(bound_agent) = st.agent_session.as_ref().map(|s| s.agent.as_str()) else {
+                st.agent_absent_scans = 0;
+                continue;
+            };
+            if self.manifests.process_has_agent(cmds, bound_agent) {
+                st.agent_absent_scans = 0;
+                continue;
+            }
+
+            st.agent_absent_scans = st.agent_absent_scans.saturating_add(1);
+            if st.agent_absent_scans < 2 {
+                continue;
+            }
+
+            // The agent process has been absent from two real process-table
+            // snapshots. Treat that as an intentional/complete return to the
+            // shell: keeping the session here would make persistence relaunch
+            // it after a detach + later restart. If another recognised agent is
+            // already running, publish that identity while its own session hook
+            // catches up; otherwise this is now a plain shell pane.
+            st.agent_session = None;
+            st.agent_absent_scans = 0;
+            st.agent = self.manifests.agent_in_processes(cmds).unwrap_or(base);
+            lifecycle_changed = true;
+        }
+        let changed = next != self.proc_commands || lifecycle_changed;
         self.proc_commands = next;
+        if lifecycle_changed {
+            self.session_dirty = true;
+        }
         changed
     }
 
@@ -4666,6 +4710,65 @@ mod tests {
         assert_eq!(sess.session_id, "abc-123");
     }
 
+    #[test]
+    fn exited_agent_becomes_shell_and_is_not_resumed() {
+        let _env = crate::persist::test_env("agent-exit-shell");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let id = app.layout().focus;
+        let root = app.panes.get(&id).unwrap().child_pid.unwrap();
+        let shell = app.panes.get(&id).unwrap().command.clone();
+        {
+            let st = app.status.get_mut(&id).unwrap();
+            st.agent = "claude".into();
+            st.agent_session = Some(AgentSession {
+                agent: "claude".into(),
+                session_id: "finished-session".into(),
+            });
+        }
+        let scan = |commands: &[&str]| {
+            Some(HashMap::from([(
+                root,
+                commands.iter().map(|s| s.to_string()).collect(),
+            )]))
+        };
+
+        // One shell-only observation is not enough: an agent may be starting or
+        // re-execing. Seeing it again resets the exit candidate, even when a
+        // different recognised agent appears earlier in the same process tree.
+        assert!(app.apply_proc_scan(scan(&[&shell])));
+        assert!(app.status.get(&id).unwrap().agent_session.is_some());
+        assert_eq!(app.status.get(&id).unwrap().agent_absent_scans, 1);
+        assert!(app.apply_proc_scan(scan(&[&shell, "codex", "claude"])));
+        assert!(app.status.get(&id).unwrap().agent_session.is_some());
+        assert_eq!(app.status.get(&id).unwrap().agent_absent_scans, 0);
+
+        // Two confirmed scans back at the shell clear the resume binding and
+        // dirty persistence. A detach may now leave this pane alive as a shell;
+        // a later server restart must not relaunch the exited agent.
+        app.session_dirty = false;
+        app.apply_proc_scan(scan(&[&shell]));
+        assert!(app.status.get(&id).unwrap().agent_session.is_some());
+        assert!(app.apply_proc_scan(scan(&[&shell])));
+        let st = app.status.get(&id).unwrap();
+        assert!(st.agent_session.is_none());
+        assert_eq!(st.agent, shell);
+        assert!(app.session_dirty);
+
+        let pane = persist::snapshot(&app)
+            .workspaces
+            .into_iter()
+            .flat_map(|ws| ws.tabs)
+            .flat_map(|tab| tab.panes)
+            .find(|(raw, _)| *raw == id.0)
+            .map(|(_, pane)| pane)
+            .unwrap();
+        assert_eq!(
+            pane.agent_session, None,
+            "the exited agent is not resumable"
+        );
+    }
+
     /// A pane's live name (`pane name`) survives a restart: it is re-attached to
     /// the pane's freshly allocated id on restore, so the sidebar/title keep it.
     #[test]
@@ -5328,23 +5431,23 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         };
         // Grab the divider and drag it 20 cells left.
-        app.handle_event(AppEvent::Mouse(mouse(
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
             line,
             area.y + 2,
-        )));
+        ))));
         assert!(app.resize_drag.is_some(), "grabbed the divider");
         let target = line.saturating_sub(20);
-        app.handle_event(AppEvent::Mouse(mouse(
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
             MouseEventKind::Drag(MouseButton::Left),
             target,
             area.y + 2,
-        )));
-        app.handle_event(AppEvent::Mouse(mouse(
+        ))));
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
             MouseEventKind::Up(MouseButton::Left),
             target,
             area.y + 2,
-        )));
+        ))));
         assert!(app.resize_drag.is_none(), "released the drag");
         assert!(
             width(&app, left) < before,
@@ -5362,13 +5465,18 @@ mod tests {
             .find(|(id, _)| *id == right)
             .map(|(_, r)| *r)
             .expect("right pane content rect");
-        app.handle_event(AppEvent::Mouse(mouse(
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
             content.x + 3,
             content.y + 3,
-        )));
+        ))));
         assert!(app.resize_drag.is_none(), "content press is not a resize");
         assert!(app.selection.is_some(), "content press starts a selection");
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            content.x + 7,
+            content.y + 3,
+        ))));
     }
 
     #[test]
@@ -5396,26 +5504,26 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         };
         // Grab the seam and drag it 6 columns to the right (wider).
-        app.handle_event(AppEvent::Mouse(mouse(
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
             MouseEventKind::Down(MouseButton::Left),
             seam.x,
             seam.y + 3,
-        )));
+        ))));
         assert_eq!(
             app.sidebar_resize,
             Some(Side::Left),
             "grabbed the left sidebar edge"
         );
-        app.handle_event(AppEvent::Mouse(mouse(
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
             MouseEventKind::Drag(MouseButton::Left),
             seam.x + 6,
             seam.y + 3,
-        )));
-        app.handle_event(AppEvent::Mouse(mouse(
+        ))));
+        assert!(app.handle_event(AppEvent::Mouse(mouse(
             MouseEventKind::Up(MouseButton::Left),
             seam.x + 6,
             seam.y + 3,
-        )));
+        ))));
         assert!(app.sidebar_resize.is_none(), "released the drag");
         assert_eq!(
             app.sidebars.left.width,
@@ -6739,11 +6847,11 @@ mod tests {
                 column: na.x + 2,
                 row: na.y + 1,
                 modifiers: KeyModifiers::NONE,
-            }));
+            }))
         };
         // Wheel down over the WORKSPACES list → it scrolls.
-        wheel(&mut app, MouseEventKind::ScrollDown);
-        wheel(&mut app, MouseEventKind::ScrollDown);
+        assert!(wheel(&mut app, MouseEventKind::ScrollDown));
+        assert!(wheel(&mut app, MouseEventKind::ScrollDown));
         draw(&mut app);
         assert_eq!(
             app.workspaces_scroll, 2,
@@ -8186,18 +8294,21 @@ mod cwd_test {
     use super::*;
 
     #[test]
-    #[ignore] // real-process timing test; flaky under parallel load. Run with --ignored.
-    fn cwd_follows_cd() {
+    fn pane_cwd_follows_cd_without_moving_its_workspace() {
+        let _env = crate::persist::test_env("pane-cwd-follows-cd");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
-        std::thread::sleep(Duration::from_millis(800));
         let id = app.layout().focus;
-        // Send the cd repeatedly in case the shell wasn't ready yet.
+        let workspace_cwd = app.ws().cwd.clone();
+        let workspace_name = app.ws().name.clone();
+        let deadline = Instant::now() + Duration::from_secs(8);
+
+        // Poll a real child process up to a deadline. Repeating the idempotent
+        // command handles shells that have not finished startup yet without a
+        // fixed readiness sleep.
         let mut got = String::new();
-        for i in 0..60 {
-            if i % 5 == 0 {
-                app.panes.get(&id).unwrap().send(b"cd /tmp\r");
-            }
+        while Instant::now() < deadline {
+            app.panes.get(&id).unwrap().send(b"cd /tmp\r");
             std::thread::sleep(Duration::from_millis(100));
             app.refresh_cwds();
             got = app.panes.get(&id).unwrap().cwd.display().to_string();
@@ -8206,10 +8317,15 @@ mod cwd_test {
             }
         }
         assert!(got.contains("tmp"), "cwd did not follow cd: got '{got}'");
-        assert!(
-            app.ws().name.contains("tmp"),
-            "ws name not updated: '{}'",
-            app.ws().name
+        assert_eq!(
+            app.ws().cwd,
+            workspace_cwd,
+            "cd changes the pane cwd, not its static workspace root"
+        );
+        assert_eq!(
+            app.ws().name,
+            workspace_name,
+            "cd does not rename the static workspace"
         );
     }
 }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -777,26 +777,39 @@ impl Manifests {
     /// Both pattern classes apply, because a command line is as deliberate as
     /// it gets. Matching is per-argv-token against the bare binary name, so
     /// `/opt/homebrew/bin/amp` counts while `--example` never can.
-    fn agent_in_processes(&self, running: &[String]) -> Option<String> {
-        for cmd in running {
-            let low = cmd.to_lowercase();
-            let mut tokens = low.split_whitespace();
-            let Some(first) = tokens.next() else { continue };
-            let first = binary_name(first);
-            if let Some(a) = self.match_binary(first) {
-                return Some(a);
-            }
-            // Several agents ship as a script run by an interpreter, so argv[0]
-            // is `node` / `python` and the real name is the script slot: the
-            // first non-flag argument. Nothing later counts -- `cargo test
-            // --example amp` must not resolve to amp.
-            if is_interpreter(first) {
-                for t in tokens {
-                    if t.starts_with('-') {
-                        continue;
-                    }
-                    return self.match_binary(binary_name(t));
+    pub(crate) fn agent_in_processes(&self, running: &[String]) -> Option<String> {
+        running
+            .iter()
+            .find_map(|cmd| self.agent_in_process_command(cmd))
+    }
+
+    /// Whether one specific agent is still present anywhere in the pane's
+    /// process tree. Lifecycle detection needs the targeted form: an agent may
+    /// itself launch another recognised agent as a child, and that must not make
+    /// its own process look absent.
+    pub(crate) fn process_has_agent(&self, running: &[String], agent: &str) -> bool {
+        running
+            .iter()
+            .any(|cmd| self.agent_in_process_command(cmd).as_deref() == Some(agent))
+    }
+
+    fn agent_in_process_command(&self, cmd: &str) -> Option<String> {
+        let low = cmd.to_lowercase();
+        let mut tokens = low.split_whitespace();
+        let first = binary_name(tokens.next()?);
+        if let Some(a) = self.match_binary(first) {
+            return Some(a);
+        }
+        // Several agents ship as a script run by an interpreter, so argv[0]
+        // is `node` / `python` and the real name is the script slot: the first
+        // non-flag argument. Nothing later counts -- `cargo test --example amp`
+        // must not resolve to amp.
+        if is_interpreter(first) {
+            for t in tokens {
+                if t.starts_with('-') {
+                    continue;
                 }
+                return self.match_binary(binary_name(t));
             }
         }
         None

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,9 @@
 //! Messages flowing into the main loop from input/PTY threads and (in server
 //! mode) from client connections.
 
-use std::sync::mpsc::SyncSender;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
 
 use ratatui::crossterm::event::{KeyEvent, MouseEvent};
 
@@ -18,10 +20,15 @@ pub enum AppEvent {
     PtyData(PaneId),
     /// The given pane's child process exited.
     PtyExit(PaneId),
-    /// A binary client attached (server mode); `frames` receives rendered frames.
+    /// A binary client attached (server mode); `messages` feeds its socket writer.
     ClientConnected {
         id: u64,
-        frames: SyncSender<ServerMessage>,
+        messages: Sender<ServerMessage>,
+        /// At most one rendered frame may wait behind the socket writer. Control
+        /// messages use the unbounded sender above, so clipboard writes and
+        /// detach notifications can never be dropped merely because a frame is
+        /// already queued.
+        frame_pending: Arc<AtomicBool>,
         cols: u16,
         rows: u16,
         terminal_colors: Option<TerminalColors>,

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -402,20 +402,16 @@ mod tests {
     /// A real scratch server must negotiate a client-owned terminal palette and
     /// return a frame. The byte-transparent bridge is covered separately by
     /// `relay_pumps_both_directions`.
-    /// Ignored: spawns processes and needs the built binary.
+    /// This remains Unix-only because the surrounding relay tests use
+    /// `UnixStream`. A filtered copy of the current test executable runs the
+    /// real server, so this works in a clean target directory without requiring
+    /// a separate `cargo build` first.
     #[test]
-    #[ignore]
     fn real_server_accepts_a_terminal_palette() {
         use crate::ipc::protocol::{self, ClientMessage, ServerMessage, PROTOCOL_VERSION};
         use std::process::{Command, Stdio};
 
-        let bin = std::env::current_exe()
-            .unwrap()
-            .parent()
-            .and_then(std::path::Path::parent)
-            .unwrap()
-            .join("bohay");
-        assert!(bin.exists(), "build the binary first: {}", bin.display());
+        let bin = std::env::current_exe().unwrap();
         let home = std::env::temp_dir().join(format!("bohay-remote-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&home);
         std::fs::create_dir_all(&home).unwrap();
@@ -430,8 +426,14 @@ mod tests {
         .unwrap();
 
         // A real server on a scratch home.
-        let mut server = Command::new(&bin)
-            .arg("server")
+        let server = Command::new(&bin)
+            .args([
+                "--exact",
+                "ipc::client::tests::terminal_palette_server_helper",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("BOHAY_TEST_PALETTE_SERVER", "1")
             .env("BOHAY_HOME", &home)
             // An agent pane inherits the live session's socket. The scratch
             // server and its cleanup must never escape this test home.
@@ -441,6 +443,21 @@ mod tests {
             .stderr(Stdio::null())
             .spawn()
             .unwrap();
+        struct ScratchServer {
+            child: std::process::Child,
+            home: std::path::PathBuf,
+        }
+        impl Drop for ScratchServer {
+            fn drop(&mut self) {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+                let _ = std::fs::remove_dir_all(&self.home);
+            }
+        }
+        let _server = ScratchServer {
+            child: server,
+            home: home.clone(),
+        };
         let sock = home.join("bohay-client.sock");
         for _ in 0..50 {
             if sock.exists() {
@@ -512,11 +529,18 @@ mod tests {
             "the server returned a real frame after palette negotiation"
         );
 
-        // Kill only the child handle this test spawned. Never address a server
-        // by an inherited environment socket during cleanup.
-        let _ = server.kill();
-        let _ = server.wait();
-        let _ = std::fs::remove_dir_all(&home);
+        // `_server` kills only the child handle spawned above, even if an
+        // assertion panics. It never addresses an inherited production socket.
+    }
+
+    /// Subprocess entry point for `real_server_accepts_a_terminal_palette`.
+    /// The ordinary test-suite invocation returns immediately; only the
+    /// explicitly marked child process enters the blocking server loop.
+    #[test]
+    fn terminal_palette_server_helper() {
+        if std::env::var_os("BOHAY_TEST_PALETTE_SERVER").is_some() {
+            crate::ipc::server::run().expect("scratch server failed");
+        }
     }
 }
 

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -629,7 +629,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "dev-tools"))]
 mod size_probe {
     use super::*;
     use ratatui::style::Color;
@@ -660,8 +660,8 @@ mod size_probe {
         b.len()
     }
 
+    /// Run with `cargo test --features dev-tools measure_wire_sizes -- --nocapture`.
     #[test]
-    #[ignore]
     fn measure_wire_sizes() {
         let f0 = full_frame(120, 32);
         let full = ser(&ServerMessage::Frame(f0.clone()));

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, RecvTimeoutError, Sender, SyncSender, TrySendError};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -30,7 +30,43 @@ const FRAME_INTERVAL: Duration = Duration::from_millis(16);
 /// than the frame cap so an idle session doesn't spin the CPU.
 const IDLE_INTERVAL: Duration = Duration::from_millis(33);
 
-type Clients = HashMap<u64, SyncSender<ServerMessage>>;
+#[derive(Clone)]
+struct ClientSender {
+    messages: Sender<ServerMessage>,
+    frame_pending: Arc<AtomicBool>,
+}
+
+enum FrameSendError {
+    Full,
+    Disconnected,
+}
+
+impl ClientSender {
+    /// Control messages are intentionally reliable. They are infrequent and
+    /// small, while rendered frames retain their independent one-frame gate.
+    fn send_control(&self, msg: ServerMessage) -> Result<(), ()> {
+        self.messages.send(msg).map_err(|_| ())
+    }
+
+    /// Queue at most one frame while the socket writer is busy. Dropped frames
+    /// are repaired by the existing `behind` full-frame resync path.
+    fn try_send_frame(&self, msg: ServerMessage) -> Result<(), FrameSendError> {
+        if self
+            .frame_pending
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(FrameSendError::Full);
+        }
+        if self.messages.send(msg).is_err() {
+            self.frame_pending.store(false, Ordering::Release);
+            return Err(FrameSendError::Disconnected);
+        }
+        Ok(())
+    }
+}
+
+type Clients = HashMap<u64, ClientSender>;
 
 pub fn run() -> Result<()> {
     let (tx, rx) = mpsc::channel::<AppEvent>();
@@ -168,20 +204,11 @@ pub fn run() -> Result<()> {
         // with no nodes; `server stop` is still what ends it.
         if app.end_session {
             app.end_session = false;
-            // NOT `broadcast`: that uses `try_send` on a capacity-1 channel and
-            // drops the message when the slot is occupied — which is routine
-            // (see `behind`). A dropped frame is self-healing; a dropped Detach
-            // is not, and would strand the client on a session with no nodes.
-            // `ServerShutdown` survives the same hazard only because the process
-            // then exits and closes every socket; here the server keeps running.
-            //
-            // So block until the writer thread takes it — on a detached thread,
-            // never on this loop, since a wedged client (a stalled ssh link)
-            // would otherwise hang the whole server.
-            for (_, tx) in clients.drain() {
-                thread::spawn(move || {
-                    let _ = tx.send(ServerMessage::Detach);
-                });
+            // Detach is a reliable control message. It does not compete with the
+            // one-frame backpressure slot, so a busy or remote client cannot
+            // lose it and cannot block this loop.
+            for (_, client) in clients.drain() {
+                let _ = client.send_control(ServerMessage::Detach);
             }
             foreground = None;
             // Persist immediately rather than waiting out the 2s debounce: the
@@ -196,7 +223,7 @@ pub fn run() -> Result<()> {
             app.detach_requested = false;
             if let Some(id) = foreground.take() {
                 if let Some(c) = clients.remove(&id) {
-                    let _ = c.try_send(ServerMessage::Detach);
+                    let _ = c.send_control(ServerMessage::Detach);
                 }
                 foreground = clients.keys().next().copied();
             }
@@ -330,7 +357,8 @@ fn apply(
     match ev {
         AppEvent::ClientConnected {
             id,
-            frames,
+            messages,
+            frame_pending,
             cols,
             rows,
             terminal_colors,
@@ -340,7 +368,13 @@ fn apply(
                     app.apply_terminal_colors(colors);
                 }
             }
-            clients.insert(id, frames);
+            clients.insert(
+                id,
+                ClientSender {
+                    messages,
+                    frame_pending,
+                },
+            );
             *foreground = Some(id);
             *size = (cols.max(1), rows.max(1));
             // Force a full frame so the new client (which diffs from nothing)
@@ -370,7 +404,7 @@ fn apply(
 }
 
 fn broadcast(clients: &mut Clients, msg: ServerMessage) {
-    clients.retain(|_, tx| !matches!(tx.try_send(msg.clone()), Err(TrySendError::Disconnected(_))));
+    clients.retain(|_, client| client.send_control(msg.clone()).is_ok());
 }
 
 /// Whether this tick must render, even when nothing in the app changed.
@@ -401,10 +435,10 @@ fn send_frame(
     for (id, tx) in clients.iter() {
         let send_full = full_for_all || behind.contains(id);
         let result = if send_full {
-            Some(tx.try_send(ServerMessage::Frame(frame.clone())))
+            Some(tx.try_send_frame(ServerMessage::Frame(frame.clone())))
         } else {
             // Up-to-date client + nothing changed ⇒ send nothing.
-            diff_msg.map(|d| tx.try_send(d.clone()))
+            diff_msg.map(|d| tx.try_send_frame(d.clone()))
         };
         match result {
             None => {}
@@ -413,10 +447,10 @@ fn send_frame(
                     behind.remove(id);
                 }
             }
-            Some(Err(TrySendError::Full(_))) => {
+            Some(Err(FrameSendError::Full)) => {
                 behind.insert(*id);
             }
-            Some(Err(TrySendError::Disconnected(_))) => dead.push(*id),
+            Some(Err(FrameSendError::Disconnected)) => dead.push(*id),
         }
     }
     for id in dead {
@@ -491,9 +525,16 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
         None
     };
 
-    let (frame_tx, frame_rx) = mpsc::sync_channel::<ServerMessage>(1);
+    let (message_tx, message_rx) = mpsc::channel::<ServerMessage>();
+    let frame_pending = Arc::new(AtomicBool::new(false));
+    let writer_frame_pending = frame_pending.clone();
     thread::spawn(move || {
-        for msg in frame_rx {
+        for msg in message_rx {
+            if matches!(msg, ServerMessage::Frame(_) | ServerMessage::FrameDiff(_)) {
+                // Match sync_channel(1): receiving frees the single frame slot,
+                // even while the socket write itself is still in progress.
+                writer_frame_pending.store(false, Ordering::Release);
+            }
             let stop = matches!(
                 msg,
                 ServerMessage::Detach | ServerMessage::ServerShutdown { .. }
@@ -507,7 +548,8 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
     if app_tx
         .send(AppEvent::ClientConnected {
             id,
-            frames: frame_tx,
+            messages: message_tx,
+            frame_pending,
             cols,
             rows,
             terminal_colors,
@@ -588,10 +630,13 @@ mod shutdown {
 
 #[cfg(test)]
 mod tests {
-    use super::needs_render;
     use super::ServerMessage;
+    use super::{broadcast, needs_render, ClientSender, FrameSendError};
+    use crate::ipc::protocol::FrameDiff;
+    use std::collections::HashMap;
+    use std::sync::atomic::AtomicBool;
     use std::sync::mpsc;
-    use std::thread;
+    use std::sync::Arc;
 
     /// A client that dropped a diff must get its full-frame resync even when the
     /// screen goes quiet. The resync only ships from inside a render, so a
@@ -615,40 +660,73 @@ mod tests {
         );
     }
 
-    /// Ending a session must actually reach the client (docs/43 §3.3). The frame
-    /// channel is `sync_channel(1)`, and `broadcast` uses `try_send`, which drops
-    /// the message when that single slot is occupied — routine enough that the
-    /// loop tracks it as `behind`. A dropped *frame* is self-healing; a dropped
-    /// *Detach* strands the client on a session with no nodes, which is the
-    /// original "the app is not closing" symptom. `ServerShutdown` survives the
-    /// same hazard only because the process then exits and closes every socket.
+    /// A tab switch requests a frame at the same time a finished selection sends
+    /// its clipboard payload. Frames may be dropped and repaired, but clipboard
+    /// writes must remain queued or the next paste uses stale clipboard content.
     #[test]
-    fn ending_a_session_delivers_detach_even_when_the_channel_is_full() {
-        use std::sync::mpsc::TrySendError;
+    fn clipboard_is_reliable_when_a_tab_frame_is_already_queued() {
+        let (messages, rx) = mpsc::channel();
+        let client = ClientSender {
+            messages,
+            frame_pending: Arc::new(AtomicBool::new(false)),
+        };
+        let frame = || {
+            ServerMessage::FrameDiff(FrameDiff {
+                width: 120,
+                height: 32,
+                runs: Vec::new(),
+                cursor: None,
+            })
+        };
 
-        let (tx, rx) = mpsc::sync_channel::<ServerMessage>(1);
-        // A queued frame occupies the only slot.
-        tx.try_send(ServerMessage::Sound).expect("slot is free");
+        assert!(client.try_send_frame(frame()).is_ok());
+        // Frame backpressure is still one deep, so output bursts cannot build an
+        // unbounded queue while a client is slow.
+        assert!(
+            matches!(client.try_send_frame(frame()), Err(FrameSendError::Full)),
+            "a second frame remains coalesced into the resync path"
+        );
 
-        // What the old path did: silently drop it.
+        let mut clients = HashMap::from([(7, client)]);
+        broadcast(
+            &mut clients,
+            ServerMessage::Clipboard("exact selection".into()),
+        );
+
+        assert!(
+            matches!(rx.recv().unwrap(), ServerMessage::FrameDiff(_)),
+            "the already queued tab frame stays first"
+        );
         assert!(
             matches!(
-                tx.try_send(ServerMessage::Detach),
-                Err(TrySendError::Full(_))
+                rx.recv().unwrap(),
+                ServerMessage::Clipboard(text) if text == "exact selection"
             ),
-            "a full channel is exactly the case that used to lose the Detach"
+            "clipboard control data cannot be dropped behind a frame"
         );
+    }
 
-        // What it does now: block until the writer drains — off-thread, so a
-        // wedged client can never hang the server loop.
-        let h = thread::spawn(move || {
-            let _ = tx.send(ServerMessage::Detach);
-        });
-        assert!(matches!(rx.recv().unwrap(), ServerMessage::Sound));
-        assert!(
-            matches!(rx.recv().unwrap(), ServerMessage::Detach),
-            "the client is told to detach even though the channel was full"
-        );
-        h.join().unwrap();
+    /// Session detach is carried by the same reliable control path. Preserve the
+    /// earlier guarantee that closing the last node cannot strand a client just
+    /// because its writer already has a frame waiting.
+    #[test]
+    fn ending_a_session_delivers_detach_behind_a_queued_frame() {
+        let (messages, rx) = mpsc::channel();
+        let client = ClientSender {
+            messages,
+            frame_pending: Arc::new(AtomicBool::new(false)),
+        };
+        assert!(client
+            .try_send_frame(ServerMessage::FrameDiff(FrameDiff {
+                width: 1,
+                height: 1,
+                runs: Vec::new(),
+                cursor: None,
+            }))
+            .is_ok());
+        assert!(client.send_control(ServerMessage::Detach).is_ok());
+
+        assert!(matches!(rx.recv().unwrap(), ServerMessage::FrameDiff(_)));
+        assert!(matches!(rx.recv().unwrap(), ServerMessage::Detach));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -882,9 +882,9 @@ mod tests {
 
     /// Manual benchmark of the server render hot path (full UI render + in-place
     /// `diff_buffer`) — the per-frame cost during typing. Run with:
-    ///   cargo test --release bench_render_hotpath -- --ignored --nocapture
+    ///   cargo test --release --features dev-tools bench_render_hotpath -- --nocapture
+    #[cfg(feature = "dev-tools")]
     #[test]
-    #[ignore]
     fn bench_render_hotpath() {
         use crate::ipc::protocol::{diff_buffer, frame_from_buffer};
         let (tx, _rx) = mpsc::channel::<AppEvent>();
@@ -1094,6 +1094,7 @@ mod tests {
     /// path after the name; off (default) it shows just the name.
     #[test]
     fn pane_title_path_setting_appends_the_path() {
+        let _env = crate::persist::test_env("pane-title-path");
         let (tx, _rx) = mpsc::channel::<AppEvent>();
         let mut app = App::new(80, 24, tx).expect("spawn pane");
         thread::sleep(Duration::from_millis(120));
@@ -1113,7 +1114,9 @@ mod tests {
                 .collect()
         };
 
-        // Default: name only, no double-space-then-path run.
+        // Keep the rendering assertion independent of config written by other
+        // tests. The default itself belongs to Config's unit contract.
+        app.config.layout.pane_title_path = false;
         let off = render(&mut app);
         assert!(off.contains("svcx"), "named pane shows its name");
         assert!(
@@ -1622,9 +1625,19 @@ mod tests {
     fn wide_emoji_marks_its_continuation_cell() {
         use ratatui::buffer::Buffer;
         use ratatui::layout::Rect;
+        use std::sync::{Arc, Mutex};
+
+        let _env = crate::persist::test_env("wide-emoji-frame");
         let (tx, _rx) = mpsc::channel::<AppEvent>();
         let mut app = App::new(80, 24, tx).expect("spawn pane");
         let id = app.layout().focus;
+        // Detach this assertion from the live shell reader. It may write its
+        // prompt between injection and rendering, which made the glyph vanish
+        // nondeterministically even though the renderer was correct.
+        let (response_tx, _response_rx) = mpsc::channel();
+        app.panes.get_mut(&id).unwrap().engine = Arc::new(Mutex::new(
+            crate::terminal::vt::alacritty::AlacrittyEngine::new(80, 24, response_tx, 2_000),
+        ));
         app.panes
             .get(&id)
             .unwrap()
@@ -1796,9 +1809,9 @@ mod tests {
 
     /// Render a representative frame (a simulated agent session in the pane) and
     /// dump it to `preview.html` so the UI can be viewed in a browser with real
-    /// colors. A dev tool, not a CI check: `cargo test generate_preview -- --ignored`.
+    /// colors. Run with `cargo test --features dev-tools generate_preview`.
+    #[cfg(feature = "dev-tools")]
     #[test]
-    #[ignore]
     fn generate_preview() {
         use crate::ui::theme::State;
         use ratatui::style::Modifier;
@@ -1937,6 +1950,7 @@ span{{white-space:pre}}</style><pre>{body}</pre>"
         eprintln!("wrote {apath}");
     }
 
+    #[cfg(feature = "dev-tools")]
     fn resolve(c: ratatui::style::Color, reset: (u8, u8, u8)) -> (u8, u8, u8) {
         use ratatui::style::Color::*;
         match c {
@@ -1962,11 +1976,13 @@ span{{white-space:pre}}</style><pre>{body}</pre>"
         }
     }
 
+    #[cfg(feature = "dev-tools")]
     fn dim(c: (u8, u8, u8)) -> (u8, u8, u8) {
         let f = |v: u8| (v as f32 * 0.6) as u8;
         (f(c.0), f(c.1), f(c.2))
     }
 
+    #[cfg(feature = "dev-tools")]
     fn xterm(i: u8) -> (u8, u8, u8) {
         // 0–15: catppuccin mocha ANSI; 16–231: 6×6×6 cube; 232–255: grayscale.
         const ANSI: [(u8, u8, u8); 16] = [
@@ -1999,8 +2015,9 @@ span{{white-space:pre}}</style><pre>{body}</pre>"
         }
     }
 
+    /// Run with `cargo test --release --features dev-tools bench_file_viewer_render -- --nocapture`.
+    #[cfg(feature = "dev-tools")]
     #[test]
-    #[ignore]
     fn bench_file_viewer_render() {
         use ratatui::{backend::TestBackend, Terminal};
         use std::time::Instant;

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -927,16 +927,15 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "dev-tools"))]
 mod theme_css {
     /// Dev tool (not a CI check), mirroring `generate_preview`: emit every
     /// palette in [`super::THEMES`] as CSS custom properties for the website's
     /// theme picker, so bohay.dev shows the *real* palettes rather than
     /// hand-copied approximations that drift.
     ///
-    /// `cargo test emit_theme_css -- --ignored --nocapture > /tmp/themes.css`
+    /// `cargo test --features dev-tools emit_theme_css -- --nocapture`
     #[test]
-    #[ignore]
     fn emit_theme_css() {
         fn hex(c: ratatui::style::Color) -> String {
             match c {


### PR DESCRIPTION
Improve bohay input, rendering, and IPC hot paths while preserving terminal, clipboard, and agent session state across pane and app transitions.

## Rendering performance

- Skip redraws when mouse movement, hover state, and plain keystrokes do not change the bohay UI.
- Coalesce rendered frames without dropping control messages behind a slow client.
- Keep developer-only benchmarks and artifact generators out of the default test registry.

## State correctness

- Preserve inactive pane scroll positions when focus moves elsewhere.
- Stop resuming agents that intentionally exited back to their shell.
- Deliver clipboard and detach messages reliably when a rendered frame is already queued.

## Test reliability

- Isolate filesystem, process, PTY, palette, and asynchronous event fixtures.
- Make the real scratch-server palette test self-contained.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`: 489 passed, 0 failed, 0 ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mouse hover behavior across menus, dialogs, file rows, links, and controls, reducing unnecessary screen redraws.
  - Preserved pane scroll positions more reliably when changing focus.
  - Improved agent lifecycle tracking, including agents that start recognized child processes.
  - Improved workspace and file-viewer behavior during resizing, dragging, refreshing, and directory changes.
  - Ensured clipboard and detach messages are delivered reliably even when rendering is busy.
- **Developer Tools**
  - Added an optional feature for running benchmarks and preview-generation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->