### PR TITLE
perf(server): answer API requests and waits without loop-tick latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ RELEASING.md
 homebrew-bohay/
 .claude/
 .agents/skills/
+tests/
 
 # Local-only maintainer identity map (contains email; not for GitHub).
 .mailmap

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -95,7 +95,14 @@ impl App {
         {
             self.last_proc_at = now;
             self.proc_scan_inflight = true;
-            let pids: Vec<u32> = self.panes.values().filter_map(|p| p.child_pid).collect();
+            let pids: Vec<u32> = self
+                .panes
+                .values()
+                .filter_map(|p| {
+                    let pid = p.child_pid.load(std::sync::atomic::Ordering::SeqCst);
+                    (pid != 0).then_some(pid)
+                })
+                .collect();
             let tx = self.app_tx.clone();
             std::thread::spawn(move || {
                 let found = crate::platform::descendant_commands(&pids);

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2,6 +2,26 @@
 //! per-pane agent-detection tick. Methods on [`App`](super::App).
 
 use super::*;
+use std::sync::mpsc::Sender;
+
+/// A parked `wait.output` request (docs/81): reply when the pane's recent
+/// output contains `needle`, or the optional deadline passes.
+pub struct OutputWait {
+    pub request_id: String,
+    pub needle: String,
+    pub reply: Sender<String>,
+    pub deadline: Option<Instant>,
+}
+
+/// The canonical `wait.output` response: `matched` says whether the marker
+/// appeared before the deadline.
+fn wait_response(request_id: &str, matched: bool, pane: Option<PaneId>) -> String {
+    let result = match pane {
+        Some(id) => json!({ "type": "wait", "matched": matched, "pane": id.0.to_string() }),
+        None => json!({ "type": "wait", "matched": matched }),
+    };
+    json!({ "id": request_id, "result": result }).to_string()
+}
 
 /// Debounce dwell for committing a newly-desired agent state (hysteresis).
 /// Active states publish instantly (responsive sidebar); the fall back to a
@@ -1803,7 +1823,7 @@ impl App {
         })
     }
 
-    fn resolve_pane(&self, p: &Value) -> Option<PaneId> {
+    pub(crate) fn resolve_pane(&self, p: &Value) -> Option<PaneId> {
         match p.get("pane") {
             Some(v) => {
                 let raw = v
@@ -1814,6 +1834,109 @@ impl App {
                 self.panes.contains_key(&id).then_some(id)
             }
             None => Some(self.layout().focus),
+        }
+    }
+
+    /// The pane's recent output snapshot — the same view `pane.read` exposes.
+    pub(crate) fn pane_recent_text(&self, id: PaneId) -> String {
+        self.panes
+            .get(&id)
+            .and_then(|pane| pane.engine.lock().ok().map(|e| e.detection_text(200)))
+            .unwrap_or_default()
+    }
+
+    /// Register a server-side `wait.output` (docs/81). An already-visible
+    /// marker replies immediately; otherwise the waiter is parked and answered
+    /// by the pane's next output event — no polling on either side.
+    pub(crate) fn register_output_wait(
+        &mut self,
+        id: PaneId,
+        request_id: String,
+        needle: String,
+        reply: Sender<String>,
+        timeout: Option<Duration>,
+    ) {
+        let recent = self.pane_recent_text(id);
+        if recent.contains(&needle) {
+            let _ = reply.send(wait_response(&request_id, true, Some(id)));
+            return;
+        }
+        let deadline = timeout.map(|d| Instant::now() + d);
+        self.output_waits.entry(id).or_default().push(OutputWait {
+            request_id,
+            needle,
+            reply,
+            deadline,
+        });
+    }
+
+    /// Answer every waiter on `id` whose needle is now in the pane's output;
+    /// keep the rest parked. Called when the pane produces output.
+    pub(crate) fn check_output_waits(&mut self, id: PaneId) {
+        if !self.output_waits.contains_key(&id) {
+            return;
+        }
+        let text = self.pane_recent_text(id);
+        let Some(waiters) = self.output_waits.get_mut(&id) else {
+            return;
+        };
+        let mut keep = Vec::with_capacity(waiters.len());
+        for waiter in waiters.drain(..) {
+            if text.contains(&waiter.needle) {
+                let _ = waiter
+                    .reply
+                    .send(wait_response(&waiter.request_id, true, Some(id)));
+            } else {
+                keep.push(waiter);
+            }
+        }
+        // A waiter still parked means the needle may land inside an already-
+        // coalesced burst. Clear the pane's announcement flag so its next
+        // output read wakes the loop immediately instead of the idle tick.
+        if !keep.is_empty() {
+            if let Some(pane) = self.panes.get(&id) {
+                pane.rearm_pty_notify();
+            }
+        }
+        *waiters = keep;
+    }
+
+    /// Parked-waiter housekeeping, called from the loop tick (docs/81):
+    /// re-test every pane with waiters against its latest output — a marker
+    /// can arrive inside an already-coalesced burst with no PtyData event —
+    /// then expire any deadline that lapsed. A no-op while nobody waits.
+    pub(crate) fn tick_output_waits(&mut self, now: Instant) {
+        if self.output_waits.is_empty() {
+            return;
+        }
+        let panes: Vec<PaneId> = self.output_waits.keys().copied().collect();
+        for id in panes {
+            self.check_output_waits(id);
+        }
+        for waiters in self.output_waits.values_mut() {
+            waiters.retain(|waiter| {
+                if waiter.deadline.is_some_and(|d| now >= d) {
+                    let _ = waiter
+                        .reply
+                        .send(wait_response(&waiter.request_id, false, None));
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        self.output_waits.retain(|_, waiters| !waiters.is_empty());
+    }
+
+    /// Fail every waiter on a closing pane; `pane.read` for it can no longer
+    /// see new output.
+    pub(crate) fn cancel_output_waits(&mut self, id: PaneId) {
+        if let Some(waiters) = self.output_waits.remove(&id) {
+            for waiter in waiters {
+                let _ = waiter
+                    .reply
+                    .send(wait_response(&waiter.request_id, false, None));
+            }
         }
     }
 
@@ -2906,5 +3029,77 @@ mod tests {
         assert!(!valid_agent_name("Bad")); // uppercase
         assert!(!valid_agent_name("has space"));
         assert!(!valid_agent_name(&"x".repeat(33))); // too long
+    }
+
+    /// `wait.output` never polls: an already-visible marker resolves on
+    /// registration, fresh output resolves on the next output event, and a
+    /// deadline lapses on the loop tick (docs/81).
+    #[test]
+    fn wait_output_resolves_immediately_or_on_output_or_deadline() {
+        use std::sync::mpsc::{Receiver, RecvTimeoutError};
+        let _env = crate::persist::test_env("wait-output");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+
+        // Immediate: the marker is already in the pane's recent output.
+        app.panes
+            .get(&pane)
+            .unwrap()
+            .engine
+            .lock()
+            .unwrap()
+            .advance(b"ready NOW\r\n");
+        let (reply, rx): (_, Receiver<String>) = std::sync::mpsc::channel();
+        app.register_output_wait(pane, "t1".into(), "NOW".into(), reply, None);
+        assert!(rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .contains("\"matched\":true"));
+
+        // Parked: resolves only when the pane produces matching output.
+        let (reply, rx): (_, Receiver<String>) = std::sync::mpsc::channel();
+        app.register_output_wait(pane, "t2".into(), "LATER".into(), reply, None);
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(50)),
+            Err(RecvTimeoutError::Timeout)
+        );
+        app.panes
+            .get(&pane)
+            .unwrap()
+            .engine
+            .lock()
+            .unwrap()
+            .advance(b"arrives LATER\r\n");
+        app.check_output_waits(pane);
+        assert!(rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .contains("\"matched\":true"));
+
+        // Deadline: an unmatched waiter lapses on the tick.
+        let (reply, rx): (_, Receiver<String>) = std::sync::mpsc::channel();
+        app.register_output_wait(
+            pane,
+            "t3".into(),
+            "NEVER".into(),
+            reply,
+            Some(Duration::from_millis(10)),
+        );
+        app.tick_output_waits(Instant::now() + Duration::from_secs(1));
+        assert!(rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .contains("\"matched\":false"));
+
+        // A closed pane fails its parked waiters.
+        let (reply, rx): (_, Receiver<String>) = std::sync::mpsc::channel();
+        app.register_output_wait(pane, "t4".into(), "NEVER".into(), reply, None);
+        app.cancel_output_waits(pane);
+        assert!(rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .contains("\"matched\":false"));
+        assert!(app.output_waits.is_empty(), "no waiters leak");
     }
 }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1868,7 +1868,12 @@ impl App {
             let _ = reply.send(wait_response(&request_id, true, Some(id)));
             return;
         }
-        let deadline = timeout.map(|d| Instant::now() + d);
+        // Always bound the wait: a client that disconnects cannot be detected on
+        // the reply channel, so an uncapped waiter would be re-scanned forever.
+        // A shorter caller-specified timeout still wins; a longer one (or none)
+        // is capped so an abandoned waiter is reclaimed within an hour.
+        const MAX_WAIT: Duration = Duration::from_secs(3600);
+        let deadline = Some(Instant::now() + timeout.unwrap_or(MAX_WAIT).min(MAX_WAIT));
         self.output_waits.entry(id).or_default().push(OutputWait {
             request_id,
             needle,
@@ -1916,9 +1921,16 @@ impl App {
         if self.output_waits.is_empty() {
             return;
         }
-        let panes: Vec<PaneId> = self.output_waits.keys().copied().collect();
-        for id in panes {
-            self.check_output_waits(id);
+        // A marker can arrive inside an already-coalesced burst, so re-test
+        // periodically — but not every tick, which would lock each waiting pane's
+        // VT engine and rebuild its recent text at the loop rate (~30-60/s).
+        // Deadline expiry below still runs on every tick.
+        if now.duration_since(self.last_output_wait_scan) >= Duration::from_millis(100) {
+            self.last_output_wait_scan = now;
+            let panes: Vec<PaneId> = self.output_waits.keys().copied().collect();
+            for id in panes {
+                self.check_output_waits(id);
+            }
         }
         for waiters in self.output_waits.values_mut() {
             waiters.retain(|waiter| {
@@ -3107,6 +3119,40 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .unwrap()
             .contains("\"matched\":false"));
+        assert!(app.output_waits.is_empty(), "no waiters leak");
+    }
+
+    /// A waiter registered without `timeout_s` still gets a bounded deadline, so
+    /// a disconnected client cannot leave it parked for the life of the pane.
+    #[test]
+    fn output_wait_without_timeout_is_bounded() {
+        let _env = crate::persist::test_env("wait-bound");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let (reply, _rx): (_, std::sync::mpsc::Receiver<String>) = std::sync::mpsc::channel();
+        app.register_output_wait(pane, "t".into(), "NEVER".into(), reply, None);
+        let waiter = &app.output_waits[&pane][0];
+        assert!(waiter.deadline.is_some(), "an abandoned waiter must expire");
+    }
+
+    /// Every pane-close path funnels through `drop_leaf_runtime`, so closing a
+    /// workspace or tab must fail its parked waiters rather than leaking them.
+    #[test]
+    fn closing_a_workspace_cancels_parked_waiters() {
+        let _env = crate::persist::test_env("wait-close-ws");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let (reply, rx): (_, std::sync::mpsc::Receiver<String>) = std::sync::mpsc::channel();
+        app.register_output_wait(pane, "t".into(), "NEVER".into(), reply, None);
+        app.close_workspace(0);
+        assert!(
+            rx.recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .contains("\"matched\":false"),
+            "a closed workspace fails its parked waiters"
+        );
         assert!(app.output_waits.is_empty(), "no waiters leak");
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1716,10 +1716,12 @@ impl App {
             return;
         };
         let cwd = pane.cwd.clone();
-        let procs = pane
-            .child_pid
-            .map(crate::platform::process_tree)
-            .unwrap_or_default();
+        let pid = pane.child_pid.load(std::sync::atomic::Ordering::SeqCst);
+        let procs = if pid != 0 {
+            crate::platform::process_tree(pid)
+        } else {
+            Vec::new()
+        };
         self.cmd_inspect = Some(CmdInspect {
             pane: id,
             cwd,

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -134,12 +134,34 @@ impl App {
     /// changes when the pane echoes (a separate `PtyData` event), so we don't waste
     /// a full render per keystroke.
     pub fn handle_event(&mut self, ev: AppEvent) -> bool {
-        // Closing the last workspace empties `workspaces` and sets `should_quit`; the
-        // loop drains the rest of the event batch before it checks that flag, so
-        // ignore events here once there's nothing left to act on (`layout()`
-        // would otherwise index an empty `workspaces`).
+        // Control-API requests and parked `wait.output` replies must be answered
+        // even with no workspace open. A server that has closed its last node
+        // stays alive (docs/43 §3.3), and the methods that reopen one are the
+        // only way back; dropping the reply channel here would leave the caller
+        // reading EOF instead of a `workspace.open` / `server.stop` answer.
         if self.workspaces.is_empty() {
-            return false;
+            match ev {
+                AppEvent::Api(req) => {
+                    let resp = self.handle_api(&req);
+                    let _ = req.reply.send(resp);
+                    return true;
+                }
+                AppEvent::WaitOutput { id, reply, .. } => {
+                    let _ = reply.send(
+                        json!({ "id": id, "error": {
+                            "code": "no_session", "message": "no active session"
+                        }})
+                        .to_string(),
+                    );
+                    return true;
+                }
+                // Closing the last workspace empties `workspaces` and sets
+                // `should_quit`; the loop drains the rest of the event batch
+                // before it checks that flag, so ignore everything else here
+                // once there's nothing left to act on (`layout()` would
+                // otherwise index an empty `workspaces`).
+                _ => return false,
+            }
         }
         match ev {
             AppEvent::Key(k) => self.handle_key(k),
@@ -2379,6 +2401,30 @@ mod tests {
             app.force_redraw,
             "resize requests a full repaint, not just a diff"
         );
+    }
+
+    // A server that has closed its last node keeps running (docs/43 §3.3), so
+    // control-API requests routed through the event channel must still be
+    // answered — otherwise the reply channel drops and the CLI reads EOF.
+    #[test]
+    fn api_requests_are_answered_with_no_workspace_open() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        app.close_workspace(0);
+        assert!(app.workspaces.is_empty(), "the only node is gone");
+        let (reply, rx) = std::sync::mpsc::channel();
+        let req = crate::ipc::api::ApiRequest {
+            id: "ping".into(),
+            method: "ping".into(),
+            params: serde_json::Value::Null,
+            reply,
+        };
+        let dirty = app.handle_event(AppEvent::Api(req));
+        assert!(dirty, "an answered control request counts as activity");
+        let resp = rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("an empty server still answers its control API");
+        assert!(resp.contains("pong"), "got a real pong, not EOF: {resp}");
     }
 
     // Agents treat Enter as "submit" and Shift+Enter as "new line". A terminal

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -180,10 +180,46 @@ impl App {
                 if let Some(s) = self.status.get_mut(&id) {
                     s.last_activity = Instant::now();
                 }
+                // A parked `wait.output` for this pane just got new output to
+                // test against — resolve it on the same wake (docs/81).
+                self.check_output_waits(id);
                 true // the pane's screen advanced
             }
             AppEvent::PtyExit(id) => {
                 self.close_pane(id);
+                true
+            }
+            // Control-API requests arrive on the event channel so the loop wakes
+            // for them immediately (docs/81). Answer inline: like the old
+            // server-side drain, an answered request counts as activity.
+            AppEvent::Api(req) => {
+                let resp = self.handle_api(&req);
+                let _ = req.reply.send(resp);
+                true
+            }
+            // A `wait.output` connection parks its reply here and blocks until
+            // the pane's output matches (docs/81) — no polling on either side.
+            AppEvent::WaitOutput {
+                id: request_id,
+                pane,
+                needle,
+                reply,
+                timeout,
+            } => {
+                let params = json!({ "pane": pane });
+                match self.resolve_pane(&params) {
+                    Some(id) => {
+                        self.register_output_wait(id, request_id, needle, reply, timeout);
+                    }
+                    None => {
+                        let _ = reply.send(
+                            json!({ "id": request_id, "error": {
+                                "code": "not_found", "message": "pane not found"
+                            }})
+                            .to_string(),
+                        );
+                    }
+                }
                 true
             }
             AppEvent::ModuleCommandFinished {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1291,6 +1291,9 @@ pub struct App {
     /// `pane.list` for diagnostics and performance comparisons.
     detection_extractions: u64,
     detection_skips: u64,
+    /// Pending server-side `wait.output` requests keyed by pane (docs/81).
+    /// Satisfied by the pane's next output event, expired by the loop tick.
+    output_waits: HashMap<PaneId, Vec<crate::app::dispatch::OutputWait>>,
     /// Scroll offsets + scrollable regions for the two sidebar lists, so long
     /// WORKSPACES / AGENTS lists can be wheeled through.
     pub workspaces_scroll: usize,
@@ -1606,6 +1609,7 @@ impl App {
                 .unwrap_or_else(Instant::now),
             detection_extractions: 0,
             detection_skips: 0,
+            output_waits: HashMap::new(),
             workspaces_scroll: 0,
             agents_scroll: 0,
             agents_active_only: false,
@@ -2033,6 +2037,7 @@ impl App {
                 .unwrap_or_else(Instant::now),
             detection_extractions: 0,
             detection_skips: 0,
+            output_waits: HashMap::new(),
             workspaces_scroll: 0,
             agents_scroll: 0,
             agents_active_only: false,
@@ -4117,6 +4122,8 @@ impl App {
 
     fn close_pane(&mut self, id: PaneId) {
         self.drop_leaf_runtime(id);
+        // Parked `wait.output` calls can never see new output on a dead pane.
+        self.cancel_output_waits(id);
         // Drop any live alias for the dead pane so a name never resolves to a
         // reallocated pane id (agent_names is ephemeral by design).
         self.agent_names.retain(|_, p| *p != id);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1294,6 +1294,10 @@ pub struct App {
     /// Pending server-side `wait.output` requests keyed by pane (docs/81).
     /// Satisfied by the pane's next output event, expired by the loop tick.
     output_waits: HashMap<PaneId, Vec<crate::app::dispatch::OutputWait>>,
+    /// Throttle for re-scanning parked waiters — the scan locks each waiting
+    /// pane's VT engine and rebuilds its recent text, so it runs at ~100ms,
+    /// not at the render frame rate. Deadline expiry still runs every tick.
+    last_output_wait_scan: Instant,
     /// Scroll offsets + scrollable regions for the two sidebar lists, so long
     /// WORKSPACES / AGENTS lists can be wheeled through.
     pub workspaces_scroll: usize,
@@ -1610,6 +1614,7 @@ impl App {
             detection_extractions: 0,
             detection_skips: 0,
             output_waits: HashMap::new(),
+            last_output_wait_scan: Instant::now(),
             workspaces_scroll: 0,
             agents_scroll: 0,
             agents_active_only: false,
@@ -2038,6 +2043,7 @@ impl App {
             detection_extractions: 0,
             detection_skips: 0,
             output_waits: HashMap::new(),
+            last_output_wait_scan: Instant::now(),
             workspaces_scroll: 0,
             agents_scroll: 0,
             agents_active_only: false,
@@ -4140,6 +4146,10 @@ impl App {
         self.panes.remove(&id);
         self.status.remove(&id);
         self.views.remove(&id);
+        // Parked `wait.output` calls can never see new output on a dead pane, and
+        // every close path (close_pane, close_tab, close_workspace) funnels
+        // through here — so cancellation cannot be forgotten by a new path.
+        self.cancel_output_waits(id);
         self.editor_files.remove(&id); // untrack an editor pane's file (docs/38)
         self.module_panes.remove(&id); // untrack a module pane (MOD-2)
         if self.preview_view == Some(id) {
@@ -4155,8 +4165,6 @@ impl App {
 
     fn close_pane(&mut self, id: PaneId) {
         self.drop_leaf_runtime(id);
-        // Parked `wait.output` calls can never see new output on a dead pane.
-        self.cancel_output_waits(id);
         // Drop any live alias for the dead pane so a name never resolves to a
         // reallocated pane id (agent_names is ephemeral by design).
         self.agent_names.retain(|_, p| *p != id);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2448,6 +2448,36 @@ impl App {
         }
     }
 
+    /// `spawn_into`, but with the shell forked off-loop (docs/82): the pane
+    /// exists immediately so `pane split` answers before paying the fork.
+    /// Used only where synchronous failure reporting is not required — the
+    /// sync `spawn_into` keeps `workspace.open`'s "shell failed to start"
+    /// contract.
+    fn spawn_into_deferred(&mut self, cwd: PathBuf) -> Option<PaneId> {
+        let id = PaneId::alloc();
+        let shell = crate::platform::resolve_shell(&self.config.shell);
+        let history_budget_bytes = self.config.scrollback_bytes();
+        let pane = Pane::spawn_deferred(
+            id,
+            80,
+            24,
+            cwd,
+            self.app_tx.clone(),
+            &shell,
+            history_budget_bytes,
+        );
+        let cmd = pane.command.clone();
+        self.panes.insert(id, pane);
+        self.status.insert(id, PaneStatus::new(cmd));
+        self.zoomed = false;
+        self.session_dirty = true;
+        self.emit_event(
+            "pane.created",
+            serde_json::json!({"pane": id.0.to_string()}),
+        );
+        Some(id)
+    }
+
     /// `spawn_into`, but the shell starts on the `resume` command (falling back
     /// to typing it into the prompt when the shell family isn't recognised) —
     /// a resumed session opens straight into its agent.
@@ -2501,7 +2531,7 @@ impl App {
 
     fn split(&mut self, axis: Axis) {
         let cwd = self.focused_cwd();
-        if let Some(id) = self.spawn_into(cwd) {
+        if let Some(id) = self.spawn_into_deferred(cwd) {
             self.layout_mut().split_focused(axis, id);
         }
     }
@@ -3613,8 +3643,10 @@ impl App {
             .panes
             .iter()
             .filter_map(|(id, p)| {
-                p.child_pid
-                    .and_then(crate::platform::process_cwd)
+                let pid = p.child_pid.load(std::sync::atomic::Ordering::SeqCst);
+                (pid != 0)
+                    .then(|| crate::platform::process_cwd(pid))
+                    .flatten()
                     .map(|c| (*id, c))
             })
             .collect();
@@ -3659,7 +3691,8 @@ impl App {
         let Some(by_pid) = found else { return false };
         let mut next: HashMap<PaneId, Vec<String>> = HashMap::new();
         for (id, pane) in self.panes.iter() {
-            if let Some(cmds) = pane.child_pid.and_then(|pid| by_pid.get(&pid)) {
+            let pid = pane.child_pid.load(std::sync::atomic::Ordering::SeqCst);
+            if let Some(cmds) = (pid != 0).then(|| by_pid.get(&pid)).flatten() {
                 next.insert(*id, cmds.clone());
             }
         }
@@ -5089,7 +5122,13 @@ mod tests {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         let id = app.layout().focus;
-        let root = app.panes.get(&id).unwrap().child_pid.unwrap();
+        let root = app
+            .panes
+            .get(&id)
+            .unwrap()
+            .child_pid
+            .load(std::sync::atomic::Ordering::SeqCst);
+        assert_ne!(root, 0, "the fresh pane has a spawned child");
         let shell = app.panes.get(&id).unwrap().command.clone();
         {
             let st = app.status.get_mut(&id).unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1015,28 +1015,59 @@ fn parse_wait(args: &[String]) -> Result<WaitSpec> {
 }
 
 /// `bohay wait …` — block until the condition holds (exit 0) or the timeout
-/// elapses (exit 2). Built entirely on existing API methods + the event stream.
+/// elapses (exit 2). `wait output` is answered server-side: the connection
+/// stays open and the server replies the moment the pane's output matches,
+/// so the CLI never polls (docs/81). Older servers answer `unknown_method`
+/// and fall back to a fast client-side poll.
 fn wait_cmd(args: &[String]) -> Result<i32> {
     let spec = parse_wait(args)?;
     let deadline = spec
         .timeout
         .map(|t| Instant::now() + Duration::from_secs_f64(t));
     match spec.condition {
-        WaitFor::Output { needle } => loop {
-            let v = send_request("pane.read", json!({ "pane": spec.pane }))?;
-            let text = v
+        WaitFor::Output { needle } => {
+            let mut params = json!({ "pane": spec.pane, "match": needle });
+            if let Some(timeout) = spec.timeout {
+                params["timeout_s"] = json!(timeout);
+            }
+            let v = send_request("wait.output", params)?;
+            let matched = v
                 .get("result")
-                .and_then(|r| r.get("text"))
-                .and_then(|t| t.as_str())
-                .unwrap_or("");
-            if text.contains(&needle) {
+                .and_then(|r| r.get("matched"))
+                .and_then(|m| m.as_bool())
+                .unwrap_or(false);
+            if matched {
                 return Ok(0);
             }
-            if deadline.is_some_and(|d| Instant::now() >= d) {
-                return Ok(2);
+            // Pre-`wait.output` server: poll pane.read at a tight interval.
+            let unknown = v
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|c| c.as_str())
+                == Some("invalid_request")
+                && v.get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .is_some_and(|m| m.starts_with("unknown method"));
+            if unknown {
+                loop {
+                    let v = send_request("pane.read", json!({ "pane": spec.pane }))?;
+                    let text = v
+                        .get("result")
+                        .and_then(|r| r.get("text"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    if text.contains(&needle) {
+                        return Ok(0);
+                    }
+                    if deadline.is_some_and(|d| Instant::now() >= d) {
+                        return Ok(2);
+                    }
+                    std::thread::sleep(Duration::from_millis(25));
+                }
             }
-            std::thread::sleep(Duration::from_millis(200));
-        },
+            Ok(2)
+        }
         WaitFor::AgentStatus { status } => wait_status_stream(&spec.pane, &status, deadline),
     }
 }
@@ -1286,8 +1317,8 @@ fn agent_send_cmd(args: &[String]) -> Result<i32> {
     }
 }
 
-/// Wait for a just-prompted agent to finish, the way `herdr agent prompt --wait`
-/// does: the prompt must produce a lifecycle change within a few seconds or we
+/// Wait for a just-prompted agent to finish, like prompt-and-wait tools do:
+/// the prompt must produce a lifecycle change within a few seconds or we
 /// call it **stalled** (exit 3) rather than hang; then we wait until the agent
 /// settles at `idle`/`done`/`blocked` (exit 0), or the deadline passes (exit 2).
 fn agent_wait_settled(pane: &str, deadline: Instant) -> Result<i32> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1066,6 +1066,16 @@ fn wait_cmd(args: &[String]) -> Result<i32> {
                     std::thread::sleep(Duration::from_millis(25));
                 }
             }
+            // A server error (bad pane id, no active session, invalid timeout) is
+            // not a timeout: report it so a failed request is not mistaken for an
+            // elapsed deadline.
+            if let Some(err) = v.get("error") {
+                let msg = err
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("wait.output failed");
+                eprintln!("wait output: {msg}");
+            }
             Ok(2)
         }
         WaitFor::AgentStatus { status } => wait_status_stream(&spec.pane, &status, deadline),

--- a/src/event.rs
+++ b/src/event.rs
@@ -113,4 +113,18 @@ pub enum AppEvent {
     /// An *asked-for* check finished (the changelog's "Check for updates"
     /// button). Carries the outcome so the answer can be shown either way.
     UpdateChecked(crate::update::CheckOutcome),
+    /// A control-API request from a CLI invocation or module process. Arrives on
+    /// the same channel as every other event so the loop wakes immediately —
+    /// draining it on the idle tick would add a tick's latency to every CLI call.
+    Api(crate::ipc::api::ApiRequest),
+    /// A `wait.output` request (docs/81): reply once the pane's output contains
+    /// the needle, or the deadline elapses. Carries its own reply channel so
+    /// the connection can block without ever polling the loop.
+    WaitOutput {
+        id: String,
+        pane: String,
+        needle: String,
+        timeout: Option<std::time::Duration>,
+        reply: Sender<String>,
+    },
 }

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -12,6 +12,7 @@ use std::thread;
 
 use serde_json::{json, Value};
 
+use crate::event::AppEvent;
 use crate::ipc::transport::{self, Conn};
 
 /// A request handed to the app loop, with a channel to send the reply back.
@@ -61,17 +62,19 @@ pub fn bind_server(
 }
 
 /// Accept API connections from an already-bound listener on a background thread.
-pub fn start_server(listener: transport::Listener, api_tx: Sender<ApiRequest>, bus: EventBus) {
+/// Requests are forwarded into the app's event channel so the loop wakes the
+/// moment one arrives instead of waiting for its idle tick.
+pub fn start_server(listener: transport::Listener, event_tx: Sender<AppEvent>, bus: EventBus) {
     thread::spawn(move || {
         for stream in transport::incoming(&listener) {
-            let api_tx = api_tx.clone();
+            let event_tx = event_tx.clone();
             let bus = bus.clone();
-            thread::spawn(move || handle_conn(stream, api_tx, bus));
+            thread::spawn(move || handle_conn(stream, event_tx, bus));
         }
     });
 }
 
-fn handle_conn(stream: Conn, api_tx: Sender<ApiRequest>, bus: EventBus) {
+fn handle_conn(stream: Conn, event_tx: Sender<AppEvent>, bus: EventBus) {
     let mut writer = stream.clone();
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
@@ -135,14 +138,52 @@ fn handle_conn(stream: Conn, api_tx: Sender<ApiRequest>, bus: EventBus) {
         return;
     }
 
+    // `wait.output` parks its reply inside the app and answers when the pane's
+    // output matches or the deadline lapses — the connection just blocks on
+    // the reply channel (docs/81).
+    if method == "wait.output" {
+        let pane = params.get("pane").and_then(|v| v.as_str()).unwrap_or("");
+        let needle = params.get("match").and_then(|v| v.as_str()).unwrap_or("");
+        let timeout = params
+            .get("timeout_s")
+            .and_then(|v| v.as_f64())
+            .map(std::time::Duration::from_secs_f64);
+        if pane.is_empty() || needle.is_empty() {
+            let _ = writeln!(
+                writer,
+                "{}",
+                json!({"id":id,"error":{"code":"invalid_request",
+                    "message":"wait.output needs a pane and a match"}})
+            );
+            return;
+        }
+        let (reply, reply_rx) = mpsc::channel::<String>();
+        if event_tx
+            .send(AppEvent::WaitOutput {
+                id,
+                pane: pane.to_string(),
+                needle: needle.to_string(),
+                timeout,
+                reply,
+            })
+            .is_err()
+        {
+            return;
+        }
+        if let Ok(resp) = reply_rx.recv() {
+            let _ = writeln!(writer, "{resp}");
+        }
+        return;
+    }
+
     let (reply, reply_rx) = mpsc::channel::<String>();
-    if api_tx
-        .send(ApiRequest {
+    if event_tx
+        .send(AppEvent::Api(ApiRequest {
             id,
             method,
             params,
             reply,
-        })
+        }))
         .is_err()
     {
         return;

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -144,10 +144,17 @@ fn handle_conn(stream: Conn, event_tx: Sender<AppEvent>, bus: EventBus) {
     if method == "wait.output" {
         let pane = params.get("pane").and_then(|v| v.as_str()).unwrap_or("");
         let needle = params.get("match").and_then(|v| v.as_str()).unwrap_or("");
-        let timeout = params
-            .get("timeout_s")
-            .and_then(|v| v.as_f64())
-            .map(std::time::Duration::from_secs_f64);
+        let timeout = match parse_timeout_s(&params) {
+            Ok(t) => t,
+            Err(msg) => {
+                let _ = writeln!(
+                    writer,
+                    "{}",
+                    json!({"id":id,"error":{"code":"invalid_request","message":msg}})
+                );
+                return;
+            }
+        };
         if pane.is_empty() || needle.is_empty() {
             let _ = writeln!(
                 writer,
@@ -190,5 +197,51 @@ fn handle_conn(stream: Conn, event_tx: Sender<AppEvent>, bus: EventBus) {
     }
     if let Ok(resp) = reply_rx.recv() {
         let _ = writeln!(writer, "{resp}");
+    }
+}
+
+/// Parse an optional `timeout_s` (fractional seconds) for `wait.output`.
+/// `None` only when the field is absent; a present but non-numeric, negative,
+/// NaN, infinite, or overflowing value is rejected rather than mapped to an
+/// unbounded wait or allowed to panic `from_secs_f64`.
+fn parse_timeout_s(params: &Value) -> Result<Option<std::time::Duration>, &'static str> {
+    let Some(v) = params.get("timeout_s") else {
+        return Ok(None);
+    };
+    let Some(secs) = v.as_f64() else {
+        return Err("timeout_s must be a number");
+    };
+    match std::time::Duration::try_from_secs_f64(secs) {
+        Ok(d) => Ok(Some(d)),
+        Err(_) => Err("timeout_s must be a non-negative finite number of seconds"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_s_parses_without_panicking() {
+        // Absent -> no deadline.
+        assert!(parse_timeout_s(&json!({})).unwrap().is_none());
+        // Valid -> Some(duration).
+        let d = parse_timeout_s(&json!({ "timeout_s": 1.5 }))
+            .unwrap()
+            .unwrap();
+        assert_eq!(d, std::time::Duration::from_millis(1500));
+        // Zero is a valid immediate deadline.
+        assert!(parse_timeout_s(&json!({ "timeout_s": 0 }))
+            .unwrap()
+            .is_some());
+        // Negative, overflowing, and non-numeric values all reject instead of
+        // panicking or silently widening the wait.
+        for bad in [
+            json!({ "timeout_s": -1.0 }),
+            json!({ "timeout_s": 1e300 }),
+            json!({ "timeout_s": "5" }),
+        ] {
+            assert!(parse_timeout_s(&bad).is_err(), "{bad} must be rejected");
+        }
     }
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -143,7 +143,6 @@ pub fn run() -> Result<()> {
     }
     api::set_socket_path(sock.clone());
 
-    let (api_tx, api_rx) = mpsc::channel::<api::ApiRequest>();
     let events = api::new_bus();
     let api_listener = api::bind_server(&sock, &startup_lock)?;
     let client_listener = match bind_client_listener(&client_sock, &startup_lock) {
@@ -171,7 +170,7 @@ pub fn run() -> Result<()> {
 
     let mut terminal_theme_enabled = app.config.theme == "terminal";
     let terminal_theme = Arc::new(AtomicBool::new(terminal_theme_enabled));
-    api::start_server(api_listener, api_tx, events);
+    api::start_server(api_listener, tx.clone(), events);
     start_client_listener(client_listener, tx.clone(), terminal_theme.clone());
     drop(startup_lock);
     // The session is restored and the API socket is listening, so a module's
@@ -260,12 +259,6 @@ pub fn run() -> Result<()> {
             foreground_activity |= changed && !background;
             background_activity |= changed && background;
         }
-        while let Ok(req) = api_rx.try_recv() {
-            let resp = app.handle_api(&req);
-            let _ = req.reply.send(resp);
-            activity = true;
-            foreground_activity = true;
-        }
         let enabled = app.config.theme == "terminal";
         if enabled != terminal_theme_enabled {
             terminal_theme_enabled = enabled;
@@ -335,10 +328,14 @@ pub fn run() -> Result<()> {
 
         // A state transition here (e.g. a silent agent reaching Done) has no PtyData
         // to ride on, so repaint when detection reports a visible change.
-        if app.detect_tick(Instant::now()) {
+        let now = Instant::now();
+        if app.detect_tick(now) {
             activity = true;
             foreground_activity = true;
         }
+        // Parked `wait.output` deadlines lapse on the tick (docs/81); a no-op
+        // while nobody is waiting.
+        app.tick_output_waits(now);
         for msg in app.pending_notify.drain(..) {
             broadcast(&mut clients, ServerMessage::Notify(msg));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -757,7 +757,6 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
     }
 
     let events = ipc::api::new_bus();
-    let (api_tx, api_rx) = mpsc::channel::<ipc::api::ApiRequest>();
     let api_listener = ipc::api::bind_server(&sock, &startup_lock)?;
 
     // Advertise the socket before spawning panes so they inherit BOHAY_SOCKET_PATH.
@@ -795,7 +794,7 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
         let tx = tx.clone();
         thread::spawn(move || input_loop(tx, pending));
     }
-    ipc::api::start_server(api_listener, api_tx, events);
+    ipc::api::start_server(api_listener, tx.clone(), events);
     drop(startup_lock);
     app.run_module_startup_hooks(); // docs/13 §3.7 — same point as the server role
     if app.config.install_agent_skill {
@@ -824,11 +823,8 @@ fn run(terminal: &mut DefaultTerminal) -> Result<()> {
         while let Ok(ev) = rx.try_recv() {
             app.handle_event(ev);
         }
-        // Service control-API requests.
-        while let Ok(req) = api_rx.try_recv() {
-            let resp = app.handle_api(&req);
-            let _ = req.reply.send(resp);
-        }
+        // Parked `wait.output` deadlines lapse on the tick (docs/81).
+        app.tick_output_waits(Instant::now());
         if app.should_quit || app.detach_requested {
             break;
         }
@@ -1902,20 +1898,21 @@ mod tests {
     fn api_serves_requests() {
         use std::io::{BufRead, BufReader, Write};
 
-        let (tx, _rx) = mpsc::channel();
-        let mut app = App::new(80, 24, tx).unwrap();
-        let (api_tx, api_rx) = mpsc::channel::<ipc::api::ApiRequest>();
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx.clone()).unwrap();
         let path = std::env::temp_dir().join(format!("bohay-test-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&path);
         let startup_lock =
             ipc::transport::acquire_server_startup_lock(path.parent().unwrap()).unwrap();
         let listener = ipc::api::bind_server(&path, &startup_lock).unwrap();
-        ipc::api::start_server(listener, api_tx, app.events.clone());
+        ipc::api::start_server(listener, tx, app.events.clone());
         drop(startup_lock);
         thread::spawn(move || {
-            while let Ok(req) = api_rx.recv() {
-                let resp = app.handle_api(&req);
-                let _ = req.reply.send(resp);
+            while let Ok(ev) = rx.recv() {
+                if let crate::event::AppEvent::Api(req) = ev {
+                    let resp = app.handle_api(&req);
+                    let _ = req.reply.send(resp);
+                }
             }
         });
 

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -411,7 +411,14 @@ impl Pane {
                     return fail();
                 };
                 drop(pair.slave);
-                // Closed between fork and handoff: hang up the fresh child.
+                // Publish the pid *before* the cancellation check: a concurrent
+                // `Drop` then either sees the pid and signals it, or sees 0 — in
+                // which case its `cancelled` store precedes this load and the
+                // hangup below runs. Checking first would let `Drop` read 0,
+                // return, and leave the child running with no owner.
+                child_pid.store(pid, Ordering::SeqCst);
+                // Closed between fork and handoff: hang up the fresh child and
+                // reap it ourselves, since no reaper thread will be spawned.
                 if cancelled.load(Ordering::SeqCst) {
                     #[cfg(unix)]
                     unsafe {
@@ -425,9 +432,11 @@ impl Pane {
                             .stderr(std::process::Stdio::null())
                             .spawn();
                     }
+                    let mut child = child;
+                    let _ = child.wait();
+                    child_exited.store(true, Ordering::SeqCst);
                     return;
                 }
-                child_pid.store(pid, Ordering::SeqCst);
 
                 // A resize raced the spawn: re-apply the latest size.
                 let latest = *size.lock().unwrap_or_else(|p| p.into_inner());

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -4,6 +4,7 @@
 
 use std::io::{Read, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -30,23 +31,30 @@ pub struct MouseModes {
 
 pub struct Pane {
     pub engine: Arc<Mutex<dyn VtEngine>>,
-    master: Box<dyn MasterPty + Send>,
+    /// `None` until a deferred spawn's worker stores it (docs/82).
+    master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
     input_tx: Sender<Vec<u8>>,
     pub cwd: PathBuf,
     pub command: String,
-    /// The shell's pid, for reading its live working directory.
-    pub child_pid: Option<u32>,
+    /// The shell's pid, for reading its live working directory and process
+    /// tree. 0 means a deferred spawn has not finished yet — callers must
+    /// treat that as "no process" rather than a real pid.
+    pub child_pid: Arc<AtomicU32>,
     /// `PtyData` coalescing: set by the reader when it announces new output,
     /// cleared by the app loop when it consumes the event. While set, further
     /// reads skip the send — a saturated PTY (thousands of 8 KB reads/s) wakes
     /// the loop once per iteration instead of once per read (measured ~30% of
     /// a core of pure wakeup churn during a `yes` firehose).
-    data_pending: Arc<std::sync::atomic::AtomicBool>,
+    data_pending: Arc<AtomicBool>,
     /// Set by the reaper once the child has been waited on. After that the OS may
     /// recycle its pid, so [`Drop`] must never signal it — it could hit an
     /// unrelated process.
-    child_exited: Arc<std::sync::atomic::AtomicBool>,
-    size: (u16, u16),
+    child_exited: Arc<AtomicBool>,
+    /// The latest requested size, shared with the deferred spawn worker so a
+    /// resize racing the spawn still lands.
+    size: Arc<Mutex<(u16, u16)>>,
+    /// Set by `Drop` so a close-before-spawn aborts the spawn worker.
+    cancelled: Arc<AtomicBool>,
 }
 
 impl Drop for Pane {
@@ -65,11 +73,17 @@ impl Drop for Pane {
     /// releases the engine and the scrollback, and the last `input_tx` drop ends
     /// the writer.
     fn drop(&mut self) {
+        // A deferred spawn that hasn't forked yet aborts in the worker; one
+        // that has forked is killed by the worker's own post-fork check.
+        self.cancelled.store(true, Ordering::SeqCst);
         // Already reaped → the pid may belong to someone else now.
-        if self.child_exited.load(std::sync::atomic::Ordering::SeqCst) {
+        if self.child_exited.load(Ordering::SeqCst) {
             return;
         }
-        let Some(pid) = self.child_pid else { return };
+        let pid = self.child_pid.load(Ordering::SeqCst);
+        if pid == 0 {
+            return;
+        }
         // SIGHUP rather than SIGKILL: a shell hangs up its jobs and exits
         // cleanly, and a deliberately `nohup`ed process still survives — the
         // same contract as closing the terminal window.
@@ -188,6 +202,35 @@ impl Pane {
         )
     }
 
+    /// Spawn an interactive shell pane whose child process starts **after**
+    /// this returns (docs/82): the pane exists (engine, input queue, writer)
+    /// immediately, and a worker thread opens the PTY, forks the shell, and
+    /// hands the writer over. `pane split` answers the CLI without paying the
+    /// fork cost on the loop thread.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn_deferred(
+        id: PaneId,
+        cols: u16,
+        rows: u16,
+        cwd: PathBuf,
+        app_tx: Sender<AppEvent>,
+        shell: &str,
+        history_budget_bytes: usize,
+    ) -> Pane {
+        let cmd = CommandBuilder::new(shell);
+        Self::build_deferred(
+            id,
+            cols,
+            rows,
+            cwd,
+            app_tx,
+            cmd,
+            basename(shell),
+            &[],
+            history_budget_bytes,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn build(
         id: PaneId,
@@ -209,29 +252,11 @@ impl Pane {
             pixel_height: 0,
         })?;
 
-        cmd.cwd(&cwd);
-        // Caller-supplied env first, then bohay's identity vars (so they can't
-        // be overridden — no spoofing the module/pane identity).
-        for (k, v) in extra_env {
-            cmd.env(k, v);
-        }
-        cmd.env("TERM", "xterm-256color");
-        cmd.env("BOHAY_ENV", "1");
-        cmd.env("BOHAY_PANE_ID", id.0.to_string());
-        if let Some(sock) = crate::ipc::api::socket_path_env() {
-            cmd.env("BOHAY_SOCKET_PATH", sock);
-        }
-        if let Some(name) = crate::session::active_name() {
-            cmd.env(crate::session::SESSION_ENV_VAR, name);
-        }
-        // This session's exact binary, so an agent can use `$BOHAY_BIN_PATH`
-        // instead of a `bohay` on PATH that may be an older install with a
-        // different CLI (skill/binary skew). Matches the server it talks to.
-        if let Ok(exe) = std::env::current_exe() {
-            cmd.env("BOHAY_BIN_PATH", exe);
-        }
+        apply_pane_env(&mut cmd, id, &cwd, extra_env);
         let child = pair.slave.spawn_command(cmd)?;
-        let child_pid = child.process_id();
+        let child_pid = child
+            .process_id()
+            .expect("a spawned child always has a pid");
         drop(pair.slave);
 
         // All bytes (user input + terminal responses) funnel through one channel
@@ -263,33 +288,196 @@ impl Pane {
         let reader = pair.master.try_clone_reader()?;
         let eng = engine.clone();
         let tx = app_tx.clone();
-        let data_pending = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let data_pending = Arc::new(AtomicBool::new(false));
         let pending = data_pending.clone();
         thread::spawn(move || read_loop(id, reader, eng, tx, pending));
 
         // Reap the child so we notice it exiting. The exit flag is set *before*
         // the event goes out, so by the time the loop closes the pane (and drops
         // it) `Drop` already knows not to signal a possibly-recycled pid.
-        let child_exited = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let child_exited = Arc::new(AtomicBool::new(false));
         let exited = child_exited.clone();
         thread::spawn(move || {
             let mut child = child;
             let _ = child.wait();
-            exited.store(true, std::sync::atomic::Ordering::SeqCst);
+            exited.store(true, Ordering::SeqCst);
             let _ = app_tx.send(AppEvent::PtyExit(id));
         });
 
         Ok(Pane {
             engine,
-            child_pid,
-            master: pair.master,
+            child_pid: Arc::new(AtomicU32::new(child_pid)),
+            master: Arc::new(Mutex::new(Some(pair.master))),
             input_tx,
             cwd,
             command,
             data_pending,
             child_exited,
-            size: (cols, rows),
+            size: Arc::new(Mutex::new((cols, rows))),
+            cancelled: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// The deferred half of `spawn_deferred` (docs/82). Returns a fully usable
+    /// pane immediately; the fork happens on a worker thread. Failures there
+    /// surface as `AppEvent::PtyExit(id)`, exactly like a child that died at
+    /// startup, so no pane is left silently dead.
+    #[allow(clippy::too_many_arguments)]
+    fn build_deferred(
+        id: PaneId,
+        cols: u16,
+        rows: u16,
+        cwd: PathBuf,
+        app_tx: Sender<AppEvent>,
+        mut cmd: CommandBuilder,
+        command: String,
+        extra_env: &[(String, String)],
+        history_budget_bytes: usize,
+    ) -> Pane {
+        // Everything a caller can observe before the child exists: the engine
+        // (pane.read, detection, rendering) and the input queue.
+        let (input_tx, input_rx) = mpsc::channel::<Vec<u8>>();
+        let engine: Arc<Mutex<dyn VtEngine>> = Arc::new(Mutex::new(AlacrittyEngine::new(
+            cols,
+            rows,
+            input_tx.clone(),
+            history_budget_bytes,
+        )));
+
+        // The writer thread starts with the pane and blocks until the spawn
+        // worker hands over the PTY writer; bytes sent meanwhile queue in
+        // input_rx. On every failure path the worker drops `master_tx`, so
+        // this thread exits with the queue instead of leaking.
+        let (master_tx, master_rx) = mpsc::channel::<Box<dyn Write + Send>>();
+        thread::spawn(move || {
+            let Ok(mut writer) = master_rx.recv() else {
+                return;
+            };
+            while let Ok(bytes) = input_rx.recv() {
+                if writer.write_all(&bytes).is_err() {
+                    break;
+                }
+                let _ = writer.flush();
+            }
+        });
+
+        let child_pid = Arc::new(AtomicU32::new(0));
+        let master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>> = Arc::new(Mutex::new(None));
+        let data_pending = Arc::new(AtomicBool::new(false));
+        let child_exited = Arc::new(AtomicBool::new(false));
+        let size = Arc::new(Mutex::new((cols, rows)));
+        let cancelled = Arc::new(AtomicBool::new(false));
+
+        let worker = {
+            let (engine, child_pid, master, data_pending, child_exited, size, cancelled) = (
+                engine.clone(),
+                child_pid.clone(),
+                master.clone(),
+                data_pending.clone(),
+                child_exited.clone(),
+                size.clone(),
+                cancelled.clone(),
+            );
+            let tx = app_tx.clone();
+            // Owned copies for the 'static worker thread.
+            let worker_cwd = cwd.clone();
+            let worker_env = extra_env.to_vec();
+            thread::spawn(move || {
+                let fail = || {
+                    let _ = tx.send(AppEvent::PtyExit(id));
+                };
+
+                let (cols, rows) = *size.lock().unwrap_or_else(|p| p.into_inner());
+                let pty_system = native_pty_system();
+                let pair = match pty_system.openpty(PtySize {
+                    rows: rows.max(1),
+                    cols: cols.max(1),
+                    pixel_width: 0,
+                    pixel_height: 0,
+                }) {
+                    Ok(pair) => pair,
+                    Err(_) => return fail(),
+                };
+                apply_pane_env(&mut cmd, id, &worker_cwd, &worker_env);
+                // Closed before the fork: abort without creating the child.
+                if cancelled.load(Ordering::SeqCst) {
+                    return;
+                }
+                let child = match pair.slave.spawn_command(cmd) {
+                    Ok(child) => child,
+                    Err(_) => return fail(),
+                };
+                let Some(pid) = child.process_id() else {
+                    return fail();
+                };
+                drop(pair.slave);
+                // Closed between fork and handoff: hang up the fresh child.
+                if cancelled.load(Ordering::SeqCst) {
+                    #[cfg(unix)]
+                    unsafe {
+                        libc::kill(pid as libc::pid_t, libc::SIGHUP);
+                    }
+                    #[cfg(windows)]
+                    {
+                        let _ = std::process::Command::new("taskkill")
+                            .args(["/PID", &pid.to_string(), "/T", "/F"])
+                            .stdout(std::process::Stdio::null())
+                            .stderr(std::process::Stdio::null())
+                            .spawn();
+                    }
+                    return;
+                }
+                child_pid.store(pid, Ordering::SeqCst);
+
+                // A resize raced the spawn: re-apply the latest size.
+                let latest = *size.lock().unwrap_or_else(|p| p.into_inner());
+                if latest != (cols, rows) {
+                    let _ = pair.master.resize(PtySize {
+                        rows: latest.1.max(1),
+                        cols: latest.0.max(1),
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    });
+                }
+
+                let writer = match pair.master.take_writer() {
+                    Ok(writer) => writer,
+                    Err(_) => {
+                        let _ = tx.send(AppEvent::PtyExit(id));
+                        return;
+                    }
+                };
+                let reader = match pair.master.try_clone_reader() {
+                    Ok(reader) => reader,
+                    Err(_) => return fail(),
+                };
+                *master.lock().unwrap_or_else(|p| p.into_inner()) = Some(pair.master);
+                let reaper_tx = tx.clone();
+                thread::spawn(move || read_loop(id, reader, engine, tx, data_pending));
+                thread::spawn(move || {
+                    let mut child = child;
+                    let _ = child.wait();
+                    child_exited.store(true, Ordering::SeqCst);
+                    let _ = reaper_tx.send(AppEvent::PtyExit(id));
+                });
+
+                let _ = master_tx.send(writer);
+            })
+        };
+        drop(worker);
+
+        Pane {
+            engine,
+            child_pid,
+            master,
+            input_tx,
+            cwd,
+            command,
+            data_pending,
+            child_exited,
+            size,
+            cancelled,
+        }
     }
 
     /// Consume the pending-output flag (the loop's re-arm cadence). Returns
@@ -472,26 +660,38 @@ impl Pane {
 
     /// Resize the PTY + engine. Returns whether the size actually changed (so the
     /// caller can note the resize for detection's post-resize grace, docs/07).
+    /// A deferred pane that has not spawned yet records the size; the spawn
+    /// worker applies it (docs/82).
     pub fn resize(&mut self, cols: u16, rows: u16) -> bool {
-        if cols == 0 || rows == 0 || (cols, rows) == self.size {
+        if cols == 0 || rows == 0 {
             return false;
         }
-        let _ = self.master.resize(PtySize {
-            rows,
-            cols,
-            pixel_width: 0,
-            pixel_height: 0,
-        });
+        {
+            let mut size = self.size.lock().unwrap_or_else(|p| p.into_inner());
+            if (cols, rows) == *size {
+                return false;
+            }
+            *size = (cols, rows);
+        }
+        if let Ok(master) = self.master.lock() {
+            if let Some(master) = master.as_ref() {
+                let _ = master.resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                });
+            }
+        }
         if let Ok(mut e) = self.engine.lock() {
             e.resize(cols, rows);
         }
-        self.size = (cols, rows);
         true
     }
 
     #[cfg(test)]
     pub(crate) fn size(&self) -> (u16, u16) {
-        self.size
+        *self.size.lock().unwrap_or_else(|p| p.into_inner())
     }
 }
 
@@ -517,14 +717,45 @@ fn basename(s: &str) -> String {
         .to_string()
 }
 
+/// Apply the working directory and identity environment every pane child
+/// inherits — shared by the synchronous and deferred spawn paths so a pane
+/// always gets the same contract regardless of when its shell starts.
+fn apply_pane_env(
+    cmd: &mut CommandBuilder,
+    id: PaneId,
+    cwd: &std::path::Path,
+    extra_env: &[(String, String)],
+) {
+    cmd.cwd(cwd);
+    // Caller-supplied env first, then bohay's identity vars (so they can't
+    // be overridden — no spoofing the module/pane identity).
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("BOHAY_ENV", "1");
+    cmd.env("BOHAY_PANE_ID", id.0.to_string());
+    if let Some(sock) = crate::ipc::api::socket_path_env() {
+        cmd.env("BOHAY_SOCKET_PATH", sock);
+    }
+    if let Some(name) = crate::session::active_name() {
+        cmd.env(crate::session::SESSION_ENV_VAR, name);
+    }
+    // This session's exact binary, so an agent can use `$BOHAY_BIN_PATH`
+    // instead of a `bohay` on PATH that may be an older install with a
+    // different CLI (skill/binary skew). Matches the server it talks to.
+    if let Ok(exe) = std::env::current_exe() {
+        cmd.env("BOHAY_BIN_PATH", exe);
+    }
+}
+
 fn read_loop(
     id: PaneId,
     mut reader: Box<dyn Read + Send>,
     engine: Arc<Mutex<dyn VtEngine>>,
     tx: Sender<AppEvent>,
-    data_pending: Arc<std::sync::atomic::AtomicBool>,
+    data_pending: Arc<AtomicBool>,
 ) {
-    use std::sync::atomic::Ordering;
     let mut buf = [0u8; 8192];
     loop {
         match reader.read(&mut buf) {
@@ -584,6 +815,91 @@ mod reap_tests {
         .expect("spawn")
     }
 
+    /// A deferred pane (docs/82) is fully usable before its shell exists:
+    /// input queued right after creation reaches the child once the worker
+    /// forks, and the pid stays 0 until then.
+    #[test]
+    fn deferred_pane_delivers_input_and_spawns_its_child() {
+        // Keep the receiver alive: the reader thread exits when its PtyData
+        // send fails, which would stop the pump after the first burst.
+        let (tx, _rx) = mpsc::channel();
+        let pane = Pane::spawn_deferred(
+            PaneId::alloc(),
+            80,
+            24,
+            std::env::temp_dir(),
+            tx,
+            "/bin/sh",
+            500,
+        );
+        assert_eq!(
+            pane.child_pid.load(Ordering::SeqCst),
+            0,
+            "the child is forked off-loop, not at construction"
+        );
+        // Input sent before the fork must still arrive (queued writer).
+        pane.send(b"echo DEFERRED-OK\r");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if pane
+                .engine
+                .lock()
+                .unwrap()
+                .detection_text(24)
+                .contains("DEFERRED-OK")
+            {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the deferred pane never delivered its input"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert_ne!(
+            pane.child_pid.load(Ordering::SeqCst),
+            0,
+            "the worker forked the child"
+        );
+    }
+
+    /// A resize issued before the deferred fork must still reach the child:
+    /// the worker opens the PTY at the latest recorded size (docs/82).
+    #[test]
+    fn deferred_pane_applies_a_resize_racing_the_spawn() {
+        let (tx, _rx) = mpsc::channel();
+        let mut pane = Pane::spawn_deferred(
+            PaneId::alloc(),
+            80,
+            24,
+            std::env::temp_dir(),
+            tx,
+            "/bin/sh",
+            500,
+        );
+        // The spawn has not forked yet: this is the racing resize.
+        assert!(pane.resize(132, 40));
+        pane.send(b"stty size\r");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if pane
+                .engine
+                .lock()
+                .unwrap()
+                .detection_text(40)
+                .contains("40 132")
+            {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the child did not see the racing resize; text: {:?}",
+                pane.engine.lock().unwrap().detection_text(40)
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+
     /// Closing a pane must hang up its child. Regression for the leak where the
     /// reader thread's cloned PTY fd kept the child alive, which in turn kept the
     /// engine (and its whole scrollback grid) and both threads alive for the life
@@ -591,7 +907,8 @@ mod reap_tests {
     #[test]
     fn dropping_a_pane_reaps_its_child() {
         let pane = spawn_sh();
-        let pid = pane.child_pid.expect("pid");
+        let pid = pane.child_pid.load(Ordering::SeqCst);
+        assert_ne!(pid, 0, "the sync spawn path has a child");
         assert!(alive(pid), "child runs while the pane is open");
         drop(pane);
         assert!(wait_gone(pid), "LEAK: child {pid} survived the pane");
@@ -602,9 +919,11 @@ mod reap_tests {
     #[test]
     fn closing_one_pane_leaves_the_others_running() {
         let keep = spawn_sh();
-        let kept_pid = keep.child_pid.expect("pid");
+        let kept_pid = keep.child_pid.load(Ordering::SeqCst);
+        assert_ne!(kept_pid, 0);
         let doomed = spawn_sh();
-        let doomed_pid = doomed.child_pid.expect("pid");
+        let doomed_pid = doomed.child_pid.load(Ordering::SeqCst);
+        assert_ne!(doomed_pid, 0);
 
         drop(doomed);
         assert!(wait_gone(doomed_pid), "the closed pane's child exited");

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -300,7 +300,16 @@ impl Pane {
             .swap(false, std::sync::atomic::Ordering::AcqRel)
     }
 
+    /// Clear the pending-output coalescing flag so the reader's next
+    /// announcement fires immediately. Input is interaction, not background
+    /// output, and a parked `wait.output` must stay event-driven (docs/81).
+    pub fn rearm_pty_notify(&self) {
+        self.data_pending
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+
     pub fn send(&self, bytes: &[u8]) {
+        self.rearm_pty_notify();
         let _ = self.input_tx.send(bytes.to_vec());
     }
 


### PR DESCRIPTION
Route control-API requests and `wait output` calls onto the app event channel so the loop wakes the moment they arrive, instead of draining them on the idle tick.

## What

- API requests now arrive as `AppEvent::Api` on the main event channel; the separate API mpsc channel is removed from both run roles.
- New server-side `wait.output` method parks the connection and answers when the pane's next output matches the needle or the deadline lapses; older servers fall back to a client-side poll.
- Parked `wait.output` deadlines lapse via `tick_output_waits` on the tick, and pane close cancels them.

## Why

The old API channel was drained only on the idle tick, adding up to one tick of latency to every CLI call and forcing prompt-and-wait flows to poll. Moving requests onto the event channel wakes the loop immediately, and `wait output` becomes fully event-driven.

## Scope notes

- `.gitignore` gains a `tests/` entry alongside the existing local-only ignores.
- `Pane::send` rearms the PTY notify flag so input wakes parked waits.

## Checks

Not run locally; the CI matrix (fmt, clippy, test on Ubuntu and macOS) will gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wait output`, allowing commands to wait for specific pane output with optional timeouts.
  * Waits support immediate matches, streaming output, timeouts, and cancellation when panes close.
  * New panes can appear and accept input or resizing while their shell starts in the background.
* **Bug Fixes**
  * Improved process tracking and pane lifecycle handling.
  * Added compatibility fallback for older servers that do not support output waits.
* **Documentation**
  * Clarified stalled-agent behavior in `agent_wait_settled` documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->