### PR TITLE
fix(files): keep diff and tree refresh off the app loop

### DIFF
--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -65,8 +65,26 @@ impl App {
         }
     }
 
-    /// Fail every parked DIFF request when its workspace disappears before the
-    /// status worker can complete it.
+    /// Fail parked DIFF requests for one workspace while preserving requests
+    /// targeting other open workspace roots.
+    pub(crate) fn fail_pending_diff_api_for_root(&mut self, closed_root: &Path, message: &str) {
+        let mut pending = std::mem::take(&mut self.pending_diff_api);
+        for (root, req) in pending.drain(..) {
+            if crate::platform::same_path(&root, closed_root) {
+                let _ = req.reply.send(
+                    serde_json::json!({"id":req.id,"error":{
+                        "code":"diff_error",
+                        "message":message
+                    }})
+                    .to_string(),
+                );
+            } else {
+                self.pending_diff_api.push((root, req));
+            }
+        }
+    }
+
+    /// Fail every parked DIFF request when no workspace remains.
     pub(crate) fn fail_pending_diff_api(&mut self, message: &str) {
         for (_, req) in self.pending_diff_api.drain(..) {
             let _ = req.reply.send(

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -65,6 +65,20 @@ impl App {
         }
     }
 
+    /// Fail every parked DIFF request when its workspace disappears before the
+    /// status worker can complete it.
+    pub(crate) fn fail_pending_diff_api(&mut self, message: &str) {
+        for (_, req) in self.pending_diff_api.drain(..) {
+            let _ = req.reply.send(
+                serde_json::json!({"id":req.id,"error":{
+                    "code":"diff_error",
+                    "message":message
+                }})
+                .to_string(),
+            );
+        }
+    }
+
     pub(crate) fn ensure_diff_snapshot(&self) -> Result<(), String> {
         if self.diff_snapshot_matches_active_workspace() {
             return Ok(());

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -14,31 +14,66 @@ use crate::layout::{Axis, TileLayout};
 use super::files::OpenTarget;
 
 impl App {
-    pub(crate) fn ensure_diff_snapshot_sync(&mut self) -> Result<(), String> {
-        let root = self.ws().cwd.clone();
-        let current_root = self
-            .diff
-            .snapshot
-            .as_ref()
-            .map(|snapshot| snapshot.visible_root.as_path());
-        if current_root.is_some_and(|existing| crate::platform::same_path(existing, &root)) {
-            return Ok(());
+    /// Route API methods that need repository status through the same off-loop
+    /// scan used by FILES and the interactive DIFF dock. A cached `diff.list`
+    /// answers immediately and merely schedules a cadence-gated refresh;
+    /// first-use methods and explicit `diff.refresh` park their reply until the
+    /// worker result returns to the single writer.
+    pub(crate) fn prepare_diff_api(
+        &mut self,
+        req: crate::ipc::api::ApiRequest,
+    ) -> Option<crate::ipc::api::ApiRequest> {
+        if !req.method.starts_with("diff.") || req.method == "diff.navigate" {
+            return Some(req);
         }
-        self.diff.status_generation = self.diff.status_generation.wrapping_add(1);
-        let token = self.diff.status_generation;
-        let snapshot = crate::diff::git::scan(&root, token)?;
-        let visible_root = root;
-        self.apply_diff_status(token, visible_root, Ok(snapshot));
-        Ok(())
+        let refresh = req.method == "diff.refresh";
+        let ready = self.diff_snapshot_matches_active_workspace();
+        if ready && !refresh {
+            if req.method == "diff.list" {
+                self.refresh_diff_status(false);
+            }
+            return Some(req);
+        }
+        let root = self.ws().cwd.clone();
+        self.pending_diff_api.push((root, req));
+        self.refresh_diff_status(true);
+        None
     }
 
-    pub(crate) fn refresh_diff_snapshot_sync(&mut self) -> Result<(), String> {
-        let root = self.ws().cwd.clone();
-        self.diff.status_generation = self.diff.status_generation.wrapping_add(1);
-        let token = self.diff.status_generation;
-        let snapshot = crate::diff::git::scan(&root, token)?;
-        self.apply_diff_status(token, root, Ok(snapshot));
-        Ok(())
+    /// Complete parked DIFF API calls only after the accepted status result has
+    /// been applied. Requests targeting a workspace that lost focus while Git
+    /// was running fail closed instead of being redirected to the new root.
+    pub(crate) fn finish_pending_diff_api(&mut self) {
+        let active_root = self.ws().cwd.clone();
+        let scan_complete = !self.diff.status_inflight;
+        let mut pending = std::mem::take(&mut self.pending_diff_api);
+        for (root, req) in pending.drain(..) {
+            if !crate::platform::same_path(&root, &active_root) {
+                let _ = req.reply.send(
+                    serde_json::json!({"id":req.id,"error":{
+                        "code":"diff_error",
+                        "message":"active workspace changed while DIFF was refreshing"
+                    }})
+                    .to_string(),
+                );
+            } else if scan_complete {
+                let response = self.handle_api(&req);
+                let _ = req.reply.send(response);
+            } else {
+                self.pending_diff_api.push((root, req));
+            }
+        }
+    }
+
+    pub(crate) fn ensure_diff_snapshot(&self) -> Result<(), String> {
+        if self.diff_snapshot_matches_active_workspace() {
+            return Ok(());
+        }
+        Err(self
+            .diff
+            .error
+            .clone()
+            .unwrap_or_else(|| "DIFF is not ready".to_string()))
     }
 
     pub(crate) fn ensure_diff_notes_sync(&mut self) -> Result<(), String> {
@@ -1738,6 +1773,19 @@ mod tests {
         RepoPath,
     };
 
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     fn install_snapshot(app: &mut App) -> DiffKey {
         let path = RepoPath::from_path(Path::new("src/lib.rs")).unwrap();
         let key = DiffKey {
@@ -1813,6 +1861,76 @@ mod tests {
             pinned: false,
         });
         app.workspaces.len() - 1
+    }
+
+    #[test]
+    fn diff_api_status_scan_is_off_loop_and_cached_lists_answer_immediately() {
+        let _env = crate::persist::test_env("diff-api-off-loop");
+        let repo = PathBuf::from(std::env::var_os("LUVUS_HOME").unwrap()).join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q"]);
+        run_git(&repo, &["config", "user.name", "Luvus Test"]);
+        run_git(&repo, &["config", "user.email", "luvus@example.invalid"]);
+        std::fs::write(repo.join("file.txt"), "base\n").unwrap();
+        run_git(&repo, &["add", "file.txt"]);
+        run_git(&repo, &["commit", "-q", "-m", "base"]);
+        std::fs::write(repo.join("file.txt"), "changed\n").unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(100, 30, tx).unwrap();
+        app.workspaces[0].cwd = repo;
+        let (reply, response) = std::sync::mpsc::channel();
+        let request = crate::ipc::api::ApiRequest {
+            id: "first-list".to_string(),
+            method: "diff.list".to_string(),
+            params: serde_json::json!({}),
+            reply,
+        };
+
+        assert!(
+            app.prepare_diff_api(request).is_none(),
+            "first list is parked"
+        );
+        assert!(app.diff.status_inflight, "the worker scan is in flight");
+        assert!(
+            response
+                .recv_timeout(std::time::Duration::from_millis(10))
+                .is_err(),
+            "the reply waits for the app loop to apply the worker result"
+        );
+        assert!(app.dispatch("ping", &serde_json::json!({})).is_ok());
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            let event = rx
+                .recv_timeout(std::time::Duration::from_millis(250))
+                .expect("status worker event");
+            let completed = matches!(&event, AppEvent::DiffStatus { .. });
+            app.handle_event(event);
+            if completed {
+                break;
+            }
+        }
+        let first: serde_json::Value = serde_json::from_str(
+            &response
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("parked list response"),
+        )
+        .unwrap();
+        assert_eq!(first["result"]["files"][0]["path"], "file.txt");
+        assert_eq!(first["result"]["refreshing"], false);
+
+        let (reply, _response) = std::sync::mpsc::channel();
+        let cached = crate::ipc::api::ApiRequest {
+            id: "cached-list".to_string(),
+            method: "diff.list".to_string(),
+            params: serde_json::json!({}),
+            reply,
+        };
+        assert!(
+            app.prepare_diff_api(cached).is_some(),
+            "a matching cached snapshot never waits on Git"
+        );
     }
 
     #[test]

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1786,7 +1786,7 @@ impl App {
             }
             // ── DIFF review (docs/88) ────────────────────────────────────
             "diff.refresh" => {
-                self.refresh_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 let generation = self
                     .diff
                     .snapshot
@@ -1796,7 +1796,7 @@ impl App {
                 Ok(json!({"type":"ok","refresh":"complete","generation":generation}))
             }
             "diff.list" => {
-                self.refresh_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 let layer = p
                     .get("layer")
                     .and_then(|value| value.as_str())
@@ -1820,11 +1820,12 @@ impl App {
                     "generation": snapshot.generation,
                     "fingerprint": snapshot.fingerprint,
                     "omitted": snapshot.omitted_files,
+                    "refreshing": self.diff.status_inflight,
                     "files": files,
                 }))
             }
             "diff.open" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 let target = match p
                     .get("placement")
                     .or_else(|| p.get("target"))
@@ -1884,7 +1885,7 @@ impl App {
                 )
             }
             "diff.get" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 let raw = req_str(p, "path")?;
                 let layer = p
                     .get("layer")
@@ -1954,7 +1955,7 @@ impl App {
                 Ok(json!({"type":"ok","pane":id.0.to_string()}))
             }
             "diff.note.list" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 self.ensure_diff_notes_sync().map_err(diff_err)?;
                 let state = p
                     .get("state")
@@ -1978,7 +1979,7 @@ impl App {
                 Ok(json!({"type":"diff_notes","notes":notes}))
             }
             "diff.note.apply" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 self.ensure_diff_notes_sync().map_err(diff_err)?;
                 let items = p
                     .get("notes")
@@ -2063,7 +2064,7 @@ impl App {
                 }))
             }
             "diff.note.add" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 self.ensure_diff_notes_sync().map_err(diff_err)?;
                 let raw = p
                     .get("file")
@@ -2126,7 +2127,7 @@ impl App {
                 Ok(json!({"type":"diff_note","note":note_json(&note)}))
             }
             "diff.note.edit" | "diff.note.resolve" | "diff.note.reopen" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 self.ensure_diff_notes_sync().map_err(diff_err)?;
                 let id = req_str(p, "id")?;
                 let note = self
@@ -2150,7 +2151,7 @@ impl App {
                 Ok(json!({"type":"diff_note","note":note_json(&updated)}))
             }
             "diff.note.remove" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 self.ensure_diff_notes_sync().map_err(diff_err)?;
                 let id = req_str(p, "id")?;
                 let note = self
@@ -2165,7 +2166,7 @@ impl App {
                 Ok(json!({"type":"ok","removed":id}))
             }
             "diff.note.send" => {
-                self.ensure_diff_snapshot_sync().map_err(diff_err)?;
+                self.ensure_diff_snapshot().map_err(diff_err)?;
                 self.ensure_diff_notes_sync().map_err(diff_err)?;
                 let target = req_str(p, "to")?;
                 let all_open = p.get("all_open").and_then(Value::as_bool).unwrap_or(false);
@@ -2259,6 +2260,7 @@ impl App {
                 Ok(json!({"type":"ok"}))
             }
             "files.tree" => {
+                self.prepare_file_tree_api(false);
                 let rows: Vec<Value> = self
                     .file_tree
                     .visible_rows()
@@ -2289,7 +2291,7 @@ impl App {
                 Ok(json!({"type":"ok"}))
             }
             "files.refresh" => {
-                self.file_tree.invalidate();
+                self.prepare_file_tree_api(true);
                 Ok(json!({"type":"ok"}))
             }
             // ── worktrees (docs/18 WT-3) ──
@@ -3192,6 +3194,10 @@ mod tests {
         let mut app = App::new(100, 30, tx).unwrap();
         app.workspaces[0].cwd = repo;
 
+        let token = 1;
+        app.diff.status_generation = token;
+        let snapshot = crate::diff::git::scan(&app.workspaces[0].cwd, token).unwrap();
+        assert!(app.apply_diff_status(token, app.workspaces[0].cwd.clone(), Ok(snapshot)));
         let refreshed = app.dispatch("diff.refresh", &json!({})).unwrap();
         assert_eq!(refreshed["refresh"], "complete");
         let listed = app

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -62,6 +62,60 @@ impl App {
         self.refresh_git_status();
     }
 
+    /// Park a first `files.tree` call until its root listing has returned from
+    /// the filesystem worker. Cached trees answer inline; no directory I/O is
+    /// ever moved onto the app loop just to make the CLI deterministic.
+    pub(crate) fn prepare_files_api(
+        &mut self,
+        req: crate::ipc::api::ApiRequest,
+    ) -> Option<crate::ipc::api::ApiRequest> {
+        if req.method != "files.tree" {
+            return Some(req);
+        }
+        self.prepare_file_tree_api(false);
+        if self.file_tree.root_loaded() {
+            return Some(req);
+        }
+        self.pending_file_tree_api
+            .push((self.ws().cwd.clone(), req));
+        None
+    }
+
+    pub(crate) fn finish_pending_files_api(&mut self, completed: &Path) {
+        let active_root = self.ws().cwd.clone();
+        let root_loaded = self.file_tree.root_loaded();
+        let mut pending = std::mem::take(&mut self.pending_file_tree_api);
+        for (root, req) in pending.drain(..) {
+            if !crate::platform::same_path(&root, &active_root) {
+                let _ = req.reply.send(
+                    serde_json::json!({"id":req.id,"error":{
+                        "code":"files_error",
+                        "message":"active workspace changed while FILES was loading"
+                    }})
+                    .to_string(),
+                );
+            } else if root_loaded && crate::platform::same_path(completed, &root) {
+                let response = self.handle_api(&req);
+                let _ = req.reply.send(response);
+            } else {
+                self.pending_file_tree_api.push((root, req));
+            }
+        }
+    }
+
+    /// Root and schedule the FILES tree for an explicit API request even when
+    /// the dock is hidden. Periodic upkeep deliberately sleeps while no FILES or
+    /// DIFF surface is visible, but `files.tree` and `files.refresh` must not
+    /// depend on a client attaching after server restore.
+    pub(crate) fn prepare_file_tree_api(&mut self, invalidate: bool) {
+        let root = self.ws().cwd.clone();
+        self.file_tree.set_root(root);
+        if invalidate {
+            self.file_tree.invalidate();
+        }
+        self.load_pending_dirs();
+    }
+
     /// Re-read the directories currently on screen so files created or removed
     /// outside luvus (by an agent, a terminal command, another process) appear.
     /// Gated to ~1.5s and never descends into collapsed folders, so it stays
@@ -1356,6 +1410,84 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir);
     }
+    #[test]
+    fn hidden_files_api_re_roots_and_reloads_after_restore() {
+        let _env = crate::persist::test_env("files-api-restore");
+        let root = std::env::temp_dir().join(format!("luvus-far-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("restored.txt"), b"restored\n").unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(100, 30, tx).unwrap();
+        app.workspaces[app.active_ws].cwd = root.clone();
+        app.sidebars
+            .left
+            .docks
+            .retain(|dock| dock != &DockKind::Files);
+        app.sidebars
+            .right
+            .docks
+            .retain(|dock| dock != &DockKind::Files);
+        let snapshot = crate::persist::snapshot(&app);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut restored = App::from_snapshot(snapshot, tx).expect("restore");
+        assert!(
+            restored.sidebars.side_of(&DockKind::Files).is_none(),
+            "the regression requires a hidden FILES dock"
+        );
+        assert!(restored.file_tree.root().as_os_str().is_empty());
+
+        let request_tree = |id: &str, app: &mut App| -> std::sync::mpsc::Receiver<String> {
+            let (reply, response) = std::sync::mpsc::channel();
+            app.handle_event(AppEvent::Api(crate::ipc::api::ApiRequest {
+                id: id.to_string(),
+                method: "files.tree".to_string(),
+                params: serde_json::json!({}),
+                reply,
+            }));
+            response
+        };
+
+        let first = request_tree("first", &mut restored);
+        assert!(
+            first
+                .recv_timeout(std::time::Duration::from_millis(10))
+                .is_err(),
+            "the first tree waits for its off-loop root read"
+        );
+        pump_until_dir_read(&rx, &mut restored, &root);
+        let loaded: serde_json::Value = serde_json::from_str(
+            &first
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("first populated tree"),
+        )
+        .unwrap();
+        assert_eq!(loaded["result"]["root"], root.to_string_lossy().as_ref());
+        assert!(loaded["result"]["rows"]
+            .as_array()
+            .is_some_and(|rows| rows.iter().any(|row| row["name"] == "restored.txt")));
+
+        restored
+            .dispatch("files.refresh", &serde_json::json!({}))
+            .unwrap();
+        let refreshed = request_tree("refreshed", &mut restored);
+        pump_until_dir_read(&rx, &mut restored, &root);
+        let refreshed: serde_json::Value = serde_json::from_str(
+            &refreshed
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("refreshed populated tree"),
+        )
+        .unwrap();
+        assert_eq!(refreshed["result"]["root"], root.to_string_lossy().as_ref());
+        assert!(refreshed["result"]["rows"]
+            .as_array()
+            .is_some_and(|rows| rows.iter().any(|row| row["name"] == "restored.txt")));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     fn file_view_frees_content_on_close() {
         let _env = crate::persist::test_env("file-mem-free");

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -103,6 +103,20 @@ impl App {
         }
     }
 
+    /// Fail every parked FILES request when its workspace can no longer
+    /// produce a directory result, such as when the final workspace closes.
+    pub(crate) fn fail_pending_files_api(&mut self, message: &str) {
+        for (_, req) in self.pending_file_tree_api.drain(..) {
+            let _ = req.reply.send(
+                serde_json::json!({"id":req.id,"error":{
+                    "code":"files_error",
+                    "message":message
+                }})
+                .to_string(),
+            );
+        }
+    }
+
     /// Root and schedule the FILES tree for an explicit API request even when
     /// the dock is hidden. Periodic upkeep deliberately sleeps while no FILES or
     /// DIFF surface is visible, but `files.tree` and `files.refresh` must not

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -103,8 +103,26 @@ impl App {
         }
     }
 
-    /// Fail every parked FILES request when its workspace can no longer
-    /// produce a directory result, such as when the final workspace closes.
+    /// Fail parked FILES requests for one workspace while preserving requests
+    /// whose directory workers still belong to another open workspace.
+    pub(crate) fn fail_pending_files_api_for_root(&mut self, closed_root: &Path, message: &str) {
+        let mut pending = std::mem::take(&mut self.pending_file_tree_api);
+        for (root, req) in pending.drain(..) {
+            if crate::platform::same_path(&root, closed_root) {
+                let _ = req.reply.send(
+                    serde_json::json!({"id":req.id,"error":{
+                        "code":"files_error",
+                        "message":message
+                    }})
+                    .to_string(),
+                );
+            } else {
+                self.pending_file_tree_api.push((root, req));
+            }
+        }
+    }
+
+    /// Fail every parked FILES request when no workspace remains.
     pub(crate) fn fail_pending_files_api(&mut self, message: &str) {
         for (_, req) in self.pending_file_tree_api.drain(..) {
             let _ = req.reply.send(

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -156,6 +156,27 @@ fn extract_rows_selection(
 }
 
 impl App {
+    fn handle_api_request(&mut self, req: crate::ipc::api::ApiRequest) -> bool {
+        if req.method == "search.query" {
+            self.start_search_api(req);
+            return true;
+        }
+        if req.method == "search.activate" {
+            let response = self.handle_search_activate(&req);
+            let _ = req.reply.send(response);
+            return true;
+        }
+        let Some(req) = self.prepare_files_api(req) else {
+            return true;
+        };
+        let Some(req) = self.prepare_diff_api(req) else {
+            return true;
+        };
+        let response = self.handle_api(&req);
+        let _ = req.reply.send(response);
+        true
+    }
+
     fn handle_theme_reloaded(
         &mut self,
         id: String,
@@ -315,20 +336,7 @@ impl App {
             // Control-API requests arrive on the event channel so the loop wakes
             // for them immediately (docs/81). Answer inline: like the old
             // server-side drain, an answered request counts as activity.
-            AppEvent::Api(req) => {
-                if req.method == "search.query" {
-                    self.start_search_api(req);
-                    return true;
-                }
-                if req.method == "search.activate" {
-                    let response = self.handle_search_activate(&req);
-                    let _ = req.reply.send(response);
-                    return true;
-                }
-                let resp = self.handle_api(&req);
-                let _ = req.reply.send(resp);
-                true
-            }
+            AppEvent::Api(req) => self.handle_api_request(req),
             AppEvent::ThemeReloaded {
                 id,
                 registry,
@@ -394,14 +402,19 @@ impl App {
                 self.active_is_mission()
             }
             AppEvent::DirRead { path, entries } => {
-                self.file_tree.apply_dir(path, entries);
+                self.file_tree.apply_dir(path.clone(), entries);
+                self.finish_pending_files_api(&path);
                 true
             }
             AppEvent::DiffStatus {
                 token,
                 visible_root,
                 result,
-            } => self.apply_diff_status(token, visible_root, result),
+            } => {
+                let changed = self.apply_diff_status(token, visible_root, result);
+                self.finish_pending_diff_api();
+                changed
+            }
             AppEvent::DiffLoaded { id, token, result } => self.apply_diff_loaded(id, token, result),
             AppEvent::DiffNotesLoaded { review_id, result } => {
                 self.apply_diff_notes_loaded(review_id, result)

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2881,6 +2881,84 @@ mod tests {
         assert!(app.pending_diff_api.is_empty());
     }
 
+    #[test]
+    fn closing_one_workspace_fails_only_its_parked_files_and_diff_requests() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        let closed_root = app.ws().cwd.clone();
+        let open_root = closed_root.join("still-open");
+        app.workspaces.push(crate::app::Workspace {
+            name: "still-open".into(),
+            cwd: open_root.clone(),
+            branch: None,
+            git_ahead_behind: None,
+            worktree: None,
+            tabs: vec![crate::app::Tab::panes(crate::layout::TileLayout::new(
+                crate::ids::PaneId::alloc(),
+            ))],
+            active_tab: 0,
+            pinned: false,
+        });
+
+        let request = |id: &str, method: &str| {
+            let (reply, response) = std::sync::mpsc::channel();
+            (
+                crate::ipc::api::ApiRequest {
+                    id: id.into(),
+                    method: method.into(),
+                    params: serde_json::Value::Null,
+                    reply,
+                },
+                response,
+            )
+        };
+        let (closed_files, closed_files_rx) = request("closed-files", "files.tree");
+        let (open_files, open_files_rx) = request("open-files", "files.tree");
+        app.pending_file_tree_api
+            .push((closed_root.clone(), closed_files));
+        app.pending_file_tree_api
+            .push((open_root.clone(), open_files));
+        let (closed_diff, closed_diff_rx) = request("closed-diff", "diff.list");
+        let (open_diff, open_diff_rx) = request("open-diff", "diff.list");
+        app.pending_diff_api
+            .push((closed_root.clone(), closed_diff));
+        app.pending_diff_api.push((open_root.clone(), open_diff));
+
+        app.close_workspace(0);
+
+        let closed_files = closed_files_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("closed workspace FILES request failed immediately");
+        assert!(closed_files.contains("files_error"));
+        assert!(closed_files.contains("workspace closed"));
+        let closed_diff = closed_diff_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("closed workspace DIFF request failed immediately");
+        assert!(closed_diff.contains("diff_error"));
+        assert!(closed_diff.contains("workspace closed"));
+
+        assert!(matches!(
+            open_files_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        assert!(matches!(
+            open_diff_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        assert_eq!(app.pending_file_tree_api.len(), 1);
+        assert!(crate::platform::same_path(
+            &app.pending_file_tree_api[0].0,
+            &open_root
+        ));
+        assert_eq!(app.pending_diff_api.len(), 1);
+        assert!(crate::platform::same_path(
+            &app.pending_diff_api[0].0,
+            &open_root
+        ));
+        assert_eq!(app.workspaces.len(), 1);
+        assert!(crate::platform::same_path(&app.ws().cwd, &open_root));
+    }
+
     // Agents treat Enter as "submit" and Shift+Enter as "new line". A terminal
     // sends a bare CR for both, so luvus asks for the disambiguating keyboard
     // protocol and forwards the modified form as `ESC CR` — the sequence agent

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2832,6 +2832,55 @@ mod tests {
         assert!(resp.contains("pong"), "got a real pong, not EOF: {resp}");
     }
 
+    #[test]
+    fn closing_last_workspace_fails_parked_files_and_diff_requests() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        let root = app.ws().cwd.clone();
+
+        let (files_reply, files_rx) = std::sync::mpsc::channel();
+        app.pending_file_tree_api.push((
+            root.clone(),
+            crate::ipc::api::ApiRequest {
+                id: "files".into(),
+                method: "files.tree".into(),
+                params: serde_json::Value::Null,
+                reply: files_reply,
+            },
+        ));
+        let (diff_reply, diff_rx) = std::sync::mpsc::channel();
+        app.pending_diff_api.push((
+            root,
+            crate::ipc::api::ApiRequest {
+                id: "diff".into(),
+                method: "diff.list".into(),
+                params: serde_json::Value::Null,
+                reply: diff_reply,
+            },
+        ));
+
+        app.close_workspace(0);
+
+        let files = files_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("FILES waiter failed when its workspace closed");
+        assert!(files.contains("files_error"), "unexpected reply: {files}");
+        assert!(
+            files.contains("no active workspace"),
+            "unexpected reply: {files}"
+        );
+        let diff = diff_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("DIFF waiter failed when its workspace closed");
+        assert!(diff.contains("diff_error"), "unexpected reply: {diff}");
+        assert!(
+            diff.contains("no active workspace"),
+            "unexpected reply: {diff}"
+        );
+        assert!(app.pending_file_tree_api.is_empty());
+        assert!(app.pending_diff_api.is_empty());
+    }
+
     // Agents treat Enter as "submit" and Shift+Enter as "new line". A terminal
     // sends a bare CR for both, so luvus asks for the disambiguating keyboard
     // protocol and forwards the modified form as `ESC CR` — the sequence agent

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4793,6 +4793,17 @@ impl App {
 
     fn close_active_ws(&mut self) {
         if self.active_ws < self.workspaces.len() {
+            if self.workspaces.len() > 1 {
+                let closed_root = self.workspaces[self.active_ws].cwd.clone();
+                self.fail_pending_files_api_for_root(
+                    &closed_root,
+                    "workspace closed while FILES was loading",
+                );
+                self.fail_pending_diff_api_for_root(
+                    &closed_root,
+                    "workspace closed while DIFF was refreshing",
+                );
+            }
             self.workspaces.remove(self.active_ws);
         }
         if self.workspaces.is_empty() {
@@ -4832,6 +4843,17 @@ impl App {
     fn close_workspace(&mut self, index: usize) {
         if index >= self.workspaces.len() {
             return;
+        }
+        if self.workspaces.len() > 1 {
+            let closed_root = self.workspaces[index].cwd.clone();
+            self.fail_pending_files_api_for_root(
+                &closed_root,
+                "workspace closed while FILES was loading",
+            );
+            self.fail_pending_diff_api_for_root(
+                &closed_root,
+                "workspace closed while DIFF was refreshing",
+            );
         }
         let ids: Vec<PaneId> = self.workspaces[index]
             .tabs

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1400,6 +1400,9 @@ pub struct App {
     /// The FILES dock (docs/38): the tree model, its scroll region, and the
     /// clickable rect per visible row (`(row index, rect)`), re-set each frame.
     pub file_tree: crate::files::FileTree,
+    /// `files.tree` callers waiting for the off-loop root directory read.
+    /// The targeted root prevents a workspace switch from redirecting a reply.
+    pending_file_tree_api: Vec<(PathBuf, crate::ipc::api::ApiRequest)>,
     pub files_area: Rect,
     pub file_tree_rects: Vec<(usize, Rect)>,
     /// FILES/DIFF header controls and DIFF list rows (docs/88).
@@ -1417,6 +1420,10 @@ pub struct App {
     pub diff: crate::diff::DiffState,
     pub diff_agent_picker: Option<crate::diff::DiffAgentPicker>,
     pub diff_menu: Option<DiffMenu>,
+    /// API requests waiting for the shared off-loop FILES/DIFF status scan.
+    /// Each retains the workspace root it targeted so a later workspace switch
+    /// cannot redirect a parked mutation or read into a different repository.
+    pending_diff_api: Vec<(PathBuf, crate::ipc::api::ApiRequest)>,
     /// Working-tree git status per path, for tinting the FILES dock (docs/38).
     /// Refreshed off-loop; empty when the tree root isn't a repo.
     pub file_git_status: HashMap<PathBuf, crate::git::local::FileStatus>,
@@ -1761,6 +1768,7 @@ impl App {
                 t.show_hidden = files_show_hidden;
                 t
             },
+            pending_file_tree_api: Vec::new(),
             files_area: Rect::ZERO,
             file_tree_rects: Vec::new(),
             files_mode: crate::diff::FilesMode::Files,
@@ -1772,6 +1780,7 @@ impl App {
             diff: crate::diff::DiffState::default(),
             diff_agent_picker: None,
             diff_menu: None,
+            pending_diff_api: Vec::new(),
             views: HashMap::new(),
             editor_files: HashMap::new(),
             recent_files: VecDeque::new(),
@@ -2260,6 +2269,7 @@ impl App {
                 t.show_hidden = files_show_hidden;
                 t
             },
+            pending_file_tree_api: Vec::new(),
             files_area: Rect::ZERO,
             file_tree_rects: Vec::new(),
             files_mode: crate::diff::FilesMode::Files,
@@ -2271,6 +2281,7 @@ impl App {
             diff: crate::diff::DiffState::default(),
             diff_agent_picker: None,
             diff_menu: None,
+            pending_diff_api: Vec::new(),
             views,
             editor_files: HashMap::new(),
             recent_files: VecDeque::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4819,6 +4819,8 @@ impl App {
     /// server to outlive, so it quits like a normal terminal app.
     fn all_workspaces_closed(&mut self) {
         self.session_dirty = true;
+        self.fail_pending_files_api("no active workspace while FILES was loading");
+        self.fail_pending_diff_api("no active workspace while DIFF was refreshing");
         if self.server_mode {
             self.end_session = true;
         } else {

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -115,6 +115,10 @@ impl FileTree {
         &self.root
     }
 
+    pub fn root_loaded(&self) -> bool {
+        self.is_loaded(&self.root)
+    }
+
     /// Point the tree at a new folder (the active node changed).
     ///
     /// The outgoing folder's open directories, cursor and scroll are **parked**

--- a/website/src/content/docs/docs/guides/diff.mdx
+++ b/website/src/content/docs/docs/guides/diff.mdx
@@ -130,7 +130,10 @@ luvus diff list --layer worktree | jq '.result.files[] | {path, status, addition
 ```
 
 `diff list` returns staged, worktree, untracked, and conflict entries as
-separate changes. A path can therefore appear more than once. Pass `--layer`
+separate changes. Its first call waits for one off-loop status scan; later calls
+return the latest shared FILES/DIFF snapshot immediately and refresh it in the
+background when due. Run `diff refresh` first when a script must wait for a new
+scan. A path can therefore appear more than once. Pass `--layer`
 to `open`, `get`, and `note add` whenever the path is present in multiple
 layers. Paths resolve from the active workspace and must remain inside its Git
 repository. Counts can be `null` in the lightweight list until that file's

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -20,7 +20,11 @@ in the workspace even when its folder has never been expanded here. Press
 Git ignore rules when Git is available, skips `.git`, and never follows
 directory symlinks.
 
-Folders expand and collapse in place. Names are tinted by git status as you
+Folders expand and collapse in place. `luvus files tree` and
+`luvus files refresh` also work while the dock is hidden or immediately after a
+server restore; directory reads stay off the app loop.
+
+Names are tinted by git status as you
 work: amber for modified, green for added or untracked, coral for deleted or
 conflicted, mint for renamed, with a letter badge and a mark on any folder that
 contains changes. Files created outside luvus, by an agent or a command in a

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -46,6 +46,7 @@ printf '%s\n' '{"id":"1","method":"ping","params":{}}' | nc -U ~/.luvus/luvus.so
 | panes | `pane.list` · `pane.split` · `pane.move` · `pane.focus` · `pane.run` · `pane.send_input` · `pane.read` · `pane.status` · `pane.close` · `attach.pane` |
 | agents | `agent.list` · `agent.get` · `agent.name` · `agent.fork` · `agent.send` · `agent.keys` · `agent.read` · `agent.sessions` · `agent.resume` · `pane.report_session` · `pane.report_event` |
 | search | `search` · `search.capabilities` · `search.query` · `search.activate` |
+| files | `files.tree` · `files.open` · `files.reveal` · `files.refresh` |
 | git | `git.status` · `git.branches` · `git.log` · `git.open` |
 | diff | `diff.refresh` · `diff.list` · `diff.open` · `diff.get` · `diff.navigate` · `diff.note.add` · `diff.note.apply` · `diff.note.list` · `diff.note.edit` · `diff.note.resolve` · `diff.note.reopen` · `diff.note.remove` · `diff.note.send` |
 | worktrees | `worktree.list` · `worktree.create` · `worktree.open` · `worktree.remove` |
@@ -220,6 +221,15 @@ Unsupported agents return `unsupported_agent`; a supported agent whose session
 ID cannot be resolved returns `session_unknown`; and PTY launch failure returns
 `spawn_failed`. Validation completes before a new pane is spawned.
 
+## Files
+
+`files.tree` returns the active workspace root and its currently expanded rows.
+When the root has not been loaded yet, including immediately after server
+restore with the FILES dock hidden, the request waits for one off-loop directory
+read rather than returning an empty root. `files.refresh` invalidates the cached
+listings and schedules that same worker immediately; it does not require a TUI
+client or visible dock.
+
 ## DIFF review
 
 DIFF methods are additive and read Git state without mutating the repository.
@@ -229,7 +239,7 @@ one layer, callers must pass `layer` instead of accepting an ambiguous result.
 | Method | Params | Result |
 |---|---|---|
 | `diff.refresh` | `{}` | completes one shared FILES/DIFF status refresh and returns its generation |
-| `diff.list` | `{layer?}` | exact staged, worktree, untracked, and conflict rows |
+| `diff.list` | `{layer?}` | cached staged, worktree, untracked, and conflict rows; schedules a bounded background refresh |
 | `diff.open` | `{path?, layer?, view?, placement?}` | opens a native preview, pane, or tab |
 | `diff.get` | `{path, layer?, include_patch?}` | bounded semantic hunks; line text is omitted by default |
 | `diff.navigate` | `{pane?, action}` | moves an open native DIFF view |
@@ -249,9 +259,13 @@ Git source lines, not rendered rows.
 
 ### Results and identifiers
 
-`diff.list` returns `result.files`. Each file includes `path`, `old_path`,
-`layer`, `status`, `additions`, `deletions`, `binary`, unresolved `notes`, review
-state, and a fingerprint. Addition and deletion counts can be `null` until the
+`diff.list` returns `result.files` from the latest shared FILES/DIFF snapshot and
+never runs Git on the app loop. On first use it waits for one off-loop scan. A
+later call returns the cache immediately and may schedule a cadence-gated
+background refresh; `result.refreshing` reports whether that refresh is in
+flight. Call `diff.refresh` when the caller must wait for a newly completed
+scan. Each file includes `path`, `old_path`, `layer`, `status`, `additions`,
+`deletions`, `binary`, unresolved `notes`, review state, and a fingerprint. Addition and deletion counts can be `null` until the
 file is loaded. If a path appears in multiple layers, all later calls for that
 path must include `layer`.
 


### PR DESCRIPTION
Move DIFF status scans and restored FILES initialization off the single-writer app loop while preserving immediate cached API responses.

## DIFF refresh

- Serve cached `diff.list` snapshots immediately.
- Run first-use, cadence, and explicit refresh work through the existing worker event.
- Park first-use and explicit-refresh replies until their workspace-bound result arrives.
- Report refresh state without blocking ping or other app-loop work.

## FILES restore

- Root hidden FILES API requests from the active restored workspace.
- Park the first `files.tree` reply until its off-loop directory read completes.
- Make `files.refresh` recover correctly without a visible dock or attached TUI.

## Validation

- `cargo test --locked`: 736 unit tests plus integration tests passed
- `cargo clippy --all-targets -- -D warnings`: passed
- `cargo fmt --all --check`: passed
- `git diff --check`: passed
- Website build: passed
- Isolated release verification confirmed cached `diff.list` latency below 0.11 ms maximum over 100 requests and a populated FILES result after restart

No unrelated files are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File-tree and diff requests now load and refresh asynchronously.
  - File-tree operations work when the FILES dock is hidden or after session restoration.
  - Diff results return cached data immediately when available and report refresh status.
  - Added file-tree API operations for retrieving, opening, revealing, and refreshing files.

- **Bug Fixes**
  - Requests remain associated with their original workspace during loading.
  - Pending requests return clear errors when their workspace is unavailable.

- **Documentation**
  - Updated guidance for asynchronous file-tree loading, diff refresh behavior, and file APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->