### PR TITLE
fix(copy): improve terminal selection and copy mode

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -70,7 +70,16 @@ fn append_selected_row(
     ((start_row, start_col), (end_row, end_col)): ((usize, usize), (usize, usize)),
 ) {
     let chars: Vec<char> = line.chars().collect();
-    let left = if row == start_row { start_col } else { 0 };
+    // A drag that starts beside the visible text must not grow leftward on
+    // middle rows: that otherwise copies the blank cell between the pane edge
+    // and every list item. Keep the drag's leftmost edge for those rows while
+    // preserving the exact start point on the first row.
+    let middle_left = start_col.min(end_col);
+    let left = if row == start_row {
+        start_col
+    } else {
+        middle_left
+    };
     let right = if row == end_row {
         end_col
     } else {
@@ -99,8 +108,26 @@ fn finish_selected_text(mut out: String) -> Option<String> {
     (!out.trim().is_empty()).then_some(out)
 }
 
-/// Extract a linear terminal selection from logical rows. Both mouse and
-/// keyboard selection feed this function, keeping clipboard semantics aligned.
+/// Drop the one blank cell which can sit between a pane edge and uniformly
+/// aligned prose. This is deliberately narrow: code with its usual two- or
+/// four-space indentation is retained exactly as selected.
+fn strip_uniform_single_cell_margin(text: String) -> String {
+    let mut saw_text = false;
+    let uniform_margin = text.lines().filter(|line| !line.is_empty()).all(|line| {
+        saw_text = true;
+        line.starts_with(' ') && !line.starts_with("  ")
+    });
+    if !saw_text || !uniform_margin {
+        return text;
+    }
+    text.lines()
+        .map(|line| line.strip_prefix(' ').unwrap_or(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Extract a terminal selection from logical rows. Both mouse and keyboard
+/// selection feed this function, keeping clipboard semantics aligned.
 fn extract_rows_selection(
     rows: &[String],
     ((start_row, start_col), (end_row, end_col)): ((usize, usize), (usize, usize)),
@@ -1463,7 +1490,7 @@ impl App {
 
     /// Begin keyboard copy mode at the visible viewport's top-left cell. The
     /// selection uses absolute history rows, so scrolling cannot invalidate it.
-    fn begin_copy_mode(&mut self) -> bool {
+    pub(super) fn begin_copy_mode(&mut self) -> bool {
         let id = self.layout().focus;
         let Some(pane) = self.panes.get(&id) else {
             return false;
@@ -1522,10 +1549,14 @@ impl App {
     }
 
     /// Copy the keyboard selection by the same clipboard queue as drag-to-copy.
-    fn finish_copy_mode(&mut self) {
+    pub(super) fn finish_copy_mode(&mut self) {
         let Some(copy) = self.copy_mode.take() else {
             return;
         };
+        let is_codex = self
+            .status
+            .get(&copy.pane)
+            .is_some_and(|status| status.agent == "codex");
         let text = self.panes.get(&copy.pane).and_then(|pane| {
             let range = copy.ordered();
             let mut output = String::new();
@@ -1542,7 +1573,13 @@ impl App {
             });
             finish_selected_text(output)
         });
-        if let Some(text) = text {
+        if let Some(text) = text.map(|text| {
+            if is_codex {
+                strip_uniform_single_cell_margin(text)
+            } else {
+                text
+            }
+        }) {
             self.pending_clipboard = Some(text);
             let msg = self.catalog.copied;
             self.show_toast(msg);
@@ -1554,7 +1591,7 @@ impl App {
         }
     }
 
-    /// Copy-mode navigation. `Shift+V` starts it, then hjkl/arrows, word jumps,
+    /// Copy-mode navigation starts from the configured prefix command, then hjkl/arrows, word jumps,
     /// page keys, Home/End, and g/G move the visual selection; y copies it.
     fn handle_copy_mode_key(&mut self, key: KeyEvent) -> bool {
         let Some(mut copy) = self.copy_mode else {
@@ -1714,7 +1751,7 @@ impl App {
             .visible_rows();
         let ((sx, sy), (ex, ey)) = sel.ordered();
         let (cx, cy) = (sel.content.x, sel.content.y);
-        extract_rows_selection(
+        let text = extract_rows_selection(
             &rows,
             (
                 (
@@ -1726,7 +1763,20 @@ impl App {
                     (ex as usize).saturating_sub(cx as usize),
                 ),
             ),
-        )
+        )?;
+        // A drag may begin in the single blank pane cell before uniformly
+        // aligned prose. Codex also emits that one-cell transcript gutter even
+        // when the drag starts on its first visible character. It remains
+        // visibly selected, but is padding rather than useful clipboard text.
+        let is_codex = self
+            .status
+            .get(&sel.pane)
+            .is_some_and(|status| status.agent == "codex");
+        Some(if sx == cx || is_codex {
+            strip_uniform_single_cell_margin(text)
+        } else {
+            text
+        })
     }
 
     /// Show a transient toast (e.g. "Copied") bottom-center for ~1.4s.
@@ -2149,14 +2199,6 @@ impl App {
                 let focus = self.layout().focus;
                 if self.views.contains_key(&focus) {
                     return self.handle_file_key(focus, key);
-                }
-                // `Shift+V` starts a visual, keyboard-driven selection. It is a
-                // host action (not terminal input), like Shift+Up scroll mode.
-                if key.modifiers.contains(KeyModifiers::SHIFT)
-                    && matches!(key.code, KeyCode::Char('v') | KeyCode::Char('V'))
-                    && self.begin_copy_mode()
-                {
-                    return true;
                 }
                 // `Shift+↑` / `Shift+PageUp` enter keyboard scroll mode (no prefix,
                 // works on a stock Mac keyboard). From there plain keys navigate.
@@ -3257,5 +3299,120 @@ mod link_click_tests {
             Some("abc\ndef"),
             "a skipped first row must not produce a leading newline"
         );
+    }
+
+    #[test]
+    fn multi_line_copy_keeps_the_drag_left_edge() {
+        // The first column is blank pane-side space before a Markdown list. A
+        // drag beginning on `-` must not add that blank to every middle row.
+        let rows = vec![
+            " - first".to_string(),
+            " - second".to_string(),
+            " - third".to_string(),
+        ];
+        assert_eq!(
+            extract_rows_selection(&rows, ((0, 1), (2, 7))).as_deref(),
+            Some("- first\n- second\n- third")
+        );
+    }
+
+    #[test]
+    fn mouse_copy_drops_a_uniform_one_cell_pane_margin() {
+        assert_eq!(
+            strip_uniform_single_cell_margin(
+                " Hello, rain on a windowpane\n Hello, wind with a traveling name\n Hello, all things we almost miss"
+                    .into()
+            ),
+            "Hello, rain on a windowpane\nHello, wind with a traveling name\nHello, all things we almost miss"
+        );
+        assert_eq!(
+            strip_uniform_single_cell_margin(
+                "    let preserved = true;\n    run(preserved);".into()
+            ),
+            "    let preserved = true;\n    run(preserved);",
+            "normal code indentation must stay intact"
+        );
+    }
+
+    #[test]
+    fn mouse_drag_copy_drops_the_pane_edge_margin_from_terminal_text() {
+        let _env = crate::persist::test_env("mouse-copy-pane-margin");
+        let source = " Morning arrives without ceremony,\r\n a thin gold line on the edge of the glass.\r\n The kettle speaks in its private language,";
+        let (mut app, mut term, _) = fixture_showing(source, 0);
+        // Hide the sidebars so the test deliberately starts at the pane's
+        // leftmost content cell, matching the screenshot case.
+        app.sidebars.left.visible = false;
+        app.sidebars.right.visible = false;
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let pane = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        let start = (content.x, content.y);
+        let end = (
+            start.0
+                + " The kettle speaks in its private language,"
+                    .chars()
+                    .count() as u16
+                - 1,
+            start.1 + 2,
+        );
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            start,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            end,
+            KeyModifiers::NONE,
+        ));
+        assert!(app.selection.is_some(), "the drag created a selection");
+        assert_eq!(
+            app.selection_text().as_deref(),
+            Some(
+                "Morning arrives without ceremony,\na thin gold line on the edge of the glass.\nThe kettle speaks in its private language,"
+            )
+        );
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            end,
+            KeyModifiers::NONE,
+        ));
+
+        assert_eq!(
+            app.pending_clipboard.as_deref(),
+            Some(
+                "Morning arrives without ceremony,\na thin gold line on the edge of the glass.\nThe kettle speaks in its private language,"
+            )
+        );
+    }
+
+    #[test]
+    fn codex_copy_drops_its_one_cell_transcript_gutter() {
+        let _env = crate::persist::test_env("codex-copy-gutter");
+        let (mut app, _term, _) = fixture_showing("  hello\r\n  world", 0);
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).expect("pane status").agent = "codex".into();
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        // The drag starts one cell in, so this verifies Codex detection rather
+        // than the generic pane-edge case above.
+        app.selection = Some(crate::app::Selection {
+            pane,
+            content,
+            anchor: (content.x + 1, content.y),
+            cursor: (content.x + 6, content.y + 1),
+        });
+
+        assert_eq!(app.selection_text().as_deref(), Some("hello\nworld"));
     }
 }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -24,6 +24,7 @@ pub enum Cmd {
     ClosePane,
     ZoomPane,
     ResizeMode,
+    CopyMode,
     NewTab,
     NextTab,
     PrevTab,
@@ -60,6 +61,7 @@ impl Cmd {
         Cmd::ClosePane,
         Cmd::ZoomPane,
         Cmd::ResizeMode,
+        Cmd::CopyMode,
         Cmd::NewTab,
         Cmd::NextTab,
         Cmd::PrevTab,
@@ -96,6 +98,7 @@ impl Cmd {
             Cmd::ClosePane => "close_pane",
             Cmd::ZoomPane => "zoom_pane",
             Cmd::ResizeMode => "resize_mode",
+            Cmd::CopyMode => "copy_mode",
             Cmd::NewTab => "new_tab",
             Cmd::NextTab => "next_tab",
             Cmd::PrevTab => "prev_tab",
@@ -135,6 +138,8 @@ impl Cmd {
             Cmd::ClosePane => cat.cmd_close_pane,
             Cmd::ZoomPane => cat.cmd_zoom_pane,
             Cmd::ResizeMode => cat.cmd_resize_mode,
+            // The Keys tab's section headings are intentionally English too.
+            Cmd::CopyMode => "Copy terminal text",
             Cmd::NewTab => cat.cmd_new_tab,
             Cmd::NextTab => cat.cmd_next_tab,
             Cmd::PrevTab => cat.cmd_prev_tab,
@@ -174,7 +179,8 @@ impl Cmd {
             | Cmd::ForkSession
             | Cmd::ClosePane
             | Cmd::ZoomPane
-            | Cmd::ResizeMode => "Panes",
+            | Cmd::ResizeMode
+            | Cmd::CopyMode => "Panes",
             Cmd::NewTab | Cmd::NextTab | Cmd::PrevTab | Cmd::RenameTab => "Tabs",
             Cmd::NewWorkspace
             | Cmd::CloseWorkspace
@@ -208,6 +214,7 @@ impl Cmd {
             Cmd::ClosePane => "x",
             Cmd::ZoomPane => "z",
             Cmd::ResizeMode => "r",
+            Cmd::CopyMode => "y",
             Cmd::NewTab => "c",
             Cmd::NextTab => "n",
             Cmd::PrevTab => "p",
@@ -287,9 +294,8 @@ pub const KEY_REFERENCE: &[(&str, &[(&str, &str)])] = &[
         ],
     ),
     (
-        "Copy mode  (no prefix)",
+        "Copy mode  (after Copy terminal text)",
         &[
-            ("Shift+v", "select terminal text with the keyboard"),
             ("arrows  hjkl", "extend the selection by character / line"),
             ("w / B", "next / previous word"),
             ("Space / b", "page down / up"),
@@ -678,6 +684,9 @@ impl App {
             }
             Cmd::ZoomPane => self.zoomed = !self.zoomed,
             Cmd::ResizeMode => self.enter_resize_mode(),
+            Cmd::CopyMode => {
+                self.begin_copy_mode();
+            }
             Cmd::NewTab => self.new_tab(),
             Cmd::NextTab => self.cycle_tab(1),
             Cmd::PrevTab => self.cycle_tab(-1),
@@ -756,6 +765,7 @@ mod tests {
         // `,` renames the tab (tmux-compatible); Settings moved to `=`.
         assert_eq!(m.get(","), Some(&Cmd::RenameTab));
         assert_eq!(m.get("="), Some(&Cmd::OpenSettings));
+        assert_eq!(m.get("y"), Some(&Cmd::CopyMode));
         // every command is reachable by its default key
         for &c in Cmd::ALL {
             assert!(m.values().any(|v| *v == c), "{c:?} bound");
@@ -769,6 +779,22 @@ mod tests {
         let m = build_keymap(&o);
         assert_eq!(m.get("t"), Some(&Cmd::NewTab));
         assert_ne!(m.get("c"), Some(&Cmd::NewTab)); // old default freed
+    }
+
+    #[test]
+    fn copy_mode_binding_is_editable_like_every_other_prefix_command() {
+        let _env = crate::persist::test_env("copy-mode-rebind");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+
+        assert_eq!(app.key_for(Cmd::CopyMode), "y");
+        app.rebind(Cmd::CopyMode, "t".into());
+        assert_eq!(app.key_for(Cmd::CopyMode), "t");
+        assert_eq!(app.keymap.get("t"), Some(&Cmd::CopyMode));
+
+        app.reset_binding(Cmd::CopyMode);
+        assert_eq!(app.key_for(Cmd::CopyMode), "y");
+        assert_eq!(app.keymap.get("y"), Some(&Cmd::CopyMode));
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1005,8 +1005,8 @@ impl Selection {
         }
     }
 
-    /// Whether terminal cell `(x, y)` is inside the linear selection (and the
-    /// pane's content area) — drives the render highlight.
+    /// Whether terminal cell `(x, y)` is inside the selection (and the pane's
+    /// content area) — drives the render highlight.
     pub fn contains(&self, x: u16, y: u16) -> bool {
         let c = self.content;
         if x < c.x || x >= c.right() || y < c.y || y >= c.bottom() {
@@ -1016,7 +1016,9 @@ impl Selection {
         if y < sy || y > ey {
             return false;
         }
-        let left = if y == sy { sx } else { c.x };
+        // Middle rows keep the drag's left edge instead of expanding into the
+        // pane margin. This keeps the highlighted range and copied text aligned.
+        let left = if y == sy { sx } else { sx.min(ex) };
         let right = if y == ey {
             ex
         } else {
@@ -4823,7 +4825,7 @@ mod tests {
     }
 
     #[test]
-    fn selection_spans_lines_linearly() {
+    fn selection_keeps_the_drag_left_edge_between_lines() {
         // Content rect at (x=2, y=1), 10 wide × 5 tall.
         let content = Rect::new(2, 1, 10, 5);
         let sel = Selection {
@@ -4836,8 +4838,10 @@ mod tests {
         assert!(sel.contains(4, 1));
         assert!(sel.contains(11, 1)); // last column (right() == 12)
         assert!(!sel.contains(3, 1)); // before the anchor
-                                      // Middle row: the full width.
-        assert!(sel.contains(2, 2) && sel.contains(11, 2));
+                                      // Middle row: it keeps the drag's left edge instead of
+                                      // expanding into the pane's left margin.
+        assert!(!sel.contains(2, 2));
+        assert!(sel.contains(4, 2) && sel.contains(11, 2));
         // Last row: up to the cursor column.
         assert!(sel.contains(6, 3));
         assert!(!sel.contains(7, 3)); // past the cursor
@@ -9052,8 +9056,12 @@ mod tests {
         };
         let offset = |app: &App| app.panes.get(&id).unwrap().scroll_state().0;
 
-        send(&mut app, KeyCode::Char('V'), KeyModifiers::SHIFT);
-        assert!(app.copy_mode.is_some(), "Shift+V enters keyboard copy mode");
+        send(&mut app, KeyCode::Char(' '), KeyModifiers::CONTROL);
+        send(&mut app, KeyCode::Char('y'), KeyModifiers::NONE);
+        assert!(
+            app.copy_mode.is_some(),
+            "the default prefix then y enters keyboard copy mode"
+        );
         send(&mut app, KeyCode::Char('g'), KeyModifiers::NONE);
         send(&mut app, KeyCode::Char('v'), KeyModifiers::NONE);
         send(&mut app, KeyCode::Char('l'), KeyModifiers::NONE);
@@ -9064,11 +9072,91 @@ mod tests {
 
         app.panes.get(&id).unwrap().scroll(8);
         let saved = offset(&app);
-        send(&mut app, KeyCode::Char('V'), KeyModifiers::SHIFT);
+        send(&mut app, KeyCode::Char(' '), KeyModifiers::CONTROL);
+        send(&mut app, KeyCode::Char('y'), KeyModifiers::NONE);
         send(&mut app, KeyCode::Char('j'), KeyModifiers::NONE);
         send(&mut app, KeyCode::Char('q'), KeyModifiers::NONE);
         assert!(app.copy_mode.is_none(), "q cancels copy mode");
         assert_eq!(offset(&app), saved, "cancel restores the prior viewport");
+    }
+
+    #[test]
+    fn keyboard_copy_trims_a_codex_transcript_gutter() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(40, 8, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).expect("pane status").agent = "codex".into();
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .engine
+            .lock()
+            .expect("engine")
+            .advance(b"\x1b[H\x1b[2J Hello\r\n world");
+        app.copy_mode = Some(CopyMode {
+            pane,
+            anchor: (1, 0),
+            cursor: (2, 5),
+            saved_scroll: 0,
+        });
+
+        app.finish_copy_mode();
+
+        assert_eq!(app.pending_clipboard.as_deref(), Some("Hello\nworld"));
+    }
+
+    #[test]
+    fn shift_v_never_enters_copy_mode() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(40, 8, tx).unwrap();
+        let pane = app.layout().focus;
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .engine
+            .lock()
+            .expect("engine")
+            .advance(b"terminal input");
+
+        assert!(
+            !app.handle_event(AppEvent::Key(KeyEvent::new(
+                KeyCode::Char('V'),
+                KeyModifiers::SHIFT,
+            ))),
+            "forwarded terminal input waits for child output to repaint"
+        );
+        assert!(
+            app.copy_mode.is_none(),
+            "uppercase V never enters copy mode"
+        );
+    }
+
+    #[test]
+    fn prefix_y_starts_copy_mode() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(40, 8, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).expect("pane status").agent = "codex".into();
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .engine
+            .lock()
+            .expect("engine")
+            .advance(b"build finished successfully");
+
+        assert!(app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char(' '),
+            KeyModifiers::CONTROL,
+        ))));
+        assert!(
+            app.handle_event(AppEvent::Key(KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::NONE,
+            ))),
+            "the default prefix then y starts copy mode over a Codex transcript"
+        );
+        assert!(app.copy_mode.is_some());
     }
 }
 

--- a/website/src/content/docs/docs/guides/scrollback.mdx
+++ b/website/src/content/docs/docs/guides/scrollback.mdx
@@ -43,9 +43,11 @@ Drag across a pane to select. Release **auto-copies** and flashes a *Copied*
 toast. luvus writes both your native OS clipboard (`pbcopy` / `wl-copy` /
 `xclip` / `clip`) and OSC 52, so it works locally *and* over SSH.
 
-For keyboard selection, press **`Shift+V`**. This enters copy mode and keeps
-all navigation inside Luvus: use arrows or `h`/`j`/`k`/`l` for character and
-line movement, `w` / `B` for words, `Space` / `b` for pages, and `g` / `G` for
-the oldest / newest retained row. Press `v` to reset the selection anchor at
-the cursor. Press **`y`** or Enter to copy and return to live output. Press
-**`q`** or Esc to cancel and restore the viewport where copy mode began.
+For keyboard selection, press **`Ctrl+Space`**, then **`y`** by default. Change
+the second key in **Settings → Keys → Copy terminal text**. Shift-based `V`
+input always passes through to the terminal, including inside agent prompts. Copy
+mode keeps all navigation inside Luvus: use arrows or `h`/`j`/`k`/`l` for
+character and line movement, `w` / `B` for words, `Space` / `b` for pages, and
+`g` / `G` for the oldest / newest retained row. Press `v` to reset the selection
+anchor at the cursor. Press **`y`** or Enter to copy and return to live output.
+Press **`q`** or Esc to cancel and restore the viewport where copy mode began.


### PR DESCRIPTION
Improve terminal copy selection behavior and make copy mode configurable.

## What
- Refines terminal selection handling in `src/app/input.rs`
- Adjusts key handling in `src/app/keys.rs`
- Threads configurable copy mode through `src/app/mod.rs`
- Updates the scrollback guide in `website/src/content/docs/docs/guides/scrollback.mdx`

## Why
- Better selection behavior in copy mode
- Expose copy-mode configuration through the app state

## Verification
- Tests: not run
- Clippy: not run
- Formatting: not run

## Scope Review
- No unrelated files found in the branch diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable keyboard copy mode, launched by `Ctrl+Space`, then `y` by default.
  * Added copy-mode navigation, selection, copying, and cancellation controls.
* **Bug Fixes**
  * Preserved the left edge of multiline mouse selections.
  * Removed unintended single-space margins from copied prose while retaining indentation.
  * Shift+V now passes through to the terminal.
* **Documentation**
  * Updated copy-mode instructions and shortcut references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->