### PR TITLE
feat(search): add global fuzzy finder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,32 @@ perf(render): avoid repeated frame allocations
 docs: clarify module setup
 ```
 
+### AI assistance and transparency
+
+Disclose substantial use of AI tools when their output or technical direction
+is included in a commit. Add an `Assisted-by:` trailer with the tool name and
+the primary model name and version:
+
+```text
+feat(search): add global fuzzy finder
+
+Assisted-by: OpenAI Codex (GPT-5.6-sol)
+```
+
+An AI-assisted contribution must still be understood, reviewed, and owned by
+the contributor. Check generated code and documentation for correctness,
+security, licensing, performance, and compatibility before submitting it.
+
+`Co-authored-by:` does not replace `Assisted-by:`. If an AI tool substantially
+writes a pull request description or review comment, disclose that assistance
+in the description or comment as well because commit trailers only describe
+the commits.
+
+Standard formatters, deterministic editor actions, and short boilerplate
+autocomplete do not require a trailer. Research, testing, debugging, or private
+review also does not require one when no substantial AI output or technical
+direction is included in the contribution. When uncertain, disclose it.
+
 Luvus squash-merges pull requests, so follow-up commits during review are fine.
 You do not need to rebuild a perfect commit history before submitting changes.
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -458,6 +458,7 @@ impl App {
         // *server's* cwd — the very thing §3.3 removed.
         const WITHOUT_NODE: &[&str] = &[
             "ping",
+            "search.capabilities",
             "server.stop",
             "workspace.open",
             "node.open",
@@ -492,6 +493,14 @@ impl App {
                 "version": env!("CARGO_PKG_VERSION"),
                 "protocol":1,
                 "session": crate::session::display_name()
+            })),
+            "search.capabilities" => Ok(json!({
+                "type": "search_capabilities",
+                "version": 1,
+                "methods": ["search.query", "search.activate"],
+                "scopes": ["all", "navigate", "files", "output"],
+                "max_results": crate::search::RESULT_CAP,
+                "max_response_bytes": crate::search::federation::MAX_SESSION_RESPONSE_BYTES,
             })),
             "theme.list" => Ok(self.theme_registry.list_json(&self.config.theme)),
             "theme.path" => Ok(json!({

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -15,6 +15,8 @@ use crate::files::FileView;
 use crate::ids::PaneId;
 use crate::layout::{Axis, TileLayout};
 
+const RECENT_FILE_CAP: usize = 12;
+
 /// Where a file opens.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum OpenTarget {
@@ -194,6 +196,23 @@ impl App {
         }
     }
 
+    /// Open a fuzzy-finder file result in a whole tab in its owning workspace.
+    /// Reuse an existing whole-file tab, but never redirect the user into a
+    /// preview or split pane that happens to show the same path.
+    pub fn open_file_search_result(&mut self, path: PathBuf) {
+        match self.file_open_editor() {
+            Some(cmd) => self.open_file_in_editor(path, &cmd),
+            None => {
+                self.remember_file(&path);
+                if let Some(id) = self.file_tab_showing(&path) {
+                    self.focus_pane_global(id);
+                } else {
+                    self.create_file_view(path, OpenTarget::Tab);
+                }
+            }
+        }
+    }
+
     /// The configured default open action (docs/38), resolved to an editor
     /// run-command — or `None` for the read-only viewer. A configured editor
     /// that is no longer installed degrades to read-only, so a plain click never
@@ -245,6 +264,7 @@ impl App {
                 // pane with no file view behind it, so without this the tab bar
                 // has nothing to derive a name from and falls back to the number.
                 self.editor_files.insert(id, path.clone());
+                self.remember_file(&path);
                 let ws = &mut self.workspaces[self.active_ws];
                 ws.tabs.push(Tab::panes(TileLayout::new(id)));
                 ws.active_tab = ws.tabs.len() - 1;
@@ -499,11 +519,24 @@ impl App {
             )
     }
 
+    /// A native file view that owns its whole tab, excluding preview/split panes.
+    fn file_tab_showing(&self, path: &std::path::Path) -> Option<PaneId> {
+        self.ws().tabs.iter().find_map(|tab| {
+            let leaves = tab.layout.leaves();
+            let [id] = leaves.as_slice() else {
+                return None;
+            };
+            matches!(self.views.get(id), Some(ViewKind::File(view)) if view.path == path)
+                .then_some(*id)
+        })
+    }
+
     /// Open `path` in a native file view (docs/38 FILE-3). `Preview` reuses the
     /// one preview pane in the active workspace; `Pane` splits a fresh permanent
     /// pane; `Tab` opens a new tab. The file is read on a worker thread and
     /// applied via `FileRead`.
     pub fn open_file_view(&mut self, path: PathBuf, target: OpenTarget) {
+        self.remember_file(&path);
         // Already open? Focus that view instead of opening a duplicate.
         if let Some(id) = self.view_showing(&path) {
             self.focus_pane_global(id);
@@ -518,6 +551,10 @@ impl App {
             }
         }
 
+        self.create_file_view(path, target);
+    }
+
+    fn create_file_view(&mut self, path: PathBuf, target: OpenTarget) {
         let id = PaneId::alloc();
         self.views
             .insert(id, ViewKind::File(FileView::new(path.clone())));
@@ -541,10 +578,20 @@ impl App {
 
     /// Point an existing view leaf at a different file and re-read it.
     fn set_view_file(&mut self, id: PaneId, path: PathBuf) {
+        self.remember_file(&path);
         if let Some(ViewKind::File(v)) = self.views.get_mut(&id) {
             *v = FileView::new(path.clone());
         }
         self.schedule_file_read(id, path);
+    }
+
+    fn remember_file(&mut self, path: &Path) {
+        let workspace = self.ws().cwd.clone();
+        self.recent_files
+            .retain(|(cwd, existing)| cwd != &workspace || existing != path);
+        self.recent_files
+            .push_front((workspace, path.to_path_buf()));
+        self.recent_files.truncate(RECENT_FILE_CAP);
     }
 
     fn schedule_file_read(&mut self, id: PaneId, path: PathBuf) {
@@ -663,6 +710,30 @@ mod tests {
     use super::*;
     use crate::app::{DockKind, FileMenu, FileMenuItem};
     use ratatui::{backend::TestBackend, Terminal};
+
+    #[test]
+    fn recent_files_are_deduplicated_newest_first_and_bounded() {
+        let _env = crate::persist::test_env("file-recent-bounded");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        for index in 0..RECENT_FILE_CAP + 3 {
+            app.remember_file(Path::new(&format!("file-{index}.rs")));
+        }
+        assert_eq!(app.recent_files.len(), RECENT_FILE_CAP);
+        assert!(app.recent_files.front().unwrap().1.ends_with("file-14.rs"));
+        assert!(app.recent_files.back().unwrap().1.ends_with("file-3.rs"));
+
+        app.remember_file(Path::new("file-8.rs"));
+        assert_eq!(app.recent_files.len(), RECENT_FILE_CAP);
+        assert!(app.recent_files.front().unwrap().1.ends_with("file-8.rs"));
+        assert_eq!(
+            app.recent_files
+                .iter()
+                .filter(|(_, path)| path.ends_with("file-8.rs"))
+                .count(),
+            1
+        );
+    }
 
     /// A file's context menu leads with open actions (read-only + one per detected
     /// editor); a folder's does not — you don't "open" a directory into an editor.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -190,6 +190,35 @@ impl App {
                 self.finish_theme_uninstall(id, result);
                 return true;
             }
+            AppEvent::SearchFilesIndexed { instance, catalogs } => {
+                return self.apply_search_files(instance, catalogs);
+            }
+            AppEvent::SearchResults {
+                instance,
+                generation,
+                matches,
+                total,
+                capped,
+            } => {
+                return self.apply_search_results(instance, generation, matches, total, capped);
+            }
+            AppEvent::SearchFederatedResults {
+                instance,
+                generation,
+                matches,
+                total,
+                partial,
+            } => {
+                return self
+                    .apply_search_federated_results(instance, generation, matches, total, partial);
+            }
+            AppEvent::SearchHandoffReady { session, result } => {
+                match result {
+                    Ok(()) => self.pending_session_switch = Some(session),
+                    Err(error) => self.show_toast(format!("session switch failed: {error}")),
+                }
+                return true;
+            }
             other => other,
         };
         // Control-API requests and parked `wait.output` replies must be answered
@@ -205,6 +234,15 @@ impl App {
                     reply,
                 } => return self.handle_theme_reloaded(id, registry, reply),
                 AppEvent::Api(req) => {
+                    if req.method == "search.query" {
+                        self.start_search_api(req);
+                        return true;
+                    }
+                    if req.method == "search.activate" {
+                        let response = self.handle_search_activate(&req);
+                        let _ = req.reply.send(response);
+                        return true;
+                    }
                     let resp = self.handle_api(&req);
                     let _ = req.reply.send(resp);
                     return true;
@@ -278,6 +316,15 @@ impl App {
             // for them immediately (docs/81). Answer inline: like the old
             // server-side drain, an answered request counts as activity.
             AppEvent::Api(req) => {
+                if req.method == "search.query" {
+                    self.start_search_api(req);
+                    return true;
+                }
+                if req.method == "search.activate" {
+                    let response = self.handle_search_activate(&req);
+                    let _ = req.reply.send(response);
+                    return true;
+                }
                 let resp = self.handle_api(&req);
                 let _ = req.reply.send(resp);
                 true
@@ -419,7 +466,11 @@ impl App {
             | AppEvent::ClientDetach { .. }
             | AppEvent::ClientInput { .. } => false,
             // Consumed by the pre-dispatch worker-result branch above.
-            AppEvent::ThemeUninstalled { .. } => unreachable!(),
+            AppEvent::ThemeUninstalled { .. }
+            | AppEvent::SearchFilesIndexed { .. }
+            | AppEvent::SearchResults { .. }
+            | AppEvent::SearchFederatedResults { .. }
+            | AppEvent::SearchHandoffReady { .. } => unreachable!(),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,7 +2,7 @@
 //! agent detection. Panes are stored flat and referenced by id from the tree
 //! (docs/04). Prefix-key driven.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::{mpsc::Sender, Arc};
 use std::time::{Duration, Instant};
@@ -37,7 +37,7 @@ mod search;
 mod settings;
 mod switcher;
 
-pub use search::{GlobalSearch, SearchFlash, SearchHit};
+pub use search::{GlobalSearch, SearchFlash};
 
 pub use keys::{key_reference_rows, presets, Cmd, KEY_REFERENCE};
 pub use modules::ModuleMenuAction;
@@ -1302,6 +1302,10 @@ pub struct App {
     pub last_cursor: Option<(u16, u16)>,
     /// Foreground client asked to detach (prefix+q). Distinct from quit.
     pub detach_requested: bool,
+    /// The foreground client selected another named session in the global
+    /// finder. The server consumes this once and sends a logical handoff only
+    /// to that client.
+    pub pending_session_switch: Option<String>,
     /// The last node was closed, ending the session (docs/43 §3.3). *Every*
     /// client detaches, so the window closes, while the server stays up with no
     /// nodes — distinct from `detach_requested` (one client leaves, session
@@ -1463,6 +1467,9 @@ pub struct App {
     /// persisted — after a restart the pane is no longer that editor, so the
     /// label must not survive it. Untracked in `drop_leaf_runtime`.
     pub editor_files: HashMap<PaneId, PathBuf>,
+    /// Most recently opened files, newest first, scoped by workspace folder.
+    /// This is a small in-memory finder convenience and is never persisted.
+    pub recent_files: VecDeque<(PathBuf, PathBuf)>,
     /// Reused single-click **preview** panes. Each workspace may own one so
     /// browsing FILES or DIFF never focuses and replaces another workspace's
     /// preview.
@@ -1707,6 +1714,7 @@ impl App {
             usage_mtimes: std::collections::HashMap::new(),
             last_cursor: None,
             detach_requested: false,
+            pending_session_switch: None,
             end_session: false,
             force_redraw: false,
             pending_notify: Vec::new(),
@@ -1766,6 +1774,7 @@ impl App {
             diff_menu: None,
             views: HashMap::new(),
             editor_files: HashMap::new(),
+            recent_files: VecDeque::new(),
             preview_views: HashSet::new(),
             file_git_status: HashMap::new(),
             git_status_inflight: false,
@@ -2204,6 +2213,7 @@ impl App {
             usage_mtimes: std::collections::HashMap::new(),
             last_cursor: None,
             detach_requested: false,
+            pending_session_switch: None,
             end_session: false,
             force_redraw: false,
             pending_notify: Vec::new(),
@@ -2263,6 +2273,7 @@ impl App {
             diff_menu: None,
             views,
             editor_files: HashMap::new(),
+            recent_files: VecDeque::new(),
             preview_views: HashSet::new(),
             file_git_status: HashMap::new(),
             git_status_inflight: false,

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -1,230 +1,656 @@
-//! Global scrollback search (docs/63): find text across the retained output of
-//! every pane at once. This module holds the pure matcher and the pane-gathering
-//! entry point; the UI overlay and the `search` socket/CLI verb are thin
-//! front-ends over `App::search_all`.
+//! Dependency-free global fuzzy finder (docs/90).
+//!
+//! Small navigation metadata is ranked immediately. Complete file-path
+//! catalogs and retained terminal output are scored on workers and merged by a
+//! query generation, so typing never scans scrollback on the app loop.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 
 use super::App;
 use crate::ids::PaneId;
+use crate::search::{
+    rank_entries, rank_entry_refs_where, FuzzyQuery, SearchEntry, SearchKind, SearchMatch,
+    SearchScope, SearchTarget, OUTPUT_INDEX_BYTES, OUTPUT_PER_PANE_CAP, OUTPUT_ROW_CAP,
+    OUTPUT_SOURCE_BYTES, RESULT_CAP,
+};
 
-/// Per-pane and overall caps on how many matches we surface. Scanning stays
-/// bounded, and the overflow is counted (not silently dropped) so a caller can
-/// show "and N more".
-pub const PER_PANE_CAP: usize = 50;
-pub const TOTAL_CAP: usize = 500;
+static NEXT_SEARCH_INSTANCE: AtomicU64 = AtomicU64::new(1);
 
-/// One match: which pane and workspace it is in, the matched line, the byte
-/// column of the match within it, and the scroll `offset` that lands on it.
-#[derive(Clone, Debug, PartialEq)]
-pub struct SearchHit {
-    pub pane: PaneId,
-    pub ws: usize,
-    pub ws_name: String,
-    /// Scroll offset (lines above the live bottom) that brings the match on
-    /// screen, for `Pane::scroll_to`.
-    pub offset: usize,
-    /// Absolute retained-row index within the pane, for stable ordering.
-    pub row: usize,
-    pub line: String,
-    pub col: usize,
-    /// Lines this match sits above the newest line, captured at search time.
-    /// Used to compute which viewport row it lands on for the jump marker.
-    pub above: usize,
-}
-
-/// A brief highlight of the line a search jump landed on (docs/63), so you can
-/// see where the result is. Cleared by `tick_search_flash` when it expires.
 pub struct SearchFlash {
     pub pane: PaneId,
-    /// Content-relative row (0 = top of the pane's content area).
     pub row: u16,
-    /// The pane's scroll offset when we jumped. The band is only drawn while the
-    /// view is unchanged, so any scroll (wheel, keys, new output) hides it.
     pub scroll: usize,
     pub until: std::time::Instant,
 }
 
-/// A raw row match before it is tagged with pane/workspace context.
-struct RowHit {
-    row: usize,
-    offset: usize,
-    col: usize,
-    line: String,
-    above: usize,
+pub struct LegacySearchHit {
+    pub pane: PaneId,
+    pub ws: usize,
+    pub ws_name: String,
+    pub offset: usize,
+    pub line: String,
+    pub col: usize,
 }
 
-/// Match `needle` against one pane's rows (`needle` is already lowercased when
-/// `case_sensitive` is false). Returns up to `cap` hits plus the *total* number
-/// found, so the caller can report an overflow. A matched row at index `i` maps
-/// to scroll offset `history - i` (clamped at 0): older rows sit further up.
-fn match_rows(
-    rows: &[String],
-    lower: &[String],
-    history: usize,
-    needle: &str,
-    case_sensitive: bool,
-    cap: usize,
-) -> (Vec<RowHit>, usize) {
-    let mut hits = Vec::new();
-    let mut total = 0usize;
-    if needle.is_empty() {
-        return (hits, 0);
-    }
-    for i in 0..rows.len() {
-        // Case-insensitive matches the row lowercased once at snapshot time (no
-        // per-keystroke allocation); case-sensitive matches the original. Either
-        // way the displayed line and columns come from the original.
-        let hay = if case_sensitive { &rows[i] } else { &lower[i] };
-        if let Some(col) = hay.find(needle) {
-            total += 1;
-            if hits.len() < cap {
-                hits.push(RowHit {
-                    row: i,
-                    offset: history.saturating_sub(i),
-                    col,
-                    line: rows[i].clone(),
-                    above: rows.len().saturating_sub(1).saturating_sub(i),
-                });
-            }
-        }
-    }
-    (hits, total)
-}
-
-/// One pane's retained text, captured once so the overlay can re-scan it per
-/// keystroke without re-locking engines (docs/63): results reflect the moment
-/// the overlay opened, which is exactly the intended, non-live behavior.
-struct PaneRows {
+struct OutputTarget {
     pane: PaneId,
-    ws: usize,
-    ws_name: String,
-    /// Original text, for the displayed line.
-    rows: Vec<String>,
-    /// The same rows lowercased once at snapshot time, so case-insensitive
-    /// matching per keystroke is a plain `find` with zero allocation.
-    lower: Vec<String>,
-    history: usize,
+    detail: Arc<str>,
+    workspace: Arc<str>,
+    engine: Arc<Mutex<dyn crate::terminal::vt::VtEngine>>,
 }
 
-/// The global-search overlay state. Present => it captures all input.
+struct SearchRequest {
+    generation: u64,
+    query: String,
+    case_sensitive: bool,
+    scope: SearchScope,
+    files: Arc<Vec<SearchEntry>>,
+}
+
+struct FederationRequest {
+    generation: u64,
+    query: String,
+    case_sensitive: bool,
+    scope: SearchScope,
+}
+
 pub struct GlobalSearch {
+    pub instance: u64,
     pub query: String,
     pub case_sensitive: bool,
-    /// Panes snapshotted at open time; scanned per keystroke.
-    snapshot: Vec<PaneRows>,
-    pub results: Vec<SearchHit>,
+    pub scope: SearchScope,
+    pub results: Vec<SearchMatch>,
     pub total: usize,
     pub cursor: usize,
-    /// True when the snapshot hit the memory cap and some panes were not
-    /// captured, surfaced in the footer so the cap is never silent.
     pub capped: bool,
-    /// result index -> its drawn row rect, set each frame by the renderer for
-    /// click hit-testing (like `switcher_rects`).
+    pub loading: bool,
     pub rects: Vec<(usize, Rect)>,
+    pub scope_rects: Vec<(SearchScope, Rect)>,
+    generation: u64,
+    metadata: Vec<SearchEntry>,
+    metadata_matches: Vec<SearchMatch>,
+    metadata_total: usize,
+    files: Arc<Vec<SearchEntry>>,
+    file_catalog_partial: bool,
+    worker_matches: Vec<SearchMatch>,
+    worker_total: usize,
+    worker_capped: bool,
+    worker: mpsc::Sender<SearchRequest>,
+    federated_matches: Vec<SearchMatch>,
+    federated_total: usize,
+    federated_partial: bool,
+    federation_loading: bool,
+    federation: Option<mpsc::Sender<FederationRequest>>,
+    recent_files: Vec<SearchEntry>,
 }
 
-/// Run the matcher over already-captured pane rows. Shared by the live overlay
-/// and the one-shot `search_all` so both surface identical results.
-fn run_search(snapshot: &[PaneRows], query: &str, case_sensitive: bool) -> (Vec<SearchHit>, usize) {
-    let mut out: Vec<SearchHit> = Vec::new();
-    let mut total = 0usize;
-    if query.is_empty() {
-        return (out, 0);
-    }
-    let needle = if case_sensitive {
-        query.to_string()
+fn tab_name(tab: &crate::app::Tab, index: usize) -> String {
+    if let Some(name) = tab.name.as_deref() {
+        name.to_string()
+    } else if tab.is_git() {
+        "git".to_string()
+    } else if tab.is_orch() {
+        "orchestration".to_string()
+    } else if tab.is_mission() {
+        "mission control".to_string()
     } else {
-        query.to_lowercase()
-    };
-    for p in snapshot {
-        let (hits, found) = match_rows(
-            &p.rows,
-            &p.lower,
-            p.history,
-            &needle,
-            case_sensitive,
-            PER_PANE_CAP,
-        );
-        total += found;
-        for h in hits {
-            if out.len() >= TOTAL_CAP {
-                break;
-            }
-            out.push(SearchHit {
-                pane: p.pane,
-                ws: p.ws,
-                ws_name: p.ws_name.clone(),
-                offset: h.offset,
-                row: h.row,
-                line: h.line,
-                col: h.col,
-                above: h.above,
-            });
-        }
+        format!("tab {}", index + 1)
     }
-    (out, total)
+}
+
+fn state_name(state: crate::ui::theme::State) -> &'static str {
+    use crate::ui::theme::State;
+    match state {
+        State::Working => "working",
+        State::Blocked => "blocked",
+        State::Done => "done",
+        State::Idle => "idle",
+        State::Unknown => "unknown",
+    }
 }
 
 impl App {
-    /// Snapshot every real PTY pane's retained scrollback once. Read-only: it
-    /// locks each engine briefly and never moves a viewport. git/orch/mission
-    /// placeholder leaves and file views have no `panes` entry, so are skipped.
-    fn search_snapshot(&self) -> (Vec<PaneRows>, bool) {
-        // Bound total captured text so a pathological scrollback (many panes at
-        // the 20k line cap) cannot spike memory. Panes are captured whole (so
-        // each keeps correct scroll offsets); once the budget is spent, the rest
-        // are skipped and `capped` is surfaced in the overlay footer.
-        const MAX_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
+    fn search_recent_files(&self) -> Vec<SearchEntry> {
+        let session = crate::session::display_name();
+        self.recent_files
+            .iter()
+            .filter_map(|(workspace_cwd, path)| {
+                let ws = self
+                    .workspaces
+                    .iter()
+                    .position(|workspace| workspace.cwd == *workspace_cwd)?;
+                let workspace = &self.workspaces[ws];
+                let relative = path
+                    .strip_prefix(workspace_cwd)
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .into_owned();
+                let label = path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| relative.clone());
+                Some(SearchEntry::new(
+                    format!("file:{ws}:{relative}"),
+                    SearchKind::File,
+                    label,
+                    format!("{} › {} › {}", session, workspace.name, relative),
+                    [relative],
+                    SearchTarget::File {
+                        ws,
+                        path: path.clone(),
+                        workspace_cwd: workspace_cwd.clone(),
+                    },
+                    false,
+                ))
+            })
+            .collect()
+    }
+
+    fn search_metadata(&self) -> Vec<SearchEntry> {
+        let session = crate::session::display_name();
         let mut out = Vec::new();
-        let mut bytes = 0usize;
-        let mut capped = false;
+
+        if let Ok(sessions) = crate::session::list_sessions() {
+            for info in sessions {
+                let current = info.name == session;
+                let state = if info.running { "running" } else { "stopped" };
+                out.push(SearchEntry::new(
+                    format!("session:{}", info.name),
+                    SearchKind::Session,
+                    info.name.clone(),
+                    state.into(),
+                    [],
+                    SearchTarget::Session {
+                        name: info.name,
+                        running: info.running,
+                        current,
+                    },
+                    current,
+                ));
+            }
+        }
+
         for (wi, ws) in self.workspaces.iter().enumerate() {
-            for tab in ws.tabs.iter() {
+            out.push(SearchEntry::new(
+                format!("workspace:{wi}"),
+                SearchKind::Workspace,
+                ws.name.clone(),
+                format!("{} › {}", session, ws.cwd.display()),
+                [
+                    ws.cwd.to_string_lossy().into_owned(),
+                    ws.branch.clone().unwrap_or_default(),
+                ],
+                SearchTarget::Workspace {
+                    ws: wi,
+                    cwd: ws.cwd.clone(),
+                },
+                wi == self.active_ws,
+            ));
+            for (ti, tab) in ws.tabs.iter().enumerate() {
+                let detail = format!("{} › {} › tab {}", session, ws.name, ti + 1);
+                out.push(SearchEntry::new(
+                    format!("tab:{wi}:{ti}"),
+                    SearchKind::Tab,
+                    tab_name(tab, ti),
+                    detail.clone(),
+                    [ws.name.clone(), (ti + 1).to_string()],
+                    SearchTarget::Tab {
+                        ws: wi,
+                        tab: ti,
+                        workspace_cwd: ws.cwd.clone(),
+                        tab_label: tab_name(tab, ti),
+                    },
+                    wi == self.active_ws && ti == ws.active_tab,
+                ));
                 for id in tab.layout.leaves() {
                     let Some(pane) = self.panes.get(&id) else {
                         continue;
                     };
-                    if bytes >= MAX_SNAPSHOT_BYTES {
+                    let alias = self
+                        .agent_names
+                        .iter()
+                        .find_map(|(name, pane_id)| (*pane_id == id).then(|| name.clone()));
+                    let title = self
+                        .status
+                        .get(&id)
+                        .and_then(|status| status.detected_title.as_deref())
+                        .map(str::to_owned)
+                        .unwrap_or_else(|| pane.command.clone());
+                    let pane_detail =
+                        format!("{} › {} › tab {} › pane {}", session, ws.name, ti + 1, id.0);
+                    out.push(SearchEntry::new(
+                        format!("pane:{}", id.0),
+                        SearchKind::Pane,
+                        alias.clone().unwrap_or_else(|| title.clone()),
+                        pane_detail.clone(),
+                        [
+                            title,
+                            pane.cwd.to_string_lossy().into_owned(),
+                            pane.command.clone(),
+                            alias.clone().unwrap_or_default(),
+                        ],
+                        SearchTarget::Pane { pane: id },
+                        wi == self.active_ws && ti == ws.active_tab && tab.layout.focus == id,
+                    ));
+                    if let Some(status) = self.status.get(&id) {
+                        let is_agent = self.manifests.is_agent(&status.agent)
+                            || status.agent_session.is_some();
+                        if is_agent {
+                            out.push(SearchEntry::new(
+                                format!("agent:{}", id.0),
+                                SearchKind::Agent,
+                                alias.clone().unwrap_or_else(|| status.agent.clone()),
+                                pane_detail,
+                                [status.agent.clone(), state_name(status.state).into()],
+                                SearchTarget::Agent { pane: id },
+                                wi == self.active_ws
+                                    && ti == ws.active_tab
+                                    && tab.layout.focus == id,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Start a public fuzzy query without blocking the single-writer app loop.
+    /// The connection's reply channel is fulfilled by this bounded worker.
+    pub fn start_search_api(&self, request: crate::ipc::api::ApiRequest) {
+        let query = request
+            .params
+            .get("query")
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let scope = match request
+            .params
+            .get("scope")
+            .and_then(|value| value.as_str())
+            .unwrap_or("all")
+        {
+            "all" => SearchScope::All,
+            "navigate" => SearchScope::Navigate,
+            "files" => SearchScope::Files,
+            "output" => SearchScope::Output,
+            _ => {
+                let _ = request.reply.send(api_error(
+                    &request.id,
+                    "scope must be all, navigate, files, or output",
+                ));
+                return;
+            }
+        };
+        let limit = request
+            .params
+            .get("limit")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(RESULT_CAP as u64);
+        if query.is_empty() || query.len() > 256 || limit == 0 || limit > RESULT_CAP as u64 {
+            let _ = request.reply.send(api_error(
+                &request.id,
+                "query must be 1..256 bytes and limit must be 1..200",
+            ));
+            return;
+        }
+        let case_sensitive = request
+            .params
+            .get("case_sensitive")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let all_sessions = request
+            .params
+            .get("all_sessions")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let metadata = self.search_metadata();
+        let output_targets = self.search_output_targets();
+        let roots: Vec<_> = self
+            .workspaces
+            .iter()
+            .enumerate()
+            .map(|(ws, workspace)| (ws, workspace.name.clone(), workspace.cwd.clone()))
+            .collect();
+        std::thread::spawn(move || {
+            let fuzzy = FuzzyQuery::new(&query, false);
+            let (mut matches, mut total) = rank_entries(&metadata, &fuzzy, scope, RESULT_CAP);
+            let mut capped = false;
+            if matches!(scope, SearchScope::All | SearchScope::Files) {
+                let (files, partial) = file_entries(roots);
+                let (mut found, count) = rank_entries(&files, &fuzzy, scope, RESULT_CAP);
+                matches.append(&mut found);
+                total = total.saturating_add(count);
+                capped |= partial;
+            }
+            if fuzzy.char_count() >= 2 && matches!(scope, SearchScope::All | SearchScope::Output) {
+                let (output, partial) = build_output_entries(output_targets);
+                let output_query = FuzzyQuery::new(&query, case_sensitive);
+                let (mut found, count) = rank_output(&output, &output_query, scope, RESULT_CAP);
+                matches.append(&mut found);
+                total = total.saturating_add(count);
+                capped |= partial;
+            }
+            if all_sessions {
+                let (sessions, session_cap) = crate::search::federation::running_sessions();
+                capped |= session_cap;
+                for session in sessions {
+                    if !crate::search::federation::session_supports_search(&session) {
                         capped = true;
                         continue;
                     }
-                    let mut rows = Vec::new();
-                    let mut lower = Vec::new();
-                    let mut history = 0;
-                    pane.for_each_retained_row(&mut |_index, retained, _row_count, line| {
-                        history = retained;
-                        bytes = bytes.saturating_add(line.len());
-                        rows.push(line.to_string());
-                        lower.push(line.to_lowercase());
-                    });
-                    out.push(PaneRows {
+                    match crate::search::federation::query_session(
+                        &session,
+                        &query,
+                        &scope.label().to_ascii_lowercase(),
+                        case_sensitive,
+                        RESULT_CAP,
+                    ) {
+                        Ok(mut result) => {
+                            total = total.saturating_add(result.total);
+                            capped |= result.partial;
+                            matches.append(&mut result.matches);
+                        }
+                        Err(_) => capped = true,
+                    }
+                }
+            }
+            sort_and_cap(&mut matches);
+            matches.truncate(limit as usize);
+            capped |= total > matches.len();
+            let results: Vec<_> = matches.iter().map(search_match_json).collect();
+            let response = serde_json::json!({
+                "id": request.id,
+                "result": {
+                    "type": "search_query",
+                    "query": query,
+                    "scope": scope.label().to_ascii_lowercase(),
+                    "total": total,
+                    "shown": results.len(),
+                    "partial": capped,
+                    "matches": results,
+                }
+            })
+            .to_string();
+            let _ = request.reply.send(response);
+        });
+    }
+
+    fn search_output_targets(&self) -> Vec<OutputTarget> {
+        let session = crate::session::display_name();
+        let mut targets = Vec::new();
+        for ws in &self.workspaces {
+            for (ti, tab) in ws.tabs.iter().enumerate() {
+                for id in tab.layout.leaves() {
+                    let Some(pane) = self.panes.get(&id) else {
+                        continue;
+                    };
+                    targets.push(OutputTarget {
                         pane: id,
-                        ws: wi,
-                        ws_name: ws.name.clone(),
-                        rows,
-                        lower,
-                        history,
+                        detail: Arc::<str>::from(format!(
+                            "{} › {} › tab {} › pane {}",
+                            session,
+                            ws.name,
+                            ti + 1,
+                            id.0
+                        )),
+                        workspace: Arc::<str>::from(ws.name.clone()),
+                        engine: Arc::clone(&pane.engine),
                     });
                 }
             }
         }
-        (out, capped)
+        targets
     }
 
-    /// One-shot search over every pane, for the `search` socket/CLI verb. Returns
-    /// the hits (capped for display) and the total number found.
-    pub fn search_all(&self, query: &str, case_sensitive: bool) -> (Vec<SearchHit>, usize) {
-        let query = if case_sensitive {
+    pub fn open_search(&mut self) {
+        let instance = NEXT_SEARCH_INSTANCE.fetch_add(1, Ordering::Relaxed);
+        let recent_files = self.search_recent_files();
+        let metadata = self.search_metadata();
+        let output_targets = self.search_output_targets();
+        let roots: Vec<_> = self
+            .workspaces
+            .iter()
+            .enumerate()
+            .map(|(ws, workspace)| (ws, workspace.name.clone(), workspace.cwd.clone()))
+            .collect();
+        let (tx, rx) = mpsc::channel::<SearchRequest>();
+        let app_tx = self.app_tx.clone();
+        std::thread::spawn(move || {
+            let catalogs = roots
+                .into_iter()
+                .map(|(ws, name, root)| {
+                    let catalog = (*crate::search::files::index_cached(&root)).clone();
+                    (ws, name, root, catalog)
+                })
+                .collect();
+            let _ = app_tx.send(crate::event::AppEvent::SearchFilesIndexed { instance, catalogs });
+            let (output, output_capped) = build_output_entries(output_targets);
+            while let Ok(mut request) = rx.recv() {
+                while let Ok(newer) = rx.try_recv() {
+                    request = newer;
+                }
+                let query = FuzzyQuery::new(&request.query, false);
+                let mut matches = Vec::new();
+                let mut total = 0usize;
+                if matches!(request.scope, SearchScope::All | SearchScope::Files) {
+                    let (mut found, count) =
+                        rank_entries(&request.files, &query, request.scope, RESULT_CAP);
+                    total = total.saturating_add(count);
+                    matches.append(&mut found);
+                }
+                if query.char_count() >= 2
+                    && matches!(request.scope, SearchScope::All | SearchScope::Output)
+                {
+                    let output_query = FuzzyQuery::new(&request.query, request.case_sensitive);
+                    let (mut found, count) =
+                        rank_output(&output, &output_query, request.scope, RESULT_CAP);
+                    total = total.saturating_add(count);
+                    matches.append(&mut found);
+                }
+                sort_and_cap(&mut matches);
+                let _ = app_tx.send(crate::event::AppEvent::SearchResults {
+                    instance,
+                    generation: request.generation,
+                    matches,
+                    total,
+                    capped: output_capped,
+                });
+            }
+        });
+
+        let (session_names, session_list_partial) = crate::search::federation::running_sessions();
+        let federation = if session_names.is_empty() {
+            None
+        } else {
+            let (federation_tx, federation_rx) = mpsc::channel::<FederationRequest>();
+            let app_tx = self.app_tx.clone();
+            std::thread::spawn(move || {
+                let mut partial_owner_set = session_list_partial;
+                let sessions: Vec<_> = session_names
+                    .into_iter()
+                    .filter(|session| {
+                        let supported = crate::search::federation::session_supports_search(session);
+                        partial_owner_set |= !supported;
+                        supported
+                    })
+                    .collect();
+                while let Ok(mut request) = federation_rx.recv() {
+                    // A short debounce prevents a slow sibling session from
+                    // receiving one expensive catalog query per typed byte.
+                    std::thread::sleep(std::time::Duration::from_millis(60));
+                    while let Ok(newer) = federation_rx.try_recv() {
+                        request = newer;
+                    }
+                    let mut matches = Vec::new();
+                    let mut total = 0usize;
+                    let mut partial = partial_owner_set;
+                    for session in &sessions {
+                        match crate::search::federation::query_session(
+                            session,
+                            &request.query,
+                            &request.scope.label().to_ascii_lowercase(),
+                            request.case_sensitive,
+                            RESULT_CAP,
+                        ) {
+                            Ok(mut result) => {
+                                total = total.saturating_add(result.total);
+                                partial |= result.partial;
+                                matches.append(&mut result.matches);
+                            }
+                            Err(_) => partial = true,
+                        }
+                    }
+                    sort_and_cap(&mut matches);
+                    let _ = app_tx.send(crate::event::AppEvent::SearchFederatedResults {
+                        instance,
+                        generation: request.generation,
+                        matches,
+                        total,
+                        partial,
+                    });
+                }
+            });
+            Some(federation_tx)
+        };
+
+        let mut search = GlobalSearch {
+            instance,
+            query: String::new(),
+            case_sensitive: false,
+            scope: SearchScope::All,
+            results: Vec::new(),
+            total: 0,
+            cursor: 0,
+            capped: false,
+            loading: true,
+            rects: Vec::new(),
+            scope_rects: Vec::new(),
+            generation: 0,
+            metadata,
+            metadata_matches: Vec::new(),
+            metadata_total: 0,
+            files: Arc::new(Vec::new()),
+            file_catalog_partial: false,
+            worker_matches: Vec::new(),
+            worker_total: 0,
+            worker_capped: false,
+            worker: tx,
+            federated_matches: Vec::new(),
+            federated_total: 0,
+            federated_partial: session_list_partial,
+            federation_loading: false,
+            federation,
+            recent_files,
+        };
+        search.recommendations();
+        self.search = Some(search);
+    }
+
+    pub fn apply_search_files(
+        &mut self,
+        instance: u64,
+        catalogs: Vec<(
+            usize,
+            String,
+            std::path::PathBuf,
+            crate::search::files::FileCatalog,
+        )>,
+    ) -> bool {
+        let Some(search) = self.search.as_mut().filter(|s| s.instance == instance) else {
+            return false;
+        };
+        let (entries, partial) = file_entries_from_catalogs(catalogs);
+        search.files = Arc::new(entries);
+        search.file_catalog_partial = partial;
+        self.search_recompute();
+        true
+    }
+
+    pub fn apply_search_results(
+        &mut self,
+        instance: u64,
+        generation: u64,
+        matches: Vec<SearchMatch>,
+        total: usize,
+        capped: bool,
+    ) -> bool {
+        let Some(search) = self
+            .search
+            .as_mut()
+            .filter(|s| s.instance == instance && s.generation == generation)
+        else {
+            return false;
+        };
+        let selected = search
+            .results
+            .get(search.cursor)
+            .map(|m| m.entry.id.clone());
+        search.worker_matches = matches;
+        search.worker_total = total;
+        search.worker_capped = capped;
+        search.loading = search.federation_loading;
+        search.merge(selected.as_deref());
+        true
+    }
+
+    pub fn apply_search_federated_results(
+        &mut self,
+        instance: u64,
+        generation: u64,
+        matches: Vec<SearchMatch>,
+        total: usize,
+        partial: bool,
+    ) -> bool {
+        let Some(search) = self
+            .search
+            .as_mut()
+            .filter(|search| search.instance == instance && search.generation == generation)
+        else {
+            return false;
+        };
+        let selected = search
+            .results
+            .get(search.cursor)
+            .map(|result| result.entry.id.clone());
+        search.federated_matches = matches;
+        search.federated_total = total;
+        search.federated_partial = partial;
+        search.federation_loading = false;
+        search.loading = false;
+        search.merge(selected.as_deref());
+        true
+    }
+
+    pub fn close_search(&mut self) {
+        self.search = None;
+    }
+
+    pub fn toggle_search(&mut self) {
+        if self.search.is_some() {
+            self.close_search();
+        } else {
+            self.open_search();
+        }
+    }
+
+    /// Preserve the exact-scrollback CLI/API contract while the interactive
+    /// overlay uses the fuzzy worker.
+    pub fn search_all(&self, query: &str, case_sensitive: bool) -> (Vec<LegacySearchHit>, usize) {
+        let needle = if case_sensitive {
             query.to_string()
         } else {
             query.to_lowercase()
         };
-        if query.is_empty() {
+        if needle.is_empty() {
             return (Vec::new(), 0);
         }
-
         let mut hits = Vec::new();
         let mut total = 0usize;
         for (wi, ws) in self.workspaces.iter().enumerate() {
@@ -234,31 +660,29 @@ impl App {
                         continue;
                     };
                     let mut pane_hits = 0usize;
-                    pane.for_each_retained_row(&mut |row, history, row_count, line| {
-                        let lowercase;
+                    pane.for_each_retained_row(&mut |row, history, _row_count, line| {
+                        let folded;
                         let haystack = if case_sensitive {
                             line
                         } else {
-                            lowercase = line.to_lowercase();
-                            &lowercase
+                            folded = line.to_lowercase();
+                            &folded
                         };
-                        let Some(col) = haystack.find(&query) else {
+                        let Some(col) = haystack.find(&needle) else {
                             return;
                         };
                         total = total.saturating_add(1);
-                        if pane_hits >= PER_PANE_CAP || hits.len() >= TOTAL_CAP {
+                        if pane_hits >= 50 || hits.len() >= 500 {
                             return;
                         }
                         pane_hits += 1;
-                        hits.push(SearchHit {
+                        hits.push(LegacySearchHit {
                             pane: id,
                             ws: wi,
                             ws_name: ws.name.clone(),
                             offset: history.saturating_sub(row),
-                            row,
                             line: line.to_string(),
                             col,
-                            above: row_count.saturating_sub(1).saturating_sub(row),
                         });
                     });
                 }
@@ -267,141 +691,353 @@ impl App {
         (hits, total)
     }
 
-    /// Open the global-search overlay: snapshot the panes now, start empty.
-    pub fn open_search(&mut self) {
-        let (snapshot, capped) = self.search_snapshot();
-        self.search = Some(GlobalSearch {
-            query: String::new(),
-            case_sensitive: false,
-            snapshot,
-            results: Vec::new(),
-            total: 0,
-            cursor: 0,
-            capped,
-            rects: Vec::new(),
-        });
-    }
-
-    pub fn close_search(&mut self) {
-        self.search = None;
-    }
-
-    /// `Cmd::GlobalSearch`: open the overlay, or close it if already open.
-    pub fn toggle_search(&mut self) {
-        if self.search.is_some() {
-            self.close_search();
-        } else {
-            self.open_search();
-        }
-    }
-
-    /// Re-run the matcher over the snapshot after the query changed.
     fn search_recompute(&mut self) {
-        if let Some(s) = self.search.as_mut() {
-            let (results, total) = run_search(&s.snapshot, &s.query, s.case_sensitive);
-            s.results = results;
-            s.total = total;
-            s.cursor = 0;
-        }
-    }
-
-    /// Move the result cursor, clamped to the result list.
-    pub fn search_move(&mut self, delta: i32) {
-        if let Some(s) = self.search.as_mut() {
-            if s.results.is_empty() {
-                s.cursor = 0;
-                return;
-            }
-            let max = s.results.len() as i32 - 1;
-            let next = (s.cursor as i32 + delta).clamp(0, max);
-            s.cursor = next as usize;
-        }
-    }
-
-    /// Jump to the selected match: focus its pane and scroll to the line.
-    pub fn search_activate(&mut self) {
-        let hit = self
-            .search
-            .as_ref()
-            .and_then(|s| s.results.get(s.cursor).cloned());
-        self.close_search();
-        let Some(h) = hit else {
+        let Some(search) = self.search.as_mut() else {
             return;
         };
-        self.focus_pane_global(h.pane);
+        search.generation = search.generation.wrapping_add(1);
+        search.worker_matches.clear();
+        search.worker_total = 0;
+        search.worker_capped = false;
+        search.federated_matches.clear();
+        search.federated_total = 0;
+        search.federation_loading = false;
+        if search.query.trim().is_empty() {
+            search.loading = false;
+            search.recommendations();
+            return;
+        }
+        let query = FuzzyQuery::new(&search.query, false);
+        let (metadata, total) = rank_entries(&search.metadata, &query, search.scope, RESULT_CAP);
+        search.metadata_matches = metadata;
+        search.metadata_total = total;
+        search.loading = true;
+        search.federation_loading = search.federation.is_some();
+        search.merge(None);
+        let _ = search.worker.send(SearchRequest {
+            generation: search.generation,
+            query: search.query.clone(),
+            case_sensitive: search.case_sensitive,
+            scope: search.scope,
+            files: Arc::clone(&search.files),
+        });
+        if let Some(worker) = &search.federation {
+            let _ = worker.send(FederationRequest {
+                generation: search.generation,
+                query: search.query.clone(),
+                case_sensitive: search.case_sensitive,
+                scope: search.scope,
+            });
+        }
+    }
 
-        // Re-derive the target from the pane's CURRENT buffer, not the snapshot
-        // taken when the overlay opened: output that arrived in between (or an
-        // agent repainting its screen) shifts every offset, which made repeated
-        // jumps land in the wrong place. Re-find the matched line (the occurrence
-        // nearest where we found it) and compute a fresh offset + row from the
-        // live grid. If the line is gone, fall back to the snapshot values.
-        let (offset, above) = match self.panes.get(&h.pane) {
+    pub fn search_move(&mut self, delta: i32) {
+        if let Some(search) = self.search.as_mut() {
+            if search.results.is_empty() {
+                search.cursor = 0;
+                return;
+            }
+            search.cursor =
+                (search.cursor as i32 + delta).clamp(0, search.results.len() as i32 - 1) as usize;
+        }
+    }
+
+    pub fn search_set_scope(&mut self, scope: SearchScope) {
+        if let Some(search) = self.search.as_mut() {
+            search.scope = scope;
+            search.cursor = 0;
+        }
+        self.search_recompute();
+    }
+
+    pub fn search_activate(&mut self) {
+        let selected = self
+            .search
+            .as_ref()
+            .and_then(|search| search.results.get(search.cursor))
+            .map(|result| result.entry.target.clone());
+        self.close_search();
+        let Some(target) = selected else {
+            return;
+        };
+        match target {
+            SearchTarget::Session { name, current, .. } => {
+                if !current {
+                    self.pending_session_switch = Some(name);
+                }
+            }
+            SearchTarget::Workspace { ws, cwd } => {
+                if self
+                    .workspaces
+                    .get(ws)
+                    .is_some_and(|workspace| workspace.cwd == cwd)
+                {
+                    self.active_ws = ws;
+                }
+            }
+            SearchTarget::Tab {
+                ws,
+                tab,
+                workspace_cwd,
+                tab_label,
+            } => {
+                if self.workspaces.get(ws).is_some_and(|workspace| {
+                    workspace.cwd == workspace_cwd
+                        && workspace
+                            .tabs
+                            .get(tab)
+                            .is_some_and(|target| tab_name(target, tab) == tab_label)
+                }) {
+                    self.active_ws = ws;
+                    self.workspaces[ws].active_tab = tab;
+                }
+            }
+            SearchTarget::Pane { pane } | SearchTarget::Agent { pane } => {
+                self.focus_pane_global(pane)
+            }
+            SearchTarget::File {
+                ws,
+                path,
+                workspace_cwd,
+            } => {
+                if self
+                    .workspaces
+                    .get(ws)
+                    .is_some_and(|workspace| workspace.cwd == workspace_cwd)
+                {
+                    self.active_ws = ws;
+                    self.open_file_search_result(path);
+                }
+            }
+            SearchTarget::Output {
+                pane,
+                row,
+                offset,
+                above,
+                line,
+            } => self.activate_output(pane, row, offset, above, &line),
+            SearchTarget::Remote {
+                session,
+                kind,
+                target,
+            } => {
+                let tx = self.app_tx.clone();
+                std::thread::spawn(move || {
+                    let result =
+                        crate::search::federation::activate_session(&session, kind, target);
+                    let _ = tx.send(crate::event::AppEvent::SearchHandoffReady { session, result });
+                });
+            }
+        }
+    }
+
+    /// Revalidate and activate one structured result returned by this session's
+    /// `search.query`. Used only by another owner before a client handoff.
+    pub fn handle_search_activate(&mut self, request: &crate::ipc::api::ApiRequest) -> String {
+        let result = (|| -> Result<(), String> {
+            let kind = request
+                .params
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| "kind is required".to_string())?;
+            let target = request
+                .params
+                .get("target")
+                .and_then(serde_json::Value::as_object)
+                .ok_or_else(|| "target must be an object".to_string())?;
+            let workspace = || {
+                let ws = target
+                    .get("workspace")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(|value| value as usize)
+                    .ok_or_else(|| "target.workspace is required".to_string())?;
+                let expected = target
+                    .get("workspace_path")
+                    .and_then(serde_json::Value::as_str)
+                    .map(std::path::PathBuf::from)
+                    .ok_or_else(|| "target.workspace_path is required".to_string())?;
+                self.workspaces
+                    .get(ws)
+                    .filter(|workspace| workspace.cwd == expected)
+                    .map(|_| ws)
+                    .ok_or_else(|| "target workspace no longer exists".to_string())
+            };
+            let pane = || {
+                target
+                    .get("pane")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|value| value.parse::<u32>().ok())
+                    .map(PaneId)
+                    .filter(|pane| self.panes.contains_key(pane))
+                    .ok_or_else(|| "target pane no longer exists".to_string())
+            };
+            match kind {
+                "folder" => {
+                    let ws = workspace()?;
+                    self.active_ws = ws;
+                }
+                "tab" => {
+                    let ws = workspace()?;
+                    let tab = target
+                        .get("tab")
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|value| usize::try_from(value).ok())
+                        .and_then(|value| value.checked_sub(1))
+                        .ok_or_else(|| "target.tab must be a 1-based index".to_string())?;
+                    let label = target
+                        .get("tab_label")
+                        .and_then(serde_json::Value::as_str)
+                        .ok_or_else(|| "target.tab_label is required".to_string())?;
+                    if !self.workspaces.get(ws).is_some_and(|workspace| {
+                        workspace
+                            .tabs
+                            .get(tab)
+                            .is_some_and(|target| tab_name(target, tab) == label)
+                    }) {
+                        return Err("target tab no longer exists".to_string());
+                    }
+                    self.active_ws = ws;
+                    self.workspaces[ws].active_tab = tab;
+                }
+                "pane" | "agent" => self.focus_pane_global(pane()?),
+                "file" => {
+                    let ws = workspace()?;
+                    let path = target
+                        .get("path")
+                        .and_then(serde_json::Value::as_str)
+                        .map(std::path::PathBuf::from)
+                        .ok_or_else(|| "target.path is required".to_string())?;
+                    let root = self
+                        .workspaces
+                        .get(ws)
+                        .map(|workspace| workspace.cwd.clone())
+                        .ok_or_else(|| "target workspace no longer exists".to_string())?;
+                    let canonical_root = root
+                        .canonicalize()
+                        .map_err(|_| "workspace path is unavailable".to_string())?;
+                    let canonical_path = path
+                        .canonicalize()
+                        .map_err(|_| "target file no longer exists".to_string())?;
+                    if !canonical_path.starts_with(&canonical_root) || !canonical_path.is_file() {
+                        return Err("target file is outside its workspace".to_string());
+                    }
+                    self.active_ws = ws;
+                    self.open_file_search_result(canonical_path);
+                }
+                "output" => {
+                    let pane = pane()?;
+                    let row = target
+                        .get("row")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0) as usize;
+                    let offset = target
+                        .get("line_offset")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0) as usize;
+                    let above = target
+                        .get("above")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0) as usize;
+                    let line = target
+                        .get("line")
+                        .and_then(serde_json::Value::as_str)
+                        .ok_or_else(|| "target output line is required".to_string())?;
+                    self.activate_output(pane, row, offset, above, line);
+                }
+                _ => return Err("kind must be folder, tab, pane, agent, file, or output".into()),
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => serde_json::json!({
+                "id": request.id,
+                "result": { "type": "search_activation", "activated": true }
+            })
+            .to_string(),
+            Err(message) => api_error(&request.id, &message),
+        }
+    }
+
+    fn activate_output(
+        &mut self,
+        pane_id: PaneId,
+        old_row: usize,
+        fallback_offset: usize,
+        fallback_above: usize,
+        line: &str,
+    ) {
+        self.focus_pane_global(pane_id);
+        let (offset, above) = match self.panes.get(&pane_id) {
             Some(pane) => {
-                let mut idx = None;
+                let mut closest = None;
                 let mut distance = usize::MAX;
                 let mut retained = 0;
                 let mut total_rows = 0;
-                pane.for_each_retained_row(&mut |row, history, row_count, line| {
+                pane.for_each_retained_row(&mut |row, history, row_count, candidate| {
                     retained = history;
                     total_rows = row_count;
-                    if line == h.line {
-                        let candidate = row.abs_diff(h.row);
-                        if candidate < distance {
-                            idx = Some(row);
-                            distance = candidate;
-                        }
+                    if candidate == line && row.abs_diff(old_row) < distance {
+                        closest = Some(row);
+                        distance = row.abs_diff(old_row);
                     }
                 });
-                match idx {
-                    Some(i) => (
-                        retained.saturating_sub(i),
-                        total_rows.saturating_sub(1).saturating_sub(i),
-                    ),
-                    None => (h.offset, h.above),
-                }
+                closest.map_or((fallback_offset, fallback_above), |row| {
+                    (
+                        retained.saturating_sub(row),
+                        total_rows.saturating_sub(1).saturating_sub(row),
+                    )
+                })
             }
             None => return,
         };
-        if let Some(pane) = self.panes.get(&h.pane) {
+        if let Some(pane) = self.panes.get(&pane_id) {
             pane.scroll_to(offset);
         }
-
-        // Flash the landed line so you can see where it is: content row
-        // (H-1) - (above - offset). Row 0 for a history match scrolled to the
-        // top, its live-screen row for a match already visible.
-        let hgt = self
+        let height = self
             .pane_content_rects
             .iter()
-            .find(|(p, _)| *p == h.pane)
-            .map(|(_, r)| r.height);
-        if let Some(hgt) = hgt.filter(|h| *h > 0) {
-            let r = (hgt as i32 - 1) - (above as i32 - offset as i32);
-            if (0..hgt as i32).contains(&r) {
+            .find(|(id, _)| *id == pane_id)
+            .map(|(_, rect)| rect.height);
+        if let Some(height) = height.filter(|height| *height > 0) {
+            let row = (height as i32 - 1) - (above as i32 - offset as i32);
+            if (0..height as i32).contains(&row) {
                 self.search_flash = Some(SearchFlash {
-                    pane: h.pane,
-                    row: r as u16,
+                    pane: pane_id,
+                    row: row as u16,
                     scroll: offset,
-                    // Persist until you interact (type/scroll) with the pane; a
-                    // long fallback keeps a forgotten flash from lingering forever.
                     until: std::time::Instant::now() + std::time::Duration::from_secs(60),
                 });
             }
         }
     }
 
-    /// A click at `(col, row)`: activate the hit row, else dismiss the overlay.
     pub fn search_click(&mut self, col: u16, row: u16) {
-        let hit = self.search.as_ref().and_then(|s| {
-            s.rects
+        let scope = self.search.as_ref().and_then(|search| {
+            search
+                .scope_rects
                 .iter()
-                .find(|(_, r)| col >= r.x && col < r.right() && row >= r.y && row < r.bottom())
-                .map(|(i, _)| *i)
+                .find(|(_, rect)| {
+                    col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
+                })
+                .map(|(scope, _)| *scope)
+        });
+        if let Some(scope) = scope {
+            self.search_set_scope(scope);
+            return;
+        }
+        let hit = self.search.as_ref().and_then(|search| {
+            search
+                .rects
+                .iter()
+                .find(|(_, rect)| {
+                    col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
+                })
+                .map(|(index, _)| *index)
         });
         match hit {
-            Some(i) => {
-                if let Some(s) = self.search.as_mut() {
-                    s.cursor = i;
+            Some(index) => {
+                if let Some(search) = self.search.as_mut() {
+                    search.cursor = index;
                 }
                 self.search_activate();
             }
@@ -409,32 +1045,55 @@ impl App {
         }
     }
 
-    /// Keyboard handling while the overlay owns input.
     pub fn search_key(&mut self, key: KeyEvent) {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
-            KeyCode::Esc => self.close_search(),
+            KeyCode::Esc => {
+                if self.search.as_ref().is_some_and(|s| !s.query.is_empty()) {
+                    if let Some(search) = self.search.as_mut() {
+                        search.query.clear();
+                    }
+                    self.search_recompute();
+                } else {
+                    self.close_search();
+                }
+            }
             KeyCode::Enter => self.search_activate(),
             KeyCode::Up => self.search_move(-1),
             KeyCode::Down => self.search_move(1),
+            KeyCode::PageUp => self.search_move(-10),
+            KeyCode::PageDown => self.search_move(10),
             KeyCode::Char('p') if ctrl => self.search_move(-1),
             KeyCode::Char('n') if ctrl => self.search_move(1),
-            // Ctrl+I toggles case sensitivity and re-runs.
-            KeyCode::Char('i') if ctrl => {
-                if let Some(s) = self.search.as_mut() {
-                    s.case_sensitive = !s.case_sensitive;
+            KeyCode::Tab if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                if let Some(scope) = self.search.as_ref().map(|s| s.scope.previous()) {
+                    self.search_set_scope(scope);
                 }
-                self.search_recompute();
+            }
+            KeyCode::Tab => {
+                if let Some(scope) = self.search.as_ref().map(|s| s.scope.next()) {
+                    self.search_set_scope(scope);
+                }
+            }
+            KeyCode::Char('i') if ctrl => {
+                if let Some(search) = self
+                    .search
+                    .as_mut()
+                    .filter(|search| matches!(search.scope, SearchScope::All | SearchScope::Output))
+                {
+                    search.case_sensitive = !search.case_sensitive;
+                    self.search_recompute();
+                }
             }
             KeyCode::Backspace => {
-                if let Some(s) = self.search.as_mut() {
-                    s.query.pop();
+                if let Some(search) = self.search.as_mut() {
+                    search.query.pop();
                 }
                 self.search_recompute();
             }
-            KeyCode::Char(c) if !ctrl => {
-                if let Some(s) = self.search.as_mut() {
-                    s.query.push(c);
+            KeyCode::Char(ch) if !ctrl => {
+                if let Some(search) = self.search.as_mut() {
+                    search.query.push(ch);
                 }
                 self.search_recompute();
             }
@@ -443,76 +1102,612 @@ impl App {
     }
 }
 
+impl GlobalSearch {
+    fn recommendations(&mut self) {
+        let mut recommendations: Vec<_> = self
+            .metadata
+            .iter()
+            .filter(|entry| self.scope.includes(entry.kind))
+            .filter(|entry| {
+                entry.active || matches!(entry.kind, SearchKind::Session | SearchKind::Agent)
+            })
+            .take(RESULT_CAP)
+            .cloned()
+            .map(|entry| SearchMatch {
+                score: entry.kind.priority() + if entry.active { 15 } else { 0 },
+                entry,
+                label_positions: Vec::new(),
+            })
+            .collect();
+        recommendations.extend(
+            self.recent_files
+                .iter()
+                .filter(|entry| self.scope.includes(entry.kind))
+                .cloned()
+                .enumerate()
+                .map(|(index, entry)| SearchMatch {
+                    score: entry.kind.priority() + 12i64.saturating_sub(index as i64),
+                    entry,
+                    label_positions: Vec::new(),
+                }),
+        );
+        recommendations.truncate(RESULT_CAP);
+        self.metadata_matches = recommendations;
+        self.metadata_total = self.metadata_matches.len();
+        self.worker_matches.clear();
+        self.worker_total = 0;
+        self.worker_capped = false;
+        self.federated_matches.clear();
+        self.federated_total = 0;
+        self.federation_loading = false;
+        self.merge(None);
+    }
+
+    fn merge(&mut self, selected: Option<&str>) {
+        self.results.clear();
+        self.results.extend(self.metadata_matches.iter().cloned());
+        self.results.extend(self.worker_matches.iter().cloned());
+        self.results.extend(self.federated_matches.iter().cloned());
+        sort_and_cap(&mut self.results);
+        self.total = self
+            .metadata_total
+            .saturating_add(self.worker_total)
+            .saturating_add(self.federated_total);
+        self.capped = self.file_catalog_partial
+            || self.worker_capped
+            || self.federated_partial
+            || self.total > self.results.len();
+        if let Some(id) = selected {
+            if let Some(index) = self.results.iter().position(|result| result.entry.id == id) {
+                self.cursor = index;
+                return;
+            }
+        }
+        self.cursor = self.cursor.min(self.results.len().saturating_sub(1));
+    }
+}
+
+fn rank_output(
+    entries: &[SearchEntry],
+    query: &FuzzyQuery,
+    scope: SearchScope,
+    cap: usize,
+) -> (Vec<SearchMatch>, usize) {
+    let mut by_pane = std::collections::HashMap::<PaneId, Vec<&SearchEntry>>::new();
+    for entry in entries {
+        if let SearchTarget::Output { pane, .. } = &entry.target {
+            by_pane.entry(*pane).or_default().push(entry);
+        }
+    }
+    let mut ranked = Vec::new();
+    let mut total = 0usize;
+    for pane_entries in by_pane.into_values() {
+        let (mut found, count) = rank_entry_refs_where(
+            pane_entries.into_iter(),
+            query,
+            scope,
+            OUTPUT_PER_PANE_CAP,
+            |score| score.output_safe(),
+        );
+        total = total.saturating_add(count);
+        ranked.append(&mut found);
+    }
+    sort_and_cap(&mut ranked);
+    ranked.truncate(cap);
+    (ranked, total)
+}
+
+fn build_output_entries(targets: Vec<OutputTarget>) -> (Arc<Vec<SearchEntry>>, bool) {
+    let mut entries = Vec::new();
+    let mut bytes = 0usize;
+    let mut index_bytes = 0usize;
+    let mut capped = false;
+    for target in targets {
+        if bytes >= OUTPUT_SOURCE_BYTES
+            || index_bytes >= OUTPUT_INDEX_BYTES
+            || entries.len() >= OUTPUT_ROW_CAP
+        {
+            capped = true;
+            break;
+        }
+        let detail_field = Arc::new(crate::search::PreparedText::from_shared(Arc::clone(
+            &target.detail,
+        )));
+        let workspace_field = Arc::new(crate::search::PreparedText::from_shared(Arc::clone(
+            &target.workspace,
+        )));
+        index_bytes = index_bytes
+            .saturating_add(detail_field.index_bytes())
+            .saturating_add(workspace_field.index_bytes());
+        let Ok(engine) = target.engine.lock() else {
+            continue;
+        };
+        let history = engine.history_len();
+        let row_count = engine.retained_row_count();
+        engine.for_each_retained_row(&mut |row, line| {
+            if bytes >= OUTPUT_SOURCE_BYTES
+                || index_bytes >= OUTPUT_INDEX_BYTES
+                || entries.len() >= OUTPUT_ROW_CAP
+            {
+                capped = true;
+                return;
+            }
+            bytes = bytes.saturating_add(line.len());
+            if bytes > OUTPUT_SOURCE_BYTES {
+                capped = true;
+                return;
+            }
+            let line = Arc::<str>::from(line);
+            let line_field = Arc::new(crate::search::PreparedText::from_shared(Arc::clone(&line)));
+            index_bytes = index_bytes.saturating_add(line_field.index_bytes());
+            if index_bytes > OUTPUT_INDEX_BYTES {
+                capped = true;
+                return;
+            }
+            entries.push(SearchEntry::new_with_prepared_fields(
+                Arc::clone(&line),
+                Arc::clone(&target.detail),
+                vec![
+                    line_field,
+                    Arc::clone(&detail_field),
+                    Arc::clone(&workspace_field),
+                ],
+                SearchTarget::Output {
+                    pane: target.pane,
+                    row,
+                    offset: history.saturating_sub(row),
+                    above: row_count.saturating_sub(1).saturating_sub(row),
+                    line,
+                },
+                false,
+                format!("output:{}:{row}", target.pane.0),
+                SearchKind::Output,
+            ));
+        });
+    }
+    (Arc::new(entries), capped)
+}
+
+fn file_entries(roots: Vec<(usize, String, std::path::PathBuf)>) -> (Vec<SearchEntry>, bool) {
+    let catalogs = roots
+        .into_iter()
+        .map(|(ws, name, root)| {
+            let catalog = (*crate::search::files::index_cached(&root)).clone();
+            (ws, name, root, catalog)
+        })
+        .collect();
+    file_entries_from_catalogs(catalogs)
+}
+
+fn file_entries_from_catalogs(
+    catalogs: Vec<(
+        usize,
+        String,
+        std::path::PathBuf,
+        crate::search::files::FileCatalog,
+    )>,
+) -> (Vec<SearchEntry>, bool) {
+    let session = crate::session::display_name();
+    let mut entries = Vec::new();
+    let mut partial = false;
+    for (ws, workspace, workspace_cwd, catalog) in catalogs {
+        partial |= catalog.partial || catalog.truncated;
+        for record in catalog.records {
+            let relative = record.relative.to_string_lossy().into_owned();
+            let label = record
+                .relative
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| relative.clone());
+            entries.push(SearchEntry::new(
+                format!("file:{ws}:{relative}"),
+                SearchKind::File,
+                label,
+                format!("{} › {} › {}", session, workspace, relative),
+                [relative],
+                SearchTarget::File {
+                    ws,
+                    path: record.path,
+                    workspace_cwd: workspace_cwd.clone(),
+                },
+                false,
+            ));
+        }
+    }
+    (entries, partial)
+}
+
+fn api_error(id: &str, message: &str) -> String {
+    serde_json::json!({
+        "id": id,
+        "error": { "code": "invalid_request", "message": message }
+    })
+    .to_string()
+}
+
+fn search_match_json(found: &SearchMatch) -> serde_json::Value {
+    let target = match &found.entry.target {
+        SearchTarget::Session {
+            name,
+            running,
+            current,
+        } => serde_json::json!({
+            "session": name,
+            "running": running,
+            "current": current,
+        }),
+        SearchTarget::Workspace { ws, cwd } => {
+            serde_json::json!({ "workspace": ws, "workspace_path": cwd.to_string_lossy() })
+        }
+        SearchTarget::Tab {
+            ws,
+            tab,
+            workspace_cwd,
+            tab_label,
+        } => {
+            serde_json::json!({
+                "workspace": ws,
+                "workspace_path": workspace_cwd.to_string_lossy(),
+                "tab": tab + 1,
+                "tab_label": tab_label,
+            })
+        }
+        SearchTarget::Pane { pane } | SearchTarget::Agent { pane } => {
+            serde_json::json!({ "pane": pane.0.to_string() })
+        }
+        SearchTarget::File {
+            ws,
+            path,
+            workspace_cwd,
+        } => serde_json::json!({
+            "workspace": ws,
+            "workspace_path": workspace_cwd.to_string_lossy(),
+            "path": path.to_string_lossy(),
+        }),
+        SearchTarget::Output {
+            pane,
+            row,
+            offset,
+            above,
+            line,
+        } => serde_json::json!({
+            "pane": pane.0.to_string(),
+            "row": row,
+            "line_offset": offset,
+            "above": above,
+            "line": line,
+        }),
+        SearchTarget::Remote { target, .. } => target.clone(),
+    };
+    serde_json::json!({
+        "id": found.entry.id,
+        "kind": found.entry.kind.label(),
+        "label": found.entry.label,
+        "detail": found.entry.detail,
+        "score": found.score,
+        "target": target,
+    })
+}
+
+fn sort_and_cap(matches: &mut Vec<SearchMatch>) {
+    matches.sort_by(|a, b| {
+        b.score
+            .cmp(&a.score)
+            .then_with(|| b.entry.active.cmp(&a.entry.active))
+            .then_with(|| a.entry.label.cmp(&b.entry.label))
+            .then_with(|| a.entry.id.cmp(&b.entry.id))
+    });
+    matches.truncate(RESULT_CAP);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn rows(lines: &[&str]) -> Vec<String> {
-        lines.iter().map(|s| s.to_string()).collect()
-    }
-
-    fn low(r: &[String]) -> Vec<String> {
-        r.iter().map(|s| s.to_lowercase()).collect()
+    fn key(ch: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE)
     }
 
     #[test]
-    fn match_rows_is_case_insensitive_by_default_and_maps_offset() {
-        let r = rows(&[
-            "nothing here",
-            "ERROR: boom",
-            "still nothing",
-            "note: error again",
-        ]);
-        // history = 2 means the first 2 rows are scrollback, the rest live.
-        let (hits, total) = match_rows(&r, &low(&r), 2, "error", false, PER_PANE_CAP);
-        assert_eq!(total, 2, "both ERROR and error match, case-insensitively");
-        assert_eq!(hits.len(), 2);
-        // Row 1 (in history) -> offset history - 1 = 1; row 3 (live) -> 0.
-        assert_eq!(hits[0].row, 1);
-        assert_eq!(hits[0].offset, 1);
-        assert_eq!(hits[1].row, 3);
-        assert_eq!(hits[1].offset, 0, "a live-screen match lands at offset 0");
-    }
-
-    #[test]
-    fn match_rows_case_sensitive_and_caps() {
-        let r = rows(&["ERROR one", "error two", "Error three"]);
-        let (hits, total) = match_rows(&r, &low(&r), 0, "error", true, PER_PANE_CAP);
-        assert_eq!(total, 1, "only the exact-case 'error' matches");
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].col, 0);
-
-        // The cap bounds the returned hits but `total` keeps counting.
-        let many = rows(&["x", "x", "x", "x", "x"]);
-        let (hits, total) = match_rows(&many, &low(&many), 0, "x", false, 2);
-        assert_eq!(hits.len(), 2, "hits capped at 2");
-        assert_eq!(total, 5, "total still reflects every match");
-    }
-
-    #[test]
-    fn empty_query_matches_nothing() {
-        let r = rows(&["a", "b"]);
-        let (hits, total) = match_rows(&r, &low(&r), 0, "", false, PER_PANE_CAP);
-        assert!(hits.is_empty());
-        assert_eq!(total, 0);
-    }
-
-    #[test]
-    fn overlay_opens_types_and_closes() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    fn overlay_opens_with_navigation_recommendations_and_fuzzy_types() {
+        let _env = crate::persist::test_env("fuzzy-search-open");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
-        assert!(app.search.is_none());
+        app.workspaces[0].name = "Backend API".into();
         app.open_search();
-        assert!(app.search.is_some(), "overlay opens");
-        let ch = |c| KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty());
-        app.search_key(ch('a'));
-        app.search_key(ch('b'));
-        assert_eq!(app.search.as_ref().unwrap().query, "ab");
-        // Cursor moves stay in bounds even with no results (must not panic).
-        app.search_move(10);
-        assert_eq!(app.search.as_ref().unwrap().cursor, 0);
-        app.search_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()));
-        assert!(app.search.is_none(), "esc closes the overlay");
+        assert!(app.search.as_ref().is_some_and(|s| !s.results.is_empty()));
+        for ch in ['b', 'a', 'p', 'i'] {
+            app.search_key(key(ch));
+        }
+        assert!(app
+            .search
+            .as_ref()
+            .unwrap()
+            .metadata_matches
+            .iter()
+            .any(|result| result.entry.kind == SearchKind::Workspace));
+    }
+
+    #[test]
+    fn metadata_uses_cached_pane_title_without_terminal_inspection() {
+        let _env = crate::persist::test_env("fuzzy-search-cached-pane-title");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).unwrap().detected_title = Some(Arc::from("Cached pane title"));
+
+        let metadata = app.search_metadata();
+        let entry = metadata
+            .iter()
+            .find(|entry| matches!(entry.target, SearchTarget::Pane { pane: id } if id == pane))
+            .expect("active pane must be searchable");
+        assert_eq!(entry.label.as_ref(), "Cached pane title");
+    }
+
+    #[test]
+    fn file_catalog_keeps_its_explicit_workspace_root() {
+        let root = std::path::PathBuf::from("/workspace/root");
+        let relative = std::path::PathBuf::from("src/main.rs");
+        let catalog = crate::search::files::FileCatalog {
+            records: vec![crate::search::files::FileRecord {
+                path: root.join(&relative),
+                relative,
+            }],
+            truncated: false,
+            partial: false,
+        };
+
+        let (entries, partial) =
+            file_entries_from_catalogs(vec![(3, "workspace".into(), root.clone(), catalog)]);
+        assert!(!partial);
+        assert!(matches!(
+            &entries[0].target,
+            SearchTarget::File { ws: 3, workspace_cwd, .. } if workspace_cwd == &root
+        ));
+    }
+
+    #[test]
+    fn escape_clears_then_closes() {
+        let _env = crate::persist::test_env("fuzzy-search-escape");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_search();
+        app.search_key(key('x'));
+        app.search_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.search.as_ref().unwrap().query, "");
+        app.search_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(app.search.is_none());
+    }
+
+    #[test]
+    fn tab_cycles_finder_scopes_in_both_directions() {
+        let _env = crate::persist::test_env("fuzzy-search-scopes");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_search();
+        app.search_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.search.as_ref().unwrap().scope, SearchScope::Navigate);
+        app.search_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::SHIFT));
+        assert_eq!(app.search.as_ref().unwrap().scope, SearchScope::All);
+    }
+
+    #[test]
+    fn case_toggle_is_available_only_when_output_is_in_scope() {
+        let _env = crate::persist::test_env("fuzzy-search-case-scope");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let ctrl_i = KeyEvent::new(KeyCode::Char('i'), KeyModifiers::CONTROL);
+        app.open_search();
+
+        app.search_set_scope(SearchScope::Files);
+        app.search_key(ctrl_i);
+        assert!(!app.search.as_ref().unwrap().case_sensitive);
+
+        app.search_set_scope(SearchScope::All);
+        app.search_key(ctrl_i);
+        assert!(app.search.as_ref().unwrap().case_sensitive);
+
+        app.search_set_scope(SearchScope::Navigate);
+        app.search_key(ctrl_i);
+        assert!(
+            app.search.as_ref().unwrap().case_sensitive,
+            "Navigate ignores the shortcut instead of changing Output's saved choice"
+        );
+    }
+
+    #[test]
+    fn empty_file_scope_recommends_recently_opened_files() {
+        let _env = crate::persist::test_env("fuzzy-search-recent-files");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let path = std::env::current_dir().unwrap().join("Cargo.toml");
+        app.open_file_view(path, crate::app::files::OpenTarget::Preview);
+        app.open_search();
+        app.search_set_scope(SearchScope::Files);
+
+        let search = app.search.as_ref().unwrap();
+        assert!(search.query.is_empty());
+        assert!(search.results.iter().any(|result| {
+            result.entry.kind == SearchKind::File && result.entry.label.as_ref() == "Cargo.toml"
+        }));
+    }
+
+    #[test]
+    fn output_ranking_drops_noisy_sparse_subsequences() {
+        let entry = |label: &str| {
+            SearchEntry::new(
+                format!("output:1:{label}"),
+                SearchKind::Output,
+                label.into(),
+                "default › workspace › tab 1 › pane 1".into(),
+                [],
+                SearchTarget::Output {
+                    pane: PaneId(1),
+                    row: 0,
+                    offset: 0,
+                    above: 0,
+                    line: label.into(),
+                },
+                false,
+            )
+        };
+        let entries = vec![entry("fuzzy-benchmark-pane-1-auth-failure")];
+
+        let (sparse, sparse_total) = rank_output(
+            &entries,
+            &FuzzyQuery::new("fzpn1fl", false),
+            SearchScope::Output,
+            10,
+        );
+        assert!(sparse.is_empty());
+        assert_eq!(sparse_total, 0);
+
+        let (dense, dense_total) = rank_output(
+            &entries,
+            &FuzzyQuery::new("auth fail", false),
+            SearchScope::Output,
+            10,
+        );
+        assert_eq!(dense.len(), 1);
+        assert_eq!(dense_total, 1);
+    }
+
+    #[test]
+    fn fuzzy_api_is_async_and_returns_typed_navigation_results() {
+        let _env = crate::persist::test_env("fuzzy-search-api");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.workspaces[0].name = "Backend API".into();
+        let (reply, response) = std::sync::mpsc::channel();
+        app.start_search_api(crate::ipc::api::ApiRequest {
+            id: "search-test".into(),
+            method: "search.query".into(),
+            params: serde_json::json!({
+                "query": "bapi",
+                "scope": "navigate",
+                "limit": 20,
+            }),
+            reply,
+        });
+        let line = response
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("search worker must reply");
+        let value: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(value["result"]["type"], "search_query");
+        assert!(value["result"]["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["kind"] == "folder" && item["label"] == "Backend API"));
+    }
+
+    #[test]
+    fn structured_activation_revalidates_targets() {
+        let _env = crate::persist::test_env("fuzzy-search-activate");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let (reply, _response) = std::sync::mpsc::channel();
+        let request = crate::ipc::api::ApiRequest {
+            id: "activate-test".into(),
+            method: "search.activate".into(),
+            params: serde_json::json!({
+                "kind": "pane",
+                "target": { "pane": pane.0.to_string() },
+            }),
+            reply,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&app.handle_search_activate(&request)).unwrap();
+        assert_eq!(value["result"]["activated"], true);
+
+        let bad = crate::ipc::api::ApiRequest {
+            id: "bad-target".into(),
+            method: "search.activate".into(),
+            params: serde_json::json!({
+                "kind": "pane",
+                "target": { "pane": "4294967295" },
+            }),
+            reply: std::sync::mpsc::channel().0,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&app.handle_search_activate(&bad)).unwrap();
+        assert_eq!(value["error"]["code"], "invalid_request");
+    }
+
+    #[test]
+    fn selecting_a_known_session_requests_one_client_handoff() {
+        let _env = crate::persist::test_env("fuzzy-search-session-handoff");
+        std::fs::create_dir_all(crate::session::session_dir_for(Some("sibling"))).unwrap();
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.open_search();
+        let index = app
+            .search
+            .as_ref()
+            .unwrap()
+            .results
+            .iter()
+            .position(|result| result.entry.id == "session:sibling")
+            .unwrap();
+        app.search.as_mut().unwrap().cursor = index;
+        app.search_activate();
+        assert_eq!(app.pending_session_switch.as_deref(), Some("sibling"));
+        assert!(app.search.is_none());
+    }
+
+    #[test]
+    fn selecting_a_file_uses_the_configured_plain_click_default() {
+        let _env = crate::persist::test_env("fuzzy-search-file-open");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let path = std::env::current_dir().unwrap().join("Cargo.toml");
+        let workspace_cwd = app.workspaces[0].cwd.clone();
+        app.open_file_view(path.clone(), crate::app::files::OpenTarget::Preview);
+        let preview = app.layout().focus;
+        let tabs_before = app.workspaces[0].tabs.len();
+
+        app.open_search();
+        let search = app.search.as_mut().unwrap();
+        search.results = vec![SearchMatch {
+            entry: SearchEntry::new(
+                "file:0:Cargo.toml".into(),
+                SearchKind::File,
+                "Cargo.toml".into(),
+                "default › Cargo.toml".into(),
+                [],
+                SearchTarget::File {
+                    ws: 0,
+                    path: path.clone(),
+                    workspace_cwd,
+                },
+                false,
+            ),
+            score: 1,
+            label_positions: Vec::new(),
+        }];
+        search.cursor = 0;
+
+        app.search_activate();
+
+        assert_eq!(
+            app.workspaces[0].tabs.len(),
+            tabs_before + 1,
+            "the read-only default opens a full file tab, like a plain FILES click"
+        );
+        assert!(app
+            .views
+            .values()
+            .any(|view| matches!(view, crate::app::ViewKind::File(file) if file.path == path)));
+        let file_tab = app.workspaces[0].active_tab;
+        let leaves = app.workspaces[0].tabs[file_tab].layout.leaves();
+        assert_eq!(leaves.len(), 1, "the fuzzy result owns a whole tab");
+        assert_ne!(leaves[0], preview, "the preview pane was not reused");
+
+        let tabs_after = app.workspaces[0].tabs.len();
+        let file_tab_view = leaves[0];
+        app.open_file_search_result(path);
+        assert_eq!(app.workspaces[0].tabs.len(), tabs_after);
+        assert_eq!(app.layout().focus, file_tab_view, "the whole tab is reused");
     }
 }

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -115,6 +115,22 @@ fn state_name(state: crate::ui::theme::State) -> &'static str {
 }
 
 impl App {
+    fn resolve_search_tab(
+        &self,
+        workspace: usize,
+        workspace_cwd: &std::path::Path,
+        leaves: &[PaneId],
+    ) -> Option<usize> {
+        if self.workspaces.get(workspace)?.cwd != workspace_cwd {
+            return None;
+        }
+        self.resolve_tab_menu_target(&super::TabMenuTarget {
+            workspace,
+            leaves: leaves.to_vec(),
+        })
+        .map(|(_, tab)| tab)
+    }
+
     fn search_recent_files(&self) -> Vec<SearchEntry> {
         let session = crate::session::display_name();
         self.recent_files
@@ -203,7 +219,7 @@ impl App {
                         ws: wi,
                         tab: ti,
                         workspace_cwd: ws.cwd.clone(),
-                        tab_label: tab_name(tab, ti),
+                        tab_leaves: tab.layout.leaves(),
                     },
                     wi == self.active_ws && ti == ws.active_tab,
                 ));
@@ -777,17 +793,11 @@ impl App {
             }
             SearchTarget::Tab {
                 ws,
-                tab,
+                tab: _,
                 workspace_cwd,
-                tab_label,
+                tab_leaves,
             } => {
-                if self.workspaces.get(ws).is_some_and(|workspace| {
-                    workspace.cwd == workspace_cwd
-                        && workspace
-                            .tabs
-                            .get(tab)
-                            .is_some_and(|target| tab_name(target, tab) == tab_label)
-                }) {
+                if let Some(tab) = self.resolve_search_tab(ws, &workspace_cwd, &tab_leaves) {
                     self.active_ws = ws;
                     self.workspaces[ws].active_tab = tab;
                 }
@@ -878,24 +888,31 @@ impl App {
                 }
                 "tab" => {
                     let ws = workspace()?;
-                    let tab = target
+                    // Keep accepting the display position for schema clarity,
+                    // but resolve the live tab from its stable leaf snapshot.
+                    let _tab = target
                         .get("tab")
                         .and_then(serde_json::Value::as_u64)
                         .and_then(|value| usize::try_from(value).ok())
                         .and_then(|value| value.checked_sub(1))
                         .ok_or_else(|| "target.tab must be a 1-based index".to_string())?;
-                    let label = target
-                        .get("tab_label")
-                        .and_then(serde_json::Value::as_str)
-                        .ok_or_else(|| "target.tab_label is required".to_string())?;
-                    if !self.workspaces.get(ws).is_some_and(|workspace| {
-                        workspace
-                            .tabs
-                            .get(tab)
-                            .is_some_and(|target| tab_name(target, tab) == label)
-                    }) {
-                        return Err("target tab no longer exists".to_string());
-                    }
+                    let leaves = target
+                        .get("tab_panes")
+                        .and_then(serde_json::Value::as_array)
+                        .ok_or_else(|| "target.tab_panes must be an array".to_string())?
+                        .iter()
+                        .map(|value| {
+                            value
+                                .as_str()
+                                .and_then(|value| value.parse::<u32>().ok())
+                                .map(PaneId)
+                                .ok_or_else(|| "target.tab_panes must contain pane IDs".to_string())
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let workspace_cwd = self.workspaces[ws].cwd.clone();
+                    let tab = self
+                        .resolve_search_tab(ws, &workspace_cwd, &leaves)
+                        .ok_or_else(|| "target tab no longer exists".to_string())?;
                     self.active_ws = ws;
                     self.workspaces[ws].active_tab = tab;
                 }
@@ -1343,13 +1360,13 @@ fn search_match_json(found: &SearchMatch) -> serde_json::Value {
             ws,
             tab,
             workspace_cwd,
-            tab_label,
+            tab_leaves,
         } => {
             serde_json::json!({
                 "workspace": ws,
                 "workspace_path": workspace_cwd.to_string_lossy(),
                 "tab": tab + 1,
-                "tab_label": tab_label,
+                "tab_panes": tab_leaves.iter().map(|pane| pane.0.to_string()).collect::<Vec<_>>(),
             })
         }
         SearchTarget::Pane { pane } | SearchTarget::Agent { pane } => {
@@ -1633,6 +1650,47 @@ mod tests {
         let value: serde_json::Value =
             serde_json::from_str(&app.handle_search_activate(&bad)).unwrap();
         assert_eq!(value["error"]["code"], "invalid_request");
+    }
+
+    #[test]
+    fn unnamed_tab_target_follows_the_tab_across_reordering() {
+        let _env = crate::persist::test_env("fuzzy-search-tab-identity");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let first = PaneId::alloc();
+        let second = PaneId::alloc();
+        app.workspaces[0].tabs = [first, second]
+            .into_iter()
+            .map(|pane| super::super::Tab::panes(crate::layout::TileLayout::new(pane)))
+            .collect();
+        app.workspaces[0].active_tab = 0;
+        let cwd = app.workspaces[0].cwd.clone();
+
+        app.move_tab(0, 1).unwrap();
+        assert_eq!(
+            app.resolve_search_tab(0, &cwd, &[first]),
+            Some(1),
+            "the target follows the original unnamed tab instead of index 1"
+        );
+
+        let request = crate::ipc::api::ApiRequest {
+            id: "tab-activate".into(),
+            method: "search.activate".into(),
+            params: serde_json::json!({
+                "kind": "tab",
+                "target": {
+                    "workspace": 0,
+                    "workspace_path": cwd,
+                    "tab": 1,
+                    "tab_panes": [first.0.to_string()],
+                },
+            }),
+            reply: std::sync::mpsc::channel().0,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&app.handle_search_activate(&request)).unwrap();
+        assert_eq!(value["result"]["activated"], true);
+        assert_eq!(app.workspaces[0].active_tab, 1);
     }
 
     #[test]

--- a/src/app/switcher.rs
+++ b/src/app/switcher.rs
@@ -70,8 +70,19 @@ impl App {
     /// section has at least one matching row.
     pub fn switcher_rows(&self) -> Vec<SwitcherRow> {
         let scope = self.switcher_scope;
-        let q = self.switcher_query.to_lowercase();
-        let matches = |hay: &str| q.is_empty() || hay.to_lowercase().contains(&q);
+        let query = crate::search::FuzzyQuery::new(&self.switcher_query, false);
+        let matches = |hay: &str| {
+            if query.is_empty() {
+                return true;
+            }
+            let prepared = crate::search::PreparedText::new(hay);
+            query
+                .score(&[crate::search::FuzzyField {
+                    text: &prepared,
+                    weight: 0,
+                }])
+                .is_some()
+        };
         let mut rows = Vec::new();
 
         // Agents: one row per pane running an agent, wherever it lives.
@@ -145,7 +156,7 @@ impl App {
                 rows.append(&mut nodes);
             }
             // The "new node" action is only offered when nothing is being filtered.
-            if q.is_empty() {
+            if query.is_empty() {
                 rows.push(SwitcherRow::Action {
                     target: SwitcherTarget::NewWorkspace,
                     label: format!("+ {}", self.catalog.cmd_new_workspace),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,6 +164,10 @@ panes / agents:
 search:
   search <text...> [--case]  find text across every pane's scrollback (docs/63);
                              --case is case-sensitive; returns matches as JSON
+  search --fuzzy <query...> [--scope all|navigate|files|output] [--all-sessions]
+                           [--limit <1-200>] [--case] [--json]
+                             rank navigation, file paths, and retained output;
+                             legacy search stays exact unless --fuzzy is passed
 
 themes:
   theme list [--json]       list built-in, installed, and virtual themes
@@ -525,7 +529,7 @@ fn write_topic_help(
             detailed_section("panes / agents:\n", "\nsearch:\n"),
         ),
         "search" => (
-            "luvus search <text...> [--case]",
+            "luvus search <text...> [--case]\n       luvus search --fuzzy <query...> [--scope all|navigate|files|output] [--all-sessions] [--limit 1-200] [--case] [--json]",
             detailed_section("search:\n", "\nthemes:\n"),
         ),
         "theme" => (
@@ -2009,21 +2013,89 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
     Ok(match (noun, verb) {
         ("ping", _) => ("ping".into(), json!({})),
         ("events", _) => ("events.subscribe".into(), json!({})),
-        // `luvus search <text...> [--case]` — scan every pane's scrollback
-        // (docs/63). Everything after `search`, minus flags, is the query.
+        // Exact scrollback search remains the default for script compatibility.
+        // The universal finder is deliberately opt-in through `--fuzzy`.
         ("search", _) => {
-            let case = args
+            let search_args = &args[2.min(args.len())..];
+            let fuzzy = search_args
                 .iter()
-                .any(|a| a == "--case" || a == "--case-sensitive");
-            let query: Vec<&str> = args[2.min(args.len())..]
-                .iter()
-                .filter(|a| !a.starts_with("--"))
-                .map(String::as_str)
-                .collect();
-            (
-                "search".into(),
-                json!({ "query": query.join(" "), "case_sensitive": case }),
-            )
+                .take_while(|arg| arg.as_str() != "--")
+                .any(|arg| arg == "--fuzzy");
+            let mut query: Vec<String> = Vec::new();
+            let mut case_sensitive = false;
+            let mut scope = "all".to_string();
+            let mut all_sessions = false;
+            let mut limit = crate::search::RESULT_CAP as u64;
+            let mut index = 0;
+            while index < search_args.len() {
+                match search_args[index].as_str() {
+                    "--" => {
+                        query.extend_from_slice(&search_args[index + 1..]);
+                        break;
+                    }
+                    "--fuzzy" | "--json" => index += 1,
+                    "--case" | "--case-sensitive" => {
+                        case_sensitive = true;
+                        index += 1;
+                    }
+                    "--all-sessions" if fuzzy => {
+                        all_sessions = true;
+                        index += 1;
+                    }
+                    "--scope" if fuzzy => {
+                        let value = search_args
+                            .get(index + 1)
+                            .ok_or_else(|| anyhow!("--scope requires a value"))?;
+                        if !matches!(value.as_str(), "all" | "navigate" | "files" | "output") {
+                            return Err(anyhow!("--scope must be all, navigate, files, or output"));
+                        }
+                        scope = value.clone();
+                        index += 2;
+                    }
+                    "--limit" if fuzzy => {
+                        let value = search_args
+                            .get(index + 1)
+                            .ok_or_else(|| anyhow!("--limit requires a value"))?;
+                        limit = value
+                            .parse::<u64>()
+                            .ok()
+                            .filter(|value| (1..=crate::search::RESULT_CAP as u64).contains(value))
+                            .ok_or_else(|| anyhow!("--limit must be between 1 and 200"))?;
+                        index += 2;
+                    }
+                    flag if flag.starts_with("--") => {
+                        return Err(anyhow!("unknown search option: {flag}"));
+                    }
+                    value => {
+                        query.push(value.to_string());
+                        index += 1;
+                    }
+                }
+            }
+            if query.is_empty() {
+                return Err(anyhow!(if fuzzy {
+                    "usage: luvus search --fuzzy <query...> [--scope all|navigate|files|output] [--all-sessions] [--limit 1-200] [--case] [--json]"
+                } else {
+                    "usage: luvus search <text...> [--case]"
+                }));
+            }
+            if fuzzy {
+                (
+                    "search.query".into(),
+                    json!({
+                        "query": query.join(" "),
+                        "scope": scope,
+                        "all_sessions": all_sessions,
+                        "limit": limit,
+                        "case_sensitive": case_sensitive,
+                    }),
+                )
+            } else {
+                (
+                    "search".into(),
+                    json!({ "query": query.join(" "), "case_sensitive": case_sensitive }),
+                )
+            }
         }
         ("agent", "sessions") => ("agent.sessions".into(), json!({})),
         ("agent", "resume") => ("agent.resume".into(), one("session_id", arg0())),
@@ -3203,6 +3275,64 @@ mod tests {
         assert_eq!(m, "tab.new");
         let (m, _) = parse(&argv("luvus agent list")).unwrap();
         assert_eq!(m, "agent.list");
+    }
+
+    #[test]
+    fn search_keeps_exact_contract_and_fuzzy_is_explicit() {
+        let (method, params) = parse(&argv("luvus search build failed --case")).unwrap();
+        assert_eq!(method, "search");
+        assert_eq!(
+            params,
+            json!({"query": "build failed", "case_sensitive": true})
+        );
+
+        let (method, params) =
+            parse(&argv("luvus search --fuzzy -- --case --scope output")).unwrap();
+        assert_eq!(method, "search.query");
+        assert_eq!(
+            params,
+            json!({
+                "query": "--case --scope output",
+                "scope": "all",
+                "all_sessions": false,
+                "limit": 200,
+                "case_sensitive": false,
+            })
+        );
+
+        let (method, params) = parse(&argv("luvus search -- --fuzzy --case")).unwrap();
+        assert_eq!(method, "search");
+        assert_eq!(
+            params,
+            json!({"query": "--fuzzy --case", "case_sensitive": false})
+        );
+
+        let (method, params) = parse(&argv(
+            "luvus search --fuzzy api auth --scope files --all-sessions --limit 25 --case --json",
+        ))
+        .unwrap();
+        assert_eq!(method, "search.query");
+        assert_eq!(
+            params,
+            json!({
+                "query": "api auth",
+                "scope": "files",
+                "all_sessions": true,
+                "limit": 25,
+                "case_sensitive": true,
+            })
+        );
+
+        for bad in [
+            "luvus search --fuzzy",
+            "luvus search --fuzzy api --scope unknown",
+            "luvus search --fuzzy api --limit 0",
+            "luvus search --fuzzy api --limit 201",
+            "luvus search api --all-sessions",
+            "luvus search api --unknown",
+        ] {
+            assert!(parse(&argv(bad)).is_err(), "{bad} must be rejected");
+        }
     }
 
     #[test]

--- a/src/event.rs
+++ b/src/event.rs
@@ -70,6 +70,37 @@ pub enum AppEvent {
         path: std::path::PathBuf,
         entries: Vec<crate::files::Entry>,
     },
+    /// A bounded global-finder file-path catalog completed off the app loop.
+    SearchFilesIndexed {
+        instance: u64,
+        catalogs: Vec<(
+            usize,
+            String,
+            std::path::PathBuf,
+            crate::search::files::FileCatalog,
+        )>,
+    },
+    /// Fuzzy file/output scoring completed on the finder's dedicated worker.
+    SearchResults {
+        instance: u64,
+        generation: u64,
+        matches: Vec<crate::search::SearchMatch>,
+        total: usize,
+        capped: bool,
+    },
+    /// Bounded result rows returned by other running named-session owners.
+    SearchFederatedResults {
+        instance: u64,
+        generation: u64,
+        matches: Vec<crate::search::SearchMatch>,
+        total: usize,
+        partial: bool,
+    },
+    /// A target in another session was revalidated and focused by its owner.
+    SearchHandoffReady {
+        session: String,
+        result: Result<(), String>,
+    },
     /// One structured Git status scan feeds FILES tint and DIFF (docs/88).
     DiffStatus {
         token: u64,

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -45,10 +45,18 @@ where
         DisableBracketedPaste
     );
     ratatui::restore();
-    result
+    match result? {
+        ClientExit::Done => Ok(()),
+        ClientExit::SwitchSession(name) => switch_session_process(&name),
+    }
 }
 
-fn run_inner<R, W>(reader: R, mut writer: W, terminal: &mut DefaultTerminal) -> Result<()>
+enum ClientExit {
+    Done,
+    SwitchSession(String),
+}
+
+fn run_inner<R, W>(reader: R, mut writer: W, terminal: &mut DefaultTerminal) -> Result<ClientExit>
 where
     R: Read,
     W: Write + Send + 'static,
@@ -113,7 +121,7 @@ where
     // Main thread: paint frames as they arrive. A full frame repaints the screen; a
     // diff writes only its changed cells straight to the terminal (no full re-blit,
     // no reconstructed frame) — so a busy session costs O(changed cells), not O(screen).
-    loop {
+    let exit = loop {
         match protocol::read_message::<_, ServerMessage>(&mut reader) {
             // A full frame repaints the whole screen; a diff writes *only its changed
             // cells* straight to the terminal (O(changed), not a whole re-blit). Each
@@ -139,12 +147,62 @@ where
             Ok(ServerMessage::Sound) => crate::emit_sound(),
             Ok(ServerMessage::Clipboard(text)) => crate::emit_clipboard(&text),
             Ok(ServerMessage::OpenUrl(url)) => crate::platform::open_url(&url),
-            Ok(ServerMessage::Detach) | Ok(ServerMessage::ServerShutdown { .. }) => break,
+            Ok(ServerMessage::SwitchSession { name }) => break ClientExit::SwitchSession(name),
+            Ok(ServerMessage::Detach) | Ok(ServerMessage::ServerShutdown { .. }) => {
+                break ClientExit::Done
+            }
             Ok(_) => {}
-            Err(_) => break, // server gone
+            Err(_) => break ClientExit::Done, // server gone
+        }
+    };
+    Ok(exit)
+}
+
+/// Replace this thin client process with the same launch mode targeting another
+/// logical session. Re-exec cleanly drops the old terminal-input thread; local
+/// launches and `--remote` retain their existing arguments and SSH options.
+fn switch_session_process(name: &str) -> Result<()> {
+    crate::session::validate_name(name).map_err(anyhow::Error::msg)?;
+    let raw: Vec<String> = std::env::args().collect();
+    let args = switched_args(&raw, name);
+    let exe = std::env::current_exe()?;
+    let mut command = std::process::Command::new(exe);
+    command
+        .args(args)
+        .env_remove("LUVUS_SOCKET_PATH")
+        .env_remove("BOHAY_SOCKET_PATH");
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        Err(command.exec().into())
+    }
+    #[cfg(not(unix))]
+    {
+        let status = command.status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(anyhow!("session client exited with {status}"))
         }
     }
-    Ok(())
+}
+
+fn switched_args(raw: &[String], name: &str) -> Vec<String> {
+    let mut out = vec!["--session".to_string(), name.to_string()];
+    let mut index = 1;
+    while index < raw.len() {
+        if raw[index] == "--session" {
+            index = (index + 2).min(raw.len());
+            continue;
+        }
+        if raw[index].starts_with("--session=") {
+            index += 1;
+            continue;
+        }
+        out.push(raw[index].clone());
+        index += 1;
+    }
+    out
 }
 
 fn input_loop<W: Write>(mut writer: W, pending: Vec<Event>) {
@@ -647,6 +705,22 @@ mod render_tests {
     use super::*;
     use ratatui::backend::TestBackend;
 
+    #[test]
+    fn session_handoff_replaces_only_the_session_selector() {
+        let raw = vec![
+            "luvus".to_string(),
+            "--session".to_string(),
+            "old".to_string(),
+            "--remote".to_string(),
+            "host".to_string(),
+            "-p".to_string(),
+            "2222".to_string(),
+        ];
+        assert_eq!(
+            switched_args(&raw, "new"),
+            ["--session", "new", "--remote", "host", "-p", "2222"]
+        );
+    }
     #[test]
     fn incremental_diff_reconstructs_the_screen() {
         let cell = |s: &str| protocol::CellData {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -158,9 +158,11 @@ where
     Ok(exit)
 }
 
-/// Replace this thin client process with the same launch mode targeting another
-/// logical session. Re-exec cleanly drops the old terminal-input thread; local
-/// launches and `--remote` retain their existing arguments and SSH options.
+/// Hand this thin client process to the same launch mode targeting another
+/// logical session. Unix replaces the process. Windows starts the successor
+/// and immediately lets this process exit, so the old terminal-input thread is
+/// never left reading alongside the new client. Local launches and `--remote`
+/// retain their existing arguments and SSH options.
 fn switch_session_process(name: &str) -> Result<()> {
     crate::session::validate_name(name).map_err(anyhow::Error::msg)?;
     let raw: Vec<String> = std::env::args().collect();
@@ -178,12 +180,8 @@ fn switch_session_process(name: &str) -> Result<()> {
     }
     #[cfg(not(unix))]
     {
-        let status = command.status()?;
-        if status.success() {
-            Ok(())
-        } else {
-            Err(anyhow!("session client exited with {status}"))
-        }
+        command.spawn()?;
+        Ok(())
     }
 }
 

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::terminal::theme_probe::TerminalColors;
 
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 const MAX_FRAME: usize = 64 * 1024 * 1024;
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -57,6 +57,12 @@ pub enum ServerMessage {
     /// the server is on another machine, and the browser you want is the one in
     /// front of you.
     OpenUrl(String),
+    /// Ask this display client to reconnect to another validated named session.
+    /// It contains no socket path or command and is resolved by the client using
+    /// the same local/remote session rules as process startup.
+    SwitchSession {
+        name: String,
+    },
     /// Tell the client to detach (server keeps running).
     Detach,
     ServerShutdown {
@@ -441,6 +447,20 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn logical_session_switch_roundtrips_without_a_socket_path() {
+        let mut bytes = Vec::new();
+        write_message(
+            &mut bytes,
+            &ServerMessage::SwitchSession { name: "api".into() },
+        )
+        .unwrap();
+        assert!(matches!(
+            read_message::<_, ServerMessage>(&mut &bytes[..]).unwrap(),
+            ServerMessage::SwitchSession { name } if name == "api"
+        ));
     }
 
     /// A wide glyph written through ratatui's own `set_string` (the path modals,

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -313,6 +313,19 @@ pub fn run() -> Result<()> {
                 foreground_activity = true;
             }
         }
+        if let Some(name) = app.pending_session_switch.take() {
+            if let Some(id) = foreground.take() {
+                if let Some(client) = clients.remove(&id) {
+                    let _ = client.send_control(ServerMessage::SwitchSession { name });
+                }
+                foreground = latest_client(&clients);
+                apply_foreground_theme(&mut app, &clients, foreground);
+                activity = true;
+                foreground_activity = true;
+            } else {
+                app.show_toast("no attached client to switch".to_string());
+            }
+        }
 
         if app.session_dirty && last_save.elapsed() > Duration::from_secs(2) {
             persist::save(&app);
@@ -806,7 +819,9 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
             }
             let stop = matches!(
                 msg,
-                ServerMessage::Detach | ServerMessage::ServerShutdown { .. }
+                ServerMessage::Detach
+                    | ServerMessage::ServerShutdown { .. }
+                    | ServerMessage::SwitchSession { .. }
             );
             match protocol::write_message_counted(&mut writer, &msg) {
                 Ok(bytes) => {

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -8,6 +8,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use fs2::FileExt;
 use interprocess::local_socket::prelude::*;
@@ -88,6 +89,15 @@ pub struct Conn(Arc<Stream>);
 impl Conn {
     fn new(stream: Stream) -> Self {
         Conn(Arc::new(stream))
+    }
+
+    /// Bound control-plane requests such as cross-session search. Unix local
+    /// sockets support kernel timeouts; named pipes may report Unsupported, in
+    /// which case callers still keep one bounded worker per endpoint.
+    pub fn set_timeouts(&self, timeout: Duration) -> io::Result<()> {
+        use interprocess::local_socket::traits::Stream as _;
+        self.0.set_recv_timeout(Some(timeout))?;
+        self.0.set_send_timeout(Some(timeout))
     }
 }
 

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -86,6 +86,12 @@ impl ServerStartupLock {
 #[derive(Clone)]
 pub struct Conn(Arc<Stream>);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TimeoutMode {
+    Kernel,
+    Nonblocking,
+}
+
 impl Conn {
     fn new(stream: Stream) -> Self {
         Conn(Arc::new(stream))
@@ -93,11 +99,23 @@ impl Conn {
 
     /// Bound control-plane requests such as cross-session search. Unix local
     /// sockets support kernel timeouts; named pipes may report Unsupported, in
-    /// which case callers still keep one bounded worker per endpoint.
-    pub fn set_timeouts(&self, timeout: Duration) -> io::Result<()> {
+    /// which case the connection becomes nonblocking so the caller can enforce
+    /// an application deadline without leaving a blocked worker behind.
+    pub fn set_timeouts(&self, timeout: Duration) -> io::Result<TimeoutMode> {
         use interprocess::local_socket::traits::Stream as _;
-        self.0.set_recv_timeout(Some(timeout))?;
-        self.0.set_send_timeout(Some(timeout))
+        for result in [
+            self.0.set_recv_timeout(Some(timeout)),
+            self.0.set_send_timeout(Some(timeout)),
+        ] {
+            if let Err(error) = result {
+                if error.kind() != io::ErrorKind::Unsupported {
+                    return Err(error);
+                }
+                self.0.set_nonblocking(true)?;
+                return Ok(TimeoutMode::Nonblocking);
+            }
+        }
+        Ok(TimeoutMode::Kernel)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod module;
 mod orch;
 mod persist;
 mod platform;
+mod search;
 mod session;
 mod skill;
 mod terminal;

--- a/src/search/federation.rs
+++ b/src/search/federation.rs
@@ -1,0 +1,284 @@
+//! Bounded named-session search over each session's owner-only control socket.
+//!
+//! A session evaluates its own catalog and returns result rows only. The
+//! requesting server never reads another session's terminal grids or starts a
+//! stopped server.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use super::{FuzzyField, FuzzyQuery, SearchEntry, SearchKind, SearchMatch, SearchTarget};
+
+pub const MAX_FEDERATED_SESSIONS: usize = 8;
+pub const MAX_SESSION_RESPONSE_BYTES: u64 = 1024 * 1024;
+const SESSION_TIMEOUT: Duration = Duration::from_millis(900);
+
+#[derive(Debug)]
+pub struct FederatedResult {
+    pub matches: Vec<SearchMatch>,
+    pub total: usize,
+    pub partial: bool,
+}
+
+/// Running sessions in the selected Luvus home, excluding the current owner.
+/// Discovery is side-effect-free and intentionally capped.
+pub fn running_sessions() -> (Vec<String>, bool) {
+    let current = crate::session::display_name();
+    let mut names: Vec<_> = crate::session::list_sessions()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|session| session.running && session.name != current)
+        .map(|session| session.name)
+        .collect();
+    names.sort_unstable();
+    let partial = names.len() > MAX_FEDERATED_SESSIONS;
+    names.truncate(MAX_FEDERATED_SESSIONS);
+    (names, partial)
+}
+
+pub fn query_session(
+    session: &str,
+    query: &str,
+    scope: &str,
+    case_sensitive: bool,
+    limit: usize,
+) -> Result<FederatedResult, String> {
+    crate::session::validate_name(session)?;
+    let name = crate::session::parse_target_name(session)?;
+    let response = request(
+        &crate::session::api_socket_path_for(name.as_deref()),
+        "search.query",
+        json!({
+            "query": query,
+            "scope": scope,
+            "case_sensitive": case_sensitive,
+            "limit": limit,
+            "all_sessions": false,
+        }),
+    )?;
+    if let Some(error) = response.get("error") {
+        return Err(error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("search request failed")
+            .to_string());
+    }
+    let result = response
+        .get("result")
+        .ok_or_else(|| "search response has no result".to_string())?;
+    let mut matches = Vec::new();
+    for item in result
+        .get("matches")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "search response has no matches".to_string())?
+        .iter()
+        .take(limit)
+    {
+        let kind = parse_kind(item.get("kind").and_then(Value::as_str).unwrap_or(""))?;
+        // Session rows are already discovered locally and would otherwise be
+        // repeated once for every queried owner.
+        if kind == SearchKind::Session {
+            continue;
+        }
+        let id = item
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "search result has no id".to_string())?;
+        let label = item
+            .get("label")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "search result has no label".to_string())?;
+        let detail = item
+            .get("detail")
+            .and_then(Value::as_str)
+            .unwrap_or(session);
+        let target = item
+            .get("target")
+            .cloned()
+            .ok_or_else(|| "search result has no target".to_string())?;
+        let score = item.get("score").and_then(Value::as_i64).unwrap_or(0);
+        let entry = SearchEntry::new(
+            format!("remote:{session}:{id}"),
+            kind,
+            label.to_string(),
+            detail.to_string(),
+            [],
+            SearchTarget::Remote {
+                session: session.to_string(),
+                kind,
+                target,
+            },
+            false,
+        );
+        let highlight_query = FuzzyQuery::new(query, case_sensitive && kind == SearchKind::Output);
+        let highlight = highlight_query.score(
+            &entry
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(index, text)| FuzzyField {
+                    text,
+                    weight: if index == 0 { 80 } else { 0 },
+                })
+                .collect::<Vec<_>>(),
+        );
+        matches.push(SearchMatch {
+            label_positions: highlight
+                .filter(|highlight| highlight.field == 0)
+                .map(|highlight| highlight.byte_positions)
+                .unwrap_or_default(),
+            entry,
+            score,
+        });
+    }
+    Ok(FederatedResult {
+        matches,
+        total: result.get("total").and_then(Value::as_u64).unwrap_or(0) as usize,
+        partial: result
+            .get("partial")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+    })
+}
+
+pub fn session_supports_search(session: &str) -> bool {
+    let Ok(name) = crate::session::parse_target_name(session) else {
+        return false;
+    };
+    request(
+        &crate::session::api_socket_path_for(name.as_deref()),
+        "search.capabilities",
+        json!({}),
+    )
+    .ok()
+    .and_then(|response| response.get("result").cloned())
+    .is_some_and(|result| {
+        result.get("version").and_then(Value::as_u64) == Some(1)
+            && result
+                .get("methods")
+                .and_then(Value::as_array)
+                .is_some_and(|methods| {
+                    methods
+                        .iter()
+                        .any(|method| method.as_str() == Some("search.query"))
+                })
+    })
+}
+
+/// Validate and focus/open a target in its owning session before client handoff.
+pub fn activate_session(session: &str, kind: SearchKind, target: Value) -> Result<(), String> {
+    crate::session::validate_name(session)?;
+    let name = crate::session::parse_target_name(session)?;
+    let response = request(
+        &crate::session::api_socket_path_for(name.as_deref()),
+        "search.activate",
+        json!({ "kind": kind.label(), "target": target }),
+    )?;
+    if let Some(error) = response.get("error") {
+        return Err(error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("target activation failed")
+            .to_string());
+    }
+    Ok(())
+}
+
+fn request(path: &Path, method: &str, params: Value) -> Result<Value, String> {
+    let mut stream = crate::ipc::transport::connect(path)
+        .map_err(|error| format!("session is unavailable: {error}"))?;
+    let _ = stream.set_timeouts(SESSION_TIMEOUT);
+    let request = json!({ "id": "federated-search", "method": method, "params": params });
+    writeln!(stream, "{request}").map_err(|error| error.to_string())?;
+    stream.flush().map_err(|error| error.to_string())?;
+
+    let mut response = String::new();
+    let bytes = stream
+        .take(MAX_SESSION_RESPONSE_BYTES + 1)
+        .read_to_string(&mut response)
+        .map_err(|error| format!("session search timed out or failed: {error}"))?;
+    if bytes as u64 > MAX_SESSION_RESPONSE_BYTES {
+        return Err("session search response exceeded 1 MiB".to_string());
+    }
+    let line = response
+        .lines()
+        .next()
+        .ok_or_else(|| "session returned an empty response".to_string())?;
+    serde_json::from_str(line).map_err(|error| format!("invalid session response: {error}"))
+}
+
+fn parse_kind(kind: &str) -> Result<SearchKind, String> {
+    match kind {
+        "session" => Ok(SearchKind::Session),
+        "folder" => Ok(SearchKind::Workspace),
+        "tab" => Ok(SearchKind::Tab),
+        "pane" => Ok(SearchKind::Pane),
+        "agent" => Ok(SearchKind::Agent),
+        "file" => Ok(SearchKind::File),
+        "output" => Ok(SearchKind::Output),
+        _ => Err(format!("unsupported search result kind: {kind}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_schema_is_strict() {
+        assert_eq!(parse_kind("folder").unwrap(), SearchKind::Workspace);
+        assert!(parse_kind("command").is_err());
+    }
+
+    #[test]
+    fn bounded_socket_query_returns_typed_remote_target() {
+        use std::io::{BufRead, BufReader};
+
+        let _env = crate::persist::test_env("federated-search-query");
+        let dir = crate::session::session_dir_for(Some("sibling"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let lock = crate::ipc::transport::acquire_server_startup_lock(&dir).unwrap();
+        let path = crate::session::api_socket_path_for(Some("sibling"));
+        let listener = crate::ipc::transport::bind(&path).unwrap();
+        let server = std::thread::spawn(move || {
+            let mut stream = crate::ipc::transport::incoming(&listener).next().unwrap();
+            let mut line = String::new();
+            BufReader::new(stream.clone()).read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(line.trim()).unwrap();
+            assert_eq!(request["method"], "search.query");
+            writeln!(
+                stream,
+                "{}",
+                json!({
+                    "id": "federated-search",
+                    "result": {
+                        "type": "search_query",
+                        "total": 1,
+                        "partial": false,
+                        "matches": [{
+                            "id": "pane:7",
+                            "kind": "pane",
+                            "label": "Codex",
+                            "detail": "sibling › api › tab 1 › pane 7",
+                            "score": 123,
+                            "target": {"pane": "7"},
+                        }]
+                    }
+                })
+            )
+            .unwrap();
+        });
+        let result = query_session("sibling", "cod", "navigate", false, 20).unwrap();
+        assert_eq!(result.matches.len(), 1);
+        assert!(matches!(
+            &result.matches[0].entry.target,
+            SearchTarget::Remote { session, .. } if session == "sibling"
+        ));
+        server.join().unwrap();
+        drop(lock);
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/search/federation.rs
+++ b/src/search/federation.rs
@@ -242,6 +242,12 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let lock = crate::ipc::transport::acquire_server_startup_lock(&dir).unwrap();
         let path = crate::session::api_socket_path_for(Some("sibling"));
+        // Long macOS socket paths resolve to an owner-scoped short alias outside
+        // the logical session directory. Mirror server startup by creating that
+        // resolved parent before binding the fake sibling session.
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
         let listener = crate::ipc::transport::bind(&path).unwrap();
         let server = std::thread::spawn(move || {
             let mut stream = crate::ipc::transport::incoming(&listener).next().unwrap();

--- a/src/search/federation.rs
+++ b/src/search/federation.rs
@@ -6,7 +6,7 @@
 
 use std::io::{Read, Write};
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 
@@ -190,24 +190,106 @@ pub fn activate_session(session: &str, kind: SearchKind, target: Value) -> Resul
 fn request(path: &Path, method: &str, params: Value) -> Result<Value, String> {
     let mut stream = crate::ipc::transport::connect(path)
         .map_err(|error| format!("session is unavailable: {error}"))?;
-    let _ = stream.set_timeouts(SESSION_TIMEOUT);
     let request = json!({ "id": "federated-search", "method": method, "params": params });
-    writeln!(stream, "{request}").map_err(|error| error.to_string())?;
-    stream.flush().map_err(|error| error.to_string())?;
-
-    let mut response = String::new();
-    let bytes = stream
-        .take(MAX_SESSION_RESPONSE_BYTES + 1)
-        .read_to_string(&mut response)
-        .map_err(|error| format!("session search timed out or failed: {error}"))?;
-    if bytes as u64 > MAX_SESSION_RESPONSE_BYTES {
-        return Err("session search response exceeded 1 MiB".to_string());
-    }
+    let wire = format!("{request}\n");
+    let response = match stream
+        .set_timeouts(SESSION_TIMEOUT)
+        .map_err(|error| format!("cannot bound session search: {error}"))?
+    {
+        crate::ipc::transport::TimeoutMode::Kernel => {
+            stream
+                .write_all(wire.as_bytes())
+                .map_err(|error| error.to_string())?;
+            stream.flush().map_err(|error| error.to_string())?;
+            let mut response = String::new();
+            let bytes = stream
+                .take(MAX_SESSION_RESPONSE_BYTES + 1)
+                .read_to_string(&mut response)
+                .map_err(|error| format!("session search timed out or failed: {error}"))?;
+            if bytes as u64 > MAX_SESSION_RESPONSE_BYTES {
+                return Err("session search response exceeded 1 MiB".to_string());
+            }
+            response
+        }
+        crate::ipc::transport::TimeoutMode::Nonblocking => {
+            request_nonblocking(&mut stream, wire.as_bytes(), SESSION_TIMEOUT)?
+        }
+    };
     let line = response
         .lines()
         .next()
         .ok_or_else(|| "session returned an empty response".to_string())?;
     serde_json::from_str(line).map_err(|error| format!("invalid session response: {error}"))
+}
+
+fn request_nonblocking(
+    stream: &mut (impl Read + Write),
+    request: &[u8],
+    timeout: Duration,
+) -> Result<String, String> {
+    let deadline = Instant::now() + timeout;
+    let mut written = 0;
+    while written < request.len() {
+        match stream.write(&request[written..]) {
+            Ok(0) => return Err("session closed while receiving search request".to_string()),
+            Ok(bytes) => written += bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                wait_for_io(deadline)?;
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    loop {
+        match stream.flush() {
+            Ok(()) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                wait_for_io(deadline)?;
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+
+    let mut response = Vec::new();
+    let mut chunk = [0u8; 16 * 1024];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) if response.is_empty() => {
+                return Err("session returned an empty response".to_string())
+            }
+            Ok(0) => break,
+            Ok(bytes) => {
+                let room = (MAX_SESSION_RESPONSE_BYTES as usize + 1).saturating_sub(response.len());
+                response.extend_from_slice(&chunk[..bytes.min(room)]);
+                if response.len() as u64 > MAX_SESSION_RESPONSE_BYTES {
+                    return Err("session search response exceeded 1 MiB".to_string());
+                }
+                if response.contains(&b'\n') {
+                    break;
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                wait_for_io(deadline)?;
+            }
+            Err(error) => return Err(format!("session search timed out or failed: {error}")),
+        }
+    }
+    String::from_utf8(response).map_err(|error| format!("invalid session response: {error}"))
+}
+
+fn wait_for_io(deadline: Instant) -> Result<(), String> {
+    let now = Instant::now();
+    if now >= deadline {
+        return Err("session search timed out".to_string());
+    }
+    std::thread::sleep(
+        deadline
+            .saturating_duration_since(now)
+            .min(Duration::from_millis(2)),
+    );
+    Ok(())
 }
 
 fn parse_kind(kind: &str) -> Result<SearchKind, String> {
@@ -227,10 +309,37 @@ fn parse_kind(kind: &str) -> Result<SearchKind, String> {
 mod tests {
     use super::*;
 
+    struct NeverReady;
+
+    impl Read for NeverReady {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::ErrorKind::WouldBlock.into())
+        }
+    }
+
+    impl Write for NeverReady {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::ErrorKind::WouldBlock.into())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn kind_schema_is_strict() {
         assert_eq!(parse_kind("folder").unwrap(), SearchKind::Workspace);
         assert!(parse_kind("command").is_err());
+    }
+
+    #[test]
+    fn nonblocking_fallback_has_an_application_deadline() {
+        let started = Instant::now();
+        let error = request_nonblocking(&mut NeverReady, b"request\n", Duration::from_millis(10))
+            .unwrap_err();
+        assert!(error.contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     #[test]

--- a/src/search/files.rs
+++ b/src/search/files.rs
@@ -1,12 +1,13 @@
 //! Bounded, off-loop file-path discovery for the global finder (docs/90).
 
 use std::collections::HashSet;
+#[cfg(unix)]
 use std::ffi::OsString;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use super::{FILE_BYTES_CAP, FILE_COUNT_CAP};
@@ -26,6 +27,7 @@ pub struct FileCatalog {
 
 const CACHE_TTL: Duration = Duration::from_secs(2);
 const CACHE_BYTES_CAP: usize = 32 * 1024 * 1024;
+const GIT_INDEX_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct CacheEntry {
     root: PathBuf,
@@ -35,6 +37,18 @@ struct CacheEntry {
 }
 
 static CACHE: OnceLock<Mutex<Vec<CacheEntry>>> = OnceLock::new();
+
+fn cached_catalog(
+    entries: &mut Vec<CacheEntry>,
+    key: &Path,
+    now: Instant,
+) -> Option<Arc<FileCatalog>> {
+    entries.retain(|entry| now.duration_since(entry.at) <= CACHE_TTL);
+    entries
+        .iter()
+        .find(|entry| entry.root == key)
+        .map(|entry| Arc::clone(&entry.catalog))
+}
 
 pub fn index(root: &Path) -> FileCatalog {
     git_files(root).unwrap_or_else(|| walk_files(root))
@@ -47,11 +61,8 @@ pub fn index_cached(root: &Path) -> Arc<FileCatalog> {
     let key = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
     let cache = CACHE.get_or_init(|| Mutex::new(Vec::new()));
     if let Ok(mut entries) = cache.lock() {
-        let now = Instant::now();
-        entries.retain(|entry| now.duration_since(entry.at) <= CACHE_TTL);
-        if let Some(entry) = entries.iter_mut().find(|entry| entry.root == key) {
-            entry.at = now;
-            return Arc::clone(&entry.catalog);
+        if let Some(catalog) = cached_catalog(&mut entries, &key, Instant::now()) {
+            return catalog;
         }
     }
 
@@ -81,6 +92,7 @@ pub fn index_cached(root: &Path) -> Arc<FileCatalog> {
 }
 
 fn git_files(root: &Path) -> Option<FileCatalog> {
+    let deadline = Instant::now() + GIT_INDEX_TIMEOUT;
     let mut child = Command::new("git")
         .arg("-C")
         .arg(root)
@@ -90,24 +102,34 @@ fn git_files(root: &Path) -> Option<FileCatalog> {
         .stderr(Stdio::null())
         .spawn()
         .ok()?;
-    let mut stdout = child.stdout.take()?;
-    let mut bytes = Vec::new();
-    let mut chunk = [0u8; 16 * 1024];
-    let mut truncated = false;
-    loop {
-        let n = stdout.read(&mut chunk).ok()?;
-        if n == 0 {
-            break;
-        }
-        let room = FILE_BYTES_CAP.saturating_sub(bytes.len());
-        bytes.extend_from_slice(&chunk[..n.min(room)]);
-        if n > room || bytes.len() >= FILE_BYTES_CAP {
-            truncated = true;
-            let _ = child.kill();
-            break;
-        }
+    let Some(stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    };
+    let (tx, rx) = mpsc::sync_channel(1);
+    let reader = std::thread::spawn(move || {
+        let _ = tx.send(read_git_output(stdout));
+    });
+    let (bytes, mut truncated) =
+        match rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+            Ok(Ok(output)) => output,
+            Ok(Err(_)) | Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = reader.join();
+                return None;
+            }
+        };
+    if truncated {
+        let _ = child.kill();
     }
-    let status = child.wait().ok()?;
+    let _ = reader.join();
+    let status = if truncated {
+        child.wait().ok()?
+    } else {
+        wait_for_child(&mut child, deadline)?
+    };
     if !status.success() && !truncated {
         return None;
     }
@@ -138,6 +160,40 @@ fn git_files(root: &Path) -> Option<FileCatalog> {
         truncated,
         partial: false,
     })
+}
+
+fn wait_for_child(
+    child: &mut std::process::Child,
+    deadline: Instant,
+) -> Option<std::process::ExitStatus> {
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(2));
+            }
+            Ok(None) | Err(_) => {
+                let _ = child.kill();
+                return child.wait().ok();
+            }
+        }
+    }
+}
+
+fn read_git_output(mut stdout: impl Read) -> std::io::Result<(Vec<u8>, bool)> {
+    let mut bytes = Vec::new();
+    let mut chunk = [0u8; 16 * 1024];
+    loop {
+        let n = stdout.read(&mut chunk)?;
+        if n == 0 {
+            return Ok((bytes, false));
+        }
+        let room = FILE_BYTES_CAP.saturating_sub(bytes.len());
+        bytes.extend_from_slice(&chunk[..n.min(room)]);
+        if n > room || bytes.len() >= FILE_BYTES_CAP {
+            return Ok((bytes, true));
+        }
+    }
 }
 
 fn walk_files(root: &Path) -> FileCatalog {
@@ -244,5 +300,35 @@ mod tests {
         let second = index_cached(&root);
         assert!(Arc::ptr_eq(&first, &second));
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn cache_ttl_is_measured_from_insertion_not_last_hit() {
+        let inserted = Instant::now();
+        let key = PathBuf::from("workspace");
+        let catalog = Arc::new(FileCatalog::default());
+        let mut entries = vec![CacheEntry {
+            root: key.clone(),
+            at: inserted,
+            bytes: 0,
+            catalog: Arc::clone(&catalog),
+        }];
+
+        let hit = cached_catalog(&mut entries, &key, inserted + CACHE_TTL / 2).unwrap();
+        assert!(Arc::ptr_eq(&hit, &catalog));
+        assert!(cached_catalog(
+            &mut entries,
+            &key,
+            inserted + CACHE_TTL + Duration::from_millis(1)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn git_output_reader_caps_bytes_without_waiting_for_eof() {
+        let data = vec![b'x'; FILE_BYTES_CAP + 1];
+        let (bytes, truncated) = read_git_output(std::io::Cursor::new(data)).unwrap();
+        assert_eq!(bytes.len(), FILE_BYTES_CAP);
+        assert!(truncated);
     }
 }

--- a/src/search/files.rs
+++ b/src/search/files.rs
@@ -1,0 +1,248 @@
+//! Bounded, off-loop file-path discovery for the global finder (docs/90).
+
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use super::{FILE_BYTES_CAP, FILE_COUNT_CAP};
+
+#[derive(Clone, Debug)]
+pub struct FileRecord {
+    pub path: PathBuf,
+    pub relative: PathBuf,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FileCatalog {
+    pub records: Vec<FileRecord>,
+    pub truncated: bool,
+    pub partial: bool,
+}
+
+const CACHE_TTL: Duration = Duration::from_secs(2);
+const CACHE_BYTES_CAP: usize = 32 * 1024 * 1024;
+
+struct CacheEntry {
+    root: PathBuf,
+    at: Instant,
+    bytes: usize,
+    catalog: Arc<FileCatalog>,
+}
+
+static CACHE: OnceLock<Mutex<Vec<CacheEntry>>> = OnceLock::new();
+
+pub fn index(root: &Path) -> FileCatalog {
+    git_files(root).unwrap_or_else(|| walk_files(root))
+}
+
+/// Reuse a recent path-only catalog across interactive and API queries. The
+/// short TTL keeps changes fresh while preventing CLI federation from running
+/// `git ls-files` for every keystroke. Entries obey a global byte cap.
+pub fn index_cached(root: &Path) -> Arc<FileCatalog> {
+    let key = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let cache = CACHE.get_or_init(|| Mutex::new(Vec::new()));
+    if let Ok(mut entries) = cache.lock() {
+        let now = Instant::now();
+        entries.retain(|entry| now.duration_since(entry.at) <= CACHE_TTL);
+        if let Some(entry) = entries.iter_mut().find(|entry| entry.root == key) {
+            entry.at = now;
+            return Arc::clone(&entry.catalog);
+        }
+    }
+
+    let catalog = Arc::new(index(root));
+    let bytes = catalog
+        .records
+        .iter()
+        .map(|record| record.path.as_os_str().len() + record.relative.as_os_str().len())
+        .sum::<usize>();
+    if let Ok(mut entries) = cache.lock() {
+        entries.retain(|entry| entry.root != key);
+        entries.push(CacheEntry {
+            root: key,
+            at: Instant::now(),
+            bytes,
+            catalog: Arc::clone(&catalog),
+        });
+        while entries.iter().map(|entry| entry.bytes).sum::<usize>() > CACHE_BYTES_CAP {
+            let Some((oldest, _)) = entries.iter().enumerate().min_by_key(|(_, entry)| entry.at)
+            else {
+                break;
+            };
+            entries.remove(oldest);
+        }
+    }
+    catalog
+}
+
+fn git_files(root: &Path) -> Option<FileCatalog> {
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-co", "--exclude-standard", "-z"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let mut stdout = child.stdout.take()?;
+    let mut bytes = Vec::new();
+    let mut chunk = [0u8; 16 * 1024];
+    let mut truncated = false;
+    loop {
+        let n = stdout.read(&mut chunk).ok()?;
+        if n == 0 {
+            break;
+        }
+        let room = FILE_BYTES_CAP.saturating_sub(bytes.len());
+        bytes.extend_from_slice(&chunk[..n.min(room)]);
+        if n > room || bytes.len() >= FILE_BYTES_CAP {
+            truncated = true;
+            let _ = child.kill();
+            break;
+        }
+    }
+    let status = child.wait().ok()?;
+    if !status.success() && !truncated {
+        return None;
+    }
+    let mut records = Vec::new();
+    let mut seen = HashSet::new();
+    for raw in bytes.split(|b| *b == 0).filter(|raw| !raw.is_empty()) {
+        if records.len() >= FILE_COUNT_CAP {
+            truncated = true;
+            break;
+        }
+        let relative = path_from_bytes(raw);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            continue;
+        }
+        if seen.insert(relative.clone()) {
+            records.push(FileRecord {
+                path: root.join(&relative),
+                relative,
+            });
+        }
+    }
+    Some(FileCatalog {
+        records,
+        truncated,
+        partial: false,
+    })
+}
+
+fn walk_files(root: &Path) -> FileCatalog {
+    let mut catalog = FileCatalog::default();
+    let mut stack = vec![(root.to_path_buf(), 0usize)];
+    let mut bytes = 0usize;
+    while let Some((dir, depth)) = stack.pop() {
+        if depth > 64 {
+            catalog.truncated = true;
+            continue;
+        }
+        let read = match fs::read_dir(&dir) {
+            Ok(read) => read,
+            Err(_) => {
+                catalog.partial = true;
+                continue;
+            }
+        };
+        let mut entries = Vec::new();
+        for entry in read {
+            match entry {
+                Ok(entry) => entries.push(entry),
+                Err(_) => catalog.partial = true,
+            }
+        }
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries.into_iter().rev() {
+            let path = entry.path();
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            let kind = match entry.file_type() {
+                Ok(kind) => kind,
+                Err(_) => {
+                    catalog.partial = true;
+                    continue;
+                }
+            };
+            if kind.is_symlink() {
+                continue;
+            }
+            if kind.is_dir() {
+                stack.push((path, depth + 1));
+                continue;
+            }
+            if !kind.is_file() {
+                continue;
+            }
+            let Ok(relative) = path.strip_prefix(root).map(Path::to_path_buf) else {
+                continue;
+            };
+            bytes = bytes.saturating_add(relative.as_os_str().len());
+            if bytes > FILE_BYTES_CAP || catalog.records.len() >= FILE_COUNT_CAP {
+                catalog.truncated = true;
+                return catalog;
+            }
+            catalog.records.push(FileRecord { path, relative });
+        }
+    }
+    catalog.records.sort_by(|a, b| a.relative.cmp(&b.relative));
+    catalog
+}
+
+#[cfg(unix)]
+fn path_from_bytes(raw: &[u8]) -> PathBuf {
+    use std::os::unix::ffi::OsStringExt;
+    PathBuf::from(OsString::from_vec(raw.to_vec()))
+}
+
+#[cfg(not(unix))]
+fn path_from_bytes(raw: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(raw).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_walk_skips_git_and_directory_symlinks() {
+        let root = std::env::temp_dir().join(format!("luvus-search-files-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+        fs::write(root.join(".git/secret"), "hidden").unwrap();
+        let catalog = walk_files(&root);
+        assert_eq!(catalog.records.len(), 1);
+        assert_eq!(catalog.records[0].relative, PathBuf::from("src/main.rs"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recent_catalog_is_reused() {
+        let root = std::env::temp_dir().join(format!(
+            "luvus-search-cache-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("one.txt"), "one").unwrap();
+        let first = index_cached(&root);
+        let second = index_cached(&root);
+        assert!(Arc::ptr_eq(&first, &second));
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/search/fuzzy.rs
+++ b/src/search/fuzzy.rs
@@ -1,0 +1,399 @@
+//! Small deterministic fuzzy scorer owned by Luvus (docs/90 FIND-1).
+
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct PreparedText {
+    original: Arc<str>,
+    folded: Vec<u8>,
+    /// One bit per ASCII byte. Unicode candidates derive boundaries only while
+    /// being scored, keeping the cached catalog close to two source copies.
+    boundaries: Vec<u8>,
+    ascii: bool,
+}
+
+impl PreparedText {
+    pub fn new(text: &str) -> Self {
+        Self::from_shared(Arc::<str>::from(text))
+    }
+
+    pub fn from_shared(original: Arc<str>) -> Self {
+        let ascii = original.is_ascii();
+        let folded = if ascii {
+            original
+                .bytes()
+                .map(|byte| byte.to_ascii_lowercase())
+                .collect()
+        } else {
+            original.to_lowercase().into_bytes()
+        };
+        let mut boundaries = vec![0u8; original.len().div_ceil(8)];
+        if ascii {
+            let bytes = original.as_bytes();
+            for index in 0..bytes.len() {
+                let boundary = index == 0
+                    || matches!(
+                        bytes[index - 1],
+                        b'/' | b'\\' | b'-' | b'_' | b'.' | b' ' | b'\t'
+                    )
+                    || (bytes[index - 1].is_ascii_lowercase() && bytes[index].is_ascii_uppercase());
+                if boundary {
+                    boundaries[index / 8] |= 1 << (index % 8);
+                }
+            }
+        }
+        Self {
+            original,
+            folded,
+            boundaries,
+            ascii,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn original(&self) -> &str {
+        &self.original
+    }
+
+    fn is_boundary(&self, index: usize) -> bool {
+        self.boundaries
+            .get(index / 8)
+            .is_some_and(|byte| byte & (1 << (index % 8)) != 0)
+    }
+
+    pub(crate) fn index_bytes(&self) -> usize {
+        self.folded.len().saturating_add(self.boundaries.len())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Token {
+    folded: String,
+    exact: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct FuzzyQuery {
+    tokens: Vec<Token>,
+    case_sensitive: bool,
+}
+
+pub struct FuzzyField<'a> {
+    pub text: &'a PreparedText,
+    pub weight: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FuzzyScore {
+    pub value: i64,
+    pub field: usize,
+    pub byte_positions: Vec<usize>,
+    output_safe: bool,
+}
+
+impl FuzzyScore {
+    /// Output rows are much noisier than short navigation labels. Exact,
+    /// prefix, and contiguous hits are always safe; an ordered subsequence is
+    /// safe only when its characters occupy at least half of the matched span.
+    pub fn output_safe(&self) -> bool {
+        self.output_safe
+    }
+}
+
+impl FuzzyQuery {
+    pub fn new(query: &str, case_sensitive: bool) -> Self {
+        let tokens = query
+            .split_whitespace()
+            .filter(|token| !token.is_empty())
+            .map(|token| Token {
+                folded: token.to_lowercase(),
+                exact: token.to_string(),
+            })
+            .collect();
+        Self {
+            tokens,
+            case_sensitive,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+
+    pub fn char_count(&self) -> usize {
+        self.tokens
+            .iter()
+            .map(|token| token.folded.chars().count())
+            .sum()
+    }
+
+    pub fn score(&self, fields: &[FuzzyField<'_>]) -> Option<FuzzyScore> {
+        if self.tokens.is_empty() || fields.is_empty() {
+            return None;
+        }
+        let mut total = 0i64;
+        let mut primary_field = usize::MAX;
+        let mut primary_positions = Vec::new();
+        let mut output_safe = true;
+        for token in &self.tokens {
+            let mut best: Option<(i64, usize, Vec<usize>, bool)> = None;
+            for (field_index, field) in fields.iter().enumerate() {
+                let scored =
+                    if field.text.ascii && token.exact.is_ascii() && token.folded.is_ascii() {
+                        let hay = if self.case_sensitive {
+                            field.text.original.as_bytes()
+                        } else {
+                            field.text.folded.as_slice()
+                        };
+                        let needle = if self.case_sensitive {
+                            token.exact.as_bytes()
+                        } else {
+                            token.folded.as_bytes()
+                        };
+                        score_one(
+                            hay,
+                            needle,
+                            |index| field.text.is_boundary(index),
+                            field.weight,
+                        )
+                    } else {
+                        let (hay, bytes, boundaries) =
+                            unicode_chars(&field.text.original, self.case_sensitive);
+                        let needle = if self.case_sensitive {
+                            token.exact.chars().collect::<Vec<_>>()
+                        } else {
+                            token.folded.chars().collect::<Vec<_>>()
+                        };
+                        score_one(
+                            &hay,
+                            &needle,
+                            |index| boundaries.get(index).copied().unwrap_or(false),
+                            field.weight,
+                        )
+                        .map(|(score, positions, safe)| {
+                            (
+                                score,
+                                positions
+                                    .into_iter()
+                                    .filter_map(|index| bytes.get(index).copied())
+                                    .collect(),
+                                safe,
+                            )
+                        })
+                    };
+                let Some((score, positions, safe)) = scored else {
+                    continue;
+                };
+                let candidate = (score, field_index, positions, safe);
+                if best.as_ref().is_none_or(|current| candidate.0 > current.0) {
+                    best = Some(candidate);
+                }
+            }
+            let (score, field, positions, safe) = best?;
+            total = total.saturating_add(score);
+            output_safe &= safe;
+            if primary_field == usize::MAX || field < primary_field {
+                primary_field = field;
+                primary_positions = positions;
+            } else if field == primary_field {
+                primary_positions.extend(positions);
+                primary_positions.sort_unstable();
+                primary_positions.dedup();
+            }
+        }
+        Some(FuzzyScore {
+            value: total,
+            field: primary_field,
+            byte_positions: primary_positions,
+            output_safe,
+        })
+    }
+}
+
+fn score_one<T: Eq>(
+    hay: &[T],
+    needle: &[T],
+    boundary: impl Fn(usize) -> bool,
+    field_weight: i64,
+) -> Option<(i64, Vec<usize>, bool)> {
+    if needle.is_empty() || needle.len() > hay.len() {
+        return None;
+    }
+    if hay == needle {
+        return Some((12_000 + field_weight, (0..needle.len()).collect(), true));
+    }
+    if hay.starts_with(needle) {
+        return Some((
+            9_000 + field_weight - hay.len() as i64,
+            (0..needle.len()).collect(),
+            true,
+        ));
+    }
+    if let Some(start) = hay
+        .windows(needle.len())
+        .position(|window| window == needle)
+    {
+        return Some((
+            6_500 + field_weight + if boundary(start) { 300 } else { 0 }
+                - start as i64 * 4
+                - (hay.len() - needle.len()) as i64,
+            (start..start + needle.len()).collect(),
+            true,
+        ));
+    }
+
+    let mut positions = Vec::with_capacity(needle.len());
+    let mut cursor = 0usize;
+    let mut score = 2_000 + field_weight;
+    for item in needle {
+        let relative = hay[cursor..]
+            .iter()
+            .position(|candidate| candidate == item)?;
+        let position = cursor + relative;
+        if positions
+            .last()
+            .is_some_and(|previous| *previous + 1 == position)
+        {
+            score += 180;
+        }
+        if boundary(position) {
+            score += 120;
+        }
+        score -= relative as i64 * 18;
+        positions.push(position);
+        cursor = position + 1;
+    }
+    let span = positions.last().copied().unwrap_or(0) - positions[0] + 1;
+    score -= (span.saturating_sub(needle.len()) as i64) * 12;
+    score -= (hay.len().saturating_sub(needle.len()) as i64).min(400);
+    let output_safe = needle.len().saturating_mul(2) >= span;
+    Some((score, positions, output_safe))
+}
+
+fn unicode_chars(text: &str, case_sensitive: bool) -> (Vec<char>, Vec<usize>, Vec<bool>) {
+    let mut chars = Vec::new();
+    let mut bytes = Vec::new();
+    let mut boundaries = Vec::new();
+    let mut previous = None;
+    for (byte, ch) in text.char_indices() {
+        let boundary = previous.is_none_or(|p: char| {
+            matches!(p, '/' | '\\' | '-' | '_' | '.' | ' ' | '\t')
+                || (p.is_lowercase() && ch.is_uppercase())
+        });
+        if case_sensitive {
+            chars.push(ch);
+            bytes.push(byte);
+            boundaries.push(boundary);
+        } else {
+            for lower in ch.to_lowercase() {
+                chars.push(lower);
+                bytes.push(byte);
+                boundaries.push(boundary);
+            }
+        }
+        previous = Some(ch);
+    }
+    (chars, bytes, boundaries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn score(query: &str, text: &str) -> Option<FuzzyScore> {
+        let text = PreparedText::new(text);
+        FuzzyQuery::new(query, false).score(&[FuzzyField {
+            text: &text,
+            weight: 0,
+        }])
+    }
+
+    #[test]
+    fn exact_prefix_contiguous_and_subsequence_order() {
+        let exact = score("api", "api").unwrap().value;
+        let prefix = score("api", "api-client").unwrap().value;
+        let contiguous = score("api", "my-api-client").unwrap().value;
+        let sparse = score("api", "a-path-item").unwrap().value;
+        assert!(exact > prefix && prefix > contiguous && contiguous > sparse);
+    }
+
+    #[test]
+    fn output_rejects_sparse_but_keeps_dense_subsequences() {
+        assert!(score("bld", "build failed").unwrap().output_safe());
+        assert!(!score("fzpn1fl", "fuzzy-benchmark-pane-1-auth-failure")
+            .unwrap()
+            .output_safe());
+        assert!(score("auth", "fuzzy benchmark auth failure")
+            .unwrap()
+            .output_safe());
+    }
+
+    #[test]
+    fn path_and_camel_boundaries_beat_unstructured_gaps() {
+        assert!(
+            score("sui", "src/ui/input.rs").unwrap().value
+                > score("sui", "some_unrelated_item").unwrap().value
+        );
+        assert!(
+            score("gsc", "GlobalSearchCatalog").unwrap().value
+                > score("gsc", "long generic source code").unwrap().value
+        );
+    }
+
+    #[test]
+    fn tokens_may_match_different_fields() {
+        let a = PreparedText::new("tests");
+        let b = PreparedText::new("default > api");
+        assert!(FuzzyQuery::new("api test", false)
+            .score(&[
+                FuzzyField {
+                    text: &a,
+                    weight: 10
+                },
+                FuzzyField {
+                    text: &b,
+                    weight: 0
+                },
+            ])
+            .is_some());
+    }
+
+    #[test]
+    fn unicode_highlights_use_original_byte_boundaries() {
+        let text = PreparedText::new("Ångström");
+        let got = FuzzyQuery::new("ång", false)
+            .score(&[FuzzyField {
+                text: &text,
+                weight: 0,
+            }])
+            .unwrap();
+        assert_eq!(got.byte_positions, vec![0, 2, 3]);
+        for byte in got.byte_positions {
+            assert!(text.original().is_char_boundary(byte));
+        }
+    }
+
+    #[test]
+    fn case_sensitive_matching_is_strict() {
+        let text = PreparedText::new("ReadMe");
+        assert!(FuzzyQuery::new("RM", true)
+            .score(&[FuzzyField {
+                text: &text,
+                weight: 0
+            }])
+            .is_some());
+        assert!(FuzzyQuery::new("rm", true)
+            .score(&[FuzzyField {
+                text: &text,
+                weight: 0
+            }])
+            .is_none());
+    }
+
+    #[test]
+    fn ascii_catalog_storage_stays_close_to_two_source_copies() {
+        let text = PreparedText::new(&"x".repeat(8192));
+        assert_eq!(text.folded.len(), 8192);
+        assert_eq!(text.boundaries.len(), 1024);
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -131,7 +131,9 @@ pub enum SearchTarget {
         ws: usize,
         tab: usize,
         workspace_cwd: PathBuf,
-        tab_label: String,
+        /// Snapshot of the tab's pane leaves. Unlike the display index, this
+        /// identity survives tab moves and swaps within the live workspace.
+        tab_leaves: Vec<PaneId>,
     },
     Pane {
         pane: PaneId,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,0 +1,457 @@
+//! Shared global-finder domain and dependency-free fuzzy matching (docs/90).
+//!
+//! App state, rendering, files, and IPC all use these types so ranking and
+//! activation never depend on parsing a displayed label.
+
+pub mod federation;
+pub mod files;
+mod fuzzy;
+
+pub use fuzzy::{FuzzyField, FuzzyQuery, PreparedText};
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::ids::PaneId;
+
+pub const RESULT_CAP: usize = 200;
+pub const OUTPUT_PER_PANE_CAP: usize = 30;
+pub const OUTPUT_SOURCE_BYTES: usize = 8 * 1024 * 1024;
+pub const OUTPUT_INDEX_BYTES: usize = 8 * 1024 * 1024;
+pub const OUTPUT_ROW_CAP: usize = 100_000;
+pub const FILE_COUNT_CAP: usize = 100_000;
+pub const FILE_BYTES_CAP: usize = 16 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SearchScope {
+    All,
+    Navigate,
+    Files,
+    Output,
+}
+
+impl SearchScope {
+    pub const ALL: [Self; 4] = [Self::All, Self::Navigate, Self::Files, Self::Output];
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::Navigate,
+            Self::Navigate => Self::Files,
+            Self::Files => Self::Output,
+            Self::Output => Self::All,
+        }
+    }
+
+    pub fn previous(self) -> Self {
+        match self {
+            Self::All => Self::Output,
+            Self::Navigate => Self::All,
+            Self::Files => Self::Navigate,
+            Self::Output => Self::Files,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::Navigate => "Navigate",
+            Self::Files => "Files",
+            Self::Output => "Output",
+        }
+    }
+
+    pub fn includes(self, kind: SearchKind) -> bool {
+        match self {
+            Self::All => true,
+            Self::Navigate => matches!(
+                kind,
+                SearchKind::Session
+                    | SearchKind::Workspace
+                    | SearchKind::Tab
+                    | SearchKind::Pane
+                    | SearchKind::Agent
+            ),
+            Self::Files => kind == SearchKind::File,
+            Self::Output => kind == SearchKind::Output,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum SearchKind {
+    Session,
+    Workspace,
+    Tab,
+    Pane,
+    Agent,
+    File,
+    Output,
+}
+
+impl SearchKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::Workspace => "folder",
+            Self::Tab => "tab",
+            Self::Pane => "pane",
+            Self::Agent => "agent",
+            Self::File => "file",
+            Self::Output => "output",
+        }
+    }
+
+    pub fn priority(self) -> i64 {
+        match self {
+            Self::Agent => 70,
+            Self::Pane => 60,
+            Self::Tab => 50,
+            Self::Workspace => 40,
+            Self::Session => 30,
+            Self::File => 20,
+            Self::Output => 10,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SearchTarget {
+    Session {
+        name: String,
+        running: bool,
+        current: bool,
+    },
+    Workspace {
+        ws: usize,
+        cwd: PathBuf,
+    },
+    Tab {
+        ws: usize,
+        tab: usize,
+        workspace_cwd: PathBuf,
+        tab_label: String,
+    },
+    Pane {
+        pane: PaneId,
+    },
+    Agent {
+        pane: PaneId,
+    },
+    File {
+        ws: usize,
+        path: PathBuf,
+        workspace_cwd: PathBuf,
+    },
+    Output {
+        pane: PaneId,
+        row: usize,
+        offset: usize,
+        above: usize,
+        line: Arc<str>,
+    },
+    /// A validated result returned by another running named session. The target
+    /// remains structured review data and is revalidated by its owning server
+    /// before the client is handed over.
+    Remote {
+        session: String,
+        kind: SearchKind,
+        target: serde_json::Value,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct SearchEntry {
+    pub id: String,
+    pub kind: SearchKind,
+    pub label: Arc<str>,
+    pub detail: Arc<str>,
+    pub fields: Vec<Arc<PreparedText>>,
+    pub target: SearchTarget,
+    pub active: bool,
+}
+
+impl SearchEntry {
+    pub fn new(
+        id: String,
+        kind: SearchKind,
+        label: String,
+        detail: String,
+        extra_fields: impl IntoIterator<Item = String>,
+        target: SearchTarget,
+        active: bool,
+    ) -> Self {
+        let label = Arc::<str>::from(label);
+        let detail = Arc::<str>::from(detail);
+        Self::new_shared(
+            label,
+            detail,
+            extra_fields
+                .into_iter()
+                .map(Arc::<str>::from)
+                .collect::<Vec<_>>(),
+            target,
+            active,
+            id,
+            kind,
+        )
+    }
+
+    pub fn new_shared(
+        label: Arc<str>,
+        detail: Arc<str>,
+        extra_fields: impl IntoIterator<Item = Arc<str>>,
+        target: SearchTarget,
+        active: bool,
+        id: String,
+        kind: SearchKind,
+    ) -> Self {
+        let mut fields = Vec::new();
+        fields.push(Arc::new(PreparedText::from_shared(Arc::clone(&label))));
+        fields.push(Arc::new(PreparedText::from_shared(Arc::clone(&detail))));
+        fields.extend(
+            extra_fields
+                .into_iter()
+                .map(PreparedText::from_shared)
+                .map(Arc::new),
+        );
+        Self::new_with_prepared_fields(label, detail, fields, target, active, id, kind)
+    }
+
+    pub(crate) fn new_with_prepared_fields(
+        label: Arc<str>,
+        detail: Arc<str>,
+        fields: Vec<Arc<PreparedText>>,
+        target: SearchTarget,
+        active: bool,
+        id: String,
+        kind: SearchKind,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            label,
+            detail,
+            fields,
+            target,
+            active,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SearchMatch {
+    pub entry: SearchEntry,
+    pub score: i64,
+    /// Byte starts in `entry.label`, suitable for Unicode-safe highlighting.
+    pub label_positions: Vec<usize>,
+}
+
+pub fn rank_entries(
+    entries: &[SearchEntry],
+    query: &FuzzyQuery,
+    scope: SearchScope,
+    cap: usize,
+) -> (Vec<SearchMatch>, usize) {
+    rank_entry_refs(entries.iter(), query, scope, cap)
+}
+
+/// Rank an arbitrary candidate iterator while retaining only the best `cap`
+/// rows. This keeps large file and output catalogs at O(cap) result memory.
+pub(crate) fn rank_entry_refs<'a>(
+    entries: impl Iterator<Item = &'a SearchEntry>,
+    query: &FuzzyQuery,
+    scope: SearchScope,
+    cap: usize,
+) -> (Vec<SearchMatch>, usize) {
+    rank_entry_refs_where(entries, query, scope, cap, |_| true)
+}
+
+/// The bounded ranker with an additional source-specific quality gate.
+pub(crate) fn rank_entry_refs_where<'a>(
+    entries: impl Iterator<Item = &'a SearchEntry>,
+    query: &FuzzyQuery,
+    scope: SearchScope,
+    cap: usize,
+    accept: impl Fn(&fuzzy::FuzzyScore) -> bool,
+) -> (Vec<SearchMatch>, usize) {
+    if query.is_empty() {
+        return (Vec::new(), 0);
+    }
+    let mut total = 0usize;
+    let mut matches = BinaryHeap::with_capacity(cap.saturating_add(1));
+    for entry in entries.filter(|entry| scope.includes(entry.kind)) {
+        let fields: Vec<_> = entry
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(index, text)| FuzzyField {
+                text,
+                weight: if index == 0 { 80 } else { 0 },
+            })
+            .collect();
+        let Some(score) = query.score(&fields) else {
+            continue;
+        };
+        if !accept(&score) {
+            continue;
+        }
+        total = total.saturating_add(1);
+        let found = SearchMatch {
+            entry: entry.clone(),
+            score: score.value + entry.kind.priority() + if entry.active { 15 } else { 0 },
+            label_positions: if score.field == 0 {
+                score.byte_positions
+            } else {
+                Vec::new()
+            },
+        };
+        if cap == 0 {
+            continue;
+        }
+        if matches.len() < cap {
+            matches.push(WorstMatch(found));
+        } else if matches
+            .peek()
+            .is_some_and(|worst| best_order(&found, &worst.0) == Ordering::Less)
+        {
+            matches.pop();
+            matches.push(WorstMatch(found));
+        }
+    }
+    let mut matches: Vec<_> = matches
+        .into_vec()
+        .into_iter()
+        .map(|ranked| ranked.0)
+        .collect();
+    matches.sort_by(best_order);
+    (matches, total)
+}
+
+fn best_order(a: &SearchMatch, b: &SearchMatch) -> Ordering {
+    b.score
+        .cmp(&a.score)
+        .then_with(|| b.entry.active.cmp(&a.entry.active))
+        .then_with(|| a.entry.label.cmp(&b.entry.label))
+        .then_with(|| a.entry.id.cmp(&b.entry.id))
+}
+
+struct WorstMatch(SearchMatch);
+
+impl PartialEq for WorstMatch {
+    fn eq(&self, other: &Self) -> bool {
+        best_order(&self.0, &other.0) == Ordering::Equal
+    }
+}
+
+impl Eq for WorstMatch {}
+
+impl PartialOrd for WorstMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for WorstMatch {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // `BinaryHeap` keeps the greatest item at the top. `best_order` sorts
+        // better rows first, so its greatest item is exactly the worst retained
+        // row and can be replaced without a full catalog sort.
+        best_order(&self.0, &other.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, label: &str, detail: &str) -> SearchEntry {
+        SearchEntry::new(
+            id.into(),
+            SearchKind::File,
+            label.into(),
+            detail.into(),
+            [],
+            SearchTarget::File {
+                ws: 0,
+                path: label.into(),
+                workspace_cwd: PathBuf::from("."),
+            },
+            false,
+        )
+    }
+
+    #[test]
+    fn global_ranking_prefers_exact_then_prefix_then_sparse() {
+        let entries = vec![
+            entry("sparse", "a-p-i", ""),
+            entry("prefix", "api-client", ""),
+            entry("exact", "api", ""),
+        ];
+        let (found, total) = rank_entries(
+            &entries,
+            &FuzzyQuery::new("api", false),
+            SearchScope::All,
+            10,
+        );
+        assert_eq!(total, 3);
+        assert_eq!(
+            found
+                .iter()
+                .map(|m| m.entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["exact", "prefix", "sparse"]
+        );
+    }
+
+    #[test]
+    fn scope_excludes_other_result_kinds() {
+        let mut file = entry("file", "main.rs", "");
+        let nav = SearchEntry::new(
+            "ws:0".into(),
+            SearchKind::Workspace,
+            "main".into(),
+            "default".into(),
+            [],
+            SearchTarget::Workspace {
+                ws: 0,
+                cwd: PathBuf::from("."),
+            },
+            false,
+        );
+        file.kind = SearchKind::File;
+        let (found, _) = rank_entries(
+            &[file, nav],
+            &FuzzyQuery::new("main", false),
+            SearchScope::Navigate,
+            10,
+        );
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].entry.kind, SearchKind::Workspace);
+    }
+
+    #[test]
+    fn bounded_top_k_matches_a_full_reference_ranking() {
+        let entries: Vec<_> = (0..500)
+            .map(|index| {
+                entry(
+                    &format!("file-{index}"),
+                    &format!("src/component_{index}_search.rs"),
+                    "workspace",
+                )
+            })
+            .collect();
+        let query = FuzzyQuery::new("search", false);
+        let (all, total) = rank_entries(&entries, &query, SearchScope::All, entries.len());
+        let (top, bounded_total) = rank_entries(&entries, &query, SearchScope::All, 17);
+        assert_eq!(total, bounded_total);
+        assert_eq!(
+            top.iter().map(|item| &item.entry.id).collect::<Vec<_>>(),
+            all.iter()
+                .take(17)
+                .map(|item| &item.entry.id)
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -1,72 +1,55 @@
-//! The global scrollback-search overlay (docs/63): a query line and a list of
-//! matches from every pane, with the query highlighted. Drawn last, over a
-//! dimmed backdrop, like the switcher. Selecting a match jumps to it.
+//! Global fuzzy-finder overlay (docs/90).
 
-use std::borrow::Cow;
+use std::collections::HashSet;
 
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Rect};
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
-use crate::app::{App, SearchHit};
+use crate::app::App;
+use crate::search::{SearchMatch, SearchScope};
 use crate::ui::theme::Theme;
 use crate::ui::RenderTarget;
 
-/// Split `line` into before / match / after spans, highlighting the query. Char
-/// boundaries are checked so non-ASCII text can never panic on a byte slice; if
-/// they do not line up, the whole line renders unhighlighted.
-///
-/// `needle` is pre-folded by the caller to match `case_sensitive`, because this
-/// runs once per visible row and the query does not change between rows.
-fn highlight(
-    line: &str,
-    needle: &str,
-    case_sensitive: bool,
-    base: Style,
-    hi: Style,
-) -> Line<'static> {
-    if !needle.is_empty() {
-        // Only the haystack is folded per row now. Borrowed when the search is
-        // case-sensitive, so the common typing frame allocates nothing here.
-        let hay: Cow<'_, str> = if case_sensitive {
-            Cow::Borrowed(line)
-        } else {
-            Cow::Owned(line.to_lowercase())
-        };
-        if let Some(bpos) = hay.find(needle) {
-            let end = bpos + needle.len();
-            if line.is_char_boundary(bpos) && line.is_char_boundary(end) {
-                return Line::from(vec![
-                    Span::styled(line[..bpos].to_string(), base),
-                    Span::styled(line[bpos..end].to_string(), hi),
-                    Span::styled(line[end..].to_string(), base),
-                ]);
-            }
-        }
+const ITEM_HEIGHT: u16 = 1;
+
+fn highlighted_label<'a>(result: &'a SearchMatch, base: Style, accent: Style) -> Line<'a> {
+    let positions: HashSet<usize> = result.label_positions.iter().copied().collect();
+    let mut spans = Vec::new();
+    for (byte, ch) in result.entry.label.char_indices() {
+        spans.push(Span::styled(
+            ch.to_string(),
+            if positions.contains(&byte) {
+                accent
+            } else {
+                base
+            },
+        ));
     }
-    Line::from(Span::styled(line.to_string(), base))
+    Line::from(spans)
 }
 
 pub(super) fn draw_search(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) {
-    // Dim the whole screen behind the modal.
     {
         let buf = f.buffer_mut();
         for y in area.y..area.bottom() {
             for x in area.x..area.right() {
-                if let Some(c) = buf.cell_mut((x, y)) {
-                    c.set_bg(t.crust);
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_bg(t.crust);
                 }
             }
         }
     }
 
-    // A compact, centered box rather than a full-height panel.
-    let w = area.width.saturating_sub(2).min(100);
-    let h = area.height.saturating_sub(2).min(36);
-    let mx = area.x + (area.width.saturating_sub(w)) / 2;
-    let my = area.y + (area.height.saturating_sub(h)) / 2;
-    let modal = Rect::new(mx, my, w, h);
+    let width = area.width.saturating_sub(2).min(100);
+    let height = area.height.saturating_sub(2).min(40);
+    let modal = Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    );
     f.render_widget(Clear, modal);
     let block = Block::new()
         .borders(Borders::ALL)
@@ -75,234 +58,243 @@ pub(super) fn draw_search(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
     let inner = block.inner(modal);
     f.render_widget(block, modal);
 
-    let title = app.catalog.cmd_search;
-    let Some(s) = app.search.as_ref() else {
+    let Some(search) = app.search.as_ref() else {
         return;
     };
+    let mut scope_rects = Vec::new();
+    let mut x = inner.x + 1;
+    for scope in SearchScope::ALL {
+        let text = format!(" {} ", scope.label());
+        let width = text.chars().count() as u16;
+        if x + width > inner.right() {
+            break;
+        }
+        let style = if search.scope == scope {
+            Style::new().fg(t.crust).bg(t.accent).bold()
+        } else {
+            Style::new().fg(t.subtext0)
+        };
+        let rect = Rect::new(x, inner.y, width, 1);
+        f.render_widget(Paragraph::new(Span::styled(text, style)), rect);
+        scope_rects.push((scope, rect));
+        x += width + 1;
+    }
 
-    // Query line: "Global search: <query>▏".
-    let case = if s.case_sensitive { " (Aa)" } else { "" };
-    f.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(format!(" {title}: "), Style::new().fg(t.subtext0)),
-            Span::styled(
-                format!("{}\u{2588}", s.query),
-                Style::new().fg(t.text).bold(),
-            ),
-            Span::styled(case.to_string(), Style::new().fg(t.overlay1)),
-        ])),
-        Rect::new(inner.x, inner.y, inner.width, 1),
-    );
-
-    // Footer: match count + key hints.
-    let more = if s.total > s.results.len() {
-        format!("  (+{} more)", s.total - s.results.len())
-    } else {
-        String::new()
-    };
-    let cap = if s.capped {
-        "  \u{00b7} scrollback capped"
+    let case = if search.case_sensitive
+        && matches!(search.scope, SearchScope::All | SearchScope::Output)
+    {
+        "  Aa"
     } else {
         ""
     };
+    let query = if search.query.is_empty() {
+        Line::from(vec![
+            Span::styled(" / ", Style::new().fg(t.overlay0)),
+            Span::styled("Find anything", Style::new().fg(t.overlay0)),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(" / ", Style::new().fg(t.overlay0)),
+            Span::styled(search.query.clone(), Style::new().fg(t.text).bold()),
+            Span::styled("▏", Style::new().fg(t.accent)),
+            Span::styled(case, Style::new().fg(t.overlay1)),
+        ])
+    };
+    f.render_widget(
+        Paragraph::new(query),
+        Rect::new(inner.x, inner.y + 2, inner.width, 1),
+    );
+
+    let list = Rect::new(
+        inner.x + 1,
+        inner.y + 4,
+        inner.width.saturating_sub(2),
+        inner.height.saturating_sub(6),
+    );
+    let visible = (list.height / ITEM_HEIGHT).max(1) as usize;
+    let scroll = if search.cursor >= visible {
+        search.cursor - visible + 1
+    } else {
+        0
+    };
+    let mut rects = Vec::new();
+    for (visible_row, index) in (scroll..search.results.len().min(scroll + visible)).enumerate() {
+        let result = &search.results[index];
+        let y = list.y + visible_row as u16 * ITEM_HEIGHT;
+        let rect = Rect::new(list.x, y, list.width, ITEM_HEIGHT.min(list.bottom() - y));
+        let selected = index == search.cursor;
+        let base = if selected {
+            Style::new().fg(t.text).bg(t.sel_bg)
+        } else {
+            Style::new().fg(t.text)
+        };
+        let accent = if selected {
+            Style::new().fg(t.accent).bg(t.sel_bg).bold()
+        } else {
+            Style::new().fg(t.accent).bold()
+        };
+        if selected {
+            let buf = f.buffer_mut();
+            for row in rect.y..rect.bottom() {
+                for col in rect.x..rect.right() {
+                    if let Some(cell) = buf.cell_mut((col, row)) {
+                        cell.set_bg(t.sel_bg);
+                    }
+                }
+            }
+        }
+        let kind = result.entry.kind.label();
+        let kind_width = (kind.chars().count() as u16).min(rect.width);
+        let gap = u16::from(rect.width > kind_width);
+        let content_width = rect.width.saturating_sub(kind_width + gap);
+        let mut row = Vec::new();
+        row.extend(highlighted_label(result, base, accent).spans);
+        row.push(Span::styled(
+            format!("  {}", result.entry.detail),
+            Style::new()
+                .fg(t.overlay0)
+                .bg(if selected { t.sel_bg } else { t.base }),
+        ));
+        if content_width > 0 {
+            f.render_widget(
+                Paragraph::new(Line::from(row)),
+                Rect::new(rect.x, rect.y, content_width, 1),
+            );
+        }
+        if kind_width > 0 {
+            f.render_widget(
+                Paragraph::new(Span::styled(
+                    kind,
+                    Style::new()
+                        .fg(t.overlay1)
+                        .bg(if selected { t.sel_bg } else { t.base }),
+                ))
+                .alignment(Alignment::Right),
+                Rect::new(rect.right() - kind_width, rect.y, kind_width, 1),
+            );
+        }
+        rects.push((index, rect));
+    }
+
+    if search.results.is_empty() {
+        let text = if search.loading {
+            "  searching…"
+        } else if search.query.is_empty() {
+            "  no recent targets"
+        } else {
+            "  no fuzzy matches"
+        };
+        f.render_widget(
+            Paragraph::new(Span::styled(text, Style::new().fg(t.overlay0))),
+            Rect::new(list.x, list.y, list.width, 1),
+        );
+    }
+
+    let loading = if search.loading { " · searching" } else { "" };
+    let capped = if search.capped { " · partial" } else { "" };
     let footer = format!(
-        " {} match{}{}{}   \u{23ce} jump \u{00b7} esc close \u{00b7} ^i case",
-        s.total,
-        if s.total == 1 { "" } else { "es" },
-        more,
-        cap,
+        " {} result{}{}{}   ↑↓ select · tab scope · ⏎ open · esc close",
+        search.total,
+        if search.total == 1 { "" } else { "s" },
+        loading,
+        capped,
     );
     f.render_widget(
         Paragraph::new(Span::styled(footer, Style::new().fg(t.overlay1))),
         Rect::new(inner.x, inner.bottom().saturating_sub(1), inner.width, 1),
     );
 
-    // Result list between the query line and the footer.
-    let list = Rect::new(
-        inner.x + 1,
-        inner.y + 2,
-        inner.width.saturating_sub(2),
-        inner.height.saturating_sub(4),
-    );
-    let viewport = list.height.max(1) as usize;
-    // Keep the cursor in view.
-    let scroll = if s.cursor >= viewport {
-        s.cursor - viewport + 1
-    } else {
-        0
-    };
-
-    let mut rects: Vec<(usize, Rect)> = Vec::new();
-    // Fold the query once for the whole list, not once per row (the overlay
-    // redraws on every keystroke, so a full viewport paid for this N times).
-    let needle: Cow<'_, str> = if s.case_sensitive {
-        Cow::Borrowed(s.query.as_str())
-    } else {
-        Cow::Owned(s.query.to_lowercase())
-    };
-    for (row, i) in (scroll..s.results.len().min(scroll + viewport)).enumerate() {
-        let hit: &SearchHit = &s.results[i];
-        let y = list.y + row as u16;
-        let rect = Rect::new(list.x, y, list.width, 1);
-        let selected = i == s.cursor;
-        let base = if selected {
-            Style::new().fg(t.text).bg(t.sel_bg)
-        } else {
-            Style::new().fg(t.subtext1)
-        };
-        let hi = if selected {
-            Style::new().fg(t.accent).bg(t.sel_bg).bold()
-        } else {
-            Style::new().fg(t.accent).bold()
-        };
-        // A dim location tag, then the matched line with the query highlighted.
-        let tag = Style::new().fg(t.overlay0);
-        let mut spans = vec![Span::styled(format!("p{} ", hit.pane.0), tag)];
-        if !hit.ws_name.is_empty() {
-            spans.push(Span::styled(format!("{} ", hit.ws_name), tag));
-        }
-        let mut line = Line::from(spans);
-        for sp in highlight(&hit.line, &needle, s.case_sensitive, base, hi).spans {
-            line.spans.push(sp);
-        }
-        if selected {
-            // Paint the whole selected row's background.
-            let buf = f.buffer_mut();
-            for x in rect.x..rect.right() {
-                if let Some(c) = buf.cell_mut((x, rect.y)) {
-                    c.set_bg(t.sel_bg);
-                }
-            }
-        }
-        f.render_widget(Paragraph::new(line), rect);
-        rects.push((i, rect));
-    }
-
-    if s.results.is_empty() && !s.query.is_empty() {
-        f.render_widget(
-            Paragraph::new(Span::styled("  no matches", Style::new().fg(t.overlay0))),
-            Rect::new(list.x, list.y, list.width, 1),
-        );
-    }
-
-    // Store the clickable rects (ends the immutable borrow of `app.search`).
-    if let Some(sm) = app.search.as_mut() {
-        sm.rects = rects;
+    if let Some(search) = app.search.as_mut() {
+        search.rects = rects;
+        search.scope_rects = scope_rects;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::highlight;
-    use ratatui::style::Style;
-
-    /// The rendered text must always be the input line, whatever the split.
-    fn joined(line: &str, needle: &str, cs: bool) -> String {
-        highlight(line, needle, cs, Style::new(), Style::new())
-            .spans
-            .iter()
-            .map(|s| s.content.as_ref())
-            .collect()
-    }
-
-    /// Which spans got the highlight style (span index 1 when a match splits).
-    fn split(line: &str, needle: &str, cs: bool) -> Vec<String> {
-        highlight(line, needle, cs, Style::new(), Style::new())
-            .spans
-            .iter()
-            .map(|s| s.content.to_string())
-            .collect()
-    }
+    use super::*;
+    use crate::search::{SearchEntry, SearchKind, SearchTarget};
+    use ratatui::buffer::Buffer;
 
     #[test]
-    fn case_insensitive_match_splits_on_the_original_casing() {
-        // The needle arrives pre-folded (the caller lowercases once per draw),
-        // so the match must still be located against the *original* line.
+    fn unicode_highlight_positions_preserve_the_label() {
+        let result = SearchMatch {
+            entry: SearchEntry::new(
+                "file:0:x".into(),
+                SearchKind::File,
+                "Ångström".into(),
+                "default › src".into(),
+                [],
+                SearchTarget::File {
+                    ws: 0,
+                    path: "x".into(),
+                    workspace_cwd: ".".into(),
+                },
+                false,
+            ),
+            score: 1,
+            label_positions: vec![0, 2, 3],
+        };
+        let line = highlighted_label(&result, Style::new(), Style::new());
         assert_eq!(
-            split("Connection REFUSED here", "refused", false),
-            vec!["Connection ", "REFUSED", " here"]
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>(),
+            "Ångström"
         );
     }
 
     #[test]
-    fn case_sensitive_match_does_not_fold() {
-        assert_eq!(
-            split("Error and error", "error", true),
-            vec!["Error and ", "error", ""]
-        );
-        // The capitalised one must not match when case-sensitive.
-        assert_eq!(split("ERROR", "error", true), vec!["ERROR"]);
-    }
-
-    #[test]
-    fn an_empty_needle_leaves_the_line_whole() {
-        assert_eq!(split("anything", "", false), vec!["anything"]);
-    }
-
-    /// Multi-byte text must never panic on a byte slice, and must round-trip.
-    #[test]
-    fn non_ascii_never_panics_and_keeps_every_character() {
-        for line in [
-            "日本語のログ refused です",
-            "émoji 🚀 refused ok",
-            "→ refused",
-        ] {
-            assert_eq!(joined(line, "refused", false), line, "round-trips: {line}");
-        }
-        // A needle that only differs by case under a non-ASCII neighbour.
-        assert_eq!(joined("café REFUSED", "refused", false), "café REFUSED");
-    }
-
-    /// The seam between `draw_search` and `highlight`: the caller folds the query
-    /// once, so an UPPERCASE query with case-sensitivity off must still match a
-    /// lowercase line. A caller that forgot to fold would render no highlight.
-    #[test]
-    fn an_uppercase_query_still_matches_when_case_insensitive() {
-        use crate::app::{App, SearchHit};
-        use crate::ids::PaneId;
-        use ratatui::{backend::TestBackend, Terminal};
-
-        let _env = crate::persist::test_env("ui-search-fold");
+    fn results_render_as_compact_single_line_rows() {
+        let _env = crate::persist::test_env("fuzzy-search-compact-rows");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(100, 30, tx).unwrap();
         app.open_search();
+        let search = app.search.as_mut().unwrap();
+        search.results = ["one.rs", "two.rs"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, label)| SearchMatch {
+                entry: SearchEntry::new(
+                    format!("file:0:{label}"),
+                    SearchKind::File,
+                    label.into(),
+                    format!("default › src/{label}"),
+                    [],
+                    SearchTarget::File {
+                        ws: 0,
+                        path: label.into(),
+                        workspace_cwd: ".".into(),
+                    },
+                    false,
+                ),
+                score: 2 - index as i64,
+                label_positions: Vec::new(),
+            })
+            .collect();
+        search.total = 2;
+        search.loading = false;
+
+        let area = Rect::new(0, 0, 100, 30);
+        let mut buffer = Buffer::empty(area);
         {
-            let s = app.search.as_mut().expect("overlay open");
-            s.query = "REFUSED".into();
-            s.case_sensitive = false;
-            s.results = vec![SearchHit {
-                pane: PaneId(1),
-                ws: 0,
-                ws_name: "proj".into(),
-                offset: 0,
-                row: 0,
-                line: "connection refused by peer".into(),
-                col: 11,
-                above: 0,
-            }];
-            s.total = 1;
+            let mut target = RenderTarget::new(&mut buffer, area);
+            draw_search(&mut target, area, &mut app, &Theme::quattro_rally());
         }
-        let mut term = Terminal::new(TestBackend::new(100, 30)).unwrap();
-        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
-        // Assert on the *styling*, not the text: an unmatched line still renders,
-        // just unhighlighted, so a text-only assertion would pass even when the
-        // caller forgets to fold and nothing highlights.
-        let buf = term.backend().buffer().clone();
-        let mut found = None;
-        for y in 0..30u16 {
-            let row: String = (0..100u16).map(|x| buf[(x, y)].symbol()).collect();
-            if let Some(col) = row.find("connection refused by peer") {
-                found = Some((y, col as u16));
-                break;
-            }
-        }
-        let (y, x0) = found.expect("the matched line rendered");
-        // "connection " is 11 chars, then the 7 chars of "refused".
-        let base_fg = buf[(x0, y)].style().fg;
-        let hit_fg = buf[(x0 + 11, y)].style().fg;
-        assert_ne!(
-            base_fg, hit_fg,
-            "the matched substring must be styled differently from the rest"
+
+        let rects = &app.search.as_ref().unwrap().rects;
+        assert_eq!(rects.len(), 2);
+        assert!(rects.iter().all(|(_, rect)| rect.height == 1));
+        assert_eq!(rects[1].1.y, rects[0].1.y + 1);
+        let first = rects[0].1;
+        let row: String = (first.x..first.right())
+            .map(|x| buffer[(x, first.y)].symbol())
+            .collect();
+        assert!(
+            row.ends_with("file"),
+            "the kind is aligned to the right: {row:?}"
         );
+        assert!(!row.contains('·'), "result kinds do not use glyph icons");
     }
 }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -105,14 +105,20 @@ pub(super) fn draw_search(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
         Rect::new(inner.x, inner.y + 2, inner.width, 1),
     );
 
+    let list_x = inner.x.saturating_add(1).min(inner.right());
+    let list_y = inner.y.saturating_add(4).min(inner.bottom());
+    let list_right = inner.right().saturating_sub(1).max(inner.x);
+    let list_bottom = inner.bottom().saturating_sub(2).max(inner.y);
     let list = Rect::new(
-        inner.x + 1,
-        inner.y + 4,
-        inner.width.saturating_sub(2),
-        inner.height.saturating_sub(6),
+        list_x,
+        list_y,
+        list_right.saturating_sub(list_x),
+        list_bottom.saturating_sub(list_y),
     );
-    let visible = (list.height / ITEM_HEIGHT).max(1) as usize;
-    let scroll = if search.cursor >= visible {
+    let visible = (list.height / ITEM_HEIGHT) as usize;
+    let scroll = if visible == 0 {
+        0
+    } else if search.cursor >= visible {
         search.cursor - visible + 1
     } else {
         0
@@ -121,7 +127,15 @@ pub(super) fn draw_search(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
     for (visible_row, index) in (scroll..search.results.len().min(scroll + visible)).enumerate() {
         let result = &search.results[index];
         let y = list.y + visible_row as u16 * ITEM_HEIGHT;
-        let rect = Rect::new(list.x, y, list.width, ITEM_HEIGHT.min(list.bottom() - y));
+        let rect = Rect::new(
+            list.x,
+            y,
+            list.width,
+            ITEM_HEIGHT.min(list.bottom().saturating_sub(y)),
+        );
+        if rect.is_empty() {
+            continue;
+        }
         let selected = index == search.cursor;
         let base = if selected {
             Style::new().fg(t.text).bg(t.sel_bg)
@@ -176,7 +190,7 @@ pub(super) fn draw_search(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
         rects.push((index, rect));
     }
 
-    if search.results.is_empty() {
+    if search.results.is_empty() && !list.is_empty() {
         let text = if search.loading {
             "  searching…"
         } else if search.query.is_empty() {
@@ -296,5 +310,32 @@ mod tests {
             "the kind is aligned to the right: {row:?}"
         );
         assert!(!row.contains('·'), "result kinds do not use glyph icons");
+    }
+
+    #[test]
+    fn short_modal_never_places_result_rows_outside_the_overlay() {
+        let _env = crate::persist::test_env("fuzzy-search-short-modal");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(12, 5, tx).unwrap();
+        app.open_search();
+
+        let area = Rect::new(0, 0, 12, 5);
+        let mut buffer = Buffer::empty(area);
+        {
+            let mut target = RenderTarget::new(&mut buffer, area);
+            draw_search(&mut target, area, &mut app, &Theme::quattro_rally());
+        }
+
+        let rects = &app.search.as_ref().unwrap().rects;
+        assert!(
+            rects.is_empty(),
+            "a five-row terminal has no drawable result row"
+        );
+        assert!(rects.iter().all(|(_, rect)| {
+            rect.y >= area.y
+                && rect.bottom() <= area.bottom()
+                && rect.x >= area.x
+                && rect.right() <= area.right()
+        }));
     }
 }

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -80,6 +80,7 @@ export default defineConfig({
             { label: 'Multi-Agent Orchestration', slug: 'docs/guides/orchestration' },
             { label: 'The Git Tab', slug: 'docs/guides/git' },
             { label: 'Browsing & Opening Files', slug: 'docs/guides/files' },
+            { label: 'Global Fuzzy Finder', slug: 'docs/guides/search' },
             { label: 'DIFF Review', slug: 'docs/guides/diff' },
             { label: 'Worktrees', slug: 'docs/guides/worktrees' },
             { label: 'Remote Sessions', slug: 'docs/guides/remote' },

--- a/website/src/content/docs/docs/explanation/security.mdx
+++ b/website/src/content/docs/docs/explanation/security.mdx
@@ -42,6 +42,15 @@ repository. Note bodies, parsed patches, and agent handoffs are bounded. Source
 context is explicitly framed as untrusted review data before it is sent to an
 agent, and sending requires an explicit target and action.
 
+## Global finder data
+
+The global finder is local and read-only until you activate a result. File
+indexing reads names and paths, not file contents, skips `.git`, and does not
+follow directory symlinks. Retained-output matching uses bounded pane history
+already owned by Luvus. Running named sessions answer bounded queries over
+their owner-only control sockets. Queries and result catalogs are not persisted
+and opening the finder never starts a stopped session.
+
 ## Remote
 
 `--remote` rides plain `ssh`: your keys, your config, no luvus network

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -14,6 +14,12 @@ Press **`Ctrl+Space e`** to show or hide it, or place it from
 **Settings → Layout** like any other dock. It follows the active workspace, so
 switching projects re-roots the tree.
 
+The global fuzzy finder can search every eligible file name and relative path
+in the workspace even when its folder has never been expanded here. Press
+`Ctrl+Space /`, then choose **Files** with `Tab`. It indexes paths only, follows
+Git ignore rules when Git is available, skips `.git`, and never follows
+directory symlinks.
+
 Folders expand and collapse in place. Names are tinted by git status as you
 work: amber for modified, green for added or untracked, coral for deleted or
 conflicted, mint for renamed, with a letter badge and a mark on any folder that

--- a/website/src/content/docs/docs/guides/remote.mdx
+++ b/website/src/content/docs/docs/guides/remote.mdx
@@ -19,5 +19,8 @@ terminal to it. No port-forwarding, no extra daemon, no config.
   session keeps running. `luvus --remote my-server` again from anywhere
   reattaches.
 - **Clipboard works:** selecting text copies to your **local** clipboard.
+- **Global finder stays remote:** `Ctrl+Space /` searches named sessions,
+  paths, and retained output from that remote Luvus home only. Selecting a
+  result in another running remote session reuses the same host and SSH options.
 
 Extra ssh arguments pass through: `luvus --remote host -p 2222 -i ~/.ssh/key`.

--- a/website/src/content/docs/docs/guides/search.mdx
+++ b/website/src/content/docs/docs/guides/search.mdx
@@ -1,0 +1,93 @@
+---
+title: Global Fuzzy Finder
+description: Find and open sessions, workspaces, tabs, panes, agents, files, and retained output from one overlay.
+---
+
+Press **`Ctrl+Space /`** to open the global fuzzy finder. It searches the
+selected Luvus home without adding another service or fuzzy-matching dependency.
+
+## What it searches
+
+| Scope | Sources |
+|---|---|
+| **All** | every source below |
+| **Navigate** | named sessions, workspaces, tabs, panes, and agents |
+| **Files** | eligible file names and workspace-relative paths |
+| **Output** | retained terminal rows from real PTY panes |
+
+Type approximate fragments in order. `bapi` can rank **Backend API**, and
+multiple words are AND terms that may match different fields. Exact and prefix
+matches rank above contiguous and sparse subsequence matches.
+
+Output is intentionally stricter than navigation and paths: an ordered fuzzy
+subsequence must fill at least half of its matched span, preventing distant
+characters in long terminal rows from flooding the results.
+
+The finder does not search arbitrary file contents or agent transcripts outside
+retained pane history.
+
+## Use the finder
+
+| Input | Action |
+|---|---|
+| type | update the fuzzy query |
+| `Up` / `Down`, `Ctrl+p` / `Ctrl+n` | move selection |
+| `PageUp` / `PageDown`, mouse wheel | move through results |
+| `Tab` / `Shift+Tab` | next or previous scope |
+| `Ctrl+i` | toggle case-sensitive Output matching |
+| `Enter`, click | activate the selected result |
+| `Esc` | clear the query, then close |
+
+Navigation rows render immediately. File paths, retained output, and results
+from other running named sessions may arrive afterward. Luvus keeps the selected
+result by identity while those sources merge into the ranked list.
+
+With an empty query, **Files** shows up to 12 recently opened files from
+workspaces that remain open. This list is memory-only and is not persisted.
+
+Activation uses the existing action for each result. A workspace or tab gains
+focus, a pane or agent focuses its exact pane, and a file opens in a whole tab
+inside its workspace using the normal **Open files with** setting. An output
+row focuses and scrolls its pane. Selecting another named session hands only
+the current display client to it. A stopped session is not started merely by
+opening or typing in the finder.
+
+With `luvus --remote`, all sources and sibling sessions come from that remote
+Luvus home. Local and remote catalogs are never mixed.
+
+## CLI
+
+The existing exact retained-output command is unchanged:
+
+```sh
+luvus search "build failed" --case
+```
+
+Fuzzy search is explicit:
+
+```sh
+luvus search --fuzzy "api auth"
+luvus search --fuzzy "auth rs" --scope files --limit 25
+luvus search --fuzzy "connection refused" --scope output --case
+luvus search --fuzzy "codex tests" --scope navigate --all-sessions
+```
+
+Scopes are `all`, `navigate`, `files`, and `output`. Limits must be from 1 to
+200. `--all-sessions` queries other running named sessions and reports partial
+results when a session is unavailable or incompatible. It never starts a
+stopped session.
+
+## Bounds and behavior
+
+- at most 200 visible results;
+- at most 30 retained-output matches per pane;
+- at most 8 MiB of retained source text per queried session;
+- at most 8 MiB of normalized retained-output index data and 100,000 rows per session;
+- at most 100,000 paths and 16 MiB of path bytes per workspace;
+- at most eight other running named sessions per query;
+- at most 1 MiB returned by each sibling session;
+- short-lived path catalogs use a 32 MiB global cache cap.
+
+Opening the finder performs no work while it is closed. Path discovery and
+retained-output scoring run outside the app loop. Large or unreadable sources
+show as partial instead of silently appearing complete.

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -45,6 +45,7 @@ printf '%s\n' '{"id":"1","method":"ping","params":{}}' | nc -U ~/.luvus/luvus.so
 | tabs | `tab.list` · `tab.new` · `tab.focus` · `tab.move` · `tab.swap` · `tab.rename` · `tab.close` |
 | panes | `pane.list` · `pane.split` · `pane.move` · `pane.focus` · `pane.run` · `pane.send_input` · `pane.read` · `pane.status` · `pane.close` · `attach.pane` |
 | agents | `agent.list` · `agent.get` · `agent.name` · `agent.fork` · `agent.send` · `agent.keys` · `agent.read` · `agent.sessions` · `agent.resume` · `pane.report_session` · `pane.report_event` |
+| search | `search` · `search.capabilities` · `search.query` · `search.activate` |
 | git | `git.status` · `git.branches` · `git.log` · `git.open` |
 | diff | `diff.refresh` · `diff.list` · `diff.open` · `diff.get` · `diff.navigate` · `diff.note.add` · `diff.note.apply` · `diff.note.list` · `diff.note.edit` · `diff.note.resolve` · `diff.note.reopen` · `diff.note.remove` · `diff.note.send` |
 | worktrees | `worktree.list` · `worktree.create` · `worktree.open` · `worktree.remove` |
@@ -57,6 +58,69 @@ Parameter shapes mirror the CLI flags (`luvus task add --paths x` →
 `{"paths": ["x"]}`). For CLI commands, an omitted pane uses
 `$LUVUS_PANE_ID` when available; a raw API request with no pane uses the
 currently focused pane.
+
+## Search
+
+The legacy `search` method remains exact retained-output search. Its existing
+request and response fields do not change.
+
+`search.query` is the typed fuzzy API:
+
+```json
+→ {
+  "id": "find-1",
+  "method": "search.query",
+  "params": {
+    "query": "api auth",
+    "scope": "all",
+    "case_sensitive": false,
+    "all_sessions": true,
+    "limit": 50
+  }
+}
+← {
+  "id": "find-1",
+  "result": {
+    "type": "search_query",
+    "query": "api auth",
+    "scope": "all",
+    "total": 3,
+    "shown": 3,
+    "partial": false,
+    "matches": [
+      {
+        "id": "workspace:0",
+        "kind": "folder",
+        "label": "api-service",
+        "detail": "default › /work/api-service",
+        "score": 4120,
+        "target": { "workspace": 0 }
+      }
+    ]
+  }
+}
+```
+
+`scope` must be `all`, `navigate`, `files`, or `output`. `query` must contain
+1 to 256 bytes after trimming, and `limit` must be 1 to 200. Case sensitivity
+applies to retained output. `all_sessions` defaults to false and queries only
+other running sessions in the selected Luvus home when true. `partial:true`
+means at least one source was capped, unreadable, unavailable, timed out, or
+incompatible.
+
+Every match has a stable result `kind` and structured `target`. Result kinds are
+`session`, `folder`, `tab`, `pane`, `agent`, `file`, and `output`. Consumers
+must not derive an action by parsing `label` or `detail`.
+
+`search.capabilities` returns the search protocol version, supported methods,
+scopes, and response limits. Cross-session callers check it before querying a
+sibling server.
+
+`search.activate` accepts one `kind` and an exact `target` returned by that same
+session. The owner revalidates workspace, tab, pane, file containment, and
+output anchors before focusing or opening anything. It is primarily used by
+Luvus during named-session handoff. Invalid or stale targets return a structured
+`invalid_request` error instead of focusing a different object.
 
 ## Organizing workspaces
 

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -84,6 +84,10 @@ panes / agents:
 search:
   search <text...> [--case]  find text across every pane's scrollback (docs/63);
                              --case is case-sensitive; returns matches as JSON
+  search --fuzzy <query...> [--scope all|navigate|files|output] [--all-sessions]
+                           [--limit <1-200>] [--case] [--json]
+                             rank navigation, file paths, and retained output;
+                             legacy search stays exact unless --fuzzy is passed
 
 themes:
   theme list [--json]       list built-in, installed, and virtual themes

--- a/website/src/content/docs/docs/reference/keybindings.mdx
+++ b/website/src/content/docs/docs/reference/keybindings.mdx
@@ -19,7 +19,7 @@ the live cheat-sheet. Remap anything, change the prefix, or apply a preset in
 | `f` | fork agent session | `g` | git tab |
 | `b` / `B` | toggle left / right sidebar | `o` | orchestration board |
 | `a` | agents All/Active | `m` | jump palette (tabs / workspaces / agents) |
-| `e` | toggle FILES dock | `/` | global search |
+| `e` | toggle FILES dock | `/` | global fuzzy finder |
 | `=` | Settings | `q` / `d` | detach |
 | `1`–`9` | jump to tab | | |
 
@@ -55,6 +55,19 @@ same as tmux's rename-window), and Settings lives on `=`. The **Menu** button
 **workspace**, and every **agent** in one overlay. Type to filter, and use the
 scope chips (or `Tab`) to narrow it to one category. Arrows move, `Enter` jumps,
 `Esc` clears the filter then closes.
+
+## The global fuzzy finder
+
+`/` opens one finder across the selected Luvus home. It ranks named sessions,
+workspaces, tabs, panes, agents, file paths, and retained pane output. Use
+`Tab` or `Shift+Tab` to move through **All**, **Navigate**, **Files**, and
+**Output**. `Ctrl+i` toggles case-sensitive retained-output matching. `Enter`
+opens the selected target. A non-empty query needs one `Esc` to clear and a
+second `Esc` to close.
+
+Navigation results appear first. File, output, and other running-session
+results arrive in the same list without resetting the selected row. See the
+[Global Fuzzy Finder](/docs/guides/search/) guide for limits and CLI use.
 
 ## No-prefix keys and menus
 


### PR DESCRIPTION
Adds a bounded global fuzzy finder across Luvus navigation, files, pane output, and running sessions.

## Global finder

- Search sessions, workspaces, tabs, panes, agents, files, and retained pane output from one overlay.
- Use dependency-free fuzzy scoring with deterministic ranking, token matching, path and word-boundary bonuses, and Unicode-safe highlights.
- Cycle All, Navigate, Files, and Output scopes from a compact single-line result list.
- Activate structured targets safely after revalidating their current workspace and pane identity.

## Files and output

- Index bounded file catalogs outside the app event loop and reuse a short-lived cache.
- Open file results in a whole tab using the configured file-opening preference.
- Recommend up to 12 recently opened files for an empty Files query without persisting additional history.
- Search bounded pane scrollback with per-pane limits and reject noisy sparse Output matches.
- Keep case sensitivity specific to Output searches.

## CLI and API

- Add opt-in `luvus search --fuzzy` with scope, session federation, case, limit, and JSON options.
- Support the `search.query` and `search.activate` API paths with bounded asynchronous work.
- Carry typed remote targets across running named sessions.
- Accept `--` as the end of CLI option parsing for flag-like query text.

## Performance and correctness

- Avoid synchronous terminal-engine locks while building searchable pane metadata.
- Preserve explicit workspace roots throughout asynchronous file indexing.
- Bound result counts, source bytes, index bytes, file catalogs, and output rows.

## Documentation

- Add the global search guide and update CLI, API, keybinding, file, remote, and security references.
- Add the AI-assistance transparency policy to `CONTRIBUTING.md` as an additional documentation change included in this branch.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --quiet`: 739 tests passed
- `cd website && npm run build`
- Release runtime check confirmed a noisy sparse Output query returns no matches while a meaningful dense query finds the expected pane output.
- Production Luvus state was not used or modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a global fuzzy finder for sessions, workspaces, tabs, panes, agents, files, and terminal output.
  - Added scoped, ranked search with highlighting, case sensitivity, loading states, result limits, and partial results.
  - Added cross-session and remote-session search with result activation and automatic session switching.
  - Added recent-file suggestions and improved file-result opening.
  - Added optional fuzzy-search CLI commands and search API support.
- **Documentation**
  - Added guides covering finder usage, files, remote behavior, security, CLI options, and API methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->