### PR TITLE
fix(files): the git tint never applied on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           cargo test --locked app::backend::tests
           cargo test --locked terminal::backend::tests
           cargo test --locked altgr
+          cargo test --locked diff::git::tests::tree_tint_uses_nested_visible_spelling_and_new_rename_path
       - name: Validate published protocol fixtures
         shell: pwsh
         run: |

--- a/src/diff/git.rs
+++ b/src/diff/git.rs
@@ -608,8 +608,9 @@ pub fn tree_tint(
     visible_root: &Path,
 ) -> HashMap<PathBuf, crate::git::local::FileStatus> {
     use crate::git::local::FileStatus;
-    let canonical =
-        std::fs::canonicalize(visible_root).unwrap_or_else(|_| visible_root.to_path_buf());
+    let Some(visible_prefix) = visible_repo_prefix(&snapshot.repo_root, visible_root) else {
+        return HashMap::new();
+    };
     let mut map = HashMap::new();
     for changed in &snapshot.files {
         let Some(path) = changed
@@ -623,10 +624,14 @@ pub fn tree_tint(
         let Ok(relative) = path.to_path_buf() else {
             continue;
         };
-        let absolute = snapshot.repo_root.join(relative);
-        if !absolute.starts_with(&canonical) {
+        let Ok(relative) = relative.strip_prefix(&visible_prefix) else {
             continue;
-        }
+        };
+        // FILES indexes paths exactly as the workspace supplied them. Build the
+        // key on that spelling instead of Git's repo-root spelling or a
+        // canonical path (`C:/repo`, `C:\repo`, and `\\?\C:\repo` can all name
+        // the same Windows directory; symlinked roots differ similarly).
+        let absolute = visible_root.join(relative);
         let status = match changed.status {
             DiffFileStatus::Added => FileStatus::Added,
             DiffFileStatus::Deleted => FileStatus::Deleted,
@@ -638,7 +643,7 @@ pub fn tree_tint(
         map.entry(absolute.clone()).or_insert(status);
         let mut current = absolute.parent();
         while let Some(dir) = current {
-            if dir == canonical || !dir.starts_with(&canonical) {
+            if dir == visible_root || !dir.starts_with(visible_root) {
                 break;
             }
             map.entry(dir.to_path_buf()).or_insert(FileStatus::DirDirty);
@@ -646,6 +651,18 @@ pub fn tree_tint(
         }
     }
     map
+}
+
+/// Locate the visible workspace inside the repository using canonical roots,
+/// then return only their relative relationship. Display/map keys are still
+/// built on `visible_root`, preserving the caller's spelling and avoiding
+/// canonicalization of changed paths that may have been deleted.
+fn visible_repo_prefix(repo_root: &Path, visible_root: &Path) -> Option<PathBuf> {
+    let canonical = std::fs::canonicalize(repo_root)
+        .ok()
+        .zip(std::fs::canonicalize(visible_root).ok())
+        .and_then(|(repo, visible)| visible.strip_prefix(repo).ok().map(PathBuf::from));
+    canonical.or_else(|| visible_root.strip_prefix(repo_root).ok().map(PathBuf::from))
 }
 
 #[cfg(test)]
@@ -728,10 +745,22 @@ mod tests {
 
     impl TestRepo {
         fn new(name: &str) -> Self {
+            let thread = std::thread::current();
+            let thread_name = thread.name().unwrap_or("test");
+            let safe_thread_name: String = thread_name
+                .chars()
+                .map(|ch| {
+                    if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                        ch
+                    } else {
+                        '-'
+                    }
+                })
+                .collect();
             let path = std::env::temp_dir().join(format!(
                 "luvus-diff-{name}-{}-{}",
                 std::process::id(),
-                std::thread::current().name().unwrap_or("test")
+                safe_thread_name
             ));
             let _ = std::fs::remove_dir_all(&path);
             std::fs::create_dir_all(&path).unwrap();
@@ -814,5 +843,60 @@ mod tests {
         assert_eq!(diff.additions, 2);
         assert_eq!(diff.deletions, 0);
         assert!(!diff.binary);
+    }
+
+    #[test]
+    fn tree_tint_uses_nested_visible_spelling_and_new_rename_path() {
+        let repo = TestRepo::new("tree-tint-nested");
+        std::fs::create_dir_all(repo.0.join("src")).unwrap();
+        std::fs::write(repo.0.join("src/old file.txt"), "old\n").unwrap();
+        std::fs::write(repo.0.join("outside.txt"), "base\n").unwrap();
+        repo.git(&["add", "src/old file.txt", "outside.txt"]);
+        repo.git(&["commit", "-qm", "base"]);
+        repo.git(&["mv", "src/old file.txt", "src/new file.txt"]);
+        std::fs::write(repo.0.join("outside.txt"), "changed\n").unwrap();
+
+        let visible = repo.0.join("src");
+        let snapshot = scan(&visible, 1).unwrap();
+        let tint = tree_tint(&snapshot, &visible);
+
+        assert_eq!(
+            tint.get(&visible.join("new file.txt")).copied(),
+            Some(crate::git::local::FileStatus::Renamed)
+        );
+        assert!(!tint.contains_key(&visible.join("old file.txt")));
+        assert!(!tint.contains_key(&repo.0.join("outside.txt")));
+        assert!(tint.keys().all(|path| path.starts_with(&visible)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tree_tint_preserves_a_symlinked_visible_root() {
+        use std::os::unix::fs::symlink;
+
+        let repo = TestRepo::new("tree-tint-symlink");
+        std::fs::create_dir_all(repo.0.join("src")).unwrap();
+        std::fs::write(repo.0.join("src/file.txt"), "base\n").unwrap();
+        repo.git(&["add", "src/file.txt"]);
+        repo.git(&["commit", "-qm", "base"]);
+        std::fs::write(repo.0.join("src/file.txt"), "changed\n").unwrap();
+
+        let link = repo.0.with_file_name(format!(
+            "{}-visible",
+            repo.0.file_name().unwrap().to_string_lossy()
+        ));
+        let _ = std::fs::remove_file(&link);
+        symlink(&repo.0, &link).unwrap();
+        let visible = link.join("src");
+        let snapshot = scan(&visible, 1).unwrap();
+        let tint = tree_tint(&snapshot, &visible);
+
+        assert_eq!(
+            tint.get(&visible.join("file.txt")).copied(),
+            Some(crate::git::local::FileStatus::Modified)
+        );
+        assert!(!tint.contains_key(&repo.0.join("src/file.txt")));
+
+        let _ = std::fs::remove_file(link);
     }
 }

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -696,18 +696,20 @@ mod tests {
         std::fs::write(dir.join("src/a.rs"), b"one\ntwo\n").unwrap(); // modified
         std::fs::write(dir.join("src/b.rs"), b"new\n").unwrap(); // untracked
         let map = super::tree_status(&dir);
-        let canon = std::fs::canonicalize(&dir).unwrap();
+        // Keys carry the caller's own spelling of `root` — that is what the file
+        // tree holds, and what the dock looks up. Anything canonicalized (the
+        // `\\?\` prefix on Windows, a resolved `/tmp` on macOS) would miss.
         assert_eq!(
-            map.get(&canon.join("src/a.rs")).copied(),
+            map.get(&dir.join("src/a.rs")).copied(),
             Some(super::FileStatus::Modified)
         );
         assert_eq!(
-            map.get(&canon.join("src/b.rs")).copied(),
+            map.get(&dir.join("src/b.rs")).copied(),
             Some(super::FileStatus::Untracked)
         );
         // the `src` dir is marked dirty (contains changes)
         assert_eq!(
-            map.get(&canon.join("src")).copied(),
+            map.get(&dir.join("src")).copied(),
             Some(super::FileStatus::DirDirty)
         );
         let _ = std::fs::remove_dir_all(&dir);
@@ -961,14 +963,21 @@ fn classify_code(code: &str) -> FileStatus {
 pub fn tree_status(root: &Path) -> std::collections::HashMap<PathBuf, FileStatus> {
     use std::collections::HashMap;
     let mut map: HashMap<PathBuf, FileStatus> = HashMap::new();
-    let Ok(top) = run(root, &["rev-parse", "--show-toplevel"]) else {
+    // `--porcelain` paths are relative to the repo toplevel; `--show-prefix` is
+    // where `root` sits inside it. Both are built onto `root` in the caller's own
+    // spelling, never onto what git prints or what `canonicalize` returns: git
+    // reports `C:/proj` with forward slashes and `canonicalize` adds the `\\?\`
+    // verbatim prefix, while the file tree holds `C:\proj`. Comparing those three
+    // spellings dropped every entry on Windows, so the FILES dock rendered
+    // untinted no matter how dirty the repo was (docs/43 WIN-6). Symlinked
+    // parents (`/tmp` on macOS) diverged the same way.
+    let Ok(prefix) = run(root, &["rev-parse", "--show-prefix"]) else {
         return map;
     };
-    let top = PathBuf::from(top.trim());
+    let prefix = prefix.trim();
     let Ok(raw) = run(root, &["status", "--porcelain=v1"]) else {
         return map;
     };
-    let canon_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     for line in raw.lines() {
         if line.len() < 4 {
             continue;
@@ -976,16 +985,16 @@ pub fn tree_status(root: &Path) -> std::collections::HashMap<PathBuf, FileStatus
         let code = &line[..2];
         // A rename shows "old -> new"; the new path is what's on disk.
         let path_str = line[3..].rsplit(" -> ").next().unwrap_or(&line[3..]);
-        let abs = top.join(path_str.trim_end_matches('/'));
         // Only entries inside the visible tree.
-        if !abs.starts_with(&canon_root) {
+        let Some(rel) = path_str.strip_prefix(prefix) else {
             continue;
-        }
+        };
+        let abs = root.join(rel.trim_end_matches('/'));
         map.insert(abs.clone(), classify_code(code));
         // Mark intermediate directories (between root and the file) as dirty.
         let mut cur = abs.parent();
         while let Some(dir) = cur {
-            if dir == canon_root || !dir.starts_with(&canon_root) {
+            if dir == root || !dir.starts_with(root) {
                 break;
             }
             map.entry(dir.to_path_buf()).or_insert(FileStatus::DirDirty);

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -696,20 +696,18 @@ mod tests {
         std::fs::write(dir.join("src/a.rs"), b"one\ntwo\n").unwrap(); // modified
         std::fs::write(dir.join("src/b.rs"), b"new\n").unwrap(); // untracked
         let map = super::tree_status(&dir);
-        // Keys carry the caller's own spelling of `root` — that is what the file
-        // tree holds, and what the dock looks up. Anything canonicalized (the
-        // `\\?\` prefix on Windows, a resolved `/tmp` on macOS) would miss.
+        let canon = std::fs::canonicalize(&dir).unwrap();
         assert_eq!(
-            map.get(&dir.join("src/a.rs")).copied(),
+            map.get(&canon.join("src/a.rs")).copied(),
             Some(super::FileStatus::Modified)
         );
         assert_eq!(
-            map.get(&dir.join("src/b.rs")).copied(),
+            map.get(&canon.join("src/b.rs")).copied(),
             Some(super::FileStatus::Untracked)
         );
         // the `src` dir is marked dirty (contains changes)
         assert_eq!(
-            map.get(&dir.join("src")).copied(),
+            map.get(&canon.join("src")).copied(),
             Some(super::FileStatus::DirDirty)
         );
         let _ = std::fs::remove_dir_all(&dir);
@@ -963,21 +961,14 @@ fn classify_code(code: &str) -> FileStatus {
 pub fn tree_status(root: &Path) -> std::collections::HashMap<PathBuf, FileStatus> {
     use std::collections::HashMap;
     let mut map: HashMap<PathBuf, FileStatus> = HashMap::new();
-    // `--porcelain` paths are relative to the repo toplevel; `--show-prefix` is
-    // where `root` sits inside it. Both are built onto `root` in the caller's own
-    // spelling, never onto what git prints or what `canonicalize` returns: git
-    // reports `C:/proj` with forward slashes and `canonicalize` adds the `\\?\`
-    // verbatim prefix, while the file tree holds `C:\proj`. Comparing those three
-    // spellings dropped every entry on Windows, so the FILES dock rendered
-    // untinted no matter how dirty the repo was (docs/43 WIN-6). Symlinked
-    // parents (`/tmp` on macOS) diverged the same way.
-    let Ok(prefix) = run(root, &["rev-parse", "--show-prefix"]) else {
+    let Ok(top) = run(root, &["rev-parse", "--show-toplevel"]) else {
         return map;
     };
-    let prefix = prefix.trim();
+    let top = PathBuf::from(top.trim());
     let Ok(raw) = run(root, &["status", "--porcelain=v1"]) else {
         return map;
     };
+    let canon_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     for line in raw.lines() {
         if line.len() < 4 {
             continue;
@@ -985,16 +976,16 @@ pub fn tree_status(root: &Path) -> std::collections::HashMap<PathBuf, FileStatus
         let code = &line[..2];
         // A rename shows "old -> new"; the new path is what's on disk.
         let path_str = line[3..].rsplit(" -> ").next().unwrap_or(&line[3..]);
+        let abs = top.join(path_str.trim_end_matches('/'));
         // Only entries inside the visible tree.
-        let Some(rel) = path_str.strip_prefix(prefix) else {
+        if !abs.starts_with(&canon_root) {
             continue;
-        };
-        let abs = root.join(rel.trim_end_matches('/'));
+        }
         map.insert(abs.clone(), classify_code(code));
         // Mark intermediate directories (between root and the file) as dirty.
         let mut cur = abs.parent();
         while let Some(dir) = cur {
-            if dir == root || !dir.starts_with(root) {
+            if dir == canon_root || !dir.starts_with(&canon_root) {
                 break;
             }
             map.entry(dir.to_path_buf()).or_insert(FileStatus::DirDirty);


### PR DESCRIPTION
## Summary

- Rebase the contribution onto the current Luvus FILES and DIFF implementation.
- Restore Git tinting on Windows when Git and the workspace use different spellings of the same path.
- Preserve caller-visible paths for symlinked and nested workspace roots.

## Implementation

- Apply the fix in src/diff/git.rs, the production path that now supplies FILES tint data.
- Resolve only the repository-to-workspace relative prefix through canonical roots, then build map keys from the workspace path supplied by the caller.
- Keep the existing porcelain v2 NUL-delimited parser, including byte-safe paths and rename records.
- Exclude repository changes outside a nested visible workspace.
- Remove the obsolete src/git/local.rs change from the final PR diff.

## Validation

- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --locked: 873 unit tests and 12 integration tests passed
- Added focused coverage for nested roots, filenames with spaces, staged renames, outside-tree filtering, and symlink spelling.
- Added the focused path-spelling regression to the native Windows CI job.

## Compatibility

No CLI, API, configuration, or file-format behavior changes. This only changes how structured Git status paths are mapped back to the visible FILES tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested workspaces, renamed files, deleted paths, and symlinked workspace locations.
  * Preserved visible path representations across supported platforms for more accurate change display.
  * Improved behavior when workspace and repository paths cannot be related.

* **Tests**
  * Added Windows coverage for nested workspace paths, rename scenarios, and symlinked roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->