### PR TITLE
feat(ipc): support independent multi-client viewports

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -37,7 +37,7 @@ impl App {
                 self.mark_user_input(); // so the echo isn't misread as agent work
                 false // goes to the pane; its echo (PtyData) renders it
             }
-            AppEvent::Resize(_, _) => {
+            AppEvent::Resize => {
                 // A resize (or a same-size resize event a terminal emits on a
                 // move/expose) may have damaged the screen — force a full repaint.
                 self.force_redraw = true;
@@ -149,7 +149,9 @@ impl App {
                 true
             }
             // Handled by the server loop; never reaches here at runtime.
-            AppEvent::ClientConnected { .. } | AppEvent::ClientDetach { .. } => false,
+            AppEvent::ClientConnected { .. }
+            | AppEvent::ClientDetach { .. }
+            | AppEvent::ClientInput { .. } => false,
         }
     }
 
@@ -1980,7 +1982,7 @@ mod tests {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = crate::app::App::new(80, 24, tx).unwrap();
         assert!(!app.force_redraw, "starts off");
-        let dirty = app.handle_event(AppEvent::Resize(100, 30));
+        let dirty = app.handle_event(AppEvent::Resize);
         assert!(dirty, "a resize warrants a redraw");
         assert!(
             app.force_redraw,

--- a/src/event.rs
+++ b/src/event.rs
@@ -11,11 +11,21 @@ use crate::ids::PaneId;
 use crate::ipc::protocol::ServerMessage;
 use crate::terminal::theme_probe::TerminalColors;
 
-pub enum AppEvent {
+/// Input originating from one attached display client. Keeping the source id at
+/// the server boundary lets the server select that client's geometry before it
+/// performs hit-testing or forwards bytes to a pane.
+pub enum ClientInput {
     Key(KeyEvent),
     Mouse(MouseEvent),
     Paste(String),
     Resize(u16, u16),
+}
+
+pub enum AppEvent {
+    Key(KeyEvent),
+    Mouse(MouseEvent),
+    Paste(String),
+    Resize,
     /// The given pane produced output; the screen changed.
     PtyData(PaneId),
     /// The given pane's child process exited.
@@ -36,6 +46,12 @@ pub enum AppEvent {
     /// A binary client detached.
     ClientDetach {
         id: u64,
+    },
+    /// Input from a binary display client. The server unwraps this only after
+    /// activating the correct per-client viewport; it never reaches `App`.
+    ClientInput {
+        id: u64,
+        input: ClientInput,
     },
     /// A module subprocess finished; fill in its log entry.
     ModuleCommandFinished {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -3,7 +3,7 @@
 //! Input arrives from clients; the JSON API also runs here. See docs/03, docs/08.
 
 use crate::ipc::transport::{self, Conn};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -17,7 +17,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 
 use crate::app::App;
-use crate::event::AppEvent;
+use crate::event::{AppEvent, ClientInput};
 use crate::ipc::api;
 use crate::ipc::protocol::{self, ClientMessage, ServerMessage};
 use crate::persist;
@@ -30,7 +30,6 @@ const FRAME_INTERVAL: Duration = Duration::from_millis(16);
 /// than the frame cap so an idle session doesn't spin the CPU.
 const IDLE_INTERVAL: Duration = Duration::from_millis(33);
 
-#[derive(Clone)]
 struct ClientSender {
     messages: Sender<ServerMessage>,
     frame_pending: Arc<AtomicBool>,
@@ -66,7 +65,44 @@ impl ClientSender {
     }
 }
 
-type Clients = HashMap<u64, ClientSender>;
+struct ClientState {
+    sender: ClientSender,
+    size: (u16, u16),
+    terminal_colors: Option<crate::terminal::theme_probe::TerminalColors>,
+    render_buf: Buffer,
+    last_frame: Option<protocol::FrameData>,
+    behind: bool,
+    force_full: bool,
+    last_activity: u64,
+}
+
+impl ClientState {
+    fn new(
+        sender: ClientSender,
+        cols: u16,
+        rows: u16,
+        terminal_colors: Option<crate::terminal::theme_probe::TerminalColors>,
+        last_activity: u64,
+    ) -> Self {
+        let size = (cols.max(1), rows.max(1));
+        Self {
+            sender,
+            size,
+            terminal_colors,
+            render_buf: Buffer::empty(Rect::new(0, 0, size.0, size.1)),
+            last_frame: None,
+            behind: false,
+            force_full: true,
+            last_activity,
+        }
+    }
+
+    fn send_control(&self, msg: ServerMessage) -> Result<(), ()> {
+        self.sender.send_control(msg)
+    }
+}
+
+type Clients = HashMap<u64, ClientState>;
 
 pub fn run() -> Result<()> {
     let (tx, rx) = mpsc::channel::<AppEvent>();
@@ -104,23 +140,12 @@ pub fn run() -> Result<()> {
 
     let mut clients: Clients = HashMap::new();
     let mut foreground: Option<u64> = None;
-    let mut size = DEFAULT_SIZE;
-    let mut backend_size = size;
-    // We render straight into a buffer we own (no ratatui `Terminal`), so a frame is
-    // one render + one `diff_buffer` — not render + Terminal's reset/diff/flush + our
-    // diff. Saved ~28% of the per-frame cost (see `bench_render_hotpath`).
-    let mut render_buf = Buffer::empty(Rect::new(0, 0, size.0, size.1));
+    // Geometry last committed to the shared PTYs and interactive hit-test state.
+    // Secondary-client projections never change it.
+    let mut interactive_size = DEFAULT_SIZE;
+    let mut next_activity = 1u64;
     let mut last_draw = Instant::now();
     let mut last_save = Instant::now();
-    // The last frame broadcast. We send only the *diff* against it (or skip an
-    // identical frame), so an idle session sends nothing and a busy one sends
-    // just the changed cells — cheap over a Unix socket, and crucial over SSH.
-    // Reset to `None` when a client attaches so the fresh client gets a full frame.
-    let mut last_frame: Option<protocol::FrameData> = None;
-    // Clients whose bounded frame channel was full when a diff went out — they
-    // dropped it, so they're resynced with a full frame next round (a dropped
-    // diff would otherwise desync them; a dropped *full* frame is self-healing).
-    let mut behind: HashSet<u64> = HashSet::new();
     // Un-rendered activity waiting for the frame cap to expire — drives a trailing
     // render so a change that lands mid-interval isn't stuck until the next event.
     let mut dirty = false;
@@ -150,8 +175,8 @@ pub fn run() -> Result<()> {
                 &mut app,
                 &mut clients,
                 &mut foreground,
-                &mut size,
-                &mut last_frame,
+                &mut interactive_size,
+                &mut next_activity,
             ),
             Err(RecvTimeoutError::Timeout) => false,
             Err(RecvTimeoutError::Disconnected) => break,
@@ -162,8 +187,8 @@ pub fn run() -> Result<()> {
                 &mut app,
                 &mut clients,
                 &mut foreground,
-                &mut size,
-                &mut last_frame,
+                &mut interactive_size,
+                &mut next_activity,
             );
         }
         while let Ok(req) = api_rx.try_recv() {
@@ -225,7 +250,9 @@ pub fn run() -> Result<()> {
                 if let Some(c) = clients.remove(&id) {
                     let _ = c.send_control(ServerMessage::Detach);
                 }
-                foreground = clients.keys().next().copied();
+                foreground = latest_client(&clients);
+                apply_foreground_theme(&mut app, &clients, foreground);
+                activity = true;
             }
         }
 
@@ -280,58 +307,20 @@ pub fn run() -> Result<()> {
         // A forced redraw (resize / focus-regained / external damage) must render
         // even if nothing else changed this tick — and so must a client that is
         // waiting on its full-frame resync (see `needs_render`).
-        dirty = needs_render(dirty, app.force_redraw, !behind.is_empty());
+        dirty = needs_render(
+            dirty,
+            app.force_redraw,
+            clients.values().any(|client| client.behind),
+        );
 
         if dirty && !clients.is_empty() && last_draw.elapsed() >= FRAME_INTERVAL {
-            let area = Rect::new(0, 0, size.0, size.1);
-            if size != backend_size {
-                render_buf = Buffer::empty(area);
-                backend_size = size;
-            }
-            render_buf.reset();
-            {
-                let mut target = ui::RenderTarget::new(&mut render_buf, area);
-                ui::render_into(&mut target, &mut app);
-            }
-            let buf = &render_buf;
-            let cursor = app.last_cursor;
-            // A full frame is needed on the first frame and on resize (a diff would
-            // be meaningless against different dims). Otherwise diff the live buffer
-            // straight against `last_frame` and update it in place — no per-frame
-            // clone or per-cell `String` (the old hot-path allocation that made
-            // panes lag under load).
-            // A forced redraw sends everyone a full frame (clears the terminal
-            // and repaints), the only way to fix damage bohay never saw.
             let forced = std::mem::take(&mut app.force_redraw);
-            let full_for_all = forced
-                || last_frame
-                    .as_ref()
-                    .is_none_or(|p| p.width != buf.area.width || p.height != buf.area.height);
-            let diff_msg = if full_for_all {
-                last_frame = Some(protocol::frame_from_buffer(buf, cursor));
-                None
-            } else {
-                let prev = last_frame.as_mut().unwrap();
-                let cursor_moved = prev.cursor != cursor;
-                let runs = protocol::diff_buffer(prev, buf);
-                prev.cursor = cursor;
-                if runs.is_empty() && !cursor_moved {
-                    None // screen unchanged — send nothing
-                } else {
-                    Some(ServerMessage::FrameDiff(protocol::FrameDiff {
-                        width: prev.width,
-                        height: prev.height,
-                        runs,
-                        cursor,
-                    }))
-                }
-            };
-            send_frame(
+            render_clients(
+                &mut app,
                 &mut clients,
-                &mut behind,
-                last_frame.as_ref().unwrap(),
-                diff_msg.as_ref(),
-                full_for_all,
+                &mut foreground,
+                &mut interactive_size,
+                forced,
             );
             last_draw = Instant::now();
             // Re-arm the PTY readers now that their output is on screen. A flag
@@ -351,8 +340,8 @@ fn apply(
     app: &mut App,
     clients: &mut Clients,
     foreground: &mut Option<u64>,
-    size: &mut (u16, u16),
-    last_frame: &mut Option<protocol::FrameData>,
+    interactive_size: &mut (u16, u16),
+    next_activity: &mut u64,
 ) -> bool {
     match ev {
         AppEvent::ClientConnected {
@@ -363,39 +352,80 @@ fn apply(
             rows,
             terminal_colors,
         } => {
-            if app.config.theme == "terminal" {
-                if let Some(colors) = terminal_colors.as_ref() {
-                    app.apply_terminal_colors(colors);
-                }
-            }
+            let activity = *next_activity;
+            *next_activity = next_activity.saturating_add(1);
             clients.insert(
                 id,
-                ClientSender {
-                    messages,
-                    frame_pending,
-                },
+                ClientState::new(
+                    ClientSender {
+                        messages,
+                        frame_pending,
+                    },
+                    cols,
+                    rows,
+                    terminal_colors,
+                    activity,
+                ),
             );
             *foreground = Some(id);
-            *size = (cols.max(1), rows.max(1));
-            // Force a full frame so the new client (which diffs from nothing)
-            // gets the complete screen.
-            *last_frame = None;
+            apply_foreground_theme(app, clients, *foreground);
             true
         }
         AppEvent::ClientDetach { id } => {
+            let was_foreground = *foreground == Some(id);
             clients.remove(&id);
-            if *foreground == Some(id) {
-                *foreground = clients.keys().next().copied();
+            if was_foreground {
+                *foreground = latest_client(clients);
+                apply_foreground_theme(app, clients, *foreground);
             }
-            false
+            was_foreground
         }
-        AppEvent::Resize(c, r) => {
-            *size = (c.max(1), r.max(1));
-            // A resize event (real size change, or a same-size event the terminal
-            // sends on a move/expose) means the screen may be damaged — force a
-            // full repaint, not a diff, even when the dimensions are unchanged.
-            app.force_redraw = true;
-            true
+        AppEvent::ClientInput { id, input } => {
+            let Some(client) = clients.get_mut(&id) else {
+                return false;
+            };
+            client.last_activity = *next_activity;
+            *next_activity = next_activity.saturating_add(1);
+
+            if let ClientInput::Resize(cols, rows) = input {
+                client.size = (cols.max(1), rows.max(1));
+                // Resize/focus repair is local to this terminal. Its next frame
+                // must be complete, but other clients keep their diff baselines.
+                client.force_full = true;
+                return true;
+            }
+
+            // Input ownership follows actual interaction, not background resize
+            // noise. Before hit-testing a newly active client, commit its view
+            // geometry and PTY dimensions synchronously.
+            let promoted = *foreground != Some(id);
+            if promoted {
+                *foreground = Some(id);
+                apply_foreground_theme(app, clients, *foreground);
+            }
+            let target_size = clients.get(&id).map(|client| client.size);
+            if promoted || target_size.is_some_and(|size| size != *interactive_size) {
+                let disconnected = clients
+                    .get_mut(&id)
+                    .is_some_and(|client| render_client(app, client, true, false));
+                if disconnected {
+                    clients.remove(&id);
+                    *foreground = latest_client(clients);
+                    apply_foreground_theme(app, clients, *foreground);
+                    return true;
+                }
+                if let Some(size) = target_size {
+                    *interactive_size = size;
+                }
+            }
+
+            let event = match input {
+                ClientInput::Key(key) => AppEvent::Key(key),
+                ClientInput::Mouse(mouse) => AppEvent::Mouse(mouse),
+                ClientInput::Paste(text) => AppEvent::Paste(text),
+                ClientInput::Resize(..) => unreachable!("handled above"),
+            };
+            app.handle_event(event)
         }
         // Redraw only if the event actually changed the UI — a plain keystroke
         // forwarded to a pane does not (its echo arrives as a separate `PtyData`).
@@ -405,6 +435,25 @@ fn apply(
 
 fn broadcast(clients: &mut Clients, msg: ServerMessage) {
     clients.retain(|_, client| client.send_control(msg.clone()).is_ok());
+}
+
+fn latest_client(clients: &Clients) -> Option<u64> {
+    clients
+        .iter()
+        .max_by_key(|(_, client)| client.last_activity)
+        .map(|(&id, _)| id)
+}
+
+fn apply_foreground_theme(app: &mut App, clients: &Clients, foreground: Option<u64>) {
+    if app.config.theme != "terminal" {
+        return;
+    }
+    if let Some(colors) = foreground
+        .and_then(|id| clients.get(&id))
+        .and_then(|client| client.terminal_colors.as_ref())
+    {
+        app.apply_terminal_colors(colors);
+    }
 }
 
 /// Whether this tick must render, even when nothing in the app changed.
@@ -421,42 +470,115 @@ fn needs_render(app_dirty: bool, force_redraw: bool, any_behind: bool) -> bool {
     app_dirty || force_redraw || any_behind
 }
 
-/// Send each client a `FrameDiff` (cheap) — or a full `Frame` if it's behind or
-/// everyone needs one (first frame / resize). A client whose bounded channel is
-/// full dropped its update and is marked `behind` for a full-frame resync.
-fn send_frame(
+/// Render the active client first so its geometry remains authoritative, then
+/// render every other client as a projection at that client's own dimensions.
+/// The common one-client case is still exactly one buffer reset, one UI render,
+/// and one in-place diff.
+fn render_clients(
+    app: &mut App,
     clients: &mut Clients,
-    behind: &mut HashSet<u64>,
-    frame: &protocol::FrameData,
-    diff_msg: Option<&ServerMessage>,
-    full_for_all: bool,
+    foreground: &mut Option<u64>,
+    interactive_size: &mut (u16, u16),
+    force_all: bool,
 ) {
+    if foreground.is_none_or(|id| !clients.contains_key(&id)) {
+        *foreground = latest_client(clients);
+        apply_foreground_theme(app, clients, *foreground);
+    }
+
+    let mut order: Vec<u64> = clients.keys().copied().collect();
+    order.sort_unstable_by_key(|id| (*foreground != Some(*id), *id));
     let mut dead = Vec::new();
-    for (id, tx) in clients.iter() {
-        let send_full = full_for_all || behind.contains(id);
-        let result = if send_full {
-            Some(tx.try_send_frame(ServerMessage::Frame(frame.clone())))
-        } else {
-            // Up-to-date client + nothing changed ⇒ send nothing.
-            diff_msg.map(|d| tx.try_send_frame(d.clone()))
-        };
-        match result {
-            None => {}
-            Some(Ok(())) => {
-                if send_full {
-                    behind.remove(id);
-                }
+    for id in order {
+        let interactive = *foreground == Some(id);
+        if let Some(client) = clients.get_mut(&id) {
+            if render_client(app, client, interactive, force_all) {
+                dead.push(id);
+            } else if interactive {
+                *interactive_size = client.size;
             }
-            Some(Err(FrameSendError::Full)) => {
-                behind.insert(*id);
-            }
-            Some(Err(FrameSendError::Disconnected)) => dead.push(*id),
         }
     }
     for id in dead {
         clients.remove(&id);
     }
-    behind.retain(|id| clients.contains_key(id));
+    if foreground.is_some_and(|id| !clients.contains_key(&id)) {
+        *foreground = latest_client(clients);
+        apply_foreground_theme(app, clients, *foreground);
+    }
+}
+
+/// Render and enqueue one client's next frame. Returns true when its writer is
+/// disconnected and the caller should remove it.
+fn render_client(
+    app: &mut App,
+    client: &mut ClientState,
+    interactive: bool,
+    force_all: bool,
+) -> bool {
+    let area = Rect::new(0, 0, client.size.0, client.size.1);
+    if client.render_buf.area != area {
+        client.render_buf = Buffer::empty(area);
+        client.last_frame = None;
+        client.force_full = true;
+    } else {
+        client.render_buf.reset();
+    }
+
+    let cursor = {
+        let mut target = ui::RenderTarget::new(&mut client.render_buf, area);
+        if interactive {
+            ui::render_into(&mut target, app);
+        } else {
+            ui::render_projection(&mut target, app);
+        }
+        target.cursor()
+    };
+
+    let full = force_all
+        || client.force_full
+        || client.behind
+        || client.last_frame.as_ref().is_none_or(|previous| {
+            previous.width != client.render_buf.area.width
+                || previous.height != client.render_buf.area.height
+        });
+    let message = if full {
+        client.last_frame = Some(protocol::frame_from_buffer(&client.render_buf, cursor));
+        Some(ServerMessage::Frame(
+            client.last_frame.as_ref().expect("frame stored").clone(),
+        ))
+    } else {
+        let previous = client.last_frame.as_mut().expect("frame baseline exists");
+        let cursor_moved = previous.cursor != cursor;
+        let runs = protocol::diff_buffer(previous, &client.render_buf);
+        previous.cursor = cursor;
+        if runs.is_empty() && !cursor_moved {
+            None
+        } else {
+            Some(ServerMessage::FrameDiff(protocol::FrameDiff {
+                width: previous.width,
+                height: previous.height,
+                runs,
+                cursor,
+            }))
+        }
+    };
+
+    let Some(message) = message else {
+        return false;
+    };
+    match client.sender.try_send_frame(message) {
+        Ok(()) => {
+            client.behind = false;
+            client.force_full = false;
+            false
+        }
+        Err(FrameSendError::Full) => {
+            client.behind = true;
+            false
+        }
+        Err(FrameSendError::Disconnected) => true,
+    }
 }
 
 fn start_client_listener(path: PathBuf, app_tx: Sender<AppEvent>, terminal_theme: Arc<AtomicBool>) {
@@ -562,22 +684,46 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
     loop {
         match protocol::read_message::<_, ClientMessage>(&mut reader) {
             Ok(ClientMessage::Key(k)) => {
-                if app_tx.send(AppEvent::Key(k)).is_err() {
+                if app_tx
+                    .send(AppEvent::ClientInput {
+                        id,
+                        input: ClientInput::Key(k),
+                    })
+                    .is_err()
+                {
                     break;
                 }
             }
             Ok(ClientMessage::Mouse(m)) => {
-                if app_tx.send(AppEvent::Mouse(m)).is_err() {
+                if app_tx
+                    .send(AppEvent::ClientInput {
+                        id,
+                        input: ClientInput::Mouse(m),
+                    })
+                    .is_err()
+                {
                     break;
                 }
             }
             Ok(ClientMessage::Paste(s)) => {
-                if app_tx.send(AppEvent::Paste(s)).is_err() {
+                if app_tx
+                    .send(AppEvent::ClientInput {
+                        id,
+                        input: ClientInput::Paste(s),
+                    })
+                    .is_err()
+                {
                     break;
                 }
             }
             Ok(ClientMessage::Resize { cols, rows }) => {
-                if app_tx.send(AppEvent::Resize(cols, rows)).is_err() {
+                if app_tx
+                    .send(AppEvent::ClientInput {
+                        id,
+                        input: ClientInput::Resize(cols, rows),
+                    })
+                    .is_err()
+                {
                     break;
                 }
             }
@@ -631,12 +777,47 @@ mod shutdown {
 #[cfg(test)]
 mod tests {
     use super::ServerMessage;
-    use super::{broadcast, needs_render, ClientSender, FrameSendError};
+    use super::{
+        apply, broadcast, needs_render, render_clients, ClientSender, ClientState, FrameSendError,
+    };
+    use crate::app::App;
+    use crate::event::{AppEvent, ClientInput};
     use crate::ipc::protocol::FrameDiff;
+    use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::collections::HashMap;
     use std::sync::atomic::AtomicBool;
     use std::sync::mpsc;
     use std::sync::Arc;
+    use std::time::Duration;
+
+    fn display_client(
+        cols: u16,
+        rows: u16,
+        activity: u64,
+    ) -> (ClientState, mpsc::Receiver<ServerMessage>) {
+        let (messages, rx) = mpsc::channel();
+        (
+            ClientState::new(
+                ClientSender {
+                    messages,
+                    frame_pending: Arc::new(AtomicBool::new(false)),
+                },
+                cols,
+                rows,
+                None,
+                activity,
+            ),
+            rx,
+        )
+    }
+
+    fn received_frame_size(rx: &mpsc::Receiver<ServerMessage>) -> (u16, u16) {
+        match rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            ServerMessage::Frame(frame) => (frame.width, frame.height),
+            ServerMessage::FrameDiff(frame) => (frame.width, frame.height),
+            _ => panic!("expected rendered frame"),
+        }
+    }
 
     /// A client that dropped a diff must get its full-frame resync even when the
     /// screen goes quiet. The resync only ships from inside a render, so a
@@ -666,10 +847,16 @@ mod tests {
     #[test]
     fn clipboard_is_reliable_when_a_tab_frame_is_already_queued() {
         let (messages, rx) = mpsc::channel();
-        let client = ClientSender {
-            messages,
-            frame_pending: Arc::new(AtomicBool::new(false)),
-        };
+        let client = ClientState::new(
+            ClientSender {
+                messages,
+                frame_pending: Arc::new(AtomicBool::new(false)),
+            },
+            120,
+            32,
+            None,
+            1,
+        );
         let frame = || {
             ServerMessage::FrameDiff(FrameDiff {
                 width: 120,
@@ -679,11 +866,14 @@ mod tests {
             })
         };
 
-        assert!(client.try_send_frame(frame()).is_ok());
+        assert!(client.sender.try_send_frame(frame()).is_ok());
         // Frame backpressure is still one deep, so output bursts cannot build an
         // unbounded queue while a client is slow.
         assert!(
-            matches!(client.try_send_frame(frame()), Err(FrameSendError::Full)),
+            matches!(
+                client.sender.try_send_frame(frame()),
+                Err(FrameSendError::Full)
+            ),
             "a second frame remains coalesced into the resync path"
         );
 
@@ -728,5 +918,91 @@ mod tests {
 
         assert!(matches!(rx.recv().unwrap(), ServerMessage::FrameDiff(_)));
         assert!(matches!(rx.recv().unwrap(), ServerMessage::Detach));
+    }
+
+    #[test]
+    fn different_client_sizes_receive_independent_frames_and_active_geometry() {
+        let _env = crate::persist::test_env("multi-client-resolution");
+        let (app_tx, _app_rx) = mpsc::channel();
+        let mut app = App::new(120, 40, app_tx).expect("app starts");
+        app.server_mode = true;
+
+        let (large, large_rx) = display_client(120, 40, 2);
+        let (small, small_rx) = display_client(40, 18, 1);
+        let mut clients = HashMap::from([(1, large), (2, small)]);
+        let mut foreground = Some(1);
+        let mut interactive_size = (120, 40);
+
+        render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            false,
+        );
+
+        assert_eq!(received_frame_size(&large_rx), (120, 40));
+        assert_eq!(received_frame_size(&small_rx), (40, 18));
+        assert_eq!(clients[&1].last_frame.as_ref().unwrap().width, 120);
+        assert_eq!(clients[&2].last_frame.as_ref().unwrap().width, 40);
+        assert_eq!(interactive_size, (120, 40));
+        assert!(!app.compact, "secondary compact projection must not leak");
+
+        let focus = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find_map(|(id, rect)| (*id == focus).then_some(*rect))
+            .expect("active pane content");
+        assert_eq!(
+            app.panes[&focus].size(),
+            (content.width, content.height),
+            "secondary projection must not resize the shared PTY"
+        );
+    }
+
+    #[test]
+    fn background_resize_is_local_and_interaction_promotes_its_view() {
+        let _env = crate::persist::test_env("multi-client-promotion");
+        let (app_tx, _app_rx) = mpsc::channel();
+        let mut app = App::new(120, 40, app_tx).expect("app starts");
+        app.server_mode = true;
+        let (large, _large_rx) = display_client(120, 40, 2);
+        let (small, small_rx) = display_client(50, 20, 1);
+        let mut clients = HashMap::from([(1, large), (2, small)]);
+        let mut foreground = Some(1);
+        let mut interactive_size = (120, 40);
+        let mut next_activity = 3;
+
+        assert!(apply(
+            AppEvent::ClientInput {
+                id: 2,
+                input: ClientInput::Resize(46, 16),
+            },
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            &mut next_activity,
+        ));
+        assert_eq!(foreground, Some(1), "background resize cannot steal input");
+        assert_eq!(clients[&2].size, (46, 16));
+        assert_eq!(interactive_size, (120, 40));
+
+        assert!(!apply(
+            AppEvent::ClientInput {
+                id: 2,
+                input: ClientInput::Key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE,)),
+            },
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            &mut next_activity,
+        ));
+        assert_eq!(foreground, Some(2));
+        assert_eq!(interactive_size, (46, 16));
+        assert!(app.compact, "the newly active narrow client owns its view");
+        assert_eq!(received_frame_size(&small_rx), (46, 16));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -850,13 +850,11 @@ fn app_event(event: Event) -> Option<AppEvent> {
     match event {
         Event::Key(k) => Some(AppEvent::Key(k)),
         Event::Mouse(m) => Some(AppEvent::Mouse(m)),
-        Event::Resize(w, h) => Some(AppEvent::Resize(w, h)),
+        Event::Resize(_, _) => Some(AppEvent::Resize),
         Event::Paste(s) => Some(AppEvent::Paste(s)),
         // Regained focus: treat like a resize to the current size, which forces
         // a full repaint and clears any stale cells from a move/expose.
-        Event::FocusGained => crossterm::terminal::size()
-            .ok()
-            .map(|(w, h)| AppEvent::Resize(w, h)),
+        Event::FocusGained => crossterm::terminal::size().ok().map(|_| AppEvent::Resize),
         _ => None,
     }
 }

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -429,6 +429,11 @@ impl Pane {
         self.size = (cols, rows);
         true
     }
+
+    #[cfg(test)]
+    pub(crate) fn size(&self) -> (u16, u16) {
+        self.size
+    }
 }
 
 /// Pasted text as the bytes to write to the child: wrapped in the

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -50,6 +50,9 @@ impl<'a> RenderTarget<'a> {
         let p = position.into();
         self.cursor = Some((p.x, p.y));
     }
+    pub fn cursor(&self) -> Option<(u16, u16)> {
+        self.cursor
+    }
 }
 
 mod board;
@@ -91,6 +94,211 @@ pub fn render(f: &mut Frame, app: &mut App) {
 /// The actual UI render, over a buffer we own (`RenderTarget`). The server calls
 /// this directly with its frame buffer; `render` above adapts a `Frame` to it.
 pub fn render_into(f: &mut RenderTarget, app: &mut App) {
+    render_into_mode(f, app, true);
+}
+
+/// Render a secondary client's viewport without letting that projection become
+/// the interactive view or resize the shared PTYs.
+///
+/// Bohay deliberately keeps one server-owned application state. Multi-client
+/// displays may have different dimensions, though, so the server renders each
+/// secondary viewport independently. The renderer records hit-test geometry and
+/// clamps a handful of scroll offsets as part of an ordinary interactive draw;
+/// preserve those values here so a passive projection cannot move the active
+/// client's cursor, scroll position, compact mode, or click targets.
+pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
+    let compact = app.compact;
+    let last_main_area = app.last_main_area;
+    let last_pane_area = app.last_pane_area;
+    let left_seam = app.left_seam;
+    let right_seam = app.right_seam;
+    let last_cursor = app.last_cursor;
+    let workspaces_scroll = app.workspaces_scroll;
+    let agents_scroll = app.agents_scroll;
+    let last_active_ws_shown = app.last_active_ws_shown;
+    let switcher_scroll = app.switcher_scroll;
+    let orch_scroll = app.orch_scroll;
+    let orch_detail_scroll = app.orch_detail_scroll;
+    let orch_area = app.orch_area;
+    let mission_scroll = app.mission_scroll;
+    let mission_area = app.mission_area;
+    let changelog_scroll = app.changelog_scroll;
+    let file_tree_scroll = app.file_tree.scroll;
+
+    // Geometry collections are write-only outputs of a render. Move the active
+    // client's values aside instead of cloning them on every secondary frame.
+    let pane_rects = std::mem::take(&mut app.pane_rects);
+    let pane_content_rects = std::mem::take(&mut app.pane_content_rects);
+    let pane_title_rects = std::mem::take(&mut app.pane_title_rects);
+    let tab_rects = std::mem::take(&mut app.tab_rects);
+    let tab_close_rects = std::mem::take(&mut app.tab_close_rects);
+    let ws_rects = std::mem::take(&mut app.ws_rects);
+    let workspace_branch_rects = std::mem::take(&mut app.workspace_branch_rects);
+    let git_section_rects = std::mem::take(&mut app.git_section_rects);
+    let agents_filter_rects = std::mem::take(&mut app.agents_filter_rects);
+    let agent_rects = std::mem::take(&mut app.agent_rects);
+    let session_rects = std::mem::take(&mut app.session_rects);
+    let file_tree_rects = std::mem::take(&mut app.file_tree_rects);
+    let module_dock_rects = std::mem::take(&mut app.module_dock_rects);
+    let picker_rects = std::mem::take(&mut app.picker_rects);
+    let settings_tab_rects = std::mem::take(&mut app.settings_tab_rects);
+    let settings_ctl_rects = std::mem::take(&mut app.settings_ctl_rects);
+    let settings_arrow_rects = std::mem::take(&mut app.settings_arrow_rects);
+    let changelog_link_rects = std::mem::take(&mut app.changelog_link_rects);
+    let switcher_rects = std::mem::take(&mut app.switcher_rects);
+    let switcher_scope_rects = std::mem::take(&mut app.switcher_scope_rects);
+    let mission_rows = std::mem::take(&mut app.mission_rows);
+    let search_rects = app
+        .search
+        .as_mut()
+        .map(|search| std::mem::take(&mut search.rects));
+    let ws_menu_items = app
+        .ws_menu
+        .as_mut()
+        .map(|menu| std::mem::take(&mut menu.items));
+    let pane_menu_state = app.pane_menu.as_mut().map(|menu| {
+        (
+            std::mem::take(&mut menu.items),
+            std::mem::take(&mut menu.tab_rects),
+            menu.move_open,
+        )
+    });
+    let agent_menu_items = app
+        .agent_menu
+        .as_mut()
+        .map(|menu| std::mem::take(&mut menu.items));
+    let file_menu_items = app
+        .file_menu
+        .as_mut()
+        .map(|menu| std::mem::take(&mut menu.items));
+    let dock_menu_rects = app
+        .dock_menu
+        .as_mut()
+        .map(|menu| std::mem::take(&mut menu.rects));
+
+    let settings_icon_rect = app.settings_icon_rect;
+    let sidebar_toggle_rect = app.sidebar_toggle_rect;
+    let right_sidebar_toggle_rect = app.right_sidebar_toggle_rect;
+    let version_rect = app.version_rect;
+    let files_area = app.files_area;
+    let workspaces_area = app.workspaces_area;
+    let agents_area = app.agents_area;
+    let pane_close_rect = app.pane_close_rect;
+    let pane_zoom_rect = app.pane_zoom_rect;
+    let tab_prev_rect = app.tab_prev_rect;
+    let tab_next_rect = app.tab_next_rect;
+    let new_ws_rect = app.new_ws_rect;
+    let switcher_button_rect = app.switcher_button_rect;
+    let settings_modal_rect = app.settings_modal_rect;
+    let settings_close_rect = app.settings_close_rect;
+    let changelog_modal_rect = app.changelog_modal_rect;
+    let changelog_close_rect = app.changelog_close_rect;
+    let changelog_check_rect = app.changelog_check_rect;
+    let modal_commit_rect = app.modal_commit_rect;
+    let modal_cancel_rect = app.modal_cancel_rect;
+
+    // Git rendering also stores its list viewport and clamps detail scroll.
+    let git_view = app.active_git_mut().map(|git| {
+        (
+            git.id,
+            git.scroll,
+            git.list_area,
+            git.contributors_more_rect,
+        )
+    });
+
+    render_into_mode(f, app, false);
+
+    app.compact = compact;
+    app.last_main_area = last_main_area;
+    app.last_pane_area = last_pane_area;
+    app.left_seam = left_seam;
+    app.right_seam = right_seam;
+    app.last_cursor = last_cursor;
+    app.workspaces_scroll = workspaces_scroll;
+    app.agents_scroll = agents_scroll;
+    app.last_active_ws_shown = last_active_ws_shown;
+    app.switcher_scroll = switcher_scroll;
+    app.orch_scroll = orch_scroll;
+    app.orch_detail_scroll = orch_detail_scroll;
+    app.orch_area = orch_area;
+    app.mission_scroll = mission_scroll;
+    app.mission_area = mission_area;
+    app.changelog_scroll = changelog_scroll;
+    app.file_tree.scroll = file_tree_scroll;
+    app.pane_rects = pane_rects;
+    app.pane_content_rects = pane_content_rects;
+    app.pane_title_rects = pane_title_rects;
+    app.tab_rects = tab_rects;
+    app.tab_close_rects = tab_close_rects;
+    app.ws_rects = ws_rects;
+    app.workspace_branch_rects = workspace_branch_rects;
+    app.git_section_rects = git_section_rects;
+    app.agents_filter_rects = agents_filter_rects;
+    app.agent_rects = agent_rects;
+    app.session_rects = session_rects;
+    app.file_tree_rects = file_tree_rects;
+    app.module_dock_rects = module_dock_rects;
+    app.picker_rects = picker_rects;
+    app.settings_tab_rects = settings_tab_rects;
+    app.settings_ctl_rects = settings_ctl_rects;
+    app.settings_arrow_rects = settings_arrow_rects;
+    app.changelog_link_rects = changelog_link_rects;
+    app.switcher_rects = switcher_rects;
+    app.switcher_scope_rects = switcher_scope_rects;
+    app.mission_rows = mission_rows;
+    if let (Some(rects), Some(search)) = (search_rects, app.search.as_mut()) {
+        search.rects = rects;
+    }
+    if let (Some(items), Some(menu)) = (ws_menu_items, app.ws_menu.as_mut()) {
+        menu.items = items;
+    }
+    if let (Some((items, tab_rects, move_open)), Some(menu)) =
+        (pane_menu_state, app.pane_menu.as_mut())
+    {
+        menu.items = items;
+        menu.tab_rects = tab_rects;
+        menu.move_open = move_open;
+    }
+    if let (Some(items), Some(menu)) = (agent_menu_items, app.agent_menu.as_mut()) {
+        menu.items = items;
+    }
+    if let (Some(items), Some(menu)) = (file_menu_items, app.file_menu.as_mut()) {
+        menu.items = items;
+    }
+    if let (Some(rects), Some(menu)) = (dock_menu_rects, app.dock_menu.as_mut()) {
+        menu.rects = rects;
+    }
+    app.settings_icon_rect = settings_icon_rect;
+    app.sidebar_toggle_rect = sidebar_toggle_rect;
+    app.right_sidebar_toggle_rect = right_sidebar_toggle_rect;
+    app.version_rect = version_rect;
+    app.files_area = files_area;
+    app.workspaces_area = workspaces_area;
+    app.agents_area = agents_area;
+    app.pane_close_rect = pane_close_rect;
+    app.pane_zoom_rect = pane_zoom_rect;
+    app.tab_prev_rect = tab_prev_rect;
+    app.tab_next_rect = tab_next_rect;
+    app.new_ws_rect = new_ws_rect;
+    app.switcher_button_rect = switcher_button_rect;
+    app.settings_modal_rect = settings_modal_rect;
+    app.settings_close_rect = settings_close_rect;
+    app.changelog_modal_rect = changelog_modal_rect;
+    app.changelog_close_rect = changelog_close_rect;
+    app.changelog_check_rect = changelog_check_rect;
+    app.modal_commit_rect = modal_commit_rect;
+    app.modal_cancel_rect = modal_cancel_rect;
+    if let Some((id, scroll, list_area, contributors_more_rect)) = git_view {
+        if let Some(git) = app.active_git_mut().filter(|git| git.id == id) {
+            git.scroll = scroll;
+            git.list_area = list_area;
+            git.contributors_more_rect = contributors_more_rect;
+        }
+    }
+}
+
+fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
     let t = app.theme.clone();
     // The active i18n catalog (Copy `&'static`), passed to draw fns that don't
     // get the whole `App` (picker, git tab) so all chrome is localized (docs/21).
@@ -200,8 +408,11 @@ pub fn render_into(f: &mut RenderTarget, app: &mut App) {
     };
     // Only frame panes when the tab is split; a lone pane needs no border.
     let bordered = rects.len() > 1;
-    for (id, rect) in &rects {
-        if let Some(content) = pane_content(*rect, bordered) {
+    if resize_panes {
+        for (id, rect) in &rects {
+            let Some(content) = pane_content(*rect, bordered) else {
+                continue;
+            };
             let resized = app
                 .panes
                 .get_mut(id)


### PR DESCRIPTION
Bohay now renders each attached terminal at its own dimensions while preserving one efficient shared session.

## Multi-client viewports

- Track terminal size, render buffer, diff baseline, and backpressure state per client.
- Render passive clients as isolated projections without resizing shared PTYs or changing active UI state.
- Promote a client only after keyboard, mouse, or paste interaction, then apply its geometry before input handling.
- Keep background resize events local and preserve the single-client one-render fast path.

## Why

Attaching terminals with different resolutions previously made one client clip content or inherit another clients dimensions. Independent viewports keep every attached display correctly sized while the actively interacting client remains authoritative for shared PTY geometry.

## Verification

- `cargo test --no-fail-fast -q`: 522 passed
- `cargo test --release ipc::server::tests --no-fail-fast -- --test-threads=1`: 5 passed
- `cargo clippy --all-targets -- -D warnings`: passed
- `cargo fmt --all`: passed
- `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple display clients with independent viewport sizes and rendering.
  * Routed keyboard, mouse, paste, and resize input to the appropriate client.
  * Improved foreground client switching based on interaction.
  * Added automatic frame recovery for clients that fall behind.

* **Bug Fixes**
  * Improved rendering consistency when clients resize or reconnect.
  * Preserved interactive UI state while displaying secondary client views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->