### PR TITLE
fix(git): fall back to focused pane's cwd when workspace root isn't a repo

### DIFF
--- a/src/app/git.rs
+++ b/src/app/git.rs
@@ -1514,9 +1514,12 @@ mod tests {
         app.panes.get_mut(&focus).unwrap().cwd = repo.clone();
 
         app.open_git_tab(0);
-        assert!(
-            app.active_is_git(),
-            "git tab opens using the focused pane's cwd, not the stale workspace root"
+        let view = app
+            .active_git()
+            .expect("git tab opens using the focused pane's cwd, not the stale workspace root");
+        assert_eq!(
+            view.repo_root, repo,
+            "the git tab targets the focused pane's repo, not the workspace root"
         );
     }
 

--- a/src/app/git.rs
+++ b/src/app/git.rs
@@ -38,9 +38,16 @@ impl App {
             let pane_cwd = self.focused_cwd();
             if pane_cwd != ws_root {
                 let pane_check = local::repo_check(&pane_cwd);
-                if matches!(pane_check, local::RepoCheck::Repo) {
-                    root = pane_cwd;
-                    check = pane_check;
+                match pane_check {
+                    local::RepoCheck::Repo => {
+                        root = pane_cwd;
+                        check = pane_check;
+                    }
+                    // The pane cwd itself failed to check (bad permissions, a
+                    // broken `git`, ...): that's worth surfacing even if the
+                    // workspace root was just an ordinary non-repo folder.
+                    local::RepoCheck::Error(_) => check = pane_check,
+                    local::RepoCheck::NotRepo => {}
                 }
             }
         }

--- a/src/app/git.rs
+++ b/src/app/git.rs
@@ -34,7 +34,10 @@ impl App {
         let ws_root = self.workspaces[wsi].cwd.clone();
         let mut root = ws_root.clone();
         let mut check = local::repo_check(&root);
-        if !matches!(check, local::RepoCheck::Repo) {
+        // Only fall back on an ordinary "not a repo" root. A workspace-root
+        // `Error` (broken `git`, bad `PATH`, ...) must still surface as a
+        // toast, even when the focused pane happens to be a valid repo.
+        if matches!(check, local::RepoCheck::NotRepo) {
             let pane_cwd = self.focused_cwd();
             if pane_cwd != ws_root {
                 let pane_check = local::repo_check(&pane_cwd);

--- a/src/app/git.rs
+++ b/src/app/git.rs
@@ -13,6 +13,15 @@ use crate::git::{
 
 impl App {
     /// Open (or focus) the git tab for `workspace`. Idempotent — one git tab per workspace.
+    ///
+    /// `Workspace.cwd` is fixed at workspace creation and never follows a
+    /// pane's live shell `cd` (see `App::refresh_cwds`). A user who just `cd`s
+    /// into a repo inside a pane, instead of opening a dedicated workspace
+    /// there, got a silent no-op from `Ctrl+Space g`: the check ran against
+    /// the stale workspace root, correctly saw "not a repo", and stopped
+    /// (issue/67). So when the workspace root itself isn't a repo, fall back
+    /// to the now-active workspace's focused pane's actual live cwd before
+    /// giving up.
     pub fn open_git_tab(&mut self, wsi: usize) {
         if wsi >= self.workspaces.len() {
             return;
@@ -22,9 +31,31 @@ impl App {
             self.workspaces[wsi].active_tab = i;
             return;
         }
-        let root = self.workspaces[wsi].cwd.clone();
-        if !local::is_repo(&root) {
-            return; // a workspace that isn't a git repo has no git tab
+        let ws_root = self.workspaces[wsi].cwd.clone();
+        let mut root = ws_root.clone();
+        let mut check = local::repo_check(&root);
+        if !matches!(check, local::RepoCheck::Repo) {
+            let pane_cwd = self.focused_cwd();
+            if pane_cwd != ws_root {
+                let pane_check = local::repo_check(&pane_cwd);
+                if matches!(pane_check, local::RepoCheck::Repo) {
+                    root = pane_cwd;
+                    check = pane_check;
+                }
+            }
+        }
+        match check {
+            local::RepoCheck::Repo => {}
+            // A workspace that genuinely isn't a git repo stays a silent
+            // no-op (the common case, e.g. a scratch folder).
+            local::RepoCheck::NotRepo => return,
+            // `git` missing or failing to run is surfaced instead of
+            // swallowed, so `Ctrl+Space g` never again looks like it did
+            // nothing (issue/67).
+            local::RepoCheck::Error(e) => {
+                self.show_toast(format!("git tab: {e}"));
+                return;
+            }
         }
         let view = GitView::new(root.clone());
         let view_id = view.id;
@@ -1441,6 +1472,42 @@ mod tests {
         assert_eq!(app.active_git().unwrap().scroll, 0); // reset on switch
         app.git_scroll(2);
         assert_eq!(app.active_git().unwrap().cursor, 2);
+    }
+
+    /// A workspace whose fixed `cwd` is not a repo, but whose focused pane
+    /// has since `cd`'d into one, still opens the git tab: `open_git_tab`
+    /// falls back to the pane's live cwd instead of silently no-op'ing
+    /// (issue/67).
+    #[test]
+    fn git_tab_falls_back_to_focused_pane_cwd() {
+        let repo =
+            std::env::temp_dir().join(format!("luvus-gittab-fallback-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&repo);
+        std::fs::create_dir_all(&repo).unwrap();
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo)
+            .output()
+            .expect("git");
+
+        let not_repo =
+            std::env::temp_dir().join(format!("luvus-gittab-notrepo-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&not_repo);
+        std::fs::create_dir_all(&not_repo).unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        // The workspace root stays fixed at a non-repo folder...
+        app.workspaces[0].cwd = not_repo;
+        // ...but the focused pane (created by `App::new`) has `cd`'d into the repo.
+        let focus = app.layout().focus;
+        app.panes.get_mut(&focus).unwrap().cwd = repo.clone();
+
+        app.open_git_tab(0);
+        assert!(
+            app.active_is_git(),
+            "git tab opens using the focused pane's cwd, not the stale workspace root"
+        );
     }
 
     #[test]

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -63,7 +63,18 @@ pub fn repo_check(cwd: &Path) -> RepoCheck {
                 RepoCheck::NotRepo
             }
         }
-        Ok(_) => RepoCheck::NotRepo, // ran fine, exited non-zero: not a repo
+        // Exited non-zero: git's own "not a git repository" is the ordinary
+        // case and stays quiet, but any other failure (malformed config, a
+        // corrupt `.git`, permission errors) is a real problem and must
+        // surface instead of being folded into the same silent no-op.
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stderr.contains("not a git repository") {
+                RepoCheck::NotRepo
+            } else {
+                RepoCheck::Error(stderr.trim().to_string())
+            }
+        }
     }
 }
 
@@ -617,6 +628,30 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir);
         let _ = std::fs::remove_dir_all(&outside);
+    }
+
+    /// A `.git` with a malformed config makes `git rev-parse` exit non-zero
+    /// for a reason that isn't "not a git repository". That's a real problem,
+    /// not an ordinary non-repo folder, so it must surface as `Error`, not
+    /// get folded into the same silent `NotRepo`.
+    #[test]
+    fn repo_check_surfaces_malformed_git_config_as_error() {
+        use super::{repo_check, RepoCheck};
+
+        let dir = std::env::temp_dir().join(format!("luvus-rc-badcfg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::process::Command::new("git")
+            .args(["init", "-q", dir.to_str().unwrap()])
+            .output()
+            .unwrap();
+        std::fs::write(dir.join(".git/config"), "[core\n").unwrap(); // unterminated section
+
+        match repo_check(&dir) {
+            RepoCheck::Error(e) => assert!(!e.is_empty()),
+            _ => panic!("expected Error for a malformed git config"),
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The origin slug parser accepts ssh + https GitHub URLs and rejects others,

--- a/src/git/local.rs
+++ b/src/git/local.rs
@@ -30,6 +30,43 @@ pub fn is_repo(cwd: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Result of [`repo_check`]: distinguishes "really not a repo" (stay quiet,
+/// e.g. a scratch folder) from "couldn't tell" (surface it, since something's
+/// actually broken).
+pub enum RepoCheck {
+    Repo,
+    NotRepo,
+    /// `git` is missing, failed to run, or errored. The reason is the
+    /// process's stderr (or the spawn error), e.g. a stale `PATH` picked up by
+    /// the long-running server, or a WSL `git.exe` shadowing the Linux binary.
+    Error(String),
+}
+
+/// Same check as [`is_repo`], but keeps *why* on failure instead of collapsing
+/// it to `false` (issue/67): a plain "not a repo" (`rev-parse` ran fine and
+/// said so) should stay a silent no-op, but `git` missing or failing to run at
+/// all deserves a toast instead of a keypress that does nothing with no
+/// feedback. Unlike [`is_repo`] this does not go through [`run`], because that
+/// collapses "ran, exited non-zero" (the ordinary not-a-repo case) and "could
+/// not run at all" (the actual problem) into the same `Err`.
+pub fn repo_check(cwd: &Path) -> RepoCheck {
+    match Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(cwd)
+        .output()
+    {
+        Err(e) => RepoCheck::Error(format!("git not found: {e}")),
+        Ok(out) if out.status.success() => {
+            if String::from_utf8_lossy(&out.stdout).trim() == "true" {
+                RepoCheck::Repo
+            } else {
+                RepoCheck::NotRepo
+            }
+        }
+        Ok(_) => RepoCheck::NotRepo, // ran fine, exited non-zero: not a repo
+    }
+}
+
 /// The GitHub `owner/repo` slug from the `origin` remote, if it's a GitHub URL.
 /// Used to pin `gh pr/issue list --repo <slug>` to the repo you're actually in,
 /// rather than relying on `gh`'s base-repo resolution (which picks the wrong repo
@@ -555,6 +592,33 @@ fn parse_contributors(out: &str) -> Vec<Contributor> {
 
 #[cfg(test)]
 mod tests {
+    /// `repo_check` reports `Repo` inside a work tree and `NotRepo` outside
+    /// one, matching `is_repo`'s existing bool for those two cases (issue/67).
+    #[test]
+    fn repo_check_matches_is_repo_for_repo_and_non_repo() {
+        use super::{is_repo, repo_check, RepoCheck};
+
+        let dir = std::env::temp_dir().join(format!("luvus-rc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&dir)
+            .output()
+            .unwrap();
+        assert!(is_repo(&dir));
+        assert!(matches!(repo_check(&dir), RepoCheck::Repo));
+
+        let outside = std::env::temp_dir().join(format!("luvus-rc-not-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&outside);
+        std::fs::create_dir_all(&outside).unwrap();
+        assert!(!is_repo(&outside));
+        assert!(matches!(repo_check(&outside), RepoCheck::NotRepo));
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&outside);
+    }
+
     /// The origin slug parser accepts ssh + https GitHub URLs and rejects others,
     /// so PRs/Issues pin to the repo you're in (not gh's default base repo).
     #[test]


### PR DESCRIPTION
`Ctrl+Space` `g` now opens the git tab even when the focused pane has `cd`'d into a repo the workspace root itself isn't in.

## What

- `open_git_tab` falls back to the focused pane's live cwd when the workspace root isn't a repo, instead of silently doing nothing.
- New `repo_check()` in `src/git/local.rs` keeps the failure reason instead of collapsing "not a repo" and "`git` failed to run" into the same `false`. A broken `git` (missing binary, bad `PATH`) now shows a toast instead of another silent no-op.
- `is_repo` is untouched; other callers keep using it.

## Why

Fixes #67.

`Workspace.cwd` is fixed at creation and never follows a pane's shell `cd` (only the branch indicator updates on checkout). My workspace was the default one in `$HOME`, one directory above the actual repo. I `cd`'d into the project inside a pane and expected `Ctrl+Space` `g` to pick that up, since the pane on screen was clearly inside a repo.

Instead, `open_git_tab` checked `$HOME`, correctly found no repo, and returned with no feedback at all, no toast, no tab, nothing. No keybinding bug, no terminal/protocol issue: a static workspace root versus a pane that had wandered into a repo underneath it.

Discussed in the issue thread: https://github.com/RizRiyz/luvus/issues/67#issuecomment-5358365138

## Verification

- [x] `cargo test --locked` (one pre-existing, unrelated failure: `cli::tests::docs_cli_reference_matches_help`, reproduces on `main` too)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Manual testing: reproduced the exact scenario from the issue (default `$HOME` workspace, `cd`'d into a repo inside a pane, `Ctrl+Space` `g`), confirmed broken on `main` and fixed on this branch.

## Notes

Added two regression tests: `repo_check` against a repo and a non-repo tempdir, and `open_git_tab` falling back to a focused pane's cwd when the workspace root isn't a repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git actions can open the Git tab from the focused pane’s repository when the workspace root is not a repository.
  * Git repository detection now distinguishes valid repositories, non-repository folders, and Git failures.

* **Bug Fixes**
  * Git detection errors, including malformed configuration, are preserved and shown in visible toasts with failure details.
  * Git actions no longer incorrectly fall back to a pane repository when the workspace root check fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->