### PR TITLE
feat(session): add isolated named Bohay servers and session management

### DIFF
--- a/plugins/bohay/skills/bohay/SKILL.md
+++ b/plugins/bohay/skills/bohay/SKILL.md
@@ -67,6 +67,9 @@ Use the installed production Bohay client:
   Bohay installed by Cargo, Homebrew, `install.sh`, or another PATH-managed
   installation.
 - Preserve an explicitly configured `BOHAY_HOME` or `BOHAY_SOCKET_PATH`.
+  Preserve `BOHAY_SESSION` too. When the user explicitly names a server
+  session, pass `--session <name>` directly to every related Bohay command.
+  Do not list sessions first, and do not silently fall back to `default`.
   Otherwise let the installed release binary use its production default at
   `$HOME/.bohay/bohay.sock`.
 - Never substitute `BOHAY_BIN_PATH` or a repository build for a missing
@@ -86,6 +89,26 @@ not describe an unapproved sandbox failure as an offline server. Only report
 the production server offline after an approved command cannot connect.
 
 Use the same selected binary and socket for the entire request.
+
+### Manage named server sessions
+
+A named session is an independent Bohay server and PTY tree, not a workspace.
+Use these commands only when the user explicitly asks to inspect or manage
+server sessions:
+
+```sh
+bohay session list
+bohay session attach <name>
+bohay session stop <name>
+bohay session delete <name>
+bohay --session <name> pane list
+```
+
+`session attach` launches or attaches the TUI. Never run it merely to test
+whether a session exists. `session stop` ends every pane in that named server.
+Before deletion, list sessions once, require the exact stopped name, and obtain
+clear authorization. Never delete `default` and never substitute workspace
+commands for server-session commands.
 
 ## Use the fast command path
 

--- a/plugins/bohay/skills/bohay/references/advanced-control.md
+++ b/plugins/bohay/skills/bohay/references/advanced-control.md
@@ -45,6 +45,10 @@ Run `bohay help` only when the requested command grammar is uncertain.
 - Resolve a pane and list its workspace's tabs before `bohay pane move <id>
   --tab <n>` or `--new-tab`. List the active workspace's tabs before `bohay tab
   move <from> <to>`; tab positions are 1-based.
+- Named servers are selected directly with `bohay --session <name> ...`.
+  `session list` is discovery only, `session attach <name>` opens the TUI,
+  `session stop <name>` ends only that server, and `session delete <name>` is
+  allowed only after an exact stopped target and explicit authorization.
 - Subscribe to events only for a live monitoring request. Stop when its
   condition is satisfied and never retain an unbounded stream.
 - Do not remove worktrees, delete or merge tasks, uninstall modules, or

--- a/skills/bohay/SKILL.md
+++ b/skills/bohay/SKILL.md
@@ -67,6 +67,9 @@ Use the installed production Bohay client:
   Bohay installed by Cargo, Homebrew, `install.sh`, or another PATH-managed
   installation.
 - Preserve an explicitly configured `BOHAY_HOME` or `BOHAY_SOCKET_PATH`.
+  Preserve `BOHAY_SESSION` too. When the user explicitly names a server
+  session, pass `--session <name>` directly to every related Bohay command.
+  Do not list sessions first, and do not silently fall back to `default`.
   Otherwise let the installed release binary use its production default at
   `$HOME/.bohay/bohay.sock`.
 - Never substitute `BOHAY_BIN_PATH` or a repository build for a missing
@@ -86,6 +89,26 @@ not describe an unapproved sandbox failure as an offline server. Only report
 the production server offline after an approved command cannot connect.
 
 Use the same selected binary and socket for the entire request.
+
+### Manage named server sessions
+
+A named session is an independent Bohay server and PTY tree, not a workspace.
+Use these commands only when the user explicitly asks to inspect or manage
+server sessions:
+
+```sh
+bohay session list
+bohay session attach <name>
+bohay session stop <name>
+bohay session delete <name>
+bohay --session <name> pane list
+```
+
+`session attach` launches or attaches the TUI. Never run it merely to test
+whether a session exists. `session stop` ends every pane in that named server.
+Before deletion, list sessions once, require the exact stopped name, and obtain
+clear authorization. Never delete `default` and never substitute workspace
+commands for server-session commands.
 
 ## Use the fast command path
 

--- a/skills/bohay/references/advanced-control.md
+++ b/skills/bohay/references/advanced-control.md
@@ -45,6 +45,10 @@ Run `bohay help` only when the requested command grammar is uncertain.
 - Resolve a pane and list its workspace's tabs before `bohay pane move <id>
   --tab <n>` or `--new-tab`. List the active workspace's tabs before `bohay tab
   move <from> <to>`; tab positions are 1-based.
+- Named servers are selected directly with `bohay --session <name> ...`.
+  `session list` is discovery only, `session attach <name>` opens the TUI,
+  `session stop <name>` ends only that server, and `session delete <name>` is
+  allowed only after an exact stopped target and explicit authorization.
 - Subscribe to events only for a live monitoring request. Stop when its
   condition is satisfied and never retain an unbounded stream.
 - Do not remove worktrees, delete or merge tasks, uninstall modules, or

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -406,7 +406,12 @@ impl App {
 
     pub(crate) fn dispatch(&mut self, method: &str, p: &Value) -> Result<Value, (String, String)> {
         match method {
-            "ping" => Ok(json!({"type":"pong","version": env!("CARGO_PKG_VERSION"),"protocol":1})),
+            "ping" => Ok(json!({
+                "type":"pong",
+                "version": env!("CARGO_PKG_VERSION"),
+                "protocol":1,
+                "session": crate::session::display_name()
+            })),
             // Re-read `~/.bohay/manifests/` (built-in + managed OTA + user) into
             // the live engine, so `server update-manifest` applies without a
             // restart. Detection uses the new rules on the next tick.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1730,7 +1730,7 @@ impl App {
                     continue;
                 }
                 // An orchestration board (docs/22): re-create the placeholder tab;
-                // its data lives in the shared `orch.json` ledger, loaded already.
+                // its data lives in this session's `orch.json` ledger, loaded already.
                 if tab.orch {
                     let placeholder = PaneId::alloc();
                     tabs.push(Tab {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,7 @@ pub fn is_cli(args: &[String]) -> bool {
                 | "help"
                 | "doctor"
                 | "skill"
+                | "session"
         )
     )
 }
@@ -42,6 +43,7 @@ bohay: Mission control for your AI coding agents
 usage: bohay <command> [args]
 
   (no args)            launch / attach the TUI
+  --session <name>     target one named server session
   help                 show this help
   doctor               check optional external tools (git, gh, …)
   ping                 check the server
@@ -169,6 +171,12 @@ orchestration (multiple agents on one project, docs/22):
 events:
   events                     stream live status changes
 
+sessions:
+  session list [--json]      list default and named server sessions
+  session attach <name>      start or attach the named session
+  session stop <name> [--json]    stop only the named session and its panes
+  session delete <name> [--json]  delete a stopped named session
+
 remote:
   --remote <host> [ssh args] attach to a bohay session on <host> over plain ssh
 
@@ -191,6 +199,9 @@ pub fn run(args: &[String]) -> Result<i32> {
     }
     if args.get(1).map(String::as_str) == Some("skill") {
         return skill_cmd(&args[2.min(args.len())..]);
+    }
+    if args.get(1).map(String::as_str) == Some("session") {
+        return session_cmd(&args[2.min(args.len())..]);
     }
     // `doctor` is a local environment check — no server needed.
     if args.get(1).map(String::as_str) == Some("doctor") {
@@ -263,6 +274,133 @@ pub fn run(args: &[String]) -> Result<i32> {
         Err(_) => println!("{line}"),
     }
     Ok(0)
+}
+
+fn session_cmd(args: &[String]) -> Result<i32> {
+    match args.first().map(String::as_str) {
+        Some("list") => session_list(&args[1..]),
+        Some("stop") => session_stop(&args[1..]),
+        Some("delete") => session_delete(&args[1..]),
+        Some("attach")
+            if matches!(
+                args.get(1).map(String::as_str),
+                Some("help" | "--help" | "-h")
+            ) =>
+        {
+            print_session_help();
+            Ok(0)
+        }
+        Some("attach") => {
+            eprintln!("usage: bohay session attach <name>");
+            Ok(2)
+        }
+        Some("help" | "--help" | "-h") => {
+            print_session_help();
+            Ok(0)
+        }
+        _ => {
+            print_session_help();
+            Ok(2)
+        }
+    }
+}
+
+fn print_session_help() {
+    eprintln!("bohay session commands:");
+    eprintln!("  bohay session list [--json]");
+    eprintln!("  bohay session attach <name>");
+    eprintln!("  bohay session stop <name> [--json]");
+    eprintln!("  bohay session delete <name> [--json]");
+}
+
+fn session_list(args: &[String]) -> Result<i32> {
+    let json = match args {
+        [] => false,
+        [flag] if flag == "--json" => true,
+        _ => return Err(anyhow!("usage: bohay session list [--json]")),
+    };
+    let sessions = crate::session::list_sessions()?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({"sessions": sessions}))?
+        );
+        return Ok(0);
+    }
+    println!("{:<24} {:<10} directory", "name", "status");
+    for session in sessions {
+        println!(
+            "{:<24} {:<10} {}",
+            session.name,
+            if session.running {
+                "running"
+            } else {
+                "stopped"
+            },
+            session.session_dir
+        );
+    }
+    Ok(0)
+}
+
+fn parse_session_name_and_json<'a>(args: &'a [String], usage: &str) -> Result<(&'a str, bool)> {
+    match args {
+        [name] => Ok((name, false)),
+        [name, flag] if flag == "--json" => Ok((name, true)),
+        _ => Err(anyhow!(usage.to_string())),
+    }
+}
+
+fn session_stop(args: &[String]) -> Result<i32> {
+    let (name, json_output) =
+        parse_session_name_and_json(args, "usage: bohay session stop <name> [--json]")?;
+    let target = match crate::session::parse_target_name(name) {
+        Ok(target) => target,
+        Err(message) => return session_error("invalid_session_name", &message, json_output),
+    };
+    match crate::session::stop_session(target.as_deref()) {
+        Ok(session) => {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({"stopped": true, "session": session}))?
+                );
+            } else {
+                println!("stopped session {}", session.name);
+            }
+            Ok(0)
+        }
+        Err(message) => session_error("session_stop_failed", &message, json_output),
+    }
+}
+
+fn session_delete(args: &[String]) -> Result<i32> {
+    let (name, json_output) =
+        parse_session_name_and_json(args, "usage: bohay session delete <name> [--json]")?;
+    match crate::session::delete_session(name) {
+        Ok(session) => {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({"deleted": true, "session": session}))?
+                );
+            } else {
+                println!("deleted session {}", session.name);
+            }
+            Ok(0)
+        }
+        Err(message) => session_error("session_delete_failed", &message, json_output),
+    }
+}
+
+fn session_error(code: &str, message: &str, json_output: bool) -> Result<i32> {
+    let error = json!({"error": {"code": code, "message": message}});
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&error)?);
+    } else {
+        eprintln!("{message}");
+    }
+    Ok(1)
 }
 
 /// `bohay module install owner/repo[/sub] [--ref REF] [--yes]` — clone + build

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -107,10 +107,10 @@ type Clients = HashMap<u64, ClientState>;
 pub fn run() -> Result<()> {
     let (tx, rx) = mpsc::channel::<AppEvent>();
 
-    // Every process targeting one BOHAY_HOME serializes startup here. This is
+    // Every process targeting one selected session serializes startup here. This is
     // deliberately before restoring panes: a losing server must exit without
     // spawning duplicate PTYs or retaining a second terminal grid.
-    let state_dir = persist::ensure_config_dir();
+    let state_dir = persist::ensure_session_dir();
     let startup_lock = transport::acquire_server_startup_lock(&state_dir)?;
     let sock = persist::socket_path();
     let client_sock = persist::client_socket_path();

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -149,8 +149,8 @@ pub fn bind(path: &Path) -> io::Result<Listener> {
         let name = path.to_fs_name::<GenericFilePath>()?;
         let listener = ListenerOptions::new().name(name).create_sync()?;
         // Owner-only: a connection to this socket is full command execution as
-        // the user, so never rely on the umask (the state dir is also forced
-        // to 0700 — see `persist::ensure_config_dir`).
+        // the user, so never rely on the umask (the selected session dir is also
+        // forced to 0700 — see `persist::ensure_session_dir`).
         {
             use std::os::unix::fs::PermissionsExt;
             let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
@@ -212,5 +212,22 @@ mod tests {
         let err = lock.reclaim_stale_socket(&path).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "do not delete");
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::pipe_id;
+    use std::path::Path;
+
+    #[test]
+    fn named_session_paths_derive_distinct_stable_pipe_ids() {
+        let alpha = pipe_id(Path::new(r"C:\Users\riz\.bohay\sessions\alpha\bohay.sock"));
+        let beta = pipe_id(Path::new(r"C:\Users\riz\.bohay\sessions\beta\bohay.sock"));
+        assert_ne!(alpha, beta);
+        assert_eq!(
+            alpha,
+            pipe_id(Path::new(r"C:\Users\riz\.bohay\sessions\alpha\bohay.sock"))
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod module;
 mod orch;
 mod persist;
 mod platform;
+mod session;
 mod skill;
 mod terminal;
 mod ui;
@@ -51,7 +52,8 @@ fn main() -> Result<()> {
     // waits aren't quantized to Windows' ~15.6ms default (the cause of laggy
     // typing in panes there). No-op on Unix; restored when `main` returns.
     let _timer = platform::high_res_timer();
-    let args: Vec<String> = std::env::args().collect();
+    let raw_args: Vec<String> = std::env::args().collect();
+    let args = session::configure_from_args(&raw_args).map_err(anyhow::Error::msg)?;
     match args.get(1).map(String::as_str) {
         // Standard CLI conveniences (don't start the server).
         Some("--version") | Some("-V") => {
@@ -326,10 +328,13 @@ fn base64_encode(data: &[u8]) -> String {
 /// Terminal.app) collapses the component entirely → one clean process mention.
 /// Every other terminal treats the OSC title as THE title, so they keep
 /// "bohay".
-pub(crate) fn window_title() -> &'static str {
+pub(crate) fn window_title() -> String {
+    if let Some(name) = session::active_name() {
+        return format!("bohay · {name}");
+    }
     match std::env::var("TERM_PROGRAM") {
-        Ok(p) if p == "Apple_Terminal" => "",
-        _ => "bohay",
+        Ok(p) if p == "Apple_Terminal" => String::new(),
+        _ => "bohay".to_string(),
     }
 }
 
@@ -430,24 +435,8 @@ fn attach_cmd(args: &[String]) -> Result<()> {
 /// socket through plain ssh and attach to it locally. No port-forwarding, no
 /// `~/.ssh/config` edits — keepalive options are passed on argv only.
 fn remote_attach(args: &[String]) -> Result<()> {
-    let host = args
-        .get(2)
-        .ok_or_else(|| anyhow!("usage: bohay --remote <host> [ssh args]"))?;
-    let mut cmd = Command::new("ssh");
-    cmd.arg("-T")
-        .arg("-o")
-        .arg("ServerAliveInterval=15")
-        .arg("-o")
-        .arg("ServerAliveCountMax=3");
-    // Any extra args (e.g. `-p 2222`, `-i key`) go to ssh, before the host.
-    for extra in args.iter().skip(3) {
-        cmd.arg(extra);
-    }
-    cmd.arg(host)
-        .arg("bohay")
-        .arg("remote-client-bridge")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped()); // stderr inherited so ssh can prompt for auth
+    let mut cmd = remote_ssh_command(args)?;
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped()); // stderr inherited so ssh can prompt for auth
     let mut child = cmd
         .spawn()
         .map_err(|e| anyhow!("failed to launch ssh: {e}"))?;
@@ -462,6 +451,32 @@ fn remote_attach(args: &[String]) -> Result<()> {
     result
 }
 
+/// Build the remote bridge command separately so session propagation stays
+/// testable without opening an SSH connection.
+fn remote_ssh_command(args: &[String]) -> Result<Command> {
+    let host = args
+        .get(2)
+        .ok_or_else(|| anyhow!("usage: bohay --remote <host> [ssh args]"))?;
+    let mut cmd = Command::new("ssh");
+    cmd.arg("-T")
+        .arg("-o")
+        .arg("ServerAliveInterval=15")
+        .arg("-o")
+        .arg("ServerAliveCountMax=3");
+    // Any extra args (e.g. `-p 2222`, `-i key`) go to ssh, before the host.
+    for extra in args.iter().skip(3) {
+        cmd.arg(extra);
+    }
+    cmd.arg(host).arg("bohay");
+    if let Some(name) = session::active_name() {
+        cmd.arg("--session").arg(name);
+    } else if session::explicit_session_requested() {
+        cmd.arg("--session").arg(session::DEFAULT_SESSION_NAME);
+    }
+    cmd.arg("remote-client-bridge").stderr(Stdio::inherit());
+    Ok(cmd)
+}
+
 fn server_running(sock: &Path) -> bool {
     ipc::transport::connect(sock).is_ok()
 }
@@ -470,6 +485,9 @@ fn spawn_server() -> Result<()> {
     let exe = std::env::current_exe()?;
     let mut cmd = Command::new(exe);
     cmd.arg("server")
+        // The selector was already resolved into BOHAY_SESSION. A parent pane's
+        // injected API socket must not leak into a newly spawned server.
+        .env_remove("BOHAY_SOCKET_PATH")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -607,12 +625,15 @@ fn update_manifest() -> Result<()> {
 fn server_start() -> Result<()> {
     let sock = persist::client_socket_path();
     if server_running(&sock) {
-        println!("bohay server already running");
+        println!(
+            "bohay server already running (session {})",
+            session::display_name()
+        );
         return Ok(());
     }
     spawn_server()?;
     wait_for_socket(&sock)?;
-    println!("bohay server started");
+    println!("bohay server started (session {})", session::display_name());
     Ok(())
 }
 
@@ -623,7 +644,7 @@ fn server_stop() -> Result<()> {
         // socket — then `stop` returning means it's really down (and a following
         // `status` reports "not running", not a half-shutdown "running").
         wait_for_shutdown(&sock);
-        println!("bohay server stopped");
+        println!("bohay server stopped (session {})", session::display_name());
     } else {
         println!("no bohay server running");
     }
@@ -639,7 +660,10 @@ fn server_restart() -> Result<()> {
     }
     spawn_server()?;
     wait_for_socket(&sock)?;
-    println!("bohay server restarted");
+    println!(
+        "bohay server restarted (session {})",
+        session::display_name()
+    );
     Ok(())
 }
 
@@ -659,12 +683,18 @@ fn wait_for_shutdown(sock: &Path) {
 fn server_status() -> Result<()> {
     let sock = persist::client_socket_path();
     if !server_running(&sock) {
-        println!("bohay server: not running");
+        println!(
+            "bohay server: not running (session {})",
+            session::display_name()
+        );
         return Ok(());
     }
     match server_version() {
         Some(running) => {
-            println!("bohay server: running (v{running})");
+            println!(
+                "bohay server: running (v{running}, session {})",
+                session::display_name()
+            );
             let binary = env!("CARGO_PKG_VERSION");
             if running != binary {
                 println!(
@@ -672,7 +702,10 @@ fn server_status() -> Result<()> {
                 );
             }
         }
-        None => println!("bohay server: running"),
+        None => println!(
+            "bohay server: running (session {})",
+            session::display_name()
+        ),
     }
     Ok(())
 }
@@ -711,7 +744,7 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
 
     // `--local` still exposes the control API, so it must obey the same
     // single-server ownership rules as the headless server.
-    let state_dir = persist::ensure_config_dir();
+    let state_dir = persist::ensure_session_dir();
     let startup_lock = ipc::transport::acquire_server_startup_lock(&state_dir)?;
     let sock = persist::socket_path();
     let client_sock = persist::client_socket_path();
@@ -918,6 +951,51 @@ mod tests {
         let data_len = u32::from_le_bytes(w[40..44].try_into().unwrap()) as usize;
         assert_eq!(w.len(), 44 + data_len, "header data length matches payload");
         assert!(data_len > 0, "non-empty audio");
+    }
+
+    #[test]
+    fn named_session_is_visible_in_the_terminal_title() {
+        let _env = crate::persist::test_env("named-session-title");
+        std::env::set_var(crate::session::SESSION_ENV_VAR, "docs");
+        assert_eq!(window_title(), "bohay · docs");
+    }
+
+    #[test]
+    fn remote_bridge_preserves_the_selected_named_session() {
+        let _env = crate::persist::test_env("named-session-remote");
+        let raw = [
+            "bohay",
+            "--session",
+            "api",
+            "--remote",
+            "devbox",
+            "-p",
+            "2222",
+        ]
+        .map(String::from);
+        let args = crate::session::configure_from_args(&raw).unwrap();
+        let command = remote_ssh_command(&args).unwrap();
+        let actual: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            actual,
+            [
+                "-T",
+                "-o",
+                "ServerAliveInterval=15",
+                "-o",
+                "ServerAliveCountMax=3",
+                "-p",
+                "2222",
+                "devbox",
+                "bohay",
+                "--session",
+                "api",
+                "remote-client-bridge",
+            ]
+        );
     }
 
     /// Manual benchmark of the server render hot path (full UI render + in-place

--- a/src/module/paths.rs
+++ b/src/module/paths.rs
@@ -23,7 +23,10 @@ pub fn config_dir(id: &str) -> PathBuf {
 
 /// Per-module state dir: `…/modules/state/<c>/`.
 pub fn state_dir(id: &str) -> PathBuf {
-    modules_root().join("state").join(sanitize(id))
+    crate::persist::session_dir()
+        .join("modules")
+        .join("state")
+        .join(sanitize(id))
 }
 
 /// The base dir for managed git checkouts: `…/modules/git/`.
@@ -106,5 +109,18 @@ mod tests {
         let s = sanitize(&long);
         assert!(s.len() <= 120);
         assert_eq!(sanitize(&long), s, "stable");
+    }
+
+    #[test]
+    fn module_config_is_global_but_runtime_state_is_session_local() {
+        let _env = crate::persist::test_env("module-session-paths");
+        let root = crate::persist::config_dir();
+        std::env::set_var(crate::session::SESSION_ENV_VAR, "alpha");
+
+        assert_eq!(config_dir("you.test"), root.join("modules/config/you.test"));
+        assert_eq!(
+            state_dir("you.test"),
+            root.join("sessions/alpha/modules/state/you.test")
+        );
     }
 }

--- a/src/module/runtime.rs
+++ b/src/module/runtime.rs
@@ -87,6 +87,9 @@ pub fn base_env(module: &InstalledModule, ctx: &Value) -> Vec<(String, String)> 
     if let Some(sock) = crate::ipc::api::socket_path_env() {
         env.push(("BOHAY_SOCKET_PATH".to_string(), sock));
     }
+    if let Some(name) = crate::session::active_name() {
+        env.push((crate::session::SESSION_ENV_VAR.to_string(), name));
+    }
     if let Ok(exe) = std::env::current_exe() {
         env.push(("BOHAY_BIN_PATH".to_string(), exe.display().to_string()));
     }

--- a/src/orch/mod.rs
+++ b/src/orch/mod.rs
@@ -2,7 +2,8 @@
 //! multi-agent orchestration (docs/22, milestone M0).
 //!
 //! **Pure state.** The only IO is its own JSON persistence in a *separate* file
-//! (`~/.bohay/orch.json`), so the ledger survives restart and never touches
+//! (`~/.bohay/orch.json` for the default server, or the selected named-session
+//! directory), so the ledger survives restart and never touches
 //! `session.json`/`SessionSnapshot` — session restore is completely unaffected.
 //! All mutation happens on the single-writer app loop (via `app/dispatch.rs`), so
 //! claims and leases are race-free by construction; this module holds no locks.
@@ -446,7 +447,7 @@ impl OrchState {
 }
 
 fn orch_path() -> PathBuf {
-    crate::persist::config_dir().join("orch.json")
+    crate::persist::session_dir().join("orch.json")
 }
 
 fn unix_now() -> u64 {

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -99,6 +99,8 @@ pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(()
 pub(crate) struct TestEnv {
     _guard: std::sync::MutexGuard<'static, ()>,
     prev: Option<std::ffi::OsString>,
+    prev_session: Option<std::ffi::OsString>,
+    prev_socket: Option<std::ffi::OsString>,
     dir: PathBuf,
 }
 
@@ -109,6 +111,15 @@ impl Drop for TestEnv {
             Some(p) => std::env::set_var("BOHAY_HOME", p),
             None => std::env::remove_var("BOHAY_HOME"),
         }
+        match &self.prev_session {
+            Some(value) => std::env::set_var(crate::session::SESSION_ENV_VAR, value),
+            None => std::env::remove_var(crate::session::SESSION_ENV_VAR),
+        }
+        match &self.prev_socket {
+            Some(value) => std::env::set_var("BOHAY_SOCKET_PATH", value),
+            None => std::env::remove_var("BOHAY_SOCKET_PATH"),
+        }
+        crate::session::clear_explicit_for_test();
         let _ = std::fs::remove_dir_all(&self.dir);
     }
 }
@@ -117,12 +128,19 @@ impl Drop for TestEnv {
 pub(crate) fn test_env(tag: &str) -> TestEnv {
     let guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let prev = std::env::var_os("BOHAY_HOME");
+    let prev_session = std::env::var_os(crate::session::SESSION_ENV_VAR);
+    let prev_socket = std::env::var_os("BOHAY_SOCKET_PATH");
     let dir = std::env::temp_dir().join(format!("bohay-test-{}-{}", tag, std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::env::set_var("BOHAY_HOME", &dir);
+    std::env::remove_var(crate::session::SESSION_ENV_VAR);
+    std::env::remove_var("BOHAY_SOCKET_PATH");
+    crate::session::clear_explicit_for_test();
     TestEnv {
         _guard: guard,
         prev,
+        prev_session,
+        prev_socket,
         dir,
     }
 }
@@ -148,19 +166,43 @@ pub fn config_dir() -> PathBuf {
 /// pathological `$BOHAY_HOME=$HOME` (never chmod the home dir itself).
 pub fn ensure_config_dir() -> PathBuf {
     let dir = config_dir();
-    let _ = fs::create_dir_all(&dir);
+    ensure_private_dir(&dir);
+    dir
+}
+
+/// Selected server runtime directory. The default session remains rooted at
+/// `config_dir`; named sessions live under `config_dir/sessions/<name>`.
+pub fn session_dir() -> PathBuf {
+    crate::session::active_dir()
+}
+
+/// Create the selected runtime directory with the same owner-only protection as
+/// the global root. This is the startup-lock namespace for one server only.
+pub fn ensure_session_dir() -> PathBuf {
+    let dir = session_dir();
+    ensure_private_dir(&dir);
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if Some(dir.as_path()) != crate::platform::home_dir().as_deref() {
-            let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
+    for socket in [socket_path(), client_socket_path()] {
+        if let Some(parent) = socket.parent().filter(|parent| *parent != dir) {
+            ensure_private_dir(parent);
         }
     }
     dir
 }
 
+fn ensure_private_dir(dir: &std::path::Path) {
+    let _ = fs::create_dir_all(dir);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if Some(dir) != crate::platform::home_dir().as_deref() {
+            let _ = fs::set_permissions(dir, fs::Permissions::from_mode(0o700));
+        }
+    }
+}
+
 fn session_path() -> PathBuf {
-    config_dir().join("session.json")
+    session_dir().join("session.json")
 }
 
 /// User-editable agent-detection manifests (docs/07). `~/.bohay/manifests/`.
@@ -244,7 +286,7 @@ not = [\"cancelled\"]
 /// **server** to bind — never reads `$BOHAY_SOCKET_PATH`, or a server spawned
 /// from inside a pane would try to bind its parent's socket.
 pub fn socket_path() -> PathBuf {
-    config_dir().join("bohay.sock")
+    crate::session::api_socket_path_for(crate::session::active_name().as_deref())
 }
 
 /// The control socket a **CLI** should talk to: the one injected into this
@@ -254,6 +296,9 @@ pub fn socket_path() -> PathBuf {
 /// out to `bohay`, or a `bohay module link` typed in a dev pane, targets the
 /// instance you're in rather than whatever `$BOHAY_HOME` defaults to.
 pub fn cli_socket_path() -> PathBuf {
+    if crate::session::explicit_session_requested() {
+        return socket_path();
+    }
     match std::env::var_os("BOHAY_SOCKET_PATH") {
         Some(p) if !p.is_empty() => PathBuf::from(p),
         _ => socket_path(),
@@ -262,7 +307,7 @@ pub fn cli_socket_path() -> PathBuf {
 
 /// The binary client/render socket path for this session.
 pub fn client_socket_path() -> PathBuf {
-    config_dir().join("bohay-client.sock")
+    crate::session::client_socket_path_for(crate::session::active_name().as_deref())
 }
 
 /// Build a snapshot from the live app.
@@ -487,7 +532,7 @@ pub fn save(app: &App) {
         let _ = fs::remove_file(session_path());
         return;
     }
-    let dir = ensure_config_dir();
+    let dir = ensure_session_dir();
     if !dir.is_dir() {
         return;
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,471 @@
+//! Named server-session selection and lifecycle.
+//!
+//! A session is one independent Bohay server namespace. Selection happens once
+//! at process startup, before normal CLI routing, so sockets, persistence, PTYs,
+//! and child processes all agree on the same owner without background polling.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+pub const SESSION_ENV_VAR: &str = "BOHAY_SESSION";
+pub const DEFAULT_SESSION_NAME: &str = "default";
+
+const MAX_SESSION_NAME_LEN: usize = 64;
+const STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const STOP_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+static EXPLICIT_SESSION_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SessionInfo {
+    pub name: String,
+    pub default: bool,
+    pub running: bool,
+    pub socket_path: String,
+    pub session_dir: String,
+}
+
+/// Resolve `session attach` and global `--session` flags before normal routing.
+/// The returned argv no longer contains the selector.
+pub fn configure_from_args(args: &[String]) -> Result<Vec<String>, String> {
+    if args.get(1).map(String::as_str) == Some("session")
+        && args.get(2).map(String::as_str) == Some("attach")
+    {
+        if matches!(
+            args.get(3).map(String::as_str),
+            Some("help" | "--help" | "-h")
+        ) {
+            return Ok(args.to_vec());
+        }
+        let Some(name) = args.get(3) else {
+            return Err("usage: bohay session attach <name>".to_string());
+        };
+        if args.len() != 4 {
+            return Err("usage: bohay session attach <name>".to_string());
+        }
+        apply_explicit_name(name)?;
+        return Ok(vec![args[0].clone()]);
+    }
+
+    let mut cleaned = Vec::with_capacity(args.len());
+    if let Some(program) = args.first() {
+        cleaned.push(program.clone());
+    }
+    let mut requested: Option<String> = None;
+    let mut index = 1;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            cleaned.extend_from_slice(&args[index..]);
+            break;
+        }
+        if arg == "--session" {
+            let Some(name) = args.get(index + 1) else {
+                return Err("missing value for --session".to_string());
+            };
+            if requested.replace(name.clone()).is_some() {
+                return Err("--session may be passed only once".to_string());
+            }
+            index += 2;
+            continue;
+        }
+        if let Some(name) = arg.strip_prefix("--session=") {
+            if requested.replace(name.to_string()).is_some() {
+                return Err("--session may be passed only once".to_string());
+            }
+            index += 1;
+            continue;
+        }
+        cleaned.push(arg.clone());
+        index += 1;
+    }
+
+    if let Some(name) = requested {
+        apply_explicit_name(&name)?;
+        return Ok(cleaned);
+    }
+
+    EXPLICIT_SESSION_REQUESTED.store(false, Ordering::Relaxed);
+    let inherited_socket = std::env::var_os("BOHAY_SOCKET_PATH").is_some_and(|v| !v.is_empty());
+    if !inherited_socket {
+        if let Ok(name) = std::env::var(SESSION_ENV_VAR) {
+            match normalize_name(&name)? {
+                Some(name) => std::env::set_var(SESSION_ENV_VAR, name),
+                None => std::env::remove_var(SESSION_ENV_VAR),
+            }
+        }
+    }
+    Ok(cleaned)
+}
+
+fn apply_explicit_name(name: &str) -> Result<(), String> {
+    match normalize_name(name)? {
+        Some(name) => std::env::set_var(SESSION_ENV_VAR, name),
+        None => std::env::remove_var(SESSION_ENV_VAR),
+    }
+    EXPLICIT_SESSION_REQUESTED.store(true, Ordering::Relaxed);
+    Ok(())
+}
+
+pub fn explicit_session_requested() -> bool {
+    EXPLICIT_SESSION_REQUESTED.load(Ordering::Relaxed)
+}
+
+pub fn active_name() -> Option<String> {
+    std::env::var(SESSION_ENV_VAR)
+        .ok()
+        .filter(|name| name != DEFAULT_SESSION_NAME)
+        .filter(|name| validate_name(name).is_ok())
+}
+
+pub fn display_name() -> String {
+    active_name().unwrap_or_else(|| DEFAULT_SESSION_NAME.to_string())
+}
+
+pub fn parse_target_name(name: &str) -> Result<Option<String>, String> {
+    normalize_name(name)
+}
+
+fn normalize_name(name: &str) -> Result<Option<String>, String> {
+    if name == DEFAULT_SESSION_NAME {
+        return Ok(None);
+    }
+    validate_name(name)?;
+    Ok(Some(name.to_string()))
+}
+
+pub fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("session name cannot be empty".to_string());
+    }
+    if name.len() > MAX_SESSION_NAME_LEN {
+        return Err(format!(
+            "session name cannot be longer than {MAX_SESSION_NAME_LEN} bytes"
+        ));
+    }
+    if matches!(name, "." | "..") {
+        return Err("session name cannot be `.` or `..`".to_string());
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+    {
+        return Err(
+            "session name may contain only ASCII letters, digits, `.`, `_`, and `-`".to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub fn session_dir_for(name: Option<&str>) -> PathBuf {
+    match name {
+        Some(name) => crate::persist::config_dir().join("sessions").join(name),
+        None => crate::persist::config_dir(),
+    }
+}
+
+pub fn active_dir() -> PathBuf {
+    session_dir_for(active_name().as_deref())
+}
+
+pub fn api_socket_path_for(name: Option<&str>) -> PathBuf {
+    socket_path_for(name, "bohay.sock", "api")
+}
+
+pub fn client_socket_path_for(name: Option<&str>) -> PathBuf {
+    socket_path_for(name, "bohay-client.sock", "client")
+}
+
+fn socket_path_for(name: Option<&str>, file_name: &str, role: &str) -> PathBuf {
+    let logical = session_dir_for(name).join(file_name);
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        // macOS allows only 103 bytes plus the terminating NUL in `sun_path`.
+        // Keep ordinary paths readable and backward-compatible, but make long
+        // custom BOHAY_HOME values usable through a stable owner-scoped alias.
+        if logical.as_os_str().as_bytes().len() >= 100 {
+            let mut hash = 0xcbf29ce484222325u64;
+            for byte in logical.as_os_str().as_bytes() {
+                hash ^= u64::from(*byte);
+                hash = hash.wrapping_mul(0x100000001b3);
+            }
+            let uid = unsafe { libc::geteuid() };
+            return PathBuf::from(format!("/tmp/bohay-{uid}/{hash:016x}-{role}.sock"));
+        }
+    }
+    logical
+}
+
+pub fn session_info(name: Option<&str>) -> SessionInfo {
+    let socket_path = api_socket_path_for(name);
+    let client_socket_path = client_socket_path_for(name);
+    SessionInfo {
+        name: name.unwrap_or(DEFAULT_SESSION_NAME).to_string(),
+        default: name.is_none(),
+        running: is_running_at(&socket_path) || is_running_at(&client_socket_path),
+        socket_path: socket_path.display().to_string(),
+        session_dir: session_dir_for(name).display().to_string(),
+    }
+}
+
+/// List known namespaces without starting a server or retaining a watcher.
+pub fn list_sessions() -> std::io::Result<Vec<SessionInfo>> {
+    let mut sessions = vec![session_info(None)];
+    let sessions_dir = crate::persist::config_dir().join("sessions");
+    let entries = match std::fs::read_dir(sessions_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(sessions),
+        Err(err) => return Err(err),
+    };
+    let mut names = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if name != DEFAULT_SESSION_NAME && validate_name(&name).is_ok() {
+            names.push(name);
+        }
+    }
+    names.sort_unstable();
+    sessions.extend(names.iter().map(|name| session_info(Some(name))));
+    Ok(sessions)
+}
+
+pub fn stop_session(name: Option<&str>) -> Result<SessionInfo, String> {
+    let api = api_socket_path_for(name);
+    let client = client_socket_path_for(name);
+    let mut stream = crate::ipc::transport::connect(&api).map_err(|err| {
+        format!(
+            "session {} is not running or cannot be reached at {}: {err}",
+            name.unwrap_or(DEFAULT_SESSION_NAME),
+            api.display()
+        )
+    })?;
+    writeln!(
+        stream,
+        "{}",
+        serde_json::json!({"id":"cli:session:stop","method":"server.stop","params":{}})
+    )
+    .map_err(|err| err.to_string())?;
+    stream.flush().map_err(|err| err.to_string())?;
+    // Do not wait for an acknowledgement here. A listener that accepts but no
+    // longer services requests must not block this lifecycle command forever.
+    // Releasing the connection and probing both endpoints below gives the
+    // entire stop operation one bounded timeout.
+    drop(stream);
+
+    let deadline = Instant::now() + STOP_TIMEOUT;
+    while Instant::now() < deadline {
+        if !is_running_at(&api) && !is_running_at(&client) {
+            return Ok(session_info(name));
+        }
+        std::thread::sleep(STOP_POLL_INTERVAL);
+    }
+    Err(format!(
+        "session {} did not stop within {}ms",
+        name.unwrap_or(DEFAULT_SESSION_NAME),
+        STOP_TIMEOUT.as_millis()
+    ))
+}
+
+pub fn delete_session(name: &str) -> Result<SessionInfo, String> {
+    if name == DEFAULT_SESSION_NAME {
+        return Err("deleting the default session is not supported".to_string());
+    }
+    validate_name(name)?;
+    let info = session_info(Some(name));
+    if info.running {
+        return Err(format!(
+            "session {name} is running; stop it before deleting"
+        ));
+    }
+    let sessions_root = crate::persist::config_dir().join("sessions");
+    let dir = session_dir_for(Some(name));
+    if dir.parent() != Some(sessions_root.as_path()) {
+        return Err("refusing to delete a path outside the sessions directory".to_string());
+    }
+    // Long Unix paths use short aliases in /tmp. A stopped session may leave
+    // stale socket files after a crash, so remove only its deterministic aliases
+    // before deleting the validated session directory.
+    #[cfg(unix)]
+    for socket in [
+        api_socket_path_for(Some(name)),
+        client_socket_path_for(Some(name)),
+    ] {
+        if !socket.starts_with(&dir) {
+            let _ = std::fs::remove_file(socket);
+        }
+    }
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(info),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(info),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn is_running_at(path: &Path) -> bool {
+    crate::ipc::transport::connect(path).is_ok()
+}
+
+#[cfg(test)]
+pub(crate) fn clear_explicit_for_test() {
+    EXPLICIT_SESSION_REQUESTED.store(false, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|part| part.to_string()).collect()
+    }
+
+    #[test]
+    fn validates_safe_session_names() {
+        for name in ["api", "work-2", "release_3", "v0.10.4"] {
+            assert!(validate_name(name).is_ok(), "{name}");
+        }
+        for name in ["", ".", "..", "a/b", "space name", "ümlaut"] {
+            assert!(validate_name(name).is_err(), "{name}");
+        }
+        assert!(validate_name(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn explicit_selector_is_stripped_and_overrides_inherited_socket() {
+        let _env = crate::persist::test_env("session-explicit");
+        std::env::set_var("BOHAY_SOCKET_PATH", "/tmp/other.sock");
+        let cleaned =
+            configure_from_args(&argv(&["bohay", "--session", "alpha", "pane", "list"])).unwrap();
+        assert_eq!(cleaned, argv(&["bohay", "pane", "list"]));
+        assert_eq!(active_name().as_deref(), Some("alpha"));
+        assert!(explicit_session_requested());
+        assert_eq!(
+            crate::persist::cli_socket_path(),
+            api_socket_path_for(Some("alpha"))
+        );
+    }
+
+    #[test]
+    fn inherited_socket_wins_without_an_explicit_selector() {
+        let _env = crate::persist::test_env("session-inherited");
+        std::env::set_var(SESSION_ENV_VAR, "alpha");
+        std::env::set_var("BOHAY_SOCKET_PATH", "/tmp/inherited.sock");
+        let cleaned = configure_from_args(&argv(&["bohay", "pane", "list"])).unwrap();
+        assert_eq!(cleaned, argv(&["bohay", "pane", "list"]));
+        assert!(!explicit_session_requested());
+        assert_eq!(
+            crate::persist::cli_socket_path(),
+            PathBuf::from("/tmp/inherited.sock")
+        );
+    }
+
+    #[test]
+    fn attach_reuses_the_normal_tui_path() {
+        let _env = crate::persist::test_env("session-attach");
+        let cleaned = configure_from_args(&argv(&["bohay", "session", "attach", "docs"])).unwrap();
+        assert_eq!(cleaned, argv(&["bohay"]));
+        assert_eq!(active_name().as_deref(), Some("docs"));
+        assert!(explicit_session_requested());
+    }
+
+    #[test]
+    fn default_paths_are_unchanged_and_named_paths_are_nested() {
+        let _env = crate::persist::test_env("session-paths");
+        #[cfg(unix)]
+        std::env::set_var(
+            "BOHAY_HOME",
+            format!("/tmp/bohay-session-paths-{}", std::process::id()),
+        );
+        let root = crate::persist::config_dir();
+        assert_eq!(session_dir_for(None), root);
+        assert_eq!(session_dir_for(Some("api")), root.join("sessions/api"));
+        assert_eq!(api_socket_path_for(None), root.join("bohay.sock"));
+        assert_eq!(
+            client_socket_path_for(Some("api")),
+            root.join("sessions/api/bohay-client.sock")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn long_unix_socket_paths_get_stable_distinct_short_aliases() {
+        let _env = crate::persist::test_env("session-long-socket-paths");
+        let long_root = crate::persist::config_dir().join("x".repeat(120));
+        std::env::set_var("BOHAY_HOME", &long_root);
+
+        let alpha_api = api_socket_path_for(Some("alpha"));
+        let alpha_client = client_socket_path_for(Some("alpha"));
+        let beta_api = api_socket_path_for(Some("beta"));
+        assert!(alpha_api.starts_with("/tmp"));
+        assert!(alpha_api.as_os_str().len() < 100);
+        assert_ne!(alpha_api, alpha_client);
+        assert_ne!(alpha_api, beta_api);
+        assert_eq!(alpha_api, api_socket_path_for(Some("alpha")));
+    }
+
+    #[test]
+    fn duplicate_selectors_are_rejected() {
+        let _env = crate::persist::test_env("session-duplicate");
+        let err = configure_from_args(&argv(&[
+            "bohay",
+            "--session",
+            "one",
+            "--session=two",
+            "pane",
+            "list",
+        ]))
+        .unwrap_err();
+        assert!(err.contains("only once"));
+    }
+
+    #[test]
+    fn environment_selector_is_used_only_without_an_inherited_socket() {
+        let _env = crate::persist::test_env("session-environment");
+        std::env::set_var(SESSION_ENV_VAR, "docs");
+        let cleaned = configure_from_args(&argv(&["bohay", "ping"])).unwrap();
+        assert_eq!(cleaned, argv(&["bohay", "ping"]));
+        assert_eq!(active_name().as_deref(), Some("docs"));
+        assert_eq!(
+            crate::persist::cli_socket_path(),
+            api_socket_path_for(Some("docs"))
+        );
+    }
+
+    #[test]
+    fn default_selector_preserves_the_legacy_root() {
+        let _env = crate::persist::test_env("session-default-selector");
+        let cleaned =
+            configure_from_args(&argv(&["bohay", "--session=default", "server", "status"]))
+                .unwrap();
+        assert_eq!(cleaned, argv(&["bohay", "server", "status"]));
+        assert_eq!(active_name(), None);
+        assert_eq!(active_dir(), crate::persist::config_dir());
+        assert!(explicit_session_requested());
+    }
+
+    #[test]
+    fn invalid_environment_selector_is_rejected_before_routing() {
+        let _env = crate::persist::test_env("session-invalid-environment");
+        std::env::set_var(SESSION_ENV_VAR, "../other");
+        let err = configure_from_args(&argv(&["bohay", "ping"])).unwrap_err();
+        assert!(err.contains("ASCII letters"));
+    }
+
+    #[test]
+    fn deletion_guards_reject_default_and_unsafe_names() {
+        let _env = crate::persist::test_env("session-delete-guards");
+        assert!(delete_session(DEFAULT_SESSION_NAME).is_err());
+        assert!(delete_session("../outside").is_err());
+    }
+}

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -221,6 +221,9 @@ impl Pane {
         if let Some(sock) = crate::ipc::api::socket_path_env() {
             cmd.env("BOHAY_SOCKET_PATH", sock);
         }
+        if let Some(name) = crate::session::active_name() {
+            cmd.env(crate::session::SESSION_ENV_VAR, name);
+        }
         // This session's exact binary, so an agent can use `$BOHAY_BIN_PATH`
         // instead of a `bohay` on PATH that may be an older install with a
         // different CLI (skill/binary skew). Matches the server it talks to.

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -13,6 +13,12 @@ buffer. The **client** is nearly stateless. It forwards your input and paints
 frames. That split is why sessions survive: the thing you close (the client)
 was never the thing that mattered.
 
+Named sessions preserve the same boundary instead of adding a global manager.
+Each running name owns one server process, startup lock, pair of sockets,
+snapshot, PTY tree, and orchestration ledger. Stopped names consume no CPU or
+memory. Shared preferences, detection manifests, skills, and module installs
+remain at the Bohay root.
+
 ## One event loop, pure state
 
 All state mutation happens on a single thread, driven by one event loop. Slow

--- a/website/src/content/docs/docs/getting-started/concepts.mdx
+++ b/website/src/content/docs/docs/getting-started/concepts.mdx
@@ -31,6 +31,22 @@ pane opens straight into its agent, nothing gets typed into a prompt in front
 of you. Live processes can't outlive their owner, so shells come back fresh,
 but you land in the same place you left.
 
+### More than one independent session
+
+The default `bohay` command keeps the same single durable server as before. If
+you need separate failure and resource boundaries, give each server a name:
+
+```sh
+bohay session attach api
+bohay session attach website
+bohay --session api pane list
+```
+
+A named session owns its own server, PTYs, agents, workspaces, tabs, snapshot,
+and orchestration ledger. It is not a workspace. `bohay session stop api`
+stops only `api`, while `website` stays responsive. `bohay session list` checks
+known sessions without starting any server or background manager.
+
 ## 2. Workspace → Tab → Pane
 
 ```

--- a/website/src/content/docs/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/docs/getting-started/installation.mdx
@@ -176,3 +176,10 @@ Everything lives in **`~/.bohay/`** (override with `$BOHAY_HOME`): your
 [configuration](/docs/reference/configuration/), the auto-saved session
 snapshot, and the orchestration ledger. The directory is created owner-only
 (`0700`).
+
+The existing default session keeps its files directly in this directory, so
+upgrading requires no migration. Named server sessions store their runtime
+files under `~/.bohay/sessions/<name>/`. Preferences, manifests, skills, and
+module installations remain shared. Rollback is therefore simple: older Bohay
+versions continue to see the unchanged default session and ignore the named
+subdirectories.

--- a/website/src/content/docs/docs/guides/codex-plugin.mdx
+++ b/website/src/content/docs/docs/guides/codex-plugin.mdx
@@ -15,6 +15,18 @@ Outside Bohay, the plugin resolves the installed `bohay` command and controls
 its configured production session. With the default configuration this is the
 server at `~/.bohay/bohay.sock`.
 
+For a named server, include the selector in the request or command:
+
+```sh
+bohay --session api agent list
+bohay --session api pane focus 7
+```
+
+The plugin preserves the inherited socket inside a managed pane. Outside a
+pane, an explicit `--session` wins over any inherited socket. It does not run
+`session list`, `help`, or `ping` before an ordinary operation, so named-session
+routing adds no discovery round trip to the fast command path.
+
 ## Install from the Bohay marketplace
 
 Register the public Bohay repository as a Codex marketplace, then install the

--- a/website/src/content/docs/docs/guides/remote.mdx
+++ b/website/src/content/docs/docs/guides/remote.mdx
@@ -5,6 +5,7 @@ description: Run a session on another machine over plain SSH, with no port forwa
 
 ```sh
 bohay --remote my-server        # any host from ~/.ssh/config, or user@host
+bohay --session api --remote my-server   # the remote host's named api session
 ```
 
 That's the whole setup. bohay connects over **plain `ssh`**, starts (or

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -4,10 +4,18 @@ description: The JSON control API, covering wire format, methods, and the event 
 ---
 
 Everything the CLI does goes over a local socket speaking newline-delimited
-JSON at `~/.bohay/bohay.sock` (the path is injected into every pane as
-`$BOHAY_SOCKET_PATH`). The CLI is a thin wrapper: **every `bohay <verb>` maps
-to one method**, so the easiest way to learn the API is to use the CLI and
-read its JSON output.
+JSON. The default server remains at `~/.bohay/bohay.sock`. A named server
+normally uses `~/.bohay/sessions/<name>/bohay.sock`. On Unix, an unusually long
+custom `BOHAY_HOME` gets a deterministic short socket alias under an owner-only
+directory in `/tmp` to stay within the operating system's path limit.
+
+The resolved path is injected into every pane as `$BOHAY_SOCKET_PATH`. That
+socket is the authority boundary, so methods do not need a session parameter.
+Use `bohay --session <name> <command>` from outside a pane. Inside a pane, keep
+the inherited socket so commands cannot drift to another server. The CLI is a
+thin wrapper: **every server command maps to one method**, so the easiest way
+to learn the API is to use the CLI and read its JSON output. Session list,
+stop, and delete are local lifecycle helpers that resolve the chosen socket.
 
 ## Wire format
 
@@ -202,5 +210,5 @@ still spell these `node.created` / `node.closed`) · `tab.created` · `tab.close
 - The socket is **owner-only** (`0600`, in a `0700` dir). Access equals
   command execution as your user. See the
   [security model](/docs/explanation/security/).
-- `ping` returns the server's version, useful for health checks and
-  upgrade detection.
+- `ping` returns the server's version and selected session name, useful for
+  health checks, upgrade detection, and routing verification.

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -15,6 +15,7 @@ bohay: Mission control for your AI coding agents
 usage: bohay <command> [args]
 
   (no args)            launch / attach the TUI
+  --session <name>     target one named server session
   help                 show this help
   doctor               check optional external tools (git, gh, …)
   ping                 check the server
@@ -141,6 +142,12 @@ orchestration (multiple agents on one project, docs/22):
 
 events:
   events                     stream live status changes
+
+sessions:
+  session list [--json]      list default and named server sessions
+  session attach <name>      start or attach the named session
+  session stop <name> [--json]    stop only the named session and its panes
+  session delete <name> [--json]  delete a stopped named session
 
 remote:
   --remote <host> [ssh args] attach to a bohay session on <host> over plain ssh


### PR DESCRIPTION
Add support for isolated named Bohay servers and session-focused workflows.

## What
- Add session-aware support across the CLI, module runtime, dispatch paths, IPC, and persistence layer.
- Add and update Bohay skill references for advanced control and isolation workflows.
- Update user docs for architecture, concepts, installation, plugin, remote, API, and CLI sections to describe new session behavior.

## Why
Users need a stable way to run multiple isolated Bohay server instances with named sessions while keeping runtime, networking, and docs aligned with the new behavior.

## Validation
- test: not run (not run in this PR step)
- clippy: not run
- formatting: not run

## Scope review
No unrelated files were identified in the commit diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multiple independent named Bohay sessions.
  - Added commands to list, attach, stop, and safely delete sessions.
  - Added `--session <name>` targeting for local and remote commands.
  - Session-specific workspaces, panes, snapshots, and orchestration state are now isolated.
  - Ping responses identify the selected session.

- **Documentation**
  - Added guidance for session management, remote connections, CLI usage, storage, and API behavior.
  - Clarified default-session compatibility and deletion safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->