### PR TITLE
feat(detect): add native fx state detection

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -204,6 +204,17 @@ impl App {
             let Some(pane) = self.panes.get(&id) else {
                 continue;
             };
+            let detection_rows = detect::screen_rows(
+                self.status
+                    .get(&id)
+                    .map(|status| status.agent.as_str())
+                    .unwrap_or(""),
+                self.proc_commands
+                    .get(&id)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]),
+                &self.manifests,
+            );
             let (last_generation, force_detect) = self
                 .status
                 .get(&id)
@@ -216,7 +227,7 @@ impl App {
                         Some((
                             generation,
                             engine.title().map(Arc::<str>::from),
-                            Arc::<str>::from(engine.detection_text(14)),
+                            Arc::<str>::from(engine.detection_text(detection_rows)),
                         ))
                     } else {
                         None

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -123,6 +123,14 @@ const KNOWN_AGENTS: &[KnownAgent] = &[
         distinct: &["pi-coding-agent"],
         ambiguous: &["pi"],
     },
+    // `fx` is a short, common token in filenames and prose, so never infer it
+    // from arbitrary screen output. Its process name and OSC title are
+    // deliberate identity signals and therefore safe.
+    KnownAgent {
+        name: "fx",
+        distinct: &[],
+        ambiguous: &["fx"],
+    },
 ];
 
 /// The runtime form of [`KnownAgent`]: owned, so `~/.luvus/manifests/*.toml` can
@@ -348,6 +356,18 @@ fn all(subs: &[&str]) -> Cond {
     Cond::All(subs.iter().map(|s| s.to_lowercase()).collect())
 }
 
+/// How much of the live terminal grid must reach the rule engine. Most agents
+/// keep state beside their bottom prompt, but fx can pin its transient activity
+/// above a tall blank footer area. Expand only a confirmed fx pane so every
+/// other pane retains the existing extraction cost and false-positive surface.
+pub(crate) fn screen_rows(known_agent: &str, running: &[String], manifests: &Manifests) -> u16 {
+    if known_agent.eq_ignore_ascii_case("fx") || manifests.process_has_agent(running, "fx") {
+        40
+    } else {
+        14
+    }
+}
+
 /// The compiled-in default rules (generic first, then per-agent).
 fn builtin_rules() -> Vec<Rule> {
     let gen = |state, priority, region, conds| Rule {
@@ -426,6 +446,73 @@ fn builtin_rules() -> Vec<Rule> {
             105,
             Region::Screen,
             vec![any(&["ctrl+c to stop"])],
+        ),
+        // fx suppresses its activity row while it needs user input. Its
+        // narrowest approval and question hints retain these paired controls,
+        // so they remain reliable even in a small pane.
+        per(
+            "fx",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&["enter confirm", "esc cancel"])],
+        ),
+        per(
+            "fx",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&["enter answer", "esc cancel"])],
+        ),
+        per(
+            "fx",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![any(&["permission needed ·", "needs permission"])],
+        ),
+        // Native fx activity rows. Match stable UI copy rather than raw PTY
+        // traffic: fx probes terminal capabilities while idle, so recent bytes
+        // alone are not evidence that the model is working.
+        per(
+            "fx",
+            State::Working,
+            125,
+            Region::Screen,
+            vec![any(&["• thinking", "retrying request in"])],
+        ),
+        per(
+            "fx",
+            State::Working,
+            120,
+            Region::Screen,
+            vec![any(&[
+                "listing |",
+                "reading |",
+                "writing |",
+                "editing |",
+                "running |",
+                "delegating |",
+                "opening |",
+            ])],
+        ),
+        per(
+            "fx",
+            State::Working,
+            120,
+            Region::Screen,
+            vec![all(&["• (", "↑", "↓"])],
+        ),
+        // Streamed response rows intentionally have no bullet or verb. The
+        // live token counter is active only while the idle input rail is absent;
+        // requiring both prevents a completed turn's retained counter from
+        // pinning fx to Working at its prompt.
+        per(
+            "fx",
+            State::Working,
+            115,
+            Region::Screen,
+            vec![all(&["(↑", "↓"]), Cond::Not(vec!["┃".to_string()])],
         ),
         // Newer Claude Code dropped the "esc to interrupt" hint and animates a
         // non-braille spinner (✢/✻/✳), so the generic working rules miss it and
@@ -966,6 +1053,135 @@ mod tests {
             &Manifests::builtin(),
         )
         .state
+    }
+
+    fn fx_state(bottom: &str, activity: bool, input: bool) -> State {
+        classify(
+            Some("fx · zai/glm-5.2"),
+            bottom,
+            activity,
+            input,
+            "zsh",
+            "fx",
+            &["/opt/homebrew/bin/fx".to_string()],
+            &Manifests::builtin(),
+        )
+        .state
+    }
+
+    #[test]
+    fn fx_identity_uses_process_or_title_not_incidental_output() {
+        let m = Manifests::builtin();
+        assert_eq!(screen_rows("", &["fx".to_string()], &m), 40);
+        assert_eq!(screen_rows("claude", &["claude".to_string()], &m), 14);
+        let running = classify(
+            Some("zsh"),
+            "generated file: effects/fx.rs",
+            true,
+            false,
+            "zsh",
+            "",
+            &["/opt/homebrew/bin/fx".to_string()],
+            &m,
+        );
+        assert_eq!(running.agent, "fx", "the running binary names the agent");
+
+        let titled = classify(
+            Some("fx · zai/glm-5.2"),
+            "",
+            false,
+            false,
+            "zsh",
+            "",
+            &[],
+            &m,
+        );
+        assert_eq!(titled.agent, "fx", "fx's OSC title is deliberate evidence");
+
+        let incidental = classify(
+            Some("zsh"),
+            "generated file: effects/fx.rs",
+            true,
+            false,
+            "zsh",
+            "",
+            &[],
+            &m,
+        );
+        assert_eq!(incidental.agent, "zsh", "screen prose must not name fx");
+    }
+
+    #[test]
+    fn fx_native_activity_rows_report_working() {
+        assert_eq!(fx_state("• Thinking (5s)", false, false), State::Working);
+        assert_eq!(
+            fx_state(
+                "Provider unavailable · HTTP 503 · retrying request in 4s · attempt 4/10",
+                false,
+                false,
+            ),
+            State::Working
+        );
+        assert_eq!(
+            fx_state("running | 1 command started", false, false),
+            State::Working
+        );
+        assert_eq!(
+            fx_state("• (12s) (↑169 ↓5.1k)", false, false),
+            State::Working
+        );
+        assert_eq!(
+            fx_state("streamed response\n  (↑1.5k ↓20)", true, false),
+            State::Working
+        );
+    }
+
+    #[test]
+    fn fx_idle_prompt_ignores_terminal_probe_activity() {
+        assert_eq!(
+            fx_state("𝒇x\n┃\nauto · zai/glm-5.2", true, false),
+            State::Idle,
+            "PTY capability traffic alone must not make an idle fx pane Working"
+        );
+        assert_eq!(
+            fx_state(
+                "last response (↑10 ↓20)\n┃\nauto · zai/glm-5.2",
+                true,
+                false
+            ),
+            State::Idle,
+            "a retained token counter above the input rail is still idle"
+        );
+    }
+
+    #[test]
+    fn fx_native_interactions_report_blocked() {
+        assert_eq!(
+            fx_state(
+                "• Thinking (4s)\nPermission needed · Choose one\nEnter Confirm    Esc Cancel",
+                true,
+                false,
+            ),
+            State::Blocked,
+            "approval must outrank a lingering activity row"
+        );
+        assert_eq!(
+            fx_state(
+                "Should we proceed?\n1) Yes\n2) No\nEnter Answer · Esc Cancel",
+                false,
+                false,
+            ),
+            State::Blocked,
+            "question prompts wait for the user"
+        );
+        assert_eq!(
+            fx_state(
+                "Subagent worker needs permission\nEnter Confirm    Esc Cancel",
+                false,
+                false,
+            ),
+            State::Blocked
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add native process-aware detection for fx agent panes, including expanded screen inspection and working or blocked state rules.

## What
- recognize fx from its process or deliberate terminal title, without incidental screen false positives
- inspect additional terminal rows only for confirmed fx panes
- classify fx thinking, tool activity, streaming, permission, and question states
- add focused regression coverage for identity, activity, idle prompts, and blocked interactions

## Verification
- cargo test --locked: 606 passed
- cargo fmt --all --check: passed
- cargo clippy --all-targets -- -D warnings: passed

## Scope
- No unrelated tracked files found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and monitoring `fx` agent sessions.
  * Expanded terminal output capture for confirmed `fx` panes.
  * Added recognition for `fx` activity, streamed responses, retries, token counts, and interaction prompts.

* **Bug Fixes**
  * Improved working-state detection for agent sessions.
  * Correctly identifies approval requests and questions requiring attention.
  * Prevents idle prompts from being incorrectly marked as active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->