### PR TITLE
fix(windows): stop console windows flashing on every child process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
         shell: pwsh
         run: |
           cargo test --locked platform::windows::tests
+          cargo test --locked platform::tests::no_window_keeps_the_command_working
           cargo test --locked ipc::transport::windows_
           cargo test --locked app::backend::tests
           cargo test --locked terminal::backend::tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ libc = "0.2"
 widestring = "1"
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Media_Audio",
     "Win32_Security",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Threading",

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -830,6 +830,7 @@ fn run_gate_command(cwd: &std::path::Path, gate: &str) -> (Option<i32>, String) 
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    crate::platform::no_window(&mut cmd);
     match cmd.output() {
         Ok(o) => {
             let mut s = String::from_utf8_lossy(&o.stdout).into_owned();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -834,7 +834,9 @@ impl AgentMenu {
 /// The workspace-rename modal: like [`TabRename`] but for a node's **label** (the
 /// folder on disk is never touched). Pre-filled with the current name.
 pub struct WsRename {
-    pub index: usize,
+    /// Stable target identity. Workspace indices can shift while the modal is
+    /// open if another workspace closes through the API.
+    pub workspace_id: String,
     pub buffer: String,
 }
 
@@ -1256,10 +1258,11 @@ pub struct App {
     pub tab_menu: Option<TabMenu>,
     /// The workspace right-click context menu, and the workspace-rename modal.
     pub ws_menu: Option<WsMenu>,
-    /// Armed worktree-delete confirmation: the workspace index of the worktree to
-    /// delete once confirmed (`y`/⏎). Destructive — removes the folder + git
-    /// worktree — so it goes through the confirm modal like the file delete.
-    pub worktree_delete: Option<usize>,
+    /// Armed worktree-delete confirmation: the stable workspace identity of the
+    /// worktree to delete once confirmed (`y`/⏎). Destructive — removes the
+    /// folder + git worktree — so it goes through the confirm modal like the file
+    /// delete. Resolve the current index only when confirmation is committed.
+    pub worktree_delete: Option<String>,
     /// Active pane context menu (right-click inside a pane); `None` when closed.
     pub pane_menu: Option<PaneMenu>,
     /// Active AGENTS-list context menu (right-click a row); `None` when closed.
@@ -3651,7 +3654,7 @@ impl App {
             WsMenuItem::Rename => self.open_ws_rename(index),
             WsMenuItem::Close => self.close_workspace(index),
             // Destructive: arm the confirm modal rather than delete immediately.
-            WsMenuItem::DeleteWorktree => self.worktree_delete = Some(index),
+            WsMenuItem::DeleteWorktree => self.worktree_delete = Some(workspace_id),
             WsMenuItem::NewWorktree => {
                 if let Some(cwd) = cwd.filter(|p| crate::git::local::is_repo(p)) {
                     self.worktree_repo = Some(cwd);
@@ -3695,7 +3698,14 @@ impl App {
     /// Guarded so it only ever acts on a **linked worktree**, never a main
     /// checkout.
     fn confirm_worktree_delete(&mut self) {
-        let Some(index) = self.worktree_delete.take() else {
+        let Some(workspace_id) = self.worktree_delete.take() else {
+            return;
+        };
+        let Some(index) = self
+            .workspaces
+            .iter()
+            .position(|workspace| workspace.id == workspace_id)
+        else {
             return;
         };
         // Extract owned paths under an immutable borrow, then act (mutable).
@@ -3731,7 +3741,7 @@ impl App {
     pub fn open_ws_rename(&mut self, index: usize) {
         if let Some(w) = self.workspaces.get(index) {
             self.ws_rename = Some(WsRename {
-                index,
+                workspace_id: w.id.clone(),
                 buffer: w.name.clone(),
             });
         }
@@ -3805,7 +3815,13 @@ impl App {
             KeyCode::Esc => self.ws_rename = None,
             KeyCode::Enter => {
                 if let Some(r) = self.ws_rename.take() {
-                    let _ = self.rename_workspace(r.index, &r.buffer);
+                    if let Some(index) = self
+                        .workspaces
+                        .iter()
+                        .position(|workspace| workspace.id == r.workspace_id)
+                    {
+                        let _ = self.rename_workspace(index, &r.buffer);
+                    }
                 }
             }
             KeyCode::Backspace => {
@@ -5326,14 +5342,14 @@ mod tests {
         app.workspaces[0].worktree = None;
 
         // A non-confirm key dismisses the modal.
-        app.worktree_delete = Some(0);
+        app.worktree_delete = Some(app.workspaces[0].id.clone());
         app.worktree_delete_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
         assert!(app.worktree_delete.is_none(), "n cancels");
 
         // Confirming on the default node (a main checkout, not a linked worktree)
         // removes nothing — the guard refuses to delete a plain workspace.
         let before = app.workspaces.len();
-        app.worktree_delete = Some(0);
+        app.worktree_delete = Some(app.workspaces[0].id.clone());
         app.worktree_delete_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
         assert!(app.worktree_delete.is_none());
         assert_eq!(
@@ -6186,8 +6202,69 @@ mod tests {
             .ws_rename
             .as_ref()
             .expect("rename targets surviving node");
-        assert_eq!(rename.index, 0);
-        assert_eq!(app.workspaces[rename.index].id, target_id);
+        assert_eq!(rename.workspace_id, target_id);
+    }
+
+    #[test]
+    fn workspace_rename_keeps_target_identity_while_modal_is_open() {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let target_id = crate::ids::public_id("workspace");
+        app.workspaces.push(Workspace {
+            id: target_id.clone(),
+            name: "target".into(),
+            cwd: app.workspaces[0].cwd.clone(),
+            branch: None,
+            git_ahead_behind: None,
+            worktree: None,
+            tabs: vec![Tab::panes(TileLayout::new(PaneId::alloc()))],
+            active_tab: 0,
+            pinned: false,
+        });
+
+        app.open_ws_rename(1);
+        app.close_workspace(0);
+        app.ws_rename.as_mut().unwrap().buffer = "renamed".into();
+        app.handle_ws_rename_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(app.workspaces[0].id, target_id);
+        assert_eq!(app.workspaces[0].name, "renamed");
+    }
+
+    #[test]
+    fn deferred_workspace_actions_abort_after_target_closes() {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let survivor_id = crate::ids::public_id("workspace");
+        app.workspaces.push(Workspace {
+            id: survivor_id.clone(),
+            name: "survivor".into(),
+            cwd: app.workspaces[0].cwd.clone(),
+            branch: None,
+            git_ahead_behind: None,
+            worktree: None,
+            tabs: vec![Tab::panes(TileLayout::new(PaneId::alloc()))],
+            active_tab: 0,
+            pinned: false,
+        });
+
+        let removed_id = app.workspaces[0].id.clone();
+        app.open_ws_rename(0);
+        app.worktree_delete = Some(removed_id);
+        app.close_workspace(0);
+
+        app.ws_rename.as_mut().unwrap().buffer = "wrong target".into();
+        app.handle_ws_rename_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.worktree_delete_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(app.workspaces.len(), 1);
+        assert_eq!(app.workspaces[0].id, survivor_id);
+        assert_eq!(app.workspaces[0].name, "survivor");
+        assert!(app.worktree_delete.is_none());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5012,6 +5012,7 @@ impl App {
 
     fn close_active_ws(&mut self) {
         if self.active_ws < self.workspaces.len() {
+            let closed_workspace_id = self.workspaces[self.active_ws].id.clone();
             if self.workspaces.len() > 1 {
                 let closed_root = self.workspaces[self.active_ws].cwd.clone();
                 self.fail_pending_files_api_for_root(
@@ -5023,6 +5024,7 @@ impl App {
                     "workspace closed while DIFF was refreshing",
                 );
             }
+            self.clear_workspace_transients(&closed_workspace_id);
             self.workspaces.remove(self.active_ws);
         }
         if self.workspaces.is_empty() {
@@ -5063,6 +5065,7 @@ impl App {
         if index >= self.workspaces.len() {
             return;
         }
+        let closed_workspace_id = self.workspaces[index].id.clone();
         if self.workspaces.len() > 1 {
             let closed_root = self.workspaces[index].cwd.clone();
             self.fail_pending_files_api_for_root(
@@ -5082,6 +5085,7 @@ impl App {
         for id in ids {
             self.drop_leaf_runtime(id);
         }
+        self.clear_workspace_transients(&closed_workspace_id);
         self.workspaces.remove(index);
         if self.workspaces.is_empty() {
             self.all_workspaces_closed();
@@ -5093,6 +5097,20 @@ impl App {
             "workspace.closed",
             serde_json::json!({"workspace": index.to_string()}),
         );
+    }
+
+    /// Dismiss deferred UI actions whose stable target is being removed.
+    fn clear_workspace_transients(&mut self, workspace_id: &str) {
+        if self
+            .ws_rename
+            .as_ref()
+            .is_some_and(|rename| rename.workspace_id == workspace_id)
+        {
+            self.ws_rename = None;
+        }
+        if self.worktree_delete.as_deref() == Some(workspace_id) {
+            self.worktree_delete = None;
+        }
     }
 
     /// Close a tab and all its panes (the "X" button / prefix+X).
@@ -6235,8 +6253,6 @@ mod tests {
 
     #[test]
     fn deferred_workspace_actions_abort_after_target_closes() {
-        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         let survivor_id = crate::ids::public_id("workspace");
@@ -6257,13 +6273,10 @@ mod tests {
         app.worktree_delete = Some(removed_id);
         app.close_workspace(0);
 
-        app.ws_rename.as_mut().unwrap().buffer = "wrong target".into();
-        app.handle_ws_rename_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        app.worktree_delete_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-
         assert_eq!(app.workspaces.len(), 1);
         assert_eq!(app.workspaces[0].id, survivor_id);
         assert_eq!(app.workspaces[0].name, "survivor");
+        assert!(app.ws_rename.is_none());
         assert!(app.worktree_delete.is_none());
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -423,6 +423,10 @@ pub(crate) const TAB_NAME_MAX: usize = 40;
 pub struct WsMenu {
     /// Target workspace index.
     pub index: usize,
+    /// Whether the target was a Git repository when the menu opened. Repository
+    /// detection launches `git`, so snapshot it once instead of doing process
+    /// I/O on every frame while the popup is visible.
+    pub is_repo: bool,
     /// Top-left corner of the popup (the click point, clamped to fit on screen).
     pub anchor: (u16, u16),
     /// Each visible item + its clickable rect, filled in by the renderer.
@@ -3472,8 +3476,10 @@ impl App {
     /// Open the workspace context menu for row `index`, anchored at the cursor.
     pub fn open_ws_menu(&mut self, index: usize, col: u16, row: u16) {
         if index < self.workspaces.len() {
+            let is_repo = crate::git::local::is_repo(&self.workspaces[index].cwd);
             self.ws_menu = Some(WsMenu {
                 index,
+                is_repo,
                 anchor: (col, row),
                 items: Vec::new(),
                 module_actions: self.module_menu_actions("workspace"),
@@ -3486,7 +3492,14 @@ impl App {
     /// (git / orch). Worktree + git actions only appear for nodes in a git repo.
     pub fn ws_menu_items(&self, index: usize) -> Vec<WsMenuItem> {
         let ws = self.workspaces.get(index);
-        let is_repo = ws.is_some_and(|w| crate::git::local::is_repo(&w.cwd));
+        let is_repo = self
+            .ws_menu
+            .as_ref()
+            .filter(|menu| menu.index == index)
+            .map(|menu| menu.is_repo)
+            // Keep this helper useful to callers that inspect rows before
+            // opening a menu. The renderer always takes the cached branch.
+            .unwrap_or_else(|| ws.is_some_and(|w| crate::git::local::is_repo(&w.cwd)));
         // A linked worktree (a `git worktree add` checkout) can be deleted; a main
         // checkout or plain workspace cannot — only closed.
         let is_worktree = ws
@@ -6106,6 +6119,26 @@ mod tests {
             app.workspace_display_order(),
             vec![(1, false), (2, true), (0, false)]
         );
+    }
+
+    #[test]
+    fn open_workspace_menu_reuses_snapshotted_repo_capability() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        // A deliberately missing path would fail a fresh `git rev-parse`. The
+        // open menu must still use its captured result instead of launching Git
+        // again during rendering.
+        app.workspaces[0].cwd = std::path::PathBuf::from("luvus-missing-menu-repo");
+        app.ws_menu = Some(WsMenu {
+            index: 0,
+            is_repo: true,
+            anchor: (0, 0),
+            items: Vec::new(),
+            module_actions: Vec::new(),
+        });
+
+        assert!(app.ws_menu_items(0).contains(&WsMenuItem::OpenGit));
+        assert!(app.ws_menu_items(0).contains(&WsMenuItem::NewWorktree));
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -421,8 +421,9 @@ pub(crate) const TAB_NAME_MAX: usize = 40;
 /// A right-click context menu on a WORKSPACES row: rename / worktree / close the
 /// node. Opened by right-clicking a workspace in the sidebar.
 pub struct WsMenu {
-    /// Target workspace index.
-    pub index: usize,
+    /// Stable target identity. Workspace indices shift when another workspace
+    /// is closed through the API while this menu is open.
+    pub workspace_id: String,
     /// Whether the target was a Git repository when the menu opened. Repository
     /// detection launches `git`, so snapshot it once instead of doing process
     /// I/O on every frame while the popup is visible.
@@ -3478,7 +3479,7 @@ impl App {
         if index < self.workspaces.len() {
             let is_repo = crate::git::local::is_repo(&self.workspaces[index].cwd);
             self.ws_menu = Some(WsMenu {
-                index,
+                workspace_id: self.workspaces[index].id.clone(),
                 is_repo,
                 anchor: (col, row),
                 items: Vec::new(),
@@ -3495,7 +3496,9 @@ impl App {
         let is_repo = self
             .ws_menu
             .as_ref()
-            .filter(|menu| menu.index == index)
+            .filter(|menu| {
+                ws.is_some_and(|workspace| workspace.id.as_str() == menu.workspace_id.as_str())
+            })
             .map(|menu| menu.is_repo)
             // Keep this helper useful to callers that inspect rows before
             // opening a menu. The renderer always takes the cached branch.
@@ -3531,6 +3534,15 @@ impl App {
             items.extend((0..extras).map(WsMenuItem::Module));
         }
         items
+    }
+
+    /// Resolve the open menu's stable target after any API-driven workspace
+    /// mutation. A missing target means the menu is stale and must be dismissed.
+    pub fn ws_menu_target_index(&self) -> Option<usize> {
+        let target = &self.ws_menu.as_ref()?.workspace_id;
+        self.workspaces
+            .iter()
+            .position(|workspace| workspace.id == *target)
     }
 
     /// The pane context-menu items: the built-ins, then any module actions
@@ -3607,14 +3619,21 @@ impl App {
 
     /// Run a context-menu action for the menu's target, then close the menu.
     pub fn ws_menu_action(&mut self, item: WsMenuItem) {
-        let Some((index, actions)) = self
+        let Some((workspace_id, actions)) = self
             .ws_menu
             .as_ref()
-            .map(|m| (m.index, m.module_actions.clone()))
+            .map(|m| (m.workspace_id.clone(), m.module_actions.clone()))
         else {
             return;
         };
         self.ws_menu = None;
+        let Some(index) = self
+            .workspaces
+            .iter()
+            .position(|workspace| workspace.id == workspace_id)
+        else {
+            return;
+        };
         let cwd = self.workspaces.get(index).map(|w| w.cwd.clone());
         match item {
             WsMenuItem::Divider => {}
@@ -6130,7 +6149,7 @@ mod tests {
         // again during rendering.
         app.workspaces[0].cwd = std::path::PathBuf::from("luvus-missing-menu-repo");
         app.ws_menu = Some(WsMenu {
-            index: 0,
+            workspace_id: app.workspaces[0].id.clone(),
             is_repo: true,
             anchor: (0, 0),
             items: Vec::new(),
@@ -6139,6 +6158,49 @@ mod tests {
 
         assert!(app.ws_menu_items(0).contains(&WsMenuItem::OpenGit));
         assert!(app.ws_menu_items(0).contains(&WsMenuItem::NewWorktree));
+    }
+
+    #[test]
+    fn workspace_menu_follows_target_identity_after_an_index_shift() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let target_id = crate::ids::public_id("workspace");
+        app.workspaces.push(Workspace {
+            id: target_id.clone(),
+            name: "target".into(),
+            cwd: app.workspaces[0].cwd.clone(),
+            branch: None,
+            git_ahead_behind: None,
+            worktree: None,
+            tabs: vec![Tab::panes(TileLayout::new(PaneId::alloc()))],
+            active_tab: 0,
+            pinned: false,
+        });
+
+        app.open_ws_menu(1, 0, 0);
+        app.close_workspace(0);
+        assert_eq!(app.ws_menu_target_index(), Some(0));
+
+        app.ws_menu_action(WsMenuItem::Rename);
+        let rename = app
+            .ws_rename
+            .as_ref()
+            .expect("rename targets surviving node");
+        assert_eq!(rename.index, 0);
+        assert_eq!(app.workspaces[rename.index].id, target_id);
+    }
+
+    #[test]
+    fn workspace_menu_dismisses_when_its_target_was_closed() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_ws_menu(0, 0, 0);
+        app.close_workspace(0);
+
+        assert_eq!(app.ws_menu_target_index(), None);
+        app.ws_menu_action(WsMenuItem::Rename);
+        assert!(app.ws_menu.is_none());
+        assert!(app.ws_rename.is_none());
     }
 
     #[test]

--- a/src/diff/git.rs
+++ b/src/diff/git.rs
@@ -515,6 +515,7 @@ fn run_git_bytes_truncating(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    crate::platform::no_window(&mut command);
     let mut child = command.spawn().map_err(|e| format!("git not found: {e}"))?;
     let mut stdout = child
         .stdout

--- a/src/git/github.rs
+++ b/src/git/github.rs
@@ -30,20 +30,20 @@ impl GhState {
 
 /// Probe `gh` once (installed? authenticated?).
 pub fn detect() -> GhState {
-    match Command::new("gh").arg("--version").output() {
-        Ok(o) if o.status.success() => match Command::new("gh").args(["auth", "status"]).output() {
-            Ok(a) if a.status.success() => GhState::Ready,
-            Ok(_) => GhState::NotAuthed,
-            Err(_) => GhState::Missing,
-        },
+    match crate::platform::no_window(Command::new("gh").arg("--version")).output() {
+        Ok(o) if o.status.success() => {
+            match crate::platform::no_window(Command::new("gh").args(["auth", "status"])).output() {
+                Ok(a) if a.status.success() => GhState::Ready,
+                Ok(_) => GhState::NotAuthed,
+                Err(_) => GhState::Missing,
+            }
+        }
         _ => GhState::Missing,
     }
 }
 
 fn run_gh(cwd: &Path, args: &[&str]) -> Result<String, String> {
-    let out = Command::new("gh")
-        .args(args)
-        .current_dir(cwd)
+    let out = crate::platform::no_window(Command::new("gh").args(args).current_dir(cwd))
         .output()
         .map_err(|e| format!("gh: {e}"))?;
     if !out.status.success() {

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -12,9 +12,7 @@ use super::model::{
 
 /// Run `git <args>` in `cwd`, returning stdout (trimmed of a trailing newline).
 fn run(cwd: &Path, args: &[&str]) -> Result<String, String> {
-    let out = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
+    let out = crate::platform::no_window(Command::new("git").args(args).current_dir(cwd))
         .output()
         .map_err(|e| format!("git not found: {e}"))?;
     if !out.status.success() {
@@ -433,9 +431,7 @@ pub enum MergeOutcome {
 /// Like [`run`] but returns the exit status + streams instead of erroring on a
 /// non-zero exit — a merge "fails" on conflict, but we need its output to react.
 fn run_status(cwd: &Path, args: &[&str]) -> Result<(bool, String, String), String> {
-    let out = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
+    let out = crate::platform::no_window(Command::new("git").args(args).current_dir(cwd))
         .output()
         .map_err(|e| format!("git not found: {e}"))?;
     Ok((

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -48,10 +48,12 @@ pub enum RepoCheck {
 /// collapses "ran, exited non-zero" (the ordinary not-a-repo case) and "could
 /// not run at all" (the actual problem) into the same `Err`.
 pub fn repo_check(cwd: &Path) -> RepoCheck {
-    match Command::new("git")
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(cwd)
-        .output()
+    match crate::platform::no_window(
+        Command::new("git")
+            .args(["rev-parse", "--is-inside-work-tree"])
+            .current_dir(cwd),
+    )
+    .output()
     {
         Err(e) => RepoCheck::Error(format!("git not found: {e}")),
         Ok(out) if out.status.success() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,13 +267,15 @@ fn wav_bytes(samples: &[i16], sr: u32) -> Vec<u8> {
 /// Play a WAV with the platform's audio tool (blocking — called in a thread).
 fn play_sound_file(path: &Path) {
     let run = |cmd: &str, args: &[&str]| -> bool {
-        Command::new(cmd)
-            .args(args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok()
+        platform::no_window(
+            Command::new(cmd)
+                .args(args)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .status()
+        .is_ok()
     };
     let owned = path.to_string_lossy().into_owned();
     let p = owned.as_str();
@@ -310,13 +312,14 @@ fn system_clipboard_copy(text: &str) -> std::io::Result<()> {
         ]
     };
     for (cmd, args) in tools {
-        let Ok(mut child) = Command::new(cmd)
-            .args(*args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-        else {
+        let Ok(mut child) = platform::no_window(
+            Command::new(cmd)
+                .args(*args)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .spawn() else {
             continue; // tool not installed — try the next
         };
         if let Some(mut stdin) = child.stdin.take() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,7 @@ fn wav_bytes(samples: &[i16], sr: u32) -> Vec<u8> {
 
 /// Play a WAV with the platform's audio tool (blocking — called in a thread).
 fn play_sound_file(path: &Path) {
+    #[cfg(not(target_os = "windows"))]
     let run = |cmd: &str, args: &[&str]| -> bool {
         platform::no_window(
             Command::new(cmd)
@@ -277,7 +278,9 @@ fn play_sound_file(path: &Path) {
         .status()
         .is_ok()
     };
+    #[cfg(not(target_os = "windows"))]
     let owned = path.to_string_lossy().into_owned();
+    #[cfg(not(target_os = "windows"))]
     let p = owned.as_str();
     #[cfg(target_os = "macos")]
     {
@@ -285,8 +288,20 @@ fn play_sound_file(path: &Path) {
     }
     #[cfg(target_os = "windows")]
     {
-        let script = format!("(New-Object Media.SoundPlayer '{p}').PlaySync()");
-        let _ = run("powershell", &["-NoProfile", "-Command", &script]);
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Media::Audio::{PlaySoundW, SND_FILENAME, SND_NODEFAULT};
+
+        let path: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+        // `PlaySoundW` is synchronous, but this function already runs on the
+        // notification thread. Native playback avoids launching a PowerShell
+        // process and therefore cannot flash a console window per sound.
+        unsafe {
+            let _ = PlaySoundW(
+                path.as_ptr(),
+                std::ptr::null_mut(),
+                SND_FILENAME | SND_NODEFAULT,
+            );
+        }
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {

--- a/src/module/discovery.rs
+++ b/src/module/discovery.rs
@@ -108,7 +108,7 @@ pub(crate) fn http_get(url: &str) -> Result<String> {
 /// Run `prog`; `Ok(None)` if it isn't installed (so we can try the next),
 /// `Err` if it ran but failed (a real network error).
 fn try_cmd(prog: &str, args: &[&str]) -> Result<Option<String>> {
-    match Command::new(prog).args(args).output() {
+    match crate::platform::no_window(Command::new(prog).args(args)).output() {
         Ok(out) if out.status.success() => {
             Ok(Some(String::from_utf8_lossy(&out.stdout).into_owned()))
         }

--- a/src/module/runtime.rs
+++ b/src/module/runtime.rs
@@ -148,6 +148,7 @@ fn run(root: &PathBuf, argv: &[String], env: &[(String, String)]) -> (Option<i32
     for (k, v) in env {
         cmd.env(k, v);
     }
+    crate::platform::no_window(&mut cmd);
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -60,7 +60,8 @@ pub fn no_window(cmd: &mut std::process::Command) -> &mut std::process::Command 
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+        use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
+        cmd.creation_flags(CREATE_NO_WINDOW);
     }
     cmd
 }
@@ -654,15 +655,16 @@ mod tests {
     fn no_window_keeps_the_command_working() {
         let mut cmd = if cfg!(windows) {
             let mut c = std::process::Command::new("cmd");
-            c.args(["/C", "exit 3"]);
+            c.args(["/C", "echo captured & exit /b 3"]);
             c
         } else {
             let mut c = std::process::Command::new("sh");
-            c.args(["-c", "exit 3"]);
+            c.args(["-c", "printf captured; exit 3"]);
             c
         };
-        let status = super::no_window(&mut cmd).status().expect("spawns");
-        assert_eq!(status.code(), Some(3));
+        let output = super::no_window(&mut cmd).output().expect("spawns");
+        assert_eq!(output.status.code(), Some(3));
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "captured");
     }
 
     #[cfg(unix)]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -43,6 +43,28 @@ fn path_key(p: &Path) -> String {
     trimmed.to_string()
 }
 
+/// Keep a spawned console program from flashing a window on Windows.
+///
+/// `luvus server` runs detached (`main::spawn_server` uses `DETACHED_PROCESS`),
+/// so it has no console of its own. Windows then hands every console child it
+/// spawns a fresh `conhost.exe` **with a visible window** — and the git poller
+/// alone spawns one every ~2 s per workspace, which strobed black windows over
+/// the desktop ~45 times a minute. `CREATE_NO_WINDOW` (0x0800_0000) gives the
+/// child a console without a window; inherited/piped stdio handles are
+/// unaffected, so captured output still arrives.
+///
+/// Only for spawns luvus captures or discards (`.output()`, `.status()`,
+/// null stdio). **Never** put this on the PTY/pane child or an agent the user
+/// interacts with — those need their real console.
+pub fn no_window(cmd: &mut std::process::Command) -> &mut std::process::Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    }
+    cmd
+}
+
 /// The user's home directory, cross-platform (`$HOME`, else `%USERPROFILE%`).
 pub fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
@@ -596,14 +618,16 @@ pub fn open_url(url: &str) {
         &[("xdg-open", &[]), ("gio", &["open"]), ("wslview", &[])]
     };
     for (cmd, args) in openers {
-        if Command::new(cmd)
-            .args(*args)
-            .arg(url)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .is_ok()
+        if no_window(
+            Command::new(cmd)
+                .args(*args)
+                .arg(url)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .spawn()
+        .is_ok()
         {
             return;
         }
@@ -620,6 +644,25 @@ mod tests {
         let second = super::process_start_marker(pid).expect("same live process marker");
         assert_eq!(first, second);
         assert!(!first.is_empty());
+    }
+
+    /// The hidden-window flag must not break output capture: a command routed
+    /// through [`no_window`] still runs and still reports its exit code. On
+    /// Windows that is the whole contract (no window, same result); elsewhere
+    /// the helper is a no-op and this pins that it stays one.
+    #[test]
+    fn no_window_keeps_the_command_working() {
+        let mut cmd = if cfg!(windows) {
+            let mut c = std::process::Command::new("cmd");
+            c.args(["/C", "exit 3"]);
+            c
+        } else {
+            let mut c = std::process::Command::new("sh");
+            c.args(["-c", "exit 3"]);
+            c
+        };
+        let status = super::no_window(&mut cmd).status().expect("spawns");
+        assert_eq!(status.code(), Some(3));
     }
 
     #[cfg(unix)]

--- a/src/search/files.rs
+++ b/src/search/files.rs
@@ -93,15 +93,16 @@ pub fn index_cached(root: &Path) -> Arc<FileCatalog> {
 
 fn git_files(root: &Path) -> Option<FileCatalog> {
     let deadline = Instant::now() + GIT_INDEX_TIMEOUT;
-    let mut child = Command::new("git")
+    let mut command = Command::new("git");
+    command
         .arg("-C")
         .arg(root)
         .args(["ls-files", "-co", "--exclude-standard", "-z"])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
+        .stderr(Stdio::null());
+    crate::platform::no_window(&mut command);
+    let mut child = command.spawn().ok()?;
     let Some(stdout) = child.stdout.take() else {
         let _ = child.kill();
         let _ = child.wait();

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -486,11 +486,13 @@ fn fetch_bytes(url: &str, limit: usize) -> Result<Vec<u8>> {
 }
 
 fn try_fetch_command(prog: &str, args: &[&str], limit: usize) -> Result<Option<Vec<u8>>> {
-    let mut child = match Command::new(prog)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+    let mut child = match crate::platform::no_window(
+        Command::new(prog)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped()),
+    )
+    .spawn()
     {
         Ok(child) => child,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -228,11 +228,13 @@ impl Drop for Pane {
         // No signals on Windows; end the whole child tree instead.
         #[cfg(windows)]
         {
-            let _ = std::process::Command::new("taskkill")
-                .args(["/PID", &pid.to_string(), "/T", "/F"])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn();
+            let _ = crate::platform::no_window(
+                std::process::Command::new("taskkill")
+                    .args(["/PID", &pid.to_string(), "/T", "/F"])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null()),
+            )
+            .spawn();
         }
     }
 }
@@ -677,11 +679,13 @@ impl Pane {
                     }
                     #[cfg(windows)]
                     {
-                        let _ = std::process::Command::new("taskkill")
-                            .args(["/PID", &pid.to_string(), "/T", "/F"])
-                            .stdout(std::process::Stdio::null())
-                            .stderr(std::process::Stdio::null())
-                            .spawn();
+                        let _ = crate::platform::no_window(
+                            std::process::Command::new("taskkill")
+                                .args(["/PID", &pid.to_string(), "/T", "/F"])
+                                .stdout(std::process::Stdio::null())
+                                .stderr(std::process::Stdio::null()),
+                        )
+                        .spawn();
                     }
                     let mut child = child;
                     let _ = child.wait();

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -92,11 +92,15 @@ pub(super) fn draw_ws_menu(
     cat: &Catalog,
     t: &Theme,
 ) {
+    let Some(index) = app.ws_menu_target_index() else {
+        app.ws_menu = None;
+        return;
+    };
     let Some(menu) = app.ws_menu.as_ref() else {
         return;
     };
     let anchor = menu.anchor;
-    let items = app.ws_menu_items(menu.index);
+    let items = app.ws_menu_items(index);
     let extras = menu.module_actions.clone();
     let rows: Vec<MenuRow> = items
         .iter()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -774,7 +774,8 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
     // worktree since it also removes the git worktree, not just a folder.
     if let Some(path) = app
         .worktree_delete
-        .and_then(|i| app.workspaces.get(i))
+        .as_deref()
+        .and_then(|id| app.workspaces.iter().find(|workspace| workspace.id == id))
         .map(|w| w.cwd.clone())
     {
         let (c, x) = files::draw_delete_confirm(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -772,12 +772,15 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
     }
     // Worktree-delete confirm (docs/18 WT): reuses the delete modal, worded for a
     // worktree since it also removes the git worktree, not just a folder.
-    if let Some(path) = app
+    let worktree_path = app
         .worktree_delete
         .as_deref()
         .and_then(|id| app.workspaces.iter().find(|workspace| workspace.id == id))
-        .map(|w| w.cwd.clone())
-    {
+        .map(|w| w.cwd.clone());
+    if app.worktree_delete.is_some() && worktree_path.is_none() {
+        app.worktree_delete = None;
+    }
+    if let Some(path) = worktree_path {
         let (c, x) = files::draw_delete_confirm(
             f,
             area,

--- a/src/update.rs
+++ b/src/update.rs
@@ -564,7 +564,9 @@ fn http_get(url: &str) -> Option<String> {
 }
 
 fn try_cmd(prog: &str, args: &[&str]) -> Option<String> {
-    let out = Command::new(prog).args(args).output().ok()?;
+    let out = crate::platform::no_window(Command::new(prog).args(args))
+        .output()
+        .ok()?;
     out.status
         .success()
         .then(|| String::from_utf8_lossy(&out.stdout).into_owned())


### PR DESCRIPTION
## The problem

On Windows, with luvus open and three panes, black console windows flash over the desktop ~45 times a minute — including while you type.

`luvus server` is spawned detached (`DETACHED_PROCESS`, `main.rs`), so it owns no console. Windows then hands every console child it spawns a fresh `conhost.exe` **with a visible window**. The git poller alone (`git rev-parse --show-toplevel`, every ~2s per workspace) is enough to cause the strobing.

## The fix

One shared place, `platform::no_window()`: it sets `CREATE_NO_WINDOW` (`0x0800_0000`) under `#[cfg(windows)]` and is a no-op everywhere else. The spawns whose output luvus captures or discards now go through it:

- `git` (`git/local.rs`: `run()` and `run_status()`) and `gh` (`git/github.rs`: `detect()`, `run_gh()`)
- the task board's quality gate (`app/board.rs`)
- module actions and discovery, skill downloads, the update check
- both `taskkill` calls in `terminal/pty.rs`
- the sound player (`powershell`) and clipboard tool (`clip`) in `main.rs`, and the `rundll32` URL opener

**Left alone on purpose:** the PTY/pane child and the agent launcher, which need their real console. The flag does not affect inherited or piped stdio, so captured output still arrives — which is exactly what the new test pins down.

## Verification

`cargo build`, `cargo fmt`, no new clippy warnings; test `platform::tests::no_window_keeps_the_command_working`. When sampling `Win32_Process`, the number of `git.exe` processes must stay the same — if it drops, the polling was broken rather than the window hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit `luvus update` command with verified direct downloads.
  * Improved terminal restoration, paste-and-submit behavior, and deferred pane startup.
  * Added native Windows audio playback and enhanced process tracking.
  * Added clearer repository detection and more reliable workspace targeting.
* **Bug Fixes**
  * Prevented visible command windows during supported background operations.
  * Standardized module discovery to the canonical module topic.
  * Improved interactive shell resume behavior and workspace menu reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Updated for current main

- rebased onto the latest `main` subprocess and Windows platform code
- covers the newer repository check, native DIFF scanner, and Git-backed file search
- uses the official Windows `CREATE_NO_WINDOW` constant
- preserves captured output, exit status, interactive panes, agents, ConPTY, and SSH
- runs the hidden-subprocess regression in Windows CI

Fixes #118
