### PR TITLE
test(windows): make the suite runnable on Windows

### DIFF
--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -718,9 +718,10 @@ mod tests {
         let mut app = App::new(120, 40, tx).unwrap();
         let tabs_before = app.workspaces[app.active_ws].tabs.len();
 
-        // `cat` stands in for an editor: a real program launched with the file as
-        // a literal argv element (present on every unix CI runner).
-        app.open_file_in_editor(file.clone(), "cat");
+        // A real program launched with the file as a literal argv element, so
+        // the pane is a true PTY: `cat` on unix, `cmd /c type` on Windows.
+        let editor = if cfg!(windows) { "cmd /c type" } else { "cat" };
+        app.open_file_in_editor(file.clone(), editor);
 
         assert_eq!(
             app.workspaces[app.active_ws].tabs.len(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8058,6 +8058,9 @@ mod tests {
     // Clicking a pane's title opens the running-command overlay. The point is
     // that the command comes from the OS, not the screen: an agent's own UI
     // elides long commands and those characters never reach luvus at all.
+    /// Unix only: `platform::process_tree` returns an empty vec off unix, so the
+    /// overlay degrades to the pane's own command and has no tree to assert.
+    #[cfg(unix)]
     #[test]
     fn clicking_a_pane_title_shows_the_real_command() {
         use ratatui::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
@@ -8814,17 +8817,23 @@ mod tests {
         let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
         app.open_settings();
         app.handle_event(AppEvent::Key(KeyEvent::new(
-            KeyCode::Char('2'),
+            KeyCode::Char('3'),
             KeyModifiers::NONE,
-        ))); // Layout
+        ))); // Layout — `1` General, `2` Theme, `3` Layout (`SettingsTab::ALL`)
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
 
         assert_eq!(app.config.shell, "default");
-        // The Shell row (control index 5) cycles forward on click.
+        // The Shell row cycles forward on click. Ask the row list where it is:
+        // a hardcoded index silently clicks whatever moved into its place.
+        let shell_idx = app
+            .layout_rows()
+            .iter()
+            .position(|r| matches!(r, crate::app::settings::LayoutRow::Shell))
+            .expect("the Layout tab has a Shell row on Windows");
         let row = app
             .settings_ctl_rects
             .iter()
-            .find(|(i, _)| *i == 5)
+            .find(|(i, _)| *i == shell_idx)
             .unwrap()
             .1;
         app.handle_event(AppEvent::Mouse(MouseEvent {
@@ -9076,6 +9085,9 @@ mod tests {
 mod cwd_test {
     use super::*;
 
+    /// Unix only: `platform::process_cwd` has no Windows implementation, so a
+    /// pane there never follows a `cd` and there is nothing to assert.
+    #[cfg(unix)]
     #[test]
     fn pane_cwd_follows_cd_without_moving_its_workspace() {
         let _env = crate::persist::test_env("pane-cwd-follows-cd");

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -765,6 +765,9 @@ detached
         g(&["init", "-q", "-b", "main"]);
         g(&["config", "user.email", "t@t"]);
         g(&["config", "user.name", "t"]);
+        // Git for Windows ships `core.autocrlf=true` in its system config, which
+        // would hand the checkouts below CRLF and fail the byte comparisons.
+        g(&["config", "core.autocrlf", "false"]);
         write("X", "base\n");
         g(&["add", "."]);
         g(&["commit", "-q", "-m", "base"]);

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -676,12 +676,23 @@ mod tests {
         fs::create_dir_all(&tmp).unwrap();
         std::env::set_var("LUVUS_COPILOT_DIR", &tmp);
         fs::write(tmp.join("bohay-agent-hook.sh"), "old managed script").unwrap();
+        // Built through serde, not `format!`: a Windows temp path is full of
+        // backslashes, and pasting one into a JSON string literal produces
+        // invalid escapes — the file then failed to parse and the assertions
+        // below read `null` for everything.
+        let legacy = tmp.join("bohay-agent-hook.sh");
+        let settings = serde_json::json!({
+            "keep": "yes",
+            "hooks": {
+                "sessionStart": [
+                    { "hooks": [ { "type": "command", "command": legacy } ] },
+                    { "hooks": [ { "type": "command", "command": "echo user" } ] },
+                ]
+            }
+        });
         fs::write(
             tmp.join("settings.json"),
-            format!(
-                r#"{{"keep":"yes","hooks":{{"sessionStart":[{{"hooks":[{{"type":"command","command":"{}/bohay-agent-hook.sh"}}]}},{{"hooks":[{{"type":"command","command":"echo user"}}]}}]}}}}"#,
-                tmp.display()
-            ),
+            serde_json::to_vec_pretty(&settings).unwrap(),
         )
         .unwrap();
 


### PR DESCRIPTION
Five tests fail on `main` on any Windows machine. The `windows build` CI job only builds, so none of this shows up there. None of these are luvus bugs — the two genuine ones are #63 and #64.

- **`settings_shell_choice_cycles_and_persists`** opened tab `2`, which has been **Theme** since General was added to `SettingsTab::ALL`, and clicked control row `5`, which has been the title-path toggle since two rows were inserted above `Shell`. So the test asserted a Windows-only picker while touching neither of them. The tab key is corrected and the row index is derived from `layout_rows()` so it cannot rot again.
- **`installing_replaces_only_the_legacy_managed_hook`** interpolated a temp path into a JSON string literal. A Windows path's backslashes are invalid JSON escapes, so `settings.json` never parsed and every assertion read `null`. Built through `serde_json::json!` instead.
- **`integrate_branch_merges_clean_then_flags_a_conflict`** compares file bytes against a checkout made under Git for Windows' shipped `core.autocrlf=true`. The throwaway repo now sets `core.autocrlf=false`.
- **`opening_with_editor_spawns_a_pty_pane_in_a_new_tab`** spawned `cat`. It now uses `cmd /c type` on Windows — still a real program in a real PTY on both platforms.
- **`pane_cwd_follows_cd_without_moving_its_workspace`** and **`clicking_a_pane_title_shows_the_real_command`** assert behaviour that only exists on unix: `platform::process_cwd` and `platform::process_tree` have no Windows implementation and return `None` / an empty vec by design. Gated `#[cfg(unix)]` rather than failing where the feature deliberately isn't there.

Worth considering separately: making the Windows CI job run `cargo test` too, now that it can pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test reliability on Windows and Unix systems.
  * Updated editor and shell tests to use platform-appropriate commands and more resilient UI selection.
  * Standardized temporary Git repositories to ensure consistent line endings.
  * Improved configuration test handling for platform-specific file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->