### PR TITLE
fix(agents): preserve fork environment and session identity

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -371,6 +371,22 @@ pub fn resume_for(
     }
 }
 
+/// Resolve the source session for a native fork.
+///
+/// A hook-reported or explicitly resumed identity always wins. Codex must have
+/// that exact binding because several live rollouts commonly share one cwd;
+/// guessing its newest file can fork a different pane's conversation. Agents
+/// without a precise integration retain the historical newest-session fallback.
+pub fn fork_session_id(agent: &str, bound: Option<&str>, cwd: &Path) -> Option<String> {
+    if let Some(id) = bound {
+        return Some(id.to_string());
+    }
+    if agent == "codex" {
+        return None;
+    }
+    latest_session(agent, cwd)
+}
+
 /// The command that **forks** an agent's session: continue from the original's
 /// full context in a new, diverging session (the original is left untouched).
 /// `None` for agents without a native fork, unknown agents, or unsafe ids.
@@ -1544,6 +1560,20 @@ mod tests {
 
         // Unknown agent stays None however it is called.
         assert!(resume_for("nope", "abc", Some(&flags), true).is_none());
+    }
+
+    #[test]
+    fn codex_fork_requires_the_selected_session_identity() {
+        let cwd = Path::new("/work/project");
+        assert_eq!(
+            fork_session_id("codex", Some("selected-rollout"), cwd).as_deref(),
+            Some("selected-rollout")
+        );
+        assert_eq!(
+            fork_session_id("codex", None, cwd),
+            None,
+            "Codex must not guess another active rollout from the shared cwd"
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2013,10 +2013,9 @@ impl App {
                     // Resume the native agent session captured at save time (a
                     // precise hook report, or one discovered from the agent's
                     // on-disk store keyed by cwd — see `persist::snapshot`).
-                    // Preferably the shell *starts* on the resume command, so
-                    // the pane opens straight into the resuming agent (nothing
-                    // visibly typed); an unrecognised shell family falls back
-                    // to typing the command after spawn.
+                    // PowerShell can start directly on the resume command.
+                    // POSIX and unrecognised shells start normally and receive
+                    // it through the PTY after interactive profile setup.
                     // Re-apply the launch flags captured at save time (docs/62),
                     // unless Settings → General turns that off.
                     let resume = ps.agent_session.as_ref().and_then(|(agent, sid)| {
@@ -2711,9 +2710,9 @@ impl App {
         Some(id)
     }
 
-    /// `spawn_into`, but the shell starts on the `resume` command (falling back
-    /// to typing it into the prompt when the shell family isn't recognised) —
-    /// a resumed session opens straight into its agent.
+    /// `spawn_into`, but queues an agent resume/fork command. POSIX and custom
+    /// shells receive it through a normal interactive PTY so profile-managed
+    /// executables are available; PowerShell can launch it directly.
     fn spawn_resume_pane(&mut self, cwd: PathBuf, resume: &str) -> Option<PaneId> {
         let id = PaneId::alloc();
         let shell = crate::platform::resolve_shell(&self.config.shell);
@@ -2809,12 +2808,12 @@ impl App {
             .get(&pane)
             .map(|p| p.cwd.clone())
             .ok_or(AgentForkError::PaneNotFound)?;
-        let sid = st
-            .agent_session
-            .as_ref()
-            .map(|s| s.session_id.clone())
-            .or_else(|| crate::agent::latest_session(&agent, &cwd));
-        let sid = sid.ok_or(AgentForkError::SessionUnknown)?;
+        let sid = crate::agent::fork_session_id(
+            &agent,
+            st.agent_session.as_ref().map(|s| s.session_id.as_str()),
+            &cwd,
+        )
+        .ok_or(AgentForkError::SessionUnknown)?;
         let fork =
             crate::agent::fork_command(&agent, &sid).ok_or(AgentForkError::UnsupportedAgent)?;
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -21,7 +21,9 @@ fn agent_hook_script(agent: &str) -> String {
 # on the hook's event name so modules and API clients get precise transitions.
 [ -n "$LUVUS_ENV" ] || exit 0
 [ -n "$LUVUS_SOCKET_PATH" ] || exit 0
-command -v luvus >/dev/null 2>&1 || exit 0
+luvus_bin="${{LUVUS_BIN_PATH:-}}"
+[ -n "$luvus_bin" ] && [ -x "$luvus_bin" ] || luvus_bin="$(command -v luvus 2>/dev/null || true)"
+[ -n "$luvus_bin" ] || exit 0
 command -v python3 >/dev/null 2>&1 || exit 0
 input="$(cat)"
 evt="$(printf '%s' "$input" | python3 -c 'import sys,json
@@ -34,14 +36,14 @@ case "$evt" in
 try:
     d=json.load(sys.stdin); print((d.get("message") or "")[:200])
 except Exception: print("")' 2>/dev/null)"
-    luvus pane report-event --agent {agent} --kind "$evt" --message "$msg" >/dev/null 2>&1
+    "$luvus_bin" pane report-event --agent {agent} --kind "$evt" --message "$msg" >/dev/null 2>&1
     ;;
   *)
     sid="$(printf '%s' "$input" | python3 -c 'import sys,json
 try:
     d=json.load(sys.stdin); print(d.get("session_id") or d.get("sessionId") or d.get("id") or "")
 except Exception: print("")' 2>/dev/null)"
-    [ -n "$sid" ] && luvus pane report --agent {agent} --session "$sid" >/dev/null 2>&1
+    [ -n "$sid" ] && "$luvus_bin" pane report --agent {agent} --session "$sid" >/dev/null 2>&1
     ;;
 esac
 exit 0
@@ -176,7 +178,7 @@ fn opencode_plugin_path() -> PathBuf {
 
 /// Where + how an agent's shell hook is configured (docs/23). `file` is the JSON
 /// config file inside `dir`; `event` is the hook key; `matcher` is an optional
-/// group matcher (Codex wants `startup|resume`).
+/// group matcher (Codex reports `startup` and `resume` SessionStart sources).
 struct HookSpec {
     dir: PathBuf,
     file: &'static str,
@@ -787,6 +789,10 @@ mod tests {
         let luvus: Vec<&Value> = groups.iter().filter(|g| group_mentions_luvus(g)).collect();
         assert_eq!(luvus.len(), 1);
         assert_eq!(luvus[0]["matcher"].as_str(), Some("startup|resume"));
+        assert!(
+            script.contains("LUVUS_BIN_PATH"),
+            "the hook uses the exact server binary even when PATH is stale"
+        );
         assert!(is_installed("codex"));
 
         std::env::remove_var("CODEX_HOME");

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -60,11 +60,12 @@ import { spawn } from "node:child_process"
 
 export const luvus = async () => {
   let last = ""
+  const luvusBin = process.env.LUVUS_BIN_PATH || "luvus"
   const report = (id) => {
     if (!id || id === last || !process.env.LUVUS_SOCKET_PATH) return
     last = id
     try {
-      spawn("luvus", ["pane", "report", "--agent", "opencode", "--session", String(id)], {
+      spawn(luvusBin, ["pane", "report", "--agent", "opencode", "--session", String(id)], {
         stdio: "ignore",
         detached: true,
       }).unref()
@@ -913,6 +914,10 @@ mod tests {
         let js = fs::read_to_string(&plugin).unwrap();
         assert!(js.contains("session.created"), "hooks the session event");
         assert!(js.contains("--agent"), "reports the session");
+        assert!(
+            js.contains("process.env.LUVUS_BIN_PATH"),
+            "uses the exact server-selected binary before PATH fallback"
+        );
         assert!(js.contains("opencode"));
         assert!(is_installed("opencode"));
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -85,10 +85,13 @@ fn platform_default_shell() -> String {
     std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
 }
 
-/// Argv that runs `cmd` inside `shell` and then continues as that same shell,
-/// interactive — how a restored agent pane resumes its session *on launch*
-/// instead of having the resume command typed into a visible prompt. `None`
-/// when the shell family isn't recognised (callers fall back to typing).
+/// Argv that runs `cmd` inside `shell` and then keeps that shell open.
+///
+/// POSIX shells deliberately return `None`: callers spawn the user's normal
+/// interactive shell and queue `cmd` through its PTY, after `.zshrc`, `.bashrc`,
+/// fish configuration, NVM, mise, and similar environment setup has run.
+/// PowerShell loads its profile for `-NoExit -Command`, so it can still start
+/// directly without exposing a prompt first.
 pub fn shell_run_then_interactive(shell: &str, cmd: &str) -> Option<Vec<String>> {
     if shell.contains('\'') {
         return None; // a quote in the shell path would break the exec quoting
@@ -98,13 +101,7 @@ pub fn shell_run_then_interactive(shell: &str, cmd: &str) -> Option<Vec<String>>
         .to_str()?
         .to_ascii_lowercase();
     match base.strip_suffix(".exe").unwrap_or(&base) {
-        // POSIX-family (fish included: `-c`, `;`, `exec`, and single quotes all
-        // behave the same for this shape).
-        "sh" | "bash" | "zsh" | "dash" | "ksh" | "fish" => Some(vec![
-            shell.to_string(),
-            "-c".to_string(),
-            format!("{cmd}; exec '{shell}'"),
-        ]),
+        "sh" | "bash" | "zsh" | "dash" | "ksh" | "fish" => None,
         "pwsh" | "powershell" => Some(vec![
             shell.to_string(),
             "-NoExit".to_string(),
@@ -586,12 +583,11 @@ mod tests {
 
     #[test]
     fn run_then_interactive_covers_shell_families() {
-        // POSIX family: -c "cmd; exec 'shell'".
-        let argv = super::shell_run_then_interactive("/bin/zsh", "claude --resume 'abc'").unwrap();
-        assert_eq!(argv[0], "/bin/zsh");
-        assert_eq!(argv[1], "-c");
-        assert_eq!(argv[2], "claude --resume 'abc'; exec '/bin/zsh'");
-        assert!(super::shell_run_then_interactive("/usr/bin/fish", "x").is_some());
+        // POSIX shells must start normally and receive the command through their
+        // PTY so profile-managed executables are available.
+        assert!(super::shell_run_then_interactive("/bin/zsh", "claude --resume 'abc'").is_none());
+        assert!(super::shell_run_then_interactive("/bin/bash", "x").is_none());
+        assert!(super::shell_run_then_interactive("/usr/bin/fish", "x").is_none());
         // PowerShell: -NoExit -Command cmd.
         let ps = super::shell_run_then_interactive("pwsh.exe", "codex resume 'a'").unwrap();
         assert_eq!(ps[1], "-NoExit");

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -127,6 +127,13 @@ The TUI action only appears for supported agents and otherwise remains a no-op.
 The CLI reports a structured error instead, so automation never mistakes an
 unsupported or unresolved fork for success.
 
+Codex forks require the exact session identity reported by its integration or
+recorded when Luvus resumes a session. Luvus never guesses the newest Codex
+rollout in a shared folder, because that could fork another pane's active
+conversation. Install or refresh the hook with
+`luvus integration install codex`; its SessionStart hook binds both new and
+resumed Codex panes to their exact rollout.
+
 ## Precise events: the integration hook
 
 Screen-based detection needs no setup and works for everything. The optional

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -219,7 +219,9 @@ when false, the current workspace, tab, pane focus, and zoom state are preserved
 
 Unsupported agents return `unsupported_agent`; a supported agent whose session
 ID cannot be resolved returns `session_unknown`; and PTY launch failure returns
-`spawn_failed`. Validation completes before a new pane is spawned.
+`spawn_failed`. Codex requires a hook-reported or Luvus-resumed exact session
+identity and never falls back to the newest rollout in the workspace. Validation
+completes before a new pane is spawned.
 
 ## Files
 


### PR DESCRIPTION
Make native agent forks use the user's configured interactive environment and prevent Codex from guessing the wrong rollout.

## Fork environment

- Start POSIX fork and resume panes as normal interactive shells.
- Queue the agent command through the PTY after shell profile initialization.
- Preserve direct PowerShell startup behavior.
- Support profile-managed executables such as NVM-installed Pi.

## Codex identity

- Require a hook-reported or Luvus-resumed exact Codex session identity.
- Never substitute the newest rollout from a shared workspace.
- Make generated hooks prefer the exact `LUVUS_BIN_PATH` over a potentially stale PATH lookup.
- Document the integration requirement for automatic Codex forks.

## Validation

- `cargo test --locked`: 739 unit tests plus integration tests passed
- `cargo clippy --all-targets -- -D warnings`: passed
- `cargo fmt --all --check`: passed
- `git diff --check`: passed
- `cargo build --locked`: passed
- Website build: passed

No unrelated files are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration and pane forking to use the correct session identity.
  * Prevented incorrect session selection in shared working folders.
  * Improved resume behavior across PowerShell, POSIX, and other shells.
  * Added clearer handling when a fork cannot be started.

* **Improvements**
  * Shell integration now supports locating the executable through `LUVUS_BIN_PATH`.

* **Documentation**
  * Clarified Codex session requirements, integration setup, and forking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->