### PR TITLE
fix(server): prevent concurrent startup from orphaning sessions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,8 +5,14 @@ title: ""
 labels: bug
 ---
 
+<!--
+Thanks for reporting a Bohay problem. Please remove anything sensitive from
+commands, paths, logs, or screenshots before submitting.
+-->
+
 **What happened?**
-A clear description of the bug — what you did, what you expected, what you got.
+Describe the actual behavior, the behavior you expected, and how it affects
+your workflow.
 
 **Steps to reproduce**
 1.
@@ -14,10 +20,18 @@ A clear description of the bug — what you did, what you expected, what you got
 3.
 
 **Environment**
-- OS + version:
-- Terminal app (iTerm2, Windows Terminal, kitty, …):
-- `bohay server status` output:
-- `bohay doctor` output:
+- OS + version (for macOS, run `sw_vers`):
+- Terminal app + version (for example Ghostty, iTerm2, Windows Terminal, or kitty):
+- Bohay version and server status (`bohay server status`):
+- Diagnostic output (`bohay doctor`):
+
+```text
+Paste command output here, with secrets removed.
+```
 
 **Anything else?**
-Screenshots, logs, or the agent you were running (claude / copilot / codex / opencode / …).
+Attach screenshots or relevant logs, name the agent you were running
+(Claude, Codex, Copilot, OpenCode, and so on), and include any useful context.
+
+For server, socket, memory, or performance reports, include the relevant
+process and socket details if your platform provides them.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "crossterm",
+ "fs2",
  "interprocess",
  "libc",
  "portable-pty",
@@ -506,6 +507,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ toml_edit = "0.22"
 bincode = { version = "2", features = ["serde"] }
 # Cross-platform local IPC: Unix-domain sockets on Unix, named pipes on Windows.
 interprocess = "2"
+# Cross-process startup lock so concurrent clients cannot orphan a live server.
+fs2 = "0.4"
 
 # `libc` (setsid + macOS proc_pidinfo) is only needed on Unix.
 [target.'cfg(unix)'.dependencies]

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -3,8 +3,9 @@
 //! requests are marshalled onto the single-threaded app loop; `events.subscribe`
 //! streams from a simple broadcast bus. See docs/08.
 
+use std::io;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
@@ -49,16 +50,18 @@ pub fn socket_path_env() -> Option<String> {
     SOCKET.get().map(|p| p.to_string_lossy().to_string())
 }
 
-/// Bind the socket and accept connections on a background thread.
-pub fn start_server(path: PathBuf, api_tx: Sender<ApiRequest>, bus: EventBus) {
-    // Creates the state dir owner-only (0700) — the socket is full control.
-    let _ = crate::persist::ensure_config_dir();
-    // Best-effort stale-socket reclaim (single-instance dev; proper detection
-    // arrives with the M2 server).
-    let listener = match transport::bind(&path) {
-        Ok(l) => l,
-        Err(_) => return,
-    };
+/// Reclaim a proven-stale API socket and bind its listener. The caller holds
+/// the per-state-directory startup lock across both API and client binds.
+pub fn bind_server(
+    path: &Path,
+    startup_lock: &transport::ServerStartupLock,
+) -> io::Result<transport::Listener> {
+    startup_lock.reclaim_stale_socket(path)?;
+    transport::bind(path)
+}
+
+/// Accept API connections from an already-bound listener on a background thread.
+pub fn start_server(listener: transport::Listener, api_tx: Sender<ApiRequest>, bus: EventBus) {
     thread::spawn(move || {
         for stream in transport::incoming(&listener) {
             let api_tx = api_tx.clone();

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -4,8 +4,8 @@
 
 use crate::ipc::transport::{self, Conn};
 use std::collections::HashMap;
-use std::io::BufReader;
-use std::path::PathBuf;
+use std::io::{self, BufReader};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::sync::Arc;
@@ -107,21 +107,51 @@ type Clients = HashMap<u64, ClientState>;
 pub fn run() -> Result<()> {
     let (tx, rx) = mpsc::channel::<AppEvent>();
 
+    // Every process targeting one BOHAY_HOME serializes startup here. This is
+    // deliberately before restoring panes: a losing server must exit without
+    // spawning duplicate PTYs or retaining a second terminal grid.
+    let state_dir = persist::ensure_config_dir();
+    let startup_lock = transport::acquire_server_startup_lock(&state_dir)?;
     let sock = persist::socket_path();
+    let client_sock = persist::client_socket_path();
+    // A responsive listener means another server owns this state directory.
+    // Do not reclaim either socket or start a competing process.
+    if transport::connect(&sock).is_ok() || transport::connect(&client_sock).is_ok() {
+        return Ok(());
+    }
     api::set_socket_path(sock.clone());
-    let mut app = App::restore_or_new(DEFAULT_SIZE.0, DEFAULT_SIZE.1, tx.clone())?;
+
+    let (api_tx, api_rx) = mpsc::channel::<api::ApiRequest>();
+    let events = api::new_bus();
+    let api_listener = api::bind_server(&sock, &startup_lock)?;
+    let client_listener = match bind_client_listener(&client_sock, &startup_lock) {
+        Ok(listener) => listener,
+        Err(err) => {
+            drop(api_listener);
+            let _ = remove_unbound_socket(&sock);
+            return Err(err.into());
+        }
+    };
+
+    let mut app = match App::restore_or_new(DEFAULT_SIZE.0, DEFAULT_SIZE.1, tx.clone()) {
+        Ok(app) => app,
+        Err(err) => {
+            drop(client_listener);
+            drop(api_listener);
+            let _ = remove_unbound_socket(&client_sock);
+            let _ = remove_unbound_socket(&sock);
+            return Err(err);
+        }
+    };
+    app.events = events.clone();
     app.server_mode = true;
     shutdown::install();
 
-    let (api_tx, api_rx) = mpsc::channel::<api::ApiRequest>();
-    api::start_server(sock, api_tx, app.events.clone());
     let mut terminal_theme_enabled = app.config.theme == "terminal";
     let terminal_theme = Arc::new(AtomicBool::new(terminal_theme_enabled));
-    start_client_listener(
-        persist::client_socket_path(),
-        tx.clone(),
-        terminal_theme.clone(),
-    );
+    api::start_server(api_listener, api_tx, events);
+    start_client_listener(client_listener, tx.clone(), terminal_theme.clone());
+    drop(startup_lock);
     // The session is restored and the API socket is listening, so a module's
     // `[[startup]]` hooks can now call back in — this is where a module
     // repaints the docks it owns (docs/13 §3.7).
@@ -581,13 +611,19 @@ fn render_client(
     }
 }
 
-fn start_client_listener(path: PathBuf, app_tx: Sender<AppEvent>, terminal_theme: Arc<AtomicBool>) {
-    // Creates the state dir owner-only (0700) — this socket drives the UI.
-    let _ = crate::persist::ensure_config_dir();
-    let listener = match transport::bind(&path) {
-        Ok(l) => l,
-        Err(_) => return,
-    };
+fn bind_client_listener(
+    path: &Path,
+    startup_lock: &transport::ServerStartupLock,
+) -> io::Result<transport::Listener> {
+    startup_lock.reclaim_stale_socket(path)?;
+    transport::bind(path)
+}
+
+fn start_client_listener(
+    listener: transport::Listener,
+    app_tx: Sender<AppEvent>,
+    terminal_theme: Arc<AtomicBool>,
+) {
     thread::spawn(move || {
         for (id, stream) in (1u64..).zip(transport::incoming(&listener)) {
             let app_tx = app_tx.clone();
@@ -595,6 +631,24 @@ fn start_client_listener(path: PathBuf, app_tx: Sender<AppEvent>, terminal_theme
             thread::spawn(move || handle_client(id, stream, app_tx, terminal_theme));
         }
     });
+}
+
+/// Remove a listener pathname only after its listener has been dropped and the
+/// startup lock is still held. Named pipes have no filesystem path to clean up.
+fn remove_unbound_socket(path: &Path) -> io::Result<()> {
+    #[cfg(windows)]
+    {
+        let _ = path;
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
 }
 
 fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme: Arc<AtomicBool>) {

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -4,14 +4,80 @@
 //! still identified by a per-session filesystem path; on Windows that path is
 //! hashed into a named-pipe id (pipes aren't filesystem paths).
 
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
 
+use fs2::FileExt;
 use interprocess::local_socket::prelude::*;
 use interprocess::local_socket::{ListenerOptions, Stream};
 
 pub use interprocess::local_socket::Listener;
+
+/// Exclusive, process-scoped guard for creating Bohay's two server sockets.
+///
+/// The lock file remains on disk after the holder exits; the OS releases the
+/// advisory lock automatically, including after a crash. Keeping the file
+/// avoids a second race around creating and deleting a lock pathname.
+pub struct ServerStartupLock {
+    _file: File,
+}
+
+/// Acquire exclusive ownership of server startup for one Bohay state directory.
+/// Hold the returned guard while checking, reclaiming, and binding both sockets.
+pub fn acquire_server_startup_lock(state_dir: &Path) -> io::Result<ServerStartupLock> {
+    fs::create_dir_all(state_dir)?;
+    let path = state_dir.join("server.lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    file.lock_exclusive()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(ServerStartupLock { _file: file })
+}
+
+impl ServerStartupLock {
+    /// Remove a socket only after its listener is proven unreachable. A live
+    /// socket is never replaced: doing so would orphan its server process.
+    pub fn reclaim_stale_socket(&self, path: &Path) -> io::Result<()> {
+        #[cfg(windows)]
+        {
+            let _ = path;
+            Ok(())
+        }
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::FileTypeExt;
+
+            let metadata = match fs::symlink_metadata(path) {
+                Ok(metadata) => metadata,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+                Err(err) => return Err(err),
+            };
+            if !metadata.file_type().is_socket() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("refusing to replace non-socket path {}", path.display()),
+                ));
+            }
+            if connect(path).is_ok() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AddrInUse,
+                    format!("a Bohay listener is already active at {}", path.display()),
+                ));
+            }
+            fs::remove_file(path)
+        }
+    }
+}
 
 /// A cloneable owned read+write handle to one connection — the portable
 /// stand-in for a cloned `UnixStream`. Clones share the full-duplex socket, so
@@ -65,7 +131,10 @@ pub fn connect(path: &Path) -> io::Result<Conn> {
     }
 }
 
-/// Bind a listener at the given per-session path (clearing a stale Unix socket).
+/// Bind a listener at the given per-session path.
+///
+/// Call [`ServerStartupLock::reclaim_stale_socket`] first while holding the
+/// state-directory startup lock. This function never removes an existing path.
 pub fn bind(path: &Path) -> io::Result<Listener> {
     #[cfg(windows)]
     {
@@ -77,7 +146,6 @@ pub fn bind(path: &Path) -> io::Result<Listener> {
     #[cfg(not(windows))]
     {
         use interprocess::local_socket::GenericFilePath;
-        let _ = std::fs::remove_file(path);
         let name = path.to_fs_name::<GenericFilePath>()?;
         let listener = ListenerOptions::new().name(name).create_sync()?;
         // Owner-only: a connection to this socket is full command execution as
@@ -94,4 +162,55 @@ pub fn bind(path: &Path) -> io::Result<Listener> {
 /// Iterate accepted connections (errors skipped), as `Conn`s.
 pub fn incoming(listener: &Listener) -> impl Iterator<Item = Conn> + '_ {
     listener.incoming().flatten().map(Conn::new)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{acquire_server_startup_lock, ServerStartupLock};
+    use std::io;
+    use std::os::unix::net::UnixListener;
+
+    fn test_socket(
+        name: &str,
+    ) -> (
+        crate::persist::TestEnv,
+        ServerStartupLock,
+        std::path::PathBuf,
+    ) {
+        let env = crate::persist::test_env(name);
+        let dir = crate::persist::ensure_config_dir();
+        let lock = acquire_server_startup_lock(&dir).unwrap();
+        (env, lock, dir.join("bohay.sock"))
+    }
+
+    #[test]
+    fn live_socket_is_never_reclaimed() {
+        let (_env, lock, path) = test_socket("live-socket");
+        let _listener = UnixListener::bind(&path).unwrap();
+
+        let err = lock.reclaim_stale_socket(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AddrInUse);
+        assert!(path.exists(), "a live socket pathname must remain in place");
+    }
+
+    #[test]
+    fn stale_socket_is_reclaimed_while_holding_startup_lock() {
+        let (_env, lock, path) = test_socket("stale-socket");
+        let listener = UnixListener::bind(&path).unwrap();
+        drop(listener);
+        assert!(path.exists(), "dropping a UnixListener leaves a stale path");
+
+        lock.reclaim_stale_socket(&path).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn non_socket_path_is_not_deleted() {
+        let (_env, lock, path) = test_socket("non-socket");
+        std::fs::write(&path, "do not delete").unwrap();
+
+        let err = lock.reclaim_stale_socket(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "do not delete");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,10 +709,34 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
     let cols = size.width.saturating_sub(34).max(20);
     let rows = size.height.saturating_sub(4).max(4);
 
-    // Advertise the socket before spawning panes so they inherit BOHAY_SOCKET_PATH.
+    // `--local` still exposes the control API, so it must obey the same
+    // single-server ownership rules as the headless server.
+    let state_dir = persist::ensure_config_dir();
+    let startup_lock = ipc::transport::acquire_server_startup_lock(&state_dir)?;
     let sock = persist::socket_path();
+    let client_sock = persist::client_socket_path();
+    if ipc::transport::connect(&sock).is_ok() || ipc::transport::connect(&client_sock).is_ok() {
+        return Err(anyhow!(
+            "a Bohay server is already active for {}; use `bohay` to attach to it",
+            state_dir.display()
+        ));
+    }
+
+    let events = ipc::api::new_bus();
+    let (api_tx, api_rx) = mpsc::channel::<ipc::api::ApiRequest>();
+    let api_listener = ipc::api::bind_server(&sock, &startup_lock)?;
+
+    // Advertise the socket before spawning panes so they inherit BOHAY_SOCKET_PATH.
     ipc::api::set_socket_path(sock.clone());
-    let mut app = App::restore_or_new(cols, rows, tx.clone())?;
+    let mut app = match App::restore_or_new(cols, rows, tx.clone()) {
+        Ok(app) => app,
+        Err(err) => {
+            drop(api_listener);
+            let _ = remove_unbound_socket(&sock);
+            return Err(err);
+        }
+    };
+    app.events = events.clone();
     app.set_color_mode(ipc::protocol::truecolor_supported());
     let pending = if app.config.theme == "terminal" {
         let probe = terminal::theme_probe::probe();
@@ -737,8 +761,8 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
         let tx = tx.clone();
         thread::spawn(move || input_loop(tx, pending));
     }
-    let (api_tx, api_rx) = mpsc::channel::<ipc::api::ApiRequest>();
-    ipc::api::start_server(sock, api_tx, app.events.clone());
+    ipc::api::start_server(api_listener, api_tx, events);
+    drop(startup_lock);
     app.run_module_startup_hooks(); // docs/13 §3.7 — same point as the server role
     if app.config.install_agent_skill {
         let _ = skill::install_default(); // keep the agent skill installed (opt out via config)
@@ -824,6 +848,24 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
 
     persist::save(&app);
     Ok(())
+}
+
+/// Clean up a just-bound Unix socket before a local startup aborts. The caller
+/// still owns the startup lock; Windows named pipes have no filesystem path.
+fn remove_unbound_socket(path: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        let _ = path;
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
 }
 
 fn input_loop(tx: Sender<AppEvent>, pending: Vec<Event>) {
@@ -1781,7 +1823,11 @@ mod tests {
         let (api_tx, api_rx) = mpsc::channel::<ipc::api::ApiRequest>();
         let path = std::env::temp_dir().join(format!("bohay-test-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&path);
-        ipc::api::start_server(path.clone(), api_tx, app.events.clone());
+        let startup_lock =
+            ipc::transport::acquire_server_startup_lock(path.parent().unwrap()).unwrap();
+        let listener = ipc::api::bind_server(&path, &startup_lock).unwrap();
+        ipc::api::start_server(listener, api_tx, app.events.clone());
+        drop(startup_lock);
         thread::spawn(move || {
             while let Ok(req) = api_rx.recv() {
                 let resp = app.handle_api(&req);


### PR DESCRIPTION
Prevent concurrent Bohay starts from replacing live sockets and leaving unreachable server processes behind.

## What

- Serialize startup per `BOHAY_HOME` with an exclusive server lock.
- Preserve responsive control and client sockets instead of unlinking them.
- Reclaim only proven-stale Unix sockets while holding the lock.
- Bind both server sockets before restoring panes or starting background work.
- Return a clear startup error when a required socket cannot bind.

## Verification

- `cargo test --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- Debug-server concurrency check: six simultaneous cold starts settled to one server owning both development sockets; repeated starts preserved the same PID.

Refs #47 

## Scope note

This branch also includes the separate `.github/ISSUE_TEMPLATE/bug_report.md` improvement so new reports request reproducible steps and real environment diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented multiple local server instances from starting simultaneously.
  - Improved handling of stale connection sockets so the application can recover cleanly after an interrupted or crashed session.
  - Preserved active connections and avoided overwriting unrelated files.
  - Added cleanup safeguards when startup or application restoration fails.

- **Documentation**
  - Expanded the bug report template with clearer impact, environment, command output, and diagnostic information fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->