### PR TITLE
fix(agent): Claude sessions were never found on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           cargo test --locked terminal::backend::tests
           cargo test --locked altgr
           cargo test --locked diff::git::tests::tree_tint_uses_nested_visible_spelling_and_new_rename_path
+          cargo test --locked agent::tests::claude_project_dir_encodes_every_non_alphanumeric
       - name: Validate published protocol fixtures
         shell: pwsh
         run: |

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -437,12 +437,16 @@ fn fx_base() -> PathBuf {
 // Conversations live at `<base>/projects/<encoded-cwd>/<session-uuid>.jsonl`,
 // where the cwd is encoded by replacing every `/` and `.` with `-`.
 
-fn claude_project_dir(base: &Path, cwd: &Path) -> PathBuf {
+pub(crate) fn claude_project_dir(base: &Path, cwd: &Path) -> PathBuf {
     let enc: String = cwd
         .to_string_lossy()
         .chars()
         .map(|c| {
-            if matches!(c, '/' | '\\' | '.') {
+            // `:` matters on Windows: Claude itself encodes `C:\Users\me` as
+            // `C--Users-me`, and leaving the colon in also makes `join` treat the
+            // component as a *drive-relative* path, so the lookup silently
+            // escaped `base` and landed next to the process working directory.
+            if matches!(c, '/' | '\\' | '.' | ':') {
                 '-'
             } else {
                 c

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -435,23 +435,23 @@ fn fx_base() -> PathBuf {
 
 // ── Claude Code ─────────────────────────────────────────────────────────────
 // Conversations live at `<base>/projects/<encoded-cwd>/<session-uuid>.jsonl`,
-// where the cwd is encoded by replacing every `/` and `.` with `-`.
+// where the cwd is encoded by replacing every character that is not
+// ASCII-alphanumeric with `-`.
 
 pub(crate) fn claude_project_dir(base: &Path, cwd: &Path) -> PathBuf {
     let enc: String = cwd
         .to_string_lossy()
         .chars()
-        .map(|c| {
-            // `:` matters on Windows: Claude itself encodes `C:\Users\me` as
-            // `C--Users-me`, and leaving the colon in also makes `join` treat the
-            // component as a *drive-relative* path, so the lookup silently
-            // escaped `base` and landed next to the process working directory.
-            if matches!(c, '/' | '\\' | '.' | ':') {
-                '-'
-            } else {
-                c
-            }
-        })
+        // Claude collapses *everything* outside `[A-Za-z0-9]`, not just the
+        // separators: spaces, underscores and non-ASCII letters go too, as its
+        // own directories show (`…\ETLS\JV_CO2_ETL_WSC` → `-ETLS-JV-CO2-ETL-WSC`,
+        // `…\Área Interna` → `--rea-Interna`). Encoding only `/ \ . :` kept the
+        // space, so every project whose path has one — on Windows, most of them
+        // — still missed. The colon matters twice over: leaving it in also makes
+        // `join` treat the component as a *drive-relative* path, so the lookup
+        // silently escaped `base` and landed next to the process working
+        // directory.
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect();
     base.join("projects").join(enc)
 }
@@ -1402,6 +1402,31 @@ mod tests {
         d
     }
 
+    /// Claude collapses every non-alphanumeric character of the cwd, not just
+    /// the separators. Encoding only `/ \ . :` kept the space in `Codigo fuente`
+    /// and no Windows project with a space in its path was ever found.
+    #[test]
+    fn claude_project_dir_encodes_every_non_alphanumeric() {
+        let enc = |cwd: &str| {
+            claude_project_dir(Path::new("/base"), Path::new(cwd))
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        };
+        assert_eq!(enc(r"C:\Users\me\proj"), "C--Users-me-proj", "drive colon");
+        assert_eq!(
+            enc(r"D:\Users\me\Codigo fuente\Personal"),
+            "D--Users-me-Codigo-fuente-Personal",
+            "the space too"
+        );
+        assert_eq!(
+            enc("/home/me/JV_CO2_ETL"),
+            "-home-me-JV-CO2-ETL",
+            "underscore"
+        );
+        assert_eq!(enc("/home/me/Área"), "-home-me--rea", "non-ASCII letter");
+    }
     #[test]
     fn resume_commands() {
         assert!(resume_command("claude", "abc")

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1407,25 +1407,39 @@ mod tests {
     /// and no Windows project with a space in its path was ever found.
     #[test]
     fn claude_project_dir_encodes_every_non_alphanumeric() {
+        let base = Path::new("claude-store");
         let enc = |cwd: &str| {
-            claude_project_dir(Path::new("/base"), Path::new(cwd))
+            claude_project_dir(base, Path::new(cwd))
                 .file_name()
                 .unwrap()
                 .to_string_lossy()
                 .into_owned()
         };
-        assert_eq!(enc(r"C:\Users\me\proj"), "C--Users-me-proj", "drive colon");
         assert_eq!(
-            enc(r"D:\Users\me\Codigo fuente\Personal"),
-            "D--Users-me-Codigo-fuente-Personal",
+            enc(r"C:\Users\developer\project"),
+            "C--Users-developer-project",
+            "drive colon"
+        );
+        assert_eq!(
+            enc(r"D:\Work\source code\project"),
+            "D--Work-source-code-project",
             "the space too"
         );
         assert_eq!(
-            enc("/home/me/JV_CO2_ETL"),
-            "-home-me-JV-CO2-ETL",
+            enc("/home/developer/data_pipeline"),
+            "-home-developer-data-pipeline",
             "underscore"
         );
-        assert_eq!(enc("/home/me/Área"), "-home-me--rea", "non-ASCII letter");
+        assert_eq!(
+            enc("/workspace/café"),
+            "-workspace-caf-",
+            "non-ASCII letter"
+        );
+        assert_eq!(
+            claude_project_dir(base, Path::new(r"C:\Users\developer\project")),
+            base.join("projects").join("C--Users-developer-project"),
+            "a Windows drive path stays inside Claude's configured store"
+        );
     }
     #[test]
     fn resume_commands() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6830,18 +6830,8 @@ mod tests {
         let store =
             std::env::temp_dir().join(format!("luvus-cross-tab-pairing-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&store);
-        let enc: String = cwd
-            .to_string_lossy()
-            .chars()
-            .map(|c| {
-                if matches!(c, '/' | '\\' | '.') {
-                    '-'
-                } else {
-                    c
-                }
-            })
-            .collect();
-        let proj = store.join("projects").join(enc);
+        // The real encoder, so a test can never drift from what luvus looks up.
+        let proj = crate::agent::claude_project_dir(&store, &cwd);
         std::fs::create_dir_all(&proj).unwrap();
         std::fs::write(proj.join("first-session.jsonl"), "{}").unwrap();
         std::thread::sleep(std::time::Duration::from_millis(20));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6550,18 +6550,8 @@ mod tests {
         // A Claude store holding exactly one session for that folder.
         let store = std::env::temp_dir().join(format!("luvus-dupsess-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&store);
-        let enc: String = cwd
-            .to_string_lossy()
-            .chars()
-            .map(|c| {
-                if matches!(c, '/' | '\\' | '.') {
-                    '-'
-                } else {
-                    c
-                }
-            })
-            .collect();
-        let proj = store.join("projects").join(enc);
+        // The real encoder, so a test can never drift from what luvus looks up.
+        let proj = crate::agent::claude_project_dir(&store, &cwd);
         std::fs::create_dir_all(&proj).unwrap();
         std::fs::write(proj.join("only-session.jsonl"), "{}").unwrap();
         std::env::set_var("CLAUDE_CONFIG_DIR", &store);
@@ -6605,18 +6595,8 @@ mod tests {
         let cwd = app.panes.get(&older).unwrap().cwd.clone();
         let store = std::env::temp_dir().join(format!("luvus-hooksess-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&store);
-        let enc: String = cwd
-            .to_string_lossy()
-            .chars()
-            .map(|c| {
-                if matches!(c, '/' | '\\' | '.') {
-                    '-'
-                } else {
-                    c
-                }
-            })
-            .collect();
-        let proj = store.join("projects").join(enc);
+        // The real encoder, so a test can never drift from what luvus looks up.
+        let proj = crate::agent::claude_project_dir(&store, &cwd);
         std::fs::create_dir_all(&proj).unwrap();
         std::fs::write(proj.join("owned.jsonl"), "{}").unwrap();
         std::env::set_var("CLAUDE_CONFIG_DIR", &store);
@@ -6672,18 +6652,8 @@ mod tests {
         // A Claude store holding the parent's session.
         let store = std::env::temp_dir().join(format!("luvus-forksess-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&store);
-        let enc: String = cwd
-            .to_string_lossy()
-            .chars()
-            .map(|c| {
-                if matches!(c, '/' | '\\' | '.') {
-                    '-'
-                } else {
-                    c
-                }
-            })
-            .collect();
-        let proj = store.join("projects").join(enc);
+        // The real encoder, so a test can never drift from what luvus looks up.
+        let proj = crate::agent::claude_project_dir(&store, &cwd);
         std::fs::create_dir_all(&proj).unwrap();
         std::fs::write(proj.join("parent-sess.jsonl"), "{}").unwrap();
         std::env::set_var("CLAUDE_CONFIG_DIR", &store);
@@ -6752,18 +6722,8 @@ mod tests {
 
         let store = std::env::temp_dir().join(format!("luvus-forknewer-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&store);
-        let enc: String = cwd
-            .to_string_lossy()
-            .chars()
-            .map(|c| {
-                if matches!(c, '/' | '\\' | '.') {
-                    '-'
-                } else {
-                    c
-                }
-            })
-            .collect();
-        let proj = store.join("projects").join(enc);
+        // The real encoder, so a test can never drift from what luvus looks up.
+        let proj = crate::agent::claude_project_dir(&store, &cwd);
         std::fs::create_dir_all(&proj).unwrap();
         std::fs::write(proj.join("parent-sess.jsonl"), "{}").unwrap();
         std::env::set_var("CLAUDE_CONFIG_DIR", &store);
@@ -6817,18 +6777,8 @@ mod tests {
 
         let store = std::env::temp_dir().join(format!("luvus-pairing-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&store);
-        let enc: String = cwd
-            .to_string_lossy()
-            .chars()
-            .map(|c| {
-                if matches!(c, '/' | '\\' | '.') {
-                    '-'
-                } else {
-                    c
-                }
-            })
-            .collect();
-        let proj = store.join("projects").join(enc);
+        // The real encoder, so a test can never drift from what luvus looks up.
+        let proj = crate::agent::claude_project_dir(&store, &cwd);
         std::fs::create_dir_all(&proj).unwrap();
         // The older pane's session was written first.
         std::fs::write(proj.join("old-sess.jsonl"), "{}").unwrap();


### PR DESCRIPTION
## Summary

- Restore Claude session discovery for Windows drive paths.
- Match the directory encoding used by Claude for separators, spaces, underscores, punctuation, and non-ASCII characters.
- Prevent a drive-relative encoded component from escaping the configured Claude session store.
- Rebase the contribution onto the current post-#63 Luvus implementation.

## Implementation

- Encode every character outside ASCII A-Z, a-z, and 0-9 as a hyphen.
- Keep the shared encoder in src/agent.rs for automatic resume, ranked session discovery, and Mission Control usage lookup.
- Route all six current duplicate-pane, hook, fork, ambiguity, and cross-tab fixtures through the production encoder.
- Preserve the newer bounded usage reader in src/agent/usage.rs instead of restoring its obsolete predecessor.
- Leave live process and sidebar state detection unchanged.

## Windows regression coverage

The focused test uses clearly synthetic paths and verifies:

- C:\Users\developer\project becomes C--Users-developer-project
- generic paths with spaces and underscores match Claude storage names
- a synthetic non-ASCII workspace name is collapsed consistently
- the resulting path stays below the configured projects directory

The regression runs in the native windows-latest CI job alongside the existing protocol and ConPTY checks.

## Local validation

- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --locked
- 874 unit tests and 12 integration tests passed before the fixture-only naming cleanup

No CLI, socket, UHP, snapshot-format, or behavior changes for other agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Claude session path coverage for Windows drives, spaces, underscores, accented characters, and store containment.
  - Updated session-related tests to consistently use production path handling, including cross-tab session pairing.
  - Added the Claude project-directory encoding test to the Windows CI suite.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->