### PR TITLE
fix(windows): AltGr must type its character, not a Ctrl chord

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           cargo test --locked ipc::transport::windows_
           cargo test --locked app::backend::tests
           cargo test --locked terminal::backend::tests
+          cargo test --locked altgr
       - name: Validate published protocol fixtures
         shell: pwsh
         run: |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3186,11 +3186,10 @@ mod tests {
     fn altgr_types_its_character_instead_of_a_control_byte() {
         let nl = b"\x1b\r";
         let altgr = KeyModifiers::CONTROL | KeyModifiers::ALT;
-        let enc = |c: char, m: KeyModifiers| {
-            encode_key(&KeyEvent::new(KeyCode::Char(c), m), nl, false)
-        };
+        let enc =
+            |c: char, m: KeyModifiers| encode_key(&KeyEvent::new(KeyCode::Char(c), m), nl, false);
         if cfg!(windows) {
-            for c in ['\\', '@', '#', '[', ']', '{', '}', '|', '~'] {
+            for c in ['\\', '@', '#', '[', ']', '{', '}', '|', '~', '€'] {
                 assert_eq!(
                     enc(c, altgr),
                     Some(c.to_string().into_bytes()),
@@ -3199,17 +3198,23 @@ mod tests {
             }
         } else {
             // Elsewhere AltGr arrives unmodified, so Ctrl+Alt stays the real
-            // chord it always was: the control byte, with Ctrl winning over Alt
-            // exactly as before this change.
-            assert_eq!(enc('\\', altgr), Some(vec![0x1c]));
+            // chord it is on current main: an Alt-prefixed control byte.
+            assert_eq!(enc('\\', altgr), Some(vec![0x1b, 0x1c]));
         }
         // A real Ctrl chord is untouched on every platform.
         assert_eq!(enc('\\', KeyModifiers::CONTROL), Some(vec![0x1c]));
         assert_eq!(enc('c', KeyModifiers::CONTROL), Some(vec![0x03]));
+        for c in ['ñ', 'á'] {
+            assert_eq!(
+                enc(c, KeyModifiers::NONE),
+                Some(c.to_string().into_bytes()),
+                "unmodified Unicode input must remain valid UTF-8"
+            );
+        }
         // The exception is for characters only: every other key keeps both
         // modifiers, so Ctrl+Alt+Enter is still a modified Enter.
         assert_eq!(
-            encode_key(&KeyEvent::new(KeyCode::Enter, altgr), nl),
+            encode_key(&KeyEvent::new(KeyCode::Enter, altgr), nl, false),
             Some(nl.to_vec()),
             "Ctrl+Alt+Enter still sends the configured newline"
         );

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3195,9 +3195,10 @@ mod tests {
                 );
             }
         } else {
-            // Elsewhere AltGr arrives unmodified, so Ctrl+Alt is a real chord:
-            // `ESC` + the control byte, exactly as before.
-            assert_eq!(enc('\\', altgr), Some(vec![0x1b, 0x1c]));
+            // Elsewhere AltGr arrives unmodified, so Ctrl+Alt stays the real
+            // chord it always was: the control byte, with Ctrl winning over Alt
+            // exactly as before this change.
+            assert_eq!(enc('\\', altgr), Some(vec![0x1c]));
         }
         // A real Ctrl chord is untouched on every platform.
         assert_eq!(enc('\\', KeyModifiers::CONTROL), Some(vec![0x1c]));

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2818,8 +2818,11 @@ fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8
     // AltGr arrives as Ctrl+Alt on Windows (`keys::is_ctrl_chord`) and types a
     // character — it is neither a Ctrl chord nor an `ESC`-prefixed Alt key.
     let ctrl = super::keys::is_ctrl_chord(key.modifiers);
-    let alt = key.modifiers.contains(KeyModifiers::ALT)
-        && !(cfg!(windows) && key.modifiers.contains(KeyModifiers::CONTROL));
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    // True exactly when `is_ctrl_chord` refused a Ctrl+Alt press as AltGr. Only
+    // the `Char` arm may act on it: every other key keeps both modifiers, so
+    // `Ctrl+Alt+Enter` is still a modified Enter and sends the newline sequence.
+    let altgr = alt && !ctrl && key.modifiers.contains(KeyModifiers::CONTROL);
     let shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
     let bytes: Vec<u8> = match key.code {
@@ -2842,7 +2845,7 @@ fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8
                 }
             } else {
                 let mut s = c.to_string().into_bytes();
-                if alt {
+                if alt && !altgr {
                     let mut v = vec![0x1b];
                     v.append(&mut s);
                     v
@@ -3203,6 +3206,13 @@ mod tests {
         // A real Ctrl chord is untouched on every platform.
         assert_eq!(enc('\\', KeyModifiers::CONTROL), Some(vec![0x1c]));
         assert_eq!(enc('c', KeyModifiers::CONTROL), Some(vec![0x03]));
+        // The exception is for characters only: every other key keeps both
+        // modifiers, so Ctrl+Alt+Enter is still a modified Enter.
+        assert_eq!(
+            encode_key(&KeyEvent::new(KeyCode::Enter, altgr), nl),
+            Some(nl.to_vec()),
+            "Ctrl+Alt+Enter still sends the configured newline"
+        );
     }
 
     /// The Shift/Alt+Enter sequence is whatever `config::shift_enter` selects —

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2815,8 +2815,11 @@ fn mouse_wheel_seq(up: bool, col: u16, row: u16, sgr: bool) -> Vec<u8> {
 /// real terminal would send them — some apps (`less`) only recognize the SS3
 /// form once they've turned the mode on.
 fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8>> {
-    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    let alt = key.modifiers.contains(KeyModifiers::ALT);
+    // AltGr arrives as Ctrl+Alt on Windows (`keys::is_ctrl_chord`) and types a
+    // character — it is neither a Ctrl chord nor an `ESC`-prefixed Alt key.
+    let ctrl = super::keys::is_ctrl_chord(key.modifiers);
+    let alt = key.modifiers.contains(KeyModifiers::ALT)
+        && !(cfg!(windows) && key.modifiers.contains(KeyModifiers::CONTROL));
     let shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
     let bytes: Vec<u8> = match key.code {
@@ -3170,6 +3173,35 @@ mod tests {
             ),
             Some(b"\r".to_vec())
         );
+    }
+
+    /// AltGr must type its character, not a control byte. The Windows console
+    /// reports AltGr as `Ctrl+Alt`, so the plain `contains(CONTROL)` test used
+    /// to send `0x1c` for a backslash and a bare `ESC` for `[` — a Spanish or
+    /// German keyboard could not type a Windows path into a pane at all.
+    #[test]
+    fn altgr_types_its_character_instead_of_a_control_byte() {
+        let nl = b"\x1b\r";
+        let altgr = KeyModifiers::CONTROL | KeyModifiers::ALT;
+        let enc = |c: char, m: KeyModifiers| {
+            encode_key(&KeyEvent::new(KeyCode::Char(c), m), nl, false)
+        };
+        if cfg!(windows) {
+            for c in ['\\', '@', '#', '[', ']', '{', '}', '|', '~'] {
+                assert_eq!(
+                    enc(c, altgr),
+                    Some(c.to_string().into_bytes()),
+                    "AltGr+{c} must reach the pane as itself"
+                );
+            }
+        } else {
+            // Elsewhere AltGr arrives unmodified, so Ctrl+Alt is a real chord:
+            // `ESC` + the control byte, exactly as before.
+            assert_eq!(enc('\\', altgr), Some(vec![0x1b, 0x1c]));
+        }
+        // A real Ctrl chord is untouched on every platform.
+        assert_eq!(enc('\\', KeyModifiers::CONTROL), Some(vec![0x1c]));
+        assert_eq!(enc('c', KeyModifiers::CONTROL), Some(vec![0x03]));
     }
 
     /// The Shift/Alt+Enter sequence is whatever `config::shift_enter` selects —

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -9,6 +9,21 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::*;
 
+/// Is this a real `Ctrl` chord, or is it AltGr typing a character?
+///
+/// The Windows console reports AltGr as `CONTROL | ALT` — the layout driver
+/// presses left-Ctrl together with right-Alt — so anything that only asks
+/// `modifiers.contains(CONTROL)` swallows every AltGr character. On the Spanish
+/// layout that is `\ @ # [ ] { } | ~ €`: typing a Windows path into a pane sent
+/// `0x1c` instead of `\`, and `[` sent a bare `ESC`.
+///
+/// Only Windows needs the distinction: X11/macOS terminals deliver an AltGr
+/// character with no modifiers at all, and there `Ctrl+Alt+<key>` really is a
+/// chord the user meant, so it must keep working.
+pub fn is_ctrl_chord(mods: KeyModifiers) -> bool {
+    mods.contains(KeyModifiers::CONTROL) && !(cfg!(windows) && mods.contains(KeyModifiers::ALT))
+}
+
 /// A prefix-mode command — the thing a key triggers after `Ctrl+Space`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Cmd {

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use super::App;
@@ -1443,6 +1443,25 @@ mod tests {
             .metadata_matches
             .iter()
             .any(|result| result.entry.kind == SearchKind::Workspace));
+    }
+
+    #[test]
+    fn altgr_character_is_text_on_windows_and_a_ctrl_chord_elsewhere() {
+        let _env = crate::persist::test_env("search-altgr");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_search();
+        app.search_key(KeyEvent::new(
+            KeyCode::Char('€'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+
+        let query = &app.search.as_ref().unwrap().query;
+        if cfg!(windows) {
+            assert_eq!(query, "€");
+        } else {
+            assert!(query.is_empty(), "Ctrl+Alt remains a real chord");
+        }
     }
 
     #[test]

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::Rect;
 
 use super::App;
@@ -1063,7 +1063,7 @@ impl App {
     }
 
     pub fn search_key(&mut self, key: KeyEvent) {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let ctrl = super::keys::is_ctrl_chord(key.modifiers); // not AltGr
         match key.code {
             KeyCode::Esc => {
                 if self.search.as_ref().is_some_and(|s| !s.query.is_empty()) {

--- a/src/app/switcher.rs
+++ b/src/app/switcher.rs
@@ -4,7 +4,7 @@
 //! `Tab`) to narrow to one category. Big tap targets on a narrow phone where the
 //! sidebar and tiled panes don't fit, and a fast quick-jump palette on desktop.
 
-use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 use crate::app::{App, SwitcherRow, SwitcherScope, SwitcherTarget};
 
@@ -289,7 +289,7 @@ impl App {
                 self.switcher_cursor = 0;
                 self.switcher_scroll = 0;
             }
-            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char(c) if !super::keys::is_ctrl_chord(key.modifiers) => {
                 self.switcher_query.push(c);
                 self.switcher_cursor = 0;
                 self.switcher_scroll = 0;

--- a/src/app/switcher.rs
+++ b/src/app/switcher.rs
@@ -317,6 +317,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use crate::app::{App, SwitcherRow, SwitcherScope, SwitcherTarget};
+    use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     fn tab_targets(app: &App) -> Vec<SwitcherTarget> {
         app.switcher_rows()
@@ -355,6 +356,27 @@ mod tests {
             "scope chips have rects"
         );
         assert!(text.contains('b'), "the query is visible");
+    }
+
+    #[test]
+    fn altgr_character_is_text_on_windows_and_a_ctrl_chord_elsewhere() {
+        let _env = crate::persist::test_env("switcher-altgr");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_switcher();
+        app.switcher_key(KeyEvent::new(
+            KeyCode::Char('€'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+
+        if cfg!(windows) {
+            assert_eq!(app.switcher_query, "€");
+        } else {
+            assert!(
+                app.switcher_query.is_empty(),
+                "Ctrl+Alt remains a real chord"
+            );
+        }
     }
 
     #[test]

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -706,6 +706,16 @@ mod render_tests {
     use ratatui::backend::TestBackend;
 
     #[test]
+    fn paste_event_preserves_windows_paths_quotes_and_unicode() {
+        let command = r#".\.venv\Scripts\python.exe .\youtube_folder_uploader.py --folder "E:\Vídeos\Pendientes €""#;
+        let message = event_message(Event::Paste(command.to_string()));
+        assert!(matches!(
+            message,
+            Some(ClientMessage::Paste(text)) if text == command
+        ));
+    }
+
+    #[test]
     fn session_handoff_replaces_only_the_session_selector() {
         let raw = vec![
             "luvus".to_string(),

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -1399,6 +1399,17 @@ mod tests {
     }
 
     #[test]
+    fn paste_preserves_windows_paths_quotes_and_unicode() {
+        let command = r#".\.venv\Scripts\python.exe .\youtube_folder_uploader.py --folder "E:\Vídeos\Pendientes €""#;
+        assert_eq!(wrap_paste(command, false), command.as_bytes());
+
+        let mut expected = b"\x1b[200~".to_vec();
+        expected.extend_from_slice(command.as_bytes());
+        expected.extend_from_slice(b"\x1b[201~");
+        assert_eq!(wrap_paste(command, true), expected);
+    }
+
+    #[test]
     fn reaper_retries_child_poll_errors() {
         assert!(!child_poll_finished(Ok(None)));
         assert!(!child_poll_finished(Err(std::io::Error::other(


### PR DESCRIPTION
## The problem

The Windows console reports AltGr as `CONTROL | ALT` — the layout driver presses left-Ctrl together with right-Alt — so every place that asked `modifiers.contains(CONTROL)` swallowed the AltGr characters.

On a Spanish keyboard those are `\ @ # [ ] { } | ~ €`:

- in a pane, `\` was sent as `0x1c` and `[` as a bare `ESC`; `# { } | ~` were dropped outright (`encode_key` returned `None`)
- the global search (`search.rs`) and the tab switcher (`switcher.rs`) ignored them the same way

The practical result: you cannot type a Windows path inside luvus.

## The fix

`keys::is_ctrl_chord()` — Ctrl, but not Ctrl+Alt on Windows — and all three sites go through it. `encode_key` also stops prefixing `ESC` for the Alt half of an AltGr press.

Windows-only by design: X11 and macOS terminals deliver an AltGr character with **no modifiers at all**, so there `Ctrl+Alt+<key>` is a real chord and keeps working as before. The test asserts both halves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fuzzy search across sessions, workspaces, tabs, panes, agents, files, terminal output, and remote sessions.
  * Added search scopes, recommendations, paging, recent-file results, and improved activation handling.
  * Added fuzzy matching when switching between workspaces.
  * Added configurable Copy Mode and expanded function-key shortcuts.

* **Bug Fixes**
  * Improved Windows AltGr and modifier handling.
  * Preserved pasted paths, quotes, Unicode characters, and command text across platforms.
  * Improved mouse navigation, scrolling, menus, and copy selection behavior.
  * Improved backend event handling and pending request completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Updated for current main

- rebased onto the latest `main` input encoder
- preserves application cursor mode and non-Windows Ctrl+Alt behavior
- covers `€`, `ñ`, and `á` alongside the original AltGr characters
- verifies pasted Windows paths, quotes, and Unicode at both input boundaries
- runs the focused AltGr regression tests in Windows CI

Fixes #103
