### PR TITLE
fix(git): render native Git tables cleanly

### DIFF
--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -2,6 +2,7 @@
 //! No new dependency (same spirit as `module/discovery.rs`). Every function
 //! returns owned data or a short error string; the caller renders it.
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -243,12 +244,28 @@ pub fn commits(cwd: &Path, n: usize, all: bool) -> Result<Vec<Commit>, String> {
     let fmt = format!("%h{F}%s{F}%an{F}%ar{F}%d", F = FIELD);
     let count = format!("-n{n}");
     let pretty = format!("--pretty=format:{fmt}");
-    let mut args: Vec<&str> = vec!["log", "--graph", &count, &pretty];
+    let args = commit_log_args(&count, &pretty, all);
+    let raw = run(cwd, &args)?;
+    Ok(parse_commits(&raw))
+}
+
+/// Arguments for the native commit-flow view. `--no-color` is mandatory: this
+/// output is rendered by Bohay, not replayed into a terminal. Git configuration
+/// such as `color.ui=always` must never leak ANSI control sequences into cells.
+fn commit_log_args<'a>(count: &'a str, pretty: &'a str, all: bool) -> Vec<&'a str> {
+    let mut args = vec!["log", "--no-color", "--graph", count, pretty];
     if all {
         args.push("--all");
     }
-    let raw = run(cwd, &args)?;
-    Ok(raw
+    args
+}
+
+fn parse_commits(raw: &str) -> Vec<Commit> {
+    // `--no-color` handles normal Git configuration. Sanitizing is a cheap
+    // defence in depth for a wrapper or malformed external output: no allocation
+    // occurs for the normal no-escape case.
+    let clean = strip_ansi(raw);
+    clean
         .lines()
         .filter_map(|line| {
             // `--graph` prefixes each line with rail glyphs before the format.
@@ -273,7 +290,59 @@ pub fn commits(cwd: &Path, n: usize, all: bool) -> Result<Vec<Commit>, String> {
                 None => None,
             }
         })
-        .collect())
+        .collect()
+}
+
+/// Remove CSI/OSC escape sequences from external text without touching normal
+/// UTF-8. This keeps native text widgets safe even if an external Git wrapper
+/// ignores `--no-color`.
+fn strip_ansi(input: &str) -> Cow<'_, str> {
+    let bytes = input.as_bytes();
+    if !bytes.contains(&0x1b) {
+        return Cow::Borrowed(input);
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let (mut start, mut i) = (0, 0);
+    while i < bytes.len() {
+        if bytes[i] != 0x1b {
+            i += 1;
+            continue;
+        }
+        out.push_str(&input[start..i]);
+        i += 1;
+        match bytes.get(i) {
+            Some(b'[') => {
+                i += 1;
+                while i < bytes.len() {
+                    let byte = bytes[i];
+                    i += 1;
+                    if (0x40..=0x7e).contains(&byte) {
+                        break;
+                    }
+                }
+            }
+            Some(b']') => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == 0x07 {
+                        i += 1;
+                        break;
+                    }
+                    if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            Some(_) => i += 1,
+            None => {}
+        }
+        start = i;
+    }
+    out.push_str(&input[start..]);
+    Cow::Owned(out)
 }
 
 /// Checkout a branch (mutating). Used by the Branches view's `enter`.
@@ -547,6 +616,39 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
     use super::*;
+
+    #[test]
+    fn commit_log_always_requests_plain_output() {
+        let args = commit_log_args("-n100", "--pretty=format:%h", true);
+        assert!(args.contains(&"--no-color"));
+        assert!(args.contains(&"--graph"));
+        assert!(args.contains(&"--all"));
+    }
+
+    #[test]
+    fn colored_git_graph_is_sanitized_before_rendering() {
+        let raw = "\x1b[31m* \x1b[0mabc1234\x1fsubject\x1fauthor\x1f2 days ago\x1f\x1b[32m(HEAD -> main)\x1b[0m\n";
+        let commits = parse_commits(raw);
+        assert_eq!(commits.len(), 1);
+        let commit = &commits[0];
+        assert_eq!(commit.graph, "* ");
+        assert_eq!(commit.sha, "abc1234");
+        assert_eq!(commit.subject, "subject");
+        assert_eq!(commit.refs, "(HEAD -> main)");
+        assert!(
+            [
+                commit.graph.as_str(),
+                commit.sha.as_str(),
+                commit.subject.as_str(),
+                commit.author.as_str(),
+                commit.when.as_str(),
+                commit.refs.as_str(),
+            ]
+            .iter()
+            .all(|field| !field.contains('\x1b')),
+            "native Git UI fields must never receive ANSI escapes"
+        );
+    }
 
     #[test]
     fn parses_remote_forms() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1820,51 +1820,68 @@ mod tests {
         let (tx, _rx) = mpsc::channel::<AppEvent>();
         let mut app = App::new(78, 30, tx).expect("spawn pane");
 
-        // Split into two panes: left runs a "claude" session, right is a shell.
+        // Split into two panes: Codex is the active working pane and Claude is
+        // a second, independent agent. This is a mission-control scene.
         let left = app.layout().focus;
         app.handle_event(key(' ', KeyModifiers::CONTROL)); // prefix (Ctrl+Space)
         app.handle_event(key('v', KeyModifiers::NONE)); // split → side by side
         if let Some(p) = app.panes.get_mut(&left) {
-            p.command = "claude".to_string();
+            p.command = "codex".to_string();
         }
 
-        // A scripted "Claude Code" session so the left pane shows rich content.
-        let payload: &[u8] = b"\x1b[2J\x1b[H\r\n\
-\x1b[38;5;213m  \xe2\x9c\xbb Claude Code\x1b[0m  \x1b[38;5;245mopus-4.8\x1b[0m\r\n\r\n\
-\x1b[38;5;245m  \xe2\x94\x82\x1b[0m \x1b[38;5;252mrefactor the auth module to use the new token store\x1b[0m\r\n\r\n\
-\x1b[38;5;114m  \xe2\x97\x8f\x1b[0m \x1b[38;5;252mRead\x1b[0m  \x1b[38;5;111msrc/auth/mod.rs\x1b[0m \x1b[38;5;245m(214 lines)\x1b[0m\r\n\
-\x1b[38;5;114m  \xe2\x97\x8f\x1b[0m \x1b[38;5;252mEdit\x1b[0m  \x1b[38;5;111msrc/auth/token.rs\x1b[0m   \x1b[38;5;114m+42\x1b[0m \x1b[38;5;210m-17\x1b[0m\r\n\
-\x1b[38;5;114m  \xe2\x97\x8f\x1b[0m \x1b[38;5;252mEdit\x1b[0m  \x1b[38;5;111msrc/auth/session.rs\x1b[0m \x1b[38;5;114m+8\x1b[0m  \x1b[38;5;210m-3\x1b[0m\r\n\r\n\
-\x1b[38;5;221m  \xe2\x97\x8f\x1b[0m \x1b[38;5;252mRunning\x1b[0m \x1b[38;5;245mcargo test auth\x1b[0m\r\n\
-\x1b[38;5;245m    test auth::token::roundtrip ... \x1b[0m\x1b[38;5;114mok\x1b[0m\r\n\
-\x1b[38;5;245m    test auth::session::expiry  ... \x1b[0m\x1b[38;5;114mok\x1b[0m\r\n\r\n\
-\x1b[38;5;245m  \xe2\x94\x94\xe2\x94\x80\x1b[0m \x1b[38;5;252mAll tests passing. Ready for review.\x1b[0m\r\n\r\n\
-\x1b[38;5;240m  \xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\x1b[0m\r\n\
-\x1b[38;5;245m  >\x1b[0m \x1b[7m \x1b[0m\r\n";
+        // The blank row immediately above and below the Codex prompt matches
+        // its live composer geometry, exercising Bohay's theme-aware composer
+        // surface in both generated previews.
+        let codex_payload = "\x1b[2J\x1b[H\r\n\
+\x1b[1m  OpenAI Codex\x1b[0m  \x1b[38;5;245mv0.147.0\x1b[0m\r\n\
+\x1b[38;5;245m  Codex · gpt-5.6-sol\x1b[0m\r\n\r\n\
+\x1b[38;5;252m  Mapping workspace changes.\x1b[0m\r\n\r\n\
+\x1b[38;5;114m  •\x1b[0m \x1b[38;5;252mExplored\x1b[0m  \x1b[38;5;111msrc/app\x1b[0m\r\n\
+\x1b[38;5;114m  •\x1b[0m \x1b[38;5;252mEdited\x1b[0m  \x1b[38;5;111mpanes.rs\x1b[0m  \x1b[38;5;114m+22\x1b[0m\r\n\
+\x1b[38;5;221m  •\x1b[0m \x1b[38;5;252mRan\x1b[0m  \x1b[38;5;114m529 passed\x1b[0m\r\n\r\n\
+\x1b[38;5;245m  Ready to review.\x1b[0m\r\n\
+\x1b[38;5;240m  ────────────────────────\x1b[0m\r\n\r\n\
+\x1b[38;5;245m  ›\x1b[0m \x1b[38;5;252mSummarize commits\x1b[0m\r\n\x1b[A";
         if let Some(p) = app.panes.get(&left) {
             if let Ok(mut e) = p.engine.lock() {
-                e.advance(payload);
+                e.advance(codex_payload.as_bytes());
             }
         }
 
-        // Right pane: a shell prompt so it isn't blank in the still image.
+        // The second pane makes the sidebar's multi-agent view meaningful too.
         let right = app.layout().focus;
-        let prompt: &[u8] = b"\x1b[2J\x1b[H\r\n  \x1b[38;5;108mbohay\x1b[0m \x1b[38;5;245m~/skyrizz/bohay\x1b[0m\r\n  \x1b[38;5;215m\xe2\x9d\xaf\x1b[0m \x1b[7m \x1b[0m\x1b[0m";
+        if let Some(p) = app.panes.get_mut(&right) {
+            p.command = "claude".to_string();
+        }
+        let prompt = "\x1b[2J\x1b[H\r\n\
+\x1b[38;5;213m  ✻ Claude Code\x1b[0m  \x1b[38;5;245mopus-4.8\x1b[0m\r\n\r\n\
+\x1b[38;5;252m  Reviewing release notes.\x1b[0m\r\n\r\n\
+\x1b[38;5;114m  ●\x1b[0m \x1b[38;5;252mRead\x1b[0m  \x1b[38;5;111mv0.10.3.md\x1b[0m\r\n\
+\x1b[38;5;221m  ●\x1b[0m \x1b[38;5;252mWorking\x1b[0m  \x1b[38;5;245mReady\x1b[0m\r\n\r\n\
+\x1b[38;5;245m  >\x1b[0m \x1b[7m \x1b[0m";
         if let Some(p) = app.panes.get(&right) {
             if let Ok(mut e) = p.engine.lock() {
-                e.advance(prompt);
+                e.advance(prompt.as_bytes());
             }
         }
 
         // Force representative states for the still image.
         if let Some(s) = app.status.get_mut(&left) {
             s.state = State::Working;
-            s.agent = "claude".to_string();
+            s.agent = "codex".to_string();
         }
         if let Some(s) = app.status.get_mut(&right) {
-            s.state = State::Idle;
-            s.agent = "zsh".to_string(); // a shell — filtered out of AGENTS
+            s.state = State::Working;
+            s.agent = "claude".to_string();
         }
+        assert!(
+            app.panes
+                .get(&left)
+                .and_then(|p| p.engine.lock().ok())
+                .and_then(|engine| engine.codex_composer_region())
+                .is_some(),
+            "the Codex fixture must retain the live composer geometry"
+        );
         // Show the workspace with its git branch.
         app.workspaces[0].branch = Some("main".to_string());
 

--- a/src/ui/git.rs
+++ b/src/ui/git.rs
@@ -11,6 +11,19 @@ use crate::git::{
 };
 use crate::i18n::Catalog;
 
+const PR_STATUS_W: usize = 13;
+const PR_NUMBER_W: usize = 6;
+const PR_AUTHOR_W: usize = 11;
+const PR_REVIEWER_W: usize = 11;
+const PR_CHECKS_W: usize = 8;
+const PR_CHANGE_W: usize = 8;
+const PR_FIXED_W: usize =
+    PR_STATUS_W + PR_NUMBER_W + PR_AUTHOR_W + PR_REVIEWER_W + PR_CHECKS_W + PR_CHANGE_W * 2;
+
+fn pr_title_width(row_width: usize) -> usize {
+    row_width.saturating_sub(PR_FIXED_W).max(12)
+}
+
 /// The view-selector label for `s` in the active language.
 fn section_label(s: Section, cat: &Catalog) -> &'static str {
     match s {
@@ -118,23 +131,36 @@ fn draw_prs(f: &mut RenderTarget, area: Rect, g: &GitView, cat: &Catalog, t: &Th
     if v.is_empty() {
         return message(f, area, cat.git_no_prs, t.green);
     }
-    let title_w = area.width.saturating_sub(62).max(12) as usize;
-    let header = Line::from(Span::styled(
-        format!(
-            "{:<13}{:<6}{:<w$}{:<11}{:<11}{}  +/-",
-            cat.col_status,
-            "#",
-            cat.col_title,
-            cat.col_author,
-            cat.col_reviewer,
-            cat.col_checks,
-            w = title_w
+    // `draw_list` reserves two cells for the selection marker. Calculate and
+    // render the header in that same content width, so its columns align exactly
+    // with the selectable rows below.
+    let row_width = area.width.saturating_sub(2) as usize;
+    let title_w = pr_title_width(row_width);
+    let header = Line::from(vec![
+        Span::styled(
+            pad(cat.col_status, PR_STATUS_W),
+            Style::new().fg(t.subtext0),
         ),
-        Style::new().fg(t.subtext0),
-    ));
+        Span::styled(pad("#", PR_NUMBER_W), Style::new().fg(t.subtext0)),
+        Span::styled(pad(cat.col_title, title_w), Style::new().fg(t.subtext0)),
+        Span::styled(
+            pad(cat.col_author, PR_AUTHOR_W),
+            Style::new().fg(t.subtext0),
+        ),
+        Span::styled(
+            pad(cat.col_reviewer, PR_REVIEWER_W),
+            Style::new().fg(t.subtext0),
+        ),
+        Span::styled(
+            pad(cat.col_checks, PR_CHECKS_W),
+            Style::new().fg(t.subtext0),
+        ),
+        Span::styled(pad("+", PR_CHANGE_W), Style::new().fg(t.subtext0)),
+        Span::styled(pad("-", PR_CHANGE_W), Style::new().fg(t.subtext0)),
+    ]);
     f.render_widget(
         Paragraph::new(header),
-        Rect::new(area.x, area.y, area.width, 1),
+        Rect::new(area.x + 2, area.y, area.width.saturating_sub(2), 1),
     );
     let list = Rect::new(
         area.x,
@@ -160,16 +186,25 @@ fn pr_line(p: &PullRequest, title_w: usize, cat: &Catalog, t: &Theme) -> Line<'s
     };
     Line::from(vec![
         Span::styled(
-            format!("{:<13}", format!("[{badge}]")),
+            pad(&format!("[{badge}]"), PR_STATUS_W),
             Style::new().fg(bcol).bold(),
         ),
-        Span::styled(format!("#{:<5}", p.number), Style::new().fg(t.subtext0)),
+        Span::styled(
+            pad(&format!("#{}", p.number), PR_NUMBER_W),
+            Style::new().fg(t.subtext0),
+        ),
         Span::styled(pad(&title, title_w), Style::new().fg(t.text)),
-        Span::styled(pad(&p.author, 10), Style::new().fg(t.subtext0)),
-        Span::styled(pad(reviewer, 10), Style::new().fg(t.amber)),
-        Span::styled(format!("  {gly}   "), Style::new().fg(ccol)),
-        Span::styled(format!("+{} ", p.additions), Style::new().fg(t.green)),
-        Span::styled(format!("-{}", p.deletions), Style::new().fg(t.coral)),
+        Span::styled(pad(&p.author, PR_AUTHOR_W), Style::new().fg(t.subtext0)),
+        Span::styled(pad(reviewer, PR_REVIEWER_W), Style::new().fg(t.amber)),
+        Span::styled(pad(gly, PR_CHECKS_W), Style::new().fg(ccol)),
+        Span::styled(
+            pad(&format!("+{}", p.additions), PR_CHANGE_W),
+            Style::new().fg(t.green),
+        ),
+        Span::styled(
+            pad(&format!("-{}", p.deletions), PR_CHANGE_W),
+            Style::new().fg(t.coral),
+        ),
     ])
 }
 
@@ -936,35 +971,89 @@ fn draw_commits(f: &mut RenderTarget, area: Rect, g: &GitView, cat: &Catalog, t:
         Load::Loaded(v) => v,
         Load::Idle => return,
     };
-    let sub_w = area.width.saturating_sub(40).max(10);
+    // Match PRs and Issues: a fluid main column plus stable metadata columns.
+    // Reserving one graph width and refs column across all rows makes the list
+    // scan as a table instead of allowing each row to drift.
+    let has_refs = v.iter().any(|c| !c.refs.is_empty());
+    let graph_width = v
+        .iter()
+        .map(|c| crate::ui::display_width(&c.graph))
+        .max()
+        .unwrap_or(0);
     let rows: Vec<Line> = filtered_commits(v, &g.filter)
         .map(|c| {
-            let mut spans = vec![];
-            if !c.graph.is_empty() {
-                spans.push(Span::styled(c.graph.clone(), Style::new().fg(t.overlay0)));
-            }
-            spans.push(Span::styled(
-                format!("{} ", c.sha),
-                Style::new().fg(t.amber),
-            ));
-            spans.push(Span::styled(
-                pad(&c.subject, sub_w as usize),
-                Style::new().fg(t.text),
-            ));
-            if !c.refs.is_empty() {
-                spans.push(Span::styled(
-                    format!("{} ", c.refs),
-                    Style::new().fg(t.mint),
-                ));
-            }
-            spans.push(Span::styled(
-                format!("{} · {}", trunc(&c.author, 12), c.when),
-                Style::new().fg(t.overlay0),
-            ));
-            Line::from(spans)
+            commit_row(
+                c,
+                area.width.saturating_sub(2) as usize,
+                graph_width,
+                has_refs,
+                t,
+            )
         })
         .collect();
     draw_list(f, area, rows, g.cursor, cat, t);
+}
+
+/// Commit table widths. The subject uses all remaining width, like PR/Issue
+/// titles, while refs, author, and relative time remain readable columns.
+fn commit_columns(row_width: usize, graph_width: usize, has_refs: bool) -> (usize, usize, usize) {
+    const SHA_WIDTH: usize = 8; // seven-char SHA plus one separating space
+    const REFS_WIDTH: usize = 30;
+    const META_WIDTH: usize = 28; // author (12) + separator + relative time
+    const SUBJECT_MIN: usize = 12;
+
+    let available = row_width.saturating_sub(graph_width + SHA_WIDTH);
+    let meta = if available >= SUBJECT_MIN + META_WIDTH {
+        META_WIDTH
+    } else {
+        0
+    };
+    let refs = if has_refs && available >= SUBJECT_MIN + meta + REFS_WIDTH {
+        REFS_WIDTH
+    } else {
+        0
+    };
+    let subject = available.saturating_sub(refs + meta).max(SUBJECT_MIN);
+    (subject, refs, meta)
+}
+
+fn commit_row(
+    c: &crate::git::model::Commit,
+    row_width: usize,
+    graph_width: usize,
+    has_refs: bool,
+    t: &Theme,
+) -> Line<'static> {
+    let (subject_w, refs_w, meta_w) = commit_columns(row_width, graph_width, has_refs);
+    let mut spans = Vec::with_capacity(7);
+    if graph_width > 0 {
+        spans.push(Span::styled(
+            pad(&c.graph, graph_width),
+            Style::new().fg(t.overlay0),
+        ));
+    }
+    spans.push(Span::styled(pad(&c.sha, 8), Style::new().fg(t.amber)));
+    spans.push(Span::styled(
+        pad(&c.subject, subject_w),
+        Style::new().fg(t.text),
+    ));
+    if refs_w > 0 {
+        spans.push(Span::styled(pad(&c.refs, refs_w), Style::new().fg(t.mint)));
+    }
+    if meta_w > 0 {
+        let when_w = 12.min(meta_w.saturating_sub(4));
+        let author_w = meta_w.saturating_sub(when_w + 3);
+        spans.push(Span::styled(
+            pad(&c.author, author_w),
+            Style::new().fg(t.subtext0),
+        ));
+        spans.push(Span::styled(" · ", Style::new().fg(t.surface1)));
+        spans.push(Span::styled(
+            trunc(&c.when, when_w),
+            Style::new().fg(t.overlay0),
+        ));
+    }
+    Line::from(spans)
 }
 
 /// Returns the clamped scroll offset and, when it is on screen, the rect of the
@@ -1241,6 +1330,43 @@ fn trunc(s: &str, n: usize) -> String {
 
 /// Truncate then pad to exactly `n` columns.
 fn pad(s: &str, n: usize) -> String {
+    if n == 0 {
+        return String::new();
+    }
     let s = trunc(s, n);
-    format!("{s:<n$} ", n = n.saturating_sub(1))
+    format!("{s:<n$}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{commit_columns, pad, pr_title_width};
+
+    #[test]
+    fn padded_columns_never_exceed_their_declared_width() {
+        assert_eq!(pad("a", 3), "a  ");
+        assert_eq!(pad("abc", 3), "abc");
+        assert_eq!(pad("abcd", 3), "ab…");
+        assert_eq!(pad("anything", 0), "");
+    }
+
+    #[test]
+    fn pr_rows_reserve_fixed_columns_before_the_title() {
+        assert_eq!(pr_title_width(140), 75);
+        assert_eq!(pr_title_width(50), 12);
+    }
+
+    #[test]
+    fn wide_commit_rows_fill_the_table_before_metadata() {
+        // Like PR/Issue titles, the subject receives every column left after
+        // the graph, refs, author, and time fields have been reserved.
+        assert_eq!(commit_columns(180, 2, true), (112, 30, 28));
+    }
+
+    #[test]
+    fn narrow_commit_rows_prioritize_the_subject() {
+        // On small displays references yield first; metadata is omitted only
+        // once it would crowd out the commit message itself.
+        assert_eq!(commit_columns(58, 2, true), (20, 0, 28));
+        assert_eq!(commit_columns(30, 2, true), (20, 0, 0));
+    }
 }


### PR DESCRIPTION
Native Git views now request and sanitize plain Git output, while Commit and Pull Request lists use stable, clipped-safe table columns.

## What

- prevent ANSI control sequences from reaching native commit-log cells
- align commit metadata and pull request Checks, additions, and deletions columns
- update the built-in preview fixture for the Codex composer

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (530 passed)
- `cargo build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Commit history displays cleanly without terminal color and control sequences.
  - Commit details remain readable across different available window widths.

- **UI Improvements**
  - Pull request lists now use aligned columns for status, number, title, author, reviewer, checks, and change counts.
  - Commit metadata columns adjust responsively when space is limited.
  - Improved spacing and alignment make repository and pull request information easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->