### PR TITLE
fix(settings): keep dock placement controls stable

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,7 @@
 # luvus installer for Windows — downloads the prebuilt binary from the GitHub
 # releases and adds it to your PATH (no admin needed).
 #
-#   irm https://raw.githubusercontent.com/RizRiyz/luvus/main/install.ps1 | iex
+#   irm https://luvus.dev/install.ps1 | iex
 #
 # Overrides (set before running):
 #   $env:LUVUS_VERSION     = 'v0.1.0'    # a specific tag (default: latest release)

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # luvus installer — downloads the right prebuilt binary for your OS/arch from the
 # GitHub releases and drops it on your PATH.
 #
-#   curl -fsSL https://raw.githubusercontent.com/RizRiyz/luvus/main/install.sh | sh
+#   curl -fsSL https://luvus.dev/install.sh | sh
 #
 # Overrides:
 #   LUVUS_VERSION=v0.1.0   install a specific tag (default: latest release)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2495,10 +2495,12 @@ impl App {
     }
 
     /// The **dock registry** (docs/29): every dock the settings can place —
-    /// built-ins plus every dock declared by an installed, runnable module, plus
-    /// any currently-mounted dock not otherwise listed (e.g. a stale config
-    /// entry). Deduplicated, built-ins first. Its current side is
-    /// `sidebars.side_of(kind)` (`None` = not placed yet).
+    /// built-ins plus every dock declared by an installed, runnable module, then
+    /// live/configured fallback docks sorted by id. The fallback order is
+    /// deliberately independent from sidebar placement: moving a dock appends it
+    /// on that side, but must not move its Settings row under the pointer.
+    /// Deduplicated, built-ins first. Its current side is `sidebars.side_of(kind)`
+    /// (`None` = not placed yet).
     pub fn available_docks(&self) -> Vec<DockKind> {
         let mut v = vec![DockKind::Workspaces, DockKind::Agents, DockKind::Files];
         for m in self.modules.modules.iter().filter(|m| m.is_runnable()) {
@@ -2509,7 +2511,21 @@ impl App {
                 }
             }
         }
-        for k in self.docks_flat() {
+
+        // A live API dock can exist without a currently-runnable declaration,
+        // and an explicitly-off stale dock exists only in `docks_off`. Keep all
+        // of them placeable, but sort this fallback set instead of deriving its
+        // order from left/right sidebar vectors that placement mutates.
+        let mut fallback: Vec<DockKind> = self
+            .module_docks
+            .keys()
+            .chain(self.config.docks_off.iter())
+            .map(|id| DockKind::Module(id.clone()))
+            .chain(self.docks_flat())
+            .collect();
+        fallback.sort_by(|a, b| a.id().cmp(b.id()));
+        fallback.dedup();
+        for k in fallback {
             if !v.contains(&k) {
                 v.push(k);
             }
@@ -9290,6 +9306,7 @@ mod tests {
         app.settings = Some(SettingsUi {
             tab: SettingsTab::Layout,
             cursor: idx,
+            layout_scroll: 0,
             capturing: false,
         });
         app.handle_settings_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -72,6 +72,10 @@ impl SettingsTab {
 pub struct SettingsUi {
     pub tab: SettingsTab,
     pub cursor: usize,
+    /// First visual row shown in the Layout tab. Persisting this while the modal
+    /// is open prevents a visible dock/bar button click from re-anchoring the
+    /// list around its newly selected row.
+    pub layout_scroll: usize,
     /// In the Keys tab: capturing the next key press to rebind `cursor`'s command.
     pub capturing: bool,
 }
@@ -228,6 +232,7 @@ impl App {
         self.settings = Some(SettingsUi {
             tab: SettingsTab::General,
             cursor: 0,
+            layout_scroll: 0,
             capturing: false,
         });
     }
@@ -273,6 +278,7 @@ impl App {
             tab,
             cursor,
             capturing,
+            ..
         }) = self.settings.as_ref()
         else {
             return;
@@ -430,6 +436,7 @@ impl App {
         if let Some(ui) = self.settings.as_mut() {
             ui.tab = tab;
             ui.cursor = cursor;
+            ui.layout_scroll = 0;
         }
     }
 
@@ -1261,6 +1268,79 @@ mod tests {
             app.config.bars.place("example:ci", region);
             assert_eq!(app.bar_setting_keys(), expected);
         }
+    }
+
+    #[test]
+    fn dock_settings_rows_stay_stable_when_placement_changes() {
+        let _env = crate::persist::test_env("dock-settings-stable");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        let alpha = DockKind::Module("example:alpha".into());
+        let beta = DockKind::Module("example:beta".into());
+        assert!(app.move_dock(&alpha, Side::Right));
+        assert!(app.move_dock(&beta, Side::Right));
+        let expected = app.available_docks();
+
+        assert!(app.move_dock(&alpha, Side::Left));
+        assert_eq!(app.available_docks(), expected);
+        app.unmount_dock(&alpha);
+        assert_eq!(app.available_docks(), expected);
+    }
+
+    #[test]
+    fn clicking_a_visible_placement_button_keeps_the_layout_viewport() {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let _env = crate::persist::test_env("settings-placement-scroll");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(100, 24, tx).unwrap();
+        let declaration = crate::bar::BarDeclaration {
+            key: crate::bar::BarWidgetKey::new("example", "status"),
+            title: "Example status".into(),
+            region: crate::bar::BarRegion::BottomRight,
+            priority: 50,
+        };
+        app.bar
+            .declarations
+            .insert(declaration.key.canonical(), declaration);
+        app.open_settings();
+        let last = app.layout_rows().len().saturating_sub(1);
+        if let Some(settings) = app.settings.as_mut() {
+            settings.tab = SettingsTab::Layout;
+            settings.cursor = last;
+        }
+
+        let mut terminal = Terminal::new(TestBackend::new(100, 24)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+        let before = app.settings.as_ref().unwrap().layout_scroll;
+        assert!(before > 0, "the regression requires a scrolled Layout list");
+
+        let rows = app.layout_rows();
+        let (_, _, button) = app
+            .settings_arrow_rects
+            .iter()
+            .find(|(index, delta, _)| {
+                *delta == 2
+                    && *index != last
+                    && matches!(
+                        rows.get(*index),
+                        Some(LayoutRow::Dock(_) | LayoutRow::Bar(_))
+                    )
+            })
+            .copied()
+            .expect("a visible placement button above the selected row");
+        app.handle_settings_click(button.x, button.y);
+        terminal
+            .draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+
+        assert_eq!(
+            app.settings.as_ref().unwrap().layout_scroll,
+            before,
+            "clicking a visible placement button must not re-anchor the modal"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -632,6 +632,9 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
         app.settings_ctl_rects = h.ctls.clone();
         app.settings_theme_remove_rects = h.theme_remove.clone();
         app.settings_arrow_rects = h.arrows.clone();
+        if let Some(settings) = app.settings.as_mut() {
+            settings.layout_scroll = h.layout_scroll;
+        }
     } else {
         app.settings_modal_rect = None;
         app.settings_close_rect = None;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -14,6 +14,7 @@ pub(super) struct SettingsHits {
     pub ctls: Vec<(usize, Rect)>,
     pub theme_remove: Vec<(String, Rect)>,
     pub arrows: Vec<(usize, i32, Rect)>,
+    pub layout_scroll: usize,
 }
 
 fn format_history_budget(bytes: usize) -> String {
@@ -55,11 +56,11 @@ pub(super) fn draw_settings(
     let inner = block.inner(modal);
     f.render_widget(block, modal);
 
-    let (tab, cursor) = app
+    let (tab, cursor, layout_scroll) = app
         .settings
         .as_ref()
-        .map(|u| (u.tab, u.cursor))
-        .unwrap_or((SettingsTab::Theme, 0));
+        .map(|u| (u.tab, u.cursor, u.layout_scroll))
+        .unwrap_or((SettingsTab::Theme, 0, 0));
 
     // ── title bar ──
     f.render_widget(
@@ -105,7 +106,8 @@ pub(super) fn draw_settings(
         inner.width,
         inner.height.saturating_sub(6),
     );
-    let (ctls, theme_remove, arrows) = draw_content(f, content, tab, cursor, app, t);
+    let (ctls, theme_remove, arrows, layout_scroll) =
+        draw_content(f, content, tab, cursor, layout_scroll, app, t);
 
     // ── footer hint (Keys tab gets its own rebind/reset hints) ──
     let footer_y = inner.bottom().saturating_sub(1);
@@ -161,6 +163,7 @@ pub(super) fn draw_settings(
         ctls,
         theme_remove,
         arrows,
+        layout_scroll,
     }
 }
 
@@ -168,6 +171,7 @@ type Content = (
     Vec<(usize, Rect)>,
     Vec<(String, Rect)>,
     Vec<(usize, i32, Rect)>,
+    usize,
 );
 
 fn draw_content(
@@ -175,12 +179,14 @@ fn draw_content(
     area: Rect,
     tab: SettingsTab,
     cursor: usize,
+    layout_scroll: usize,
     app: &App,
     t: &Theme,
 ) -> Content {
     let mut ctls = Vec::new();
     let mut theme_remove = Vec::new();
     let mut arrows = Vec::new();
+    let mut resolved_layout_scroll = layout_scroll;
     let cat = app.catalog;
     match tab {
         SettingsTab::Theme => {
@@ -347,9 +353,8 @@ fn draw_content(
                 .iter()
                 .position(|v| matches!(v, V::Ctl(i) if *i == cursor))
                 .unwrap_or(0);
-            let scroll = cur_vis
-                .saturating_sub(avail.saturating_sub(1))
-                .min(vis.len().saturating_sub(avail));
+            let scroll = keep_visible_scroll(layout_scroll, cur_vis, avail, vis.len());
+            resolved_layout_scroll = scroll;
             for (row_i, v) in vis.iter().enumerate().skip(scroll).take(avail) {
                 let y = area.y + (row_i - scroll) as u16;
                 let i = match v {
@@ -1122,7 +1127,20 @@ fn draw_content(
             }
         }
     }
-    (ctls, theme_remove, arrows)
+    (ctls, theme_remove, arrows, resolved_layout_scroll)
+}
+
+/// Preserve the current viewport whenever the selected row is already visible;
+/// move it only far enough to reveal keyboard navigation beyond either edge.
+fn keep_visible_scroll(scroll: usize, cursor: usize, viewport: usize, total: usize) -> usize {
+    let viewport = viewport.max(1);
+    let mut scroll = scroll.min(total.saturating_sub(viewport));
+    if cursor < scroll {
+        scroll = cursor;
+    } else if cursor >= scroll.saturating_add(viewport) {
+        scroll = cursor.saturating_add(1).saturating_sub(viewport);
+    }
+    scroll.min(total.saturating_sub(viewport))
 }
 
 /// The one-line summary of what a module contributes, e.g. `· 2 actions · 1 dock`.
@@ -1456,5 +1474,19 @@ fn fill_bg(f: &mut RenderTarget, rect: Rect, color: ratatui::style::Color) {
         for x in rect.x..rect.right() {
             buf[(x, y)].set_bg(color);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::keep_visible_scroll;
+
+    #[test]
+    fn layout_scroll_moves_only_when_selection_leaves_the_viewport() {
+        assert_eq!(keep_visible_scroll(10, 15, 12, 40), 10);
+        assert_eq!(keep_visible_scroll(10, 10, 12, 40), 10);
+        assert_eq!(keep_visible_scroll(10, 9, 12, 40), 9);
+        assert_eq!(keep_visible_scroll(10, 22, 12, 40), 11);
+        assert_eq!(keep_visible_scroll(30, 15, 12, 20), 8);
     }
 }


### PR DESCRIPTION
Keep the Layout settings viewport stable while docks and bars are moved.

## What

- Preserve the visible Layout viewport when clicking a placement control.
- Keep fallback dock rows in a stable order independent of their current sidebar placement.
- Add regression coverage for the viewport and dock ordering behavior.

## Validation

- `cargo fmt --check`
- Targeted settings and UI tests

## Scope note

- This branch also updates installer comment examples to use `luvus.dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Layout settings tab now preserves its scroll position while changing dock placements, keeping the selected item visible.
  - Dock entries in Settings now maintain a consistent order regardless of sidebar placement changes.

- **Documentation**
  - Updated PowerShell and shell installer instructions to use the official `luvus.dev` installation URLs.

- **Bug Fixes**
  - Improved Settings navigation behavior at the edges of the Layout tab to prevent unexpected viewport jumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->