### PR TITLE
feat(picker): paste a path to jump there, instead of leaking it to the pane

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -680,8 +680,19 @@ impl App {
     /// all single-line fields.
     fn paste_into_modal(&mut self, s: &str) -> bool {
         use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        // The folder picker has no text field to fill: a pasted path *is* the
+        // navigation. Pasting a path is how you reach a deep folder, so this is
+        // the one modal where the text means "go here" rather than "type here".
+        if self.picker.as_ref().is_some_and(|p| p.creating.is_none()) {
+            self.picker_goto(s);
+            return true;
+        }
         let handler: fn(&mut Self, KeyEvent) = if self.module_setting_edit.is_some() {
             Self::handle_module_setting_key
+        } else if self.search.is_some() {
+            Self::search_key
+        } else if self.picker.is_some() {
+            Self::handle_picker_key // the new-folder name sub-mode
         } else if self.worktree_prompt.is_some() {
             Self::handle_worktree_prompt_key
         } else if self.tab_rename.is_some() {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -680,20 +680,27 @@ impl App {
     /// all single-line fields.
     fn paste_into_modal(&mut self, s: &str) -> bool {
         use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-        // The folder picker has no text field to fill: a pasted path *is* the
-        // navigation. Pasting a path is how you reach a deep folder, so this is
-        // the one modal where the text means "go here" rather than "type here".
-        if self.picker.as_ref().is_some_and(|p| p.creating.is_none()) {
-            self.picker_goto(s);
+        if self.module_setting_edit.is_some() {
+            for character in s.chars().filter(|character| !character.is_control()) {
+                self.handle_module_setting_key(KeyEvent::new(
+                    KeyCode::Char(character),
+                    KeyModifiers::NONE,
+                ));
+            }
             return true;
         }
-        let handler: fn(&mut Self, KeyEvent) = if self.module_setting_edit.is_some() {
-            Self::handle_module_setting_key
-        } else if self.search.is_some() {
-            Self::search_key
-        } else if self.picker.is_some() {
-            Self::handle_picker_key // the new-folder name sub-mode
-        } else if self.worktree_prompt.is_some() {
+        // Search can rank a large catalog, so append the whole paste and launch
+        // one recomputation instead of replaying one query per character.
+        if self.search.is_some() {
+            self.search_paste(s);
+            return true;
+        }
+        // The picker owns both text sub-modes and direct path navigation.
+        if self.picker.is_some() {
+            self.picker_paste(s);
+            return true;
+        }
+        let handler: fn(&mut Self, KeyEvent) = if self.worktree_prompt.is_some() {
             Self::handle_worktree_prompt_key
         } else if self.tab_rename.is_some() {
             Self::handle_tab_rename_key

--- a/src/app/picker.rs
+++ b/src/app/picker.rs
@@ -206,14 +206,21 @@ impl App {
     /// Accepts what a file manager or a shell actually puts on the clipboard:
     /// surrounding whitespace and quotes are stripped, and a pasted *file* lands
     /// on its parent folder (dragging a file in is a normal way to mean "this
-    /// project"). Anything that doesn't resolve leaves the browsed folder alone
-    /// and reports it in the modal rather than silently doing nothing.
+    /// project"). A relative path resolves against the folder being browsed, so
+    /// pasting `src/app` walks down from here — and a bare `Cargo.toml` can't
+    /// leave the picker on the empty parent path. Anything that doesn't resolve
+    /// leaves the browsed folder alone and reports it in the modal rather than
+    /// silently doing nothing.
     pub fn picker_goto(&mut self, raw: &str) {
         let text = raw.trim().trim_matches(['"', '\'']).trim();
         if text.is_empty() {
             return;
         }
         let path = PathBuf::from(text);
+        let path = match self.picker.as_ref() {
+            Some(p) if path.is_relative() => p.path.join(path),
+            _ => path,
+        };
         let target = if path.is_dir() {
             Some(path)
         } else if path.is_file() {
@@ -795,6 +802,21 @@ mod tests {
         app.handle_event(crate::event::AppEvent::Paste("nope-not-a-path".into()));
         assert_eq!(app.picker.as_ref().unwrap().path, deep);
         assert!(app.picker.as_ref().unwrap().error.is_some());
+
+        // A relative path resolves against the browsed folder — including a bare
+        // filename, whose parent is the empty path and would otherwise strand
+        // the picker on a folder that does not exist.
+        app.handle_event(crate::event::AppEvent::Paste("f.txt".into()));
+        assert_eq!(app.picker.as_ref().unwrap().path, deep);
+        assert!(app.picker.as_ref().unwrap().error.is_none());
+        app.picker.as_mut().unwrap().path = tmp.clone();
+        app.picker_refresh();
+        app.handle_event(crate::event::AppEvent::Paste("a/b".into()));
+        assert_eq!(
+            app.picker.as_ref().unwrap().path,
+            deep,
+            "walked down from here"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/app/picker.rs
+++ b/src/app/picker.rs
@@ -200,49 +200,26 @@ impl App {
         }
     }
 
-    /// Jump the picker to a pasted path — the way you get to a folder that is
-    /// twenty levels deep or on another drive without walking there row by row.
-    ///
-    /// Accepts what a file manager or a shell actually puts on the clipboard:
-    /// surrounding whitespace and quotes are stripped, and a pasted *file* lands
-    /// on its parent folder (dragging a file in is a normal way to mean "this
-    /// project"). A relative path resolves against the folder being browsed, so
-    /// pasting `src/app` walks down from here — and a bare `Cargo.toml` can't
-    /// leave the picker on the empty parent path. Anything that doesn't resolve
-    /// leaves the browsed folder alone and reports it in the modal rather than
-    /// silently doing nothing.
-    pub fn picker_goto(&mut self, raw: &str) {
-        let text = raw.trim().trim_matches(['"', '\'']).trim();
+    /// Consume a paste without letting it reach the pane behind the picker.
+    /// Text sub-modes receive text; otherwise a pasted path navigates directly.
+    pub fn picker_paste(&mut self, raw: &str) {
+        let text: String = raw.chars().filter(|c| !c.is_control()).collect();
         if text.is_empty() {
             return;
         }
-        let path = PathBuf::from(text);
-        let path = match self.picker.as_ref() {
-            Some(p) if path.is_relative() => p.path.join(path),
-            _ => path,
-        };
-        let target = if path.is_dir() {
-            Some(path)
-        } else if path.is_file() {
-            path.parent().map(PathBuf::from)
-        } else {
-            None
-        };
-        match target {
-            Some(dir) => {
-                if let Some(p) = self.picker.as_mut() {
-                    p.path = dir;
-                    p.cursor = 0;
-                    p.error = None;
-                }
-                self.picker_refresh();
+        if let Some(picker) = self.picker.as_mut() {
+            if let Some(buffer) = picker.creating.as_mut() {
+                buffer.push_str(&text);
+                picker.error = None;
+                return;
             }
-            None => {
-                if let Some(p) = self.picker.as_mut() {
-                    p.error = Some(format!("no such folder: {text}"));
-                }
+            if let Some(buffer) = picker.going_to.as_mut() {
+                buffer.push_str(&text);
+                picker.error = None;
+                return;
             }
         }
+        self.picker_go_to(text);
     }
 
     /// Key handling while the folder picker is open.
@@ -363,9 +340,20 @@ impl App {
     }
 
     /// Resolve an entered path and browse to it. Absolute paths, paths relative
-    /// to the currently browsed folder, and `~` / `~/...` are supported.
+    /// to the currently browsed folder, and `~` / `~/...` are supported. A file
+    /// path browses its parent directory without opening a workspace.
     fn picker_go_to(&mut self, input: String) {
         let entered = input.trim();
+        let entered = entered
+            .strip_prefix('"')
+            .and_then(|text| text.strip_suffix('"'))
+            .or_else(|| {
+                entered
+                    .strip_prefix('\'')
+                    .and_then(|text| text.strip_suffix('\''))
+            })
+            .unwrap_or(entered)
+            .trim();
         if entered.is_empty() {
             let error = self.catalog.enter_folder_path.to_string();
             if let Some(p) = self.picker.as_mut() {
@@ -391,7 +379,16 @@ impl App {
             })
         };
 
-        let Some(target) = target.filter(|path| path.is_dir()) else {
+        let target = target.and_then(|path| {
+            if path.is_dir() {
+                Some(path)
+            } else if path.is_file() {
+                path.parent().map(PathBuf::from)
+            } else {
+                None
+            }
+        });
+        let Some(target) = target else {
             let error = format!("{}: {entered}", self.catalog.folder_not_found);
             if let Some(p) = self.picker.as_mut() {
                 p.error = Some(error);
@@ -816,6 +813,40 @@ mod tests {
             app.picker.as_ref().unwrap().path,
             deep,
             "walked down from here"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn paste_respects_picker_text_modes() {
+        let _env = crate::persist::test_env("picker-paste-modes");
+        let tmp = std::env::temp_dir().join(format!("luvus-pickmodes-{}", std::process::id()));
+        let deep = tmp.join("nested");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&deep).unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_folder_picker_at(tmp.clone());
+
+        app.picker_start_go_to();
+        app.handle_event(AppEvent::Paste(format!("\"{}\"\n", deep.display())));
+        let picker = app.picker.as_ref().unwrap();
+        assert_eq!(picker.path, tmp, "paste only fills the Go To field");
+        assert_eq!(
+            picker.going_to.as_deref(),
+            Some(format!("\"{}\"", deep.display()).as_str())
+        );
+
+        app.handle_picker_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.picker.as_ref().unwrap().path, deep);
+
+        app.handle_picker_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        app.handle_event(AppEvent::Paste("new\nfolder".into()));
+        assert_eq!(
+            app.picker.as_ref().unwrap().creating.as_deref(),
+            Some("newfolder")
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/src/app/picker.rs
+++ b/src/app/picker.rs
@@ -200,6 +200,44 @@ impl App {
         }
     }
 
+    /// Jump the picker to a pasted path — the way you get to a folder that is
+    /// twenty levels deep or on another drive without walking there row by row.
+    ///
+    /// Accepts what a file manager or a shell actually puts on the clipboard:
+    /// surrounding whitespace and quotes are stripped, and a pasted *file* lands
+    /// on its parent folder (dragging a file in is a normal way to mean "this
+    /// project"). Anything that doesn't resolve leaves the browsed folder alone
+    /// and reports it in the modal rather than silently doing nothing.
+    pub fn picker_goto(&mut self, raw: &str) {
+        let text = raw.trim().trim_matches(['"', '\'']).trim();
+        if text.is_empty() {
+            return;
+        }
+        let path = PathBuf::from(text);
+        let target = if path.is_dir() {
+            Some(path)
+        } else if path.is_file() {
+            path.parent().map(PathBuf::from)
+        } else {
+            None
+        };
+        match target {
+            Some(dir) => {
+                if let Some(p) = self.picker.as_mut() {
+                    p.path = dir;
+                    p.cursor = 0;
+                    p.error = None;
+                }
+                self.picker_refresh();
+            }
+            None => {
+                if let Some(p) = self.picker.as_mut() {
+                    p.error = Some(format!("no such folder: {text}"));
+                }
+            }
+        }
+    }
+
     /// Key handling while the folder picker is open.
     pub fn handle_picker_key(&mut self, key: KeyEvent) {
         // New-folder name input sub-mode.
@@ -718,6 +756,45 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         }));
         assert!(app.picker.as_ref().unwrap().going_to.is_some());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A pasted path navigates the picker instead of leaking into the pane
+    /// behind it — the only way to reach a deep folder without walking there.
+    #[test]
+    fn pasting_a_path_jumps_the_picker_there() {
+        let tmp = std::env::temp_dir().join(format!("luvus-pickpaste-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let deep = tmp.join("a").join("b");
+        std::fs::create_dir_all(&deep).unwrap();
+        std::fs::write(deep.join("f.txt"), "hi").unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_folder_picker();
+
+        // Quoted, with trailing whitespace — what a file manager actually pastes.
+        app.handle_event(crate::event::AppEvent::Paste(format!(
+            "\"{}\"  ",
+            deep.display()
+        )));
+        assert_eq!(
+            app.picker.as_ref().unwrap().path,
+            deep,
+            "jumped to the path"
+        );
+
+        // A pasted *file* means its folder.
+        app.handle_event(crate::event::AppEvent::Paste(
+            deep.join("f.txt").display().to_string(),
+        ));
+        assert_eq!(app.picker.as_ref().unwrap().path, deep);
+
+        // Nonsense reports itself and leaves the browsed folder alone.
+        app.handle_event(crate::event::AppEvent::Paste("nope-not-a-path".into()));
+        assert_eq!(app.picker.as_ref().unwrap().path, deep);
+        assert!(app.picker.as_ref().unwrap().error.is_some());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -1117,6 +1117,21 @@ impl App {
             _ => {}
         }
     }
+
+    /// Append pasted text to the fuzzy query and recompute once. Replaying a
+    /// paste as keys would rank metadata and queue worker requests per character.
+    pub fn search_paste(&mut self, pasted: &str) {
+        let Some(search) = self.search.as_mut() else {
+            return;
+        };
+        let previous_len = search.query.len();
+        search
+            .query
+            .extend(pasted.chars().filter(|character| !character.is_control()));
+        if search.query.len() != previous_len {
+            self.search_recompute();
+        }
+    }
 }
 
 impl GlobalSearch {
@@ -1710,6 +1725,21 @@ mod tests {
             serde_json::from_str(&app.handle_search_activate(&request)).unwrap();
         assert_eq!(value["result"]["activated"], true);
         assert_eq!(app.workspaces[0].active_tab, 1);
+    }
+
+    #[test]
+    fn pasted_text_updates_the_fuzzy_query_once() {
+        let _env = crate::persist::test_env("fuzzy-search-paste");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_search();
+        let generation = app.search.as_ref().unwrap().generation;
+
+        assert!(app.handle_event(crate::event::AppEvent::Paste("Cargo\n.toml".into())));
+
+        let search = app.search.as_ref().unwrap();
+        assert_eq!(search.query, "Cargo.toml");
+        assert_eq!(search.generation, generation.wrapping_add(1));
     }
 
     #[test]


### PR DESCRIPTION
## The problem

`paste_into_modal` (`app/input.rs`) listed the rename prompts but neither the folder picker nor the global search, even though both capture the keyboard in `handle_key`. Pasting with either of them open sent the text **to the pane behind the modal**: a pasted path ended up in whatever shell or agent happened to be focused.

And the picker only navigates with `j/k/h/l`, so there was no way to reach a deep folder or another drive without walking the tree row by row.

## The fix

- The global search receives the paste as its query.
- The picker has no text field, so a pasted path **is** the navigation: it jumps there. Surrounding whitespace and quotes are stripped (what a file manager actually puts on the clipboard), a pasted file lands on its parent folder, and anything that does not resolve leaves the browsed folder alone and says so in the modal instead of silently doing nothing.
- The picker's "new folder" sub-mode still receives the paste as text.

Follows #61: with AltGr fixed you can *type* the path, and with this you can *paste* it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Folder picker now supports hidden-file toggling, a Home shortcut, mouse interactions, and Go To navigation.
  * Pasted paths may be quoted, absolute, home-relative, or current-folder-relative; file paths open their containing folder.
  * Search fields now accept pasted text while filtering control characters.
  * Improved terminal keyboard shortcuts, mouse interactions, diff navigation, and Git file opening.
  * Added clearer terminal lifecycle and no-workspace responses.

* **Bug Fixes**
  * Invalid pasted paths show an error without changing the current folder.
  * Copy selections now avoid unwanted margins and transcript gutters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->