### PR TITLE
feat(website): showcase DIFF and Luvus Bar

### DIFF
--- a/src/ui/changelog.rs
+++ b/src/ui/changelog.rs
@@ -21,6 +21,7 @@ pub const RECENT: usize = 3;
 /// Where the footer link goes. The site renders the same `changelog/*.md` files,
 /// so it can never disagree with what is embedded here.
 pub const CHANGELOG_URL: &str = "https://luvus.dev/changelog";
+pub const LUVUS_UPDATE_COMMAND: &str = "luvus update";
 pub const CURL_UPDATE_COMMAND: &str = "curl -fsSL https://luvus.dev/install.sh | sh";
 pub const BREW_UPDATE_COMMAND: &str = "brew upgrade luvus";
 
@@ -88,9 +89,8 @@ pub(super) fn draw_changelog(f: &mut RenderTarget, area: Rect, app: &mut App, t:
     hline(f, inner.x, inner.y + 1, inner.width, t);
 
     // ── "how to update" header, always shown above the notes ──
-    // Luvus cannot replace its running executable, so these rows copy the two
-    // supported upgrade commands instead. When the background check found a
-    // newer release, an accent headline leads.
+    // These rows copy the updater and package-specific upgrade commands. When
+    // the background check found a newer release, an accent headline leads.
     let mut top = inner.y + 2;
     if let Some(v) = app.update_available.clone() {
         f.render_widget(
@@ -115,7 +115,11 @@ pub(super) fn draw_changelog(f: &mut RenderTarget, area: Rect, app: &mut App, t:
     top += 1;
 
     app.changelog_copy_rects.clear();
-    for command in [CURL_UPDATE_COMMAND, BREW_UPDATE_COMMAND] {
+    for command in [
+        LUVUS_UPDATE_COMMAND,
+        CURL_UPDATE_COMMAND,
+        BREW_UPDATE_COMMAND,
+    ] {
         let row = Rect::new(inner.x + 1, top, inner.width.saturating_sub(2), 1);
         let hot = app
             .hover
@@ -477,7 +481,9 @@ fn hline(f: &mut RenderTarget, x: u16, y: u16, w: u16, t: &Theme) {
 
 #[cfg(test)]
 mod tests {
-    use super::{BREW_UPDATE_COMMAND, CHANGELOG_URL, CURL_UPDATE_COMMAND, RECENT};
+    use super::{
+        BREW_UPDATE_COMMAND, CHANGELOG_URL, CURL_UPDATE_COMMAND, LUVUS_UPDATE_COMMAND, RECENT,
+    };
     use crate::app::App;
     use crate::changelog::{Seg, CHANGELOG};
     use ratatui::backend::TestBackend;
@@ -780,7 +786,7 @@ mod tests {
     }
 
     #[test]
-    fn update_guide_shows_only_the_copyable_brew_and_curl_commands() {
+    fn update_guide_shows_the_copyable_luvus_brew_and_curl_commands() {
         let _env = crate::persist::test_env("cl-update-guide");
         let (app, term) = open();
         let screen: String = term
@@ -790,6 +796,7 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect();
+        assert!(screen.contains(LUVUS_UPDATE_COMMAND));
         assert!(screen.contains(CURL_UPDATE_COMMAND));
         assert!(screen.contains(BREW_UPDATE_COMMAND));
         assert!(!screen.contains("cargo install luvus"));
@@ -798,7 +805,11 @@ mod tests {
                 .iter()
                 .map(|(_, command)| command.as_str())
                 .collect::<Vec<_>>(),
-            vec![CURL_UPDATE_COMMAND, BREW_UPDATE_COMMAND]
+            vec![
+                LUVUS_UPDATE_COMMAND,
+                CURL_UPDATE_COMMAND,
+                BREW_UPDATE_COMMAND
+            ]
         );
     }
 

--- a/website/src/components/LegalPage.astro
+++ b/website/src/components/LegalPage.astro
@@ -5,6 +5,7 @@ import '../styles/themes.css';
 import { DEFAULT_THEME } from '../lib/themes';
 import Logo from './Logo.astro';
 import ThemeProvider from './ThemeProvider.astro';
+import XLogo from './XLogo.astro';
 
 interface Props {
   title: string;
@@ -16,6 +17,7 @@ interface Props {
 const { title, description, path, updated } = Astro.props;
 const canonical = new URL(path, 'https://luvus.dev').toString();
 const GITHUB = 'https://github.com/RizRiyz/luvus';
+const X = 'https://x.com/luvusdev';
 ---
 
 <!doctype html>
@@ -47,7 +49,10 @@ const GITHUB = 'https://github.com/RizRiyz/luvus';
           <a href="/docs/">Docs</a>
           <a href="/modules/">Modules</a>
           <a href="/changelog/">Changelog</a>
-          <a href={GITHUB}>GitHub</a>
+          <a href={GITHUB} class="social-icon" aria-label="Luvus on GitHub" title="GitHub">
+            <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path></svg>
+          </a>
+          <a href={X} class="social-icon" aria-label="Luvus on X" title="X"><XLogo /></a>
         </div>
       </div>
     </nav>
@@ -101,6 +106,16 @@ const GITHUB = 'https://github.com/RizRiyz/luvus';
   }
   .brand { display: inline-flex; align-items: center; gap: 0.65rem; font-weight: 760; font-size: 1.05rem; }
   .nav-links { display: flex; align-items: center; gap: 1.3rem; color: var(--sub); font-size: 0.9rem; }
+  .social-icon {
+    display: inline-flex;
+    width: 33px;
+    height: 33px;
+    flex: 0 0 33px;
+    box-sizing: border-box;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--line);
+  }
   .nav-links a:hover, .foot-links a:hover { color: var(--accent); }
   main { min-height: calc(100vh - 190px); }
   article { width: min(780px, calc(100% - 2.5rem)); margin: 0 auto; padding: 5rem 0 6rem; }

--- a/website/src/components/SocialIcons.astro
+++ b/website/src/components/SocialIcons.astro
@@ -4,7 +4,10 @@
 // the site header rather than like a separate documentation site. Starlight
 // renders this group in the header on desktop and in the mobile menu below it,
 // which is exactly where a site nav belongs on both.
+import XLogo from './XLogo.astro';
+
 const GITHUB = 'https://github.com/RizRiyz/luvus';
+const X = 'https://x.com/luvusdev';
 
 const LINKS = [
   { label: 'Docs', href: '/docs/' },
@@ -33,6 +36,9 @@ const path = Astro.url.pathname;
       ></path></svg
     >
   </a>
+  <a href={X} class="gh" aria-label="Luvus on X" title="X">
+    <XLogo />
+  </a>
 </nav>
 
 <style>
@@ -60,8 +66,12 @@ const path = Astro.url.pathname;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    width: 33px;
+    height: 33px;
+    flex: 0 0 33px;
+    box-sizing: border-box;
     border: 1px solid var(--line);
-    padding: 0.4rem;
+    padding: 0;
     transition: border-color 0.15s, color 0.15s;
   }
   .gh:hover {

--- a/website/src/components/XLogo.astro
+++ b/website/src/components/XLogo.astro
@@ -1,0 +1,22 @@
+---
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+const { width = 18, height = 18 } = Astro.props;
+---
+
+<svg
+  width={width}
+  height={height}
+  viewBox="0 0 1200 1227"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path
+    fill="currentColor"
+    d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z"
+  ></path>
+</svg>

--- a/website/src/pages/_compare.astro
+++ b/website/src/pages/_compare.astro
@@ -11,8 +11,10 @@ import '@fontsource/ibm-plex-mono/500.css';
 import '@fontsource/ibm-plex-mono/600.css';
 import '@fontsource/ibm-plex-mono/700.css';
 import Logo from '../components/Logo.astro';
+import XLogo from '../components/XLogo.astro';
 
 const GITHUB = 'https://github.com/RizRiyz/luvus';
+const X = 'https://x.com/luvusdev';
 const title = 'Compare luvus vs Herdr, tmux, and Zellij';
 const description =
   'How luvus compares to Herdr, tmux, and Zellij for running AI coding agents: live agent status, token and cost tracking, reboot-proof session resume, session forking, a built-in git tab, composable extensions, and multi-agent orchestration.';
@@ -186,6 +188,7 @@ const LANDSCAPE = [
               ></path></svg
             >
             </a>
+          <a href={X} class="gh" aria-label="Luvus on X" title="X"><XLogo /></a>
         </div>
       </div>
     </nav>
@@ -423,7 +426,8 @@ const LANDSCAPE = [
       .nav-links a[aria-current='page'] { color: var(--accent); }
       .gh {
         display: inline-flex; align-items: center; justify-content: center;
-        border: 1px solid var(--line); padding: 0.4rem;
+        width: 33px; height: 33px; flex: 0 0 33px; box-sizing: border-box;
+        border: 1px solid var(--line); padding: 0;
         transition: border-color 0.15s, color 0.15s;
       }
       .gh:hover { border-color: var(--accent); color: var(--accent); }

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -19,9 +19,11 @@ import '@fontsource/ibm-plex-mono/700.css';
 import '@fontsource/orbit/400.css'; // the wordmark face
 import { createMarkdownProcessor } from '@astrojs/markdown-remark';
 import Logo from '../components/Logo.astro';
+import XLogo from '../components/XLogo.astro';
 import { NAV_MARK } from '../lib/mark';
 
 const GITHUB = 'https://github.com/RizRiyz/luvus';
+const X = 'https://x.com/luvusdev';
 const RELEASES = `${GITHUB}/releases`;
 const title = 'Changelog — luvus';
 const description =
@@ -170,6 +172,7 @@ const entries = await Promise.all(
               ></path></svg
             >
             </a>
+          <a href={X} class="gh" aria-label="Luvus on X" title="X"><XLogo /></a>
         </div>
       </div>
     </nav>
@@ -398,7 +401,8 @@ const entries = await Promise.all(
       .nav-links a[aria-current='page'] { color: var(--accent); }
       .gh {
         display: inline-flex; align-items: center; justify-content: center;
-        border: 1px solid var(--line); padding: 0.4rem;
+        width: 33px; height: 33px; flex: 0 0 33px; box-sizing: border-box;
+        border: 1px solid var(--line); padding: 0;
         transition: border-color 0.15s, color 0.15s;
       }
       .gh:hover { border-color: var(--accent); color: var(--accent); }

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -14,6 +14,7 @@ import '@fontsource/ibm-plex-mono/600.css';
 import '@fontsource/ibm-plex-mono/700.css';
 import '@fontsource/orbit/400.css'; // the wordmark face
 import Logo from '../components/Logo.astro';
+import XLogo from '../components/XLogo.astro';
 // The surviving Luvus mark. Imported raw and retinted at build time so it can be a
 // theme-aware line drawing rather than a flat image:
 //   * the white backing rect goes, or it would be a white square on a dark page;
@@ -73,6 +74,7 @@ import IconAider from '../assets/icons/aider.svg';
 import droidMask from '../assets/icons/droid-mask.png';
 
 const GITHUB = 'https://github.com/RizRiyz/luvus';
+const X = 'https://x.com/luvusdev';
 
 // Every agent in `detect::KNOWN_AGENTS` (14), which CLAUDE.md requires this
 // grid to stay truthful to. `aider` and `droid` have no icon in assets/icons,
@@ -169,6 +171,7 @@ const ogImage = 'https://luvus.dev/og.png';
             ></path></svg
           >
         </a>
+        <a href={X} class="gh" aria-label="Luvus on X" title="X"><XLogo /></a>
       </div>
       </div>
     </nav>
@@ -473,6 +476,42 @@ const ogImage = 'https://luvus.dev/og.png';
         </article>
 
         <article class="frow">
+          <span class="fr-k">Review</span>
+          <div class="fr-text">
+            <h3>Review every change where the work happens</h3>
+            <p>DIFF keeps staged, worktree, untracked, and conflicted changes separate, then renders each file in Auto, Split, or Stack view. Leave a local note on one line or a range and send only that focused feedback to a live agent. It is read-only and never stages, discards, commits, or pushes.</p>
+            <a class="fc-go" href="/docs/guides/diff/">Native DIFF review →</a>
+          </div>
+          <div class="fm diff-mock" aria-hidden="true">
+            <div class="fm-head"><span>▴ DIFF · src/app.rs</span><em><b class="fd-add">+5</b> <b class="fd-del">-2</b> · SPLIT</em></div>
+            <div class="fd-hunk">@@ -42,4 +42,5 @@ fn dispatch</div>
+            <div class="fd-labels"><span>OLD</span><span>NEW</span></div>
+            <div class="fd-row">
+              <span class="fd-code del"><i>42 −</i><code>if input.is_empty() &#123;</code></span>
+              <span class="fd-code add"><i>42 +</i><code>let value = input.trim();</code></span>
+            </div>
+            <div class="fd-row">
+              <span class="fd-code del"><i>43 −</i><code>return Err(Empty);</code></span>
+              <span class="fd-code add"><i>43 +</i><code>if value.is_empty() &#123;</code></span>
+            </div>
+            <div class="fd-row">
+              <span class="fd-code gap"><i></i><code></code></span>
+              <span class="fd-code add"><i>44 +</i><code>return Err(Empty);</code></span>
+            </div>
+            <div class="fd-row">
+              <span class="fd-code ctx"><i>44</i><code>&#125;</code></span>
+              <span class="fd-code ctx"><i>45</i><code>&#125;</code></span>
+            </div>
+            <div class="fd-note">
+              <span><b>NOTE · R42-R44</b><em>local</em></span>
+              <p>Good guard. Add the whitespace-only case.</p>
+              <i>send → codex</i>
+            </div>
+            <div class="fm-foot">s split/stack · n note · a send to agent · f filter</div>
+          </div>
+        </article>
+
+        <article class="frow">
           <span class="fr-k">Read</span>
           <div class="fr-text">
             <h3>Read what agents touch</h3>
@@ -529,6 +568,36 @@ const ogImage = 'https://luvus.dev/og.png';
         </article>
 
         <article class="frow">
+          <span class="fr-k">Extend</span>
+          <div class="fr-text">
+            <h3>Put live status in the Luvus Bar</h3>
+            <p>Modules can publish compact, theme-aware widgets beside the tabs or inside the bottom status row without taking space from a pane. Move each widget to Top, Bottom, or Off from Layout settings or the CLI. When space gets tight, Luvus compacts widgets before protected tabs, key hints, or the version are touched.</p>
+            <a class="fc-go" href="/docs/guides/bar/">Build for the Luvus Bar →</a>
+          </div>
+          <div class="fm bar-mock" aria-hidden="true">
+            <div class="fb-shell">
+              <div class="fb-top">
+                <span class="fb-tab on">1 main</span>
+                <span class="fb-tab">2 ▴ diff</span>
+                <span class="fb-tab add">+</span>
+                <span class="fb-widget"><i></i> CI <b>14/14</b></span>
+              </div>
+              <div class="fb-pane">
+                <span><i>❯</i> cargo test --workspace</span>
+                <span class="dim">running 14 focused checks…</span>
+                <span class="pass">✓ all checks passed in 4.2s</span>
+              </div>
+              <div class="fb-bottom">
+                <span class="fb-prefix">⌃Space · prefix</span>
+                <span class="fb-runtime">NORMAL · 2 panes · tab 1/3</span>
+                <span class="fb-version">v0.11.0</span>
+              </div>
+            </div>
+            <div class="fm-foot"><b>CI status</b> · Top &nbsp; Bottom &nbsp; Off</div>
+          </div>
+        </article>
+
+        <article class="frow">
           <span class="fr-k">Reach</span>
           <div class="fr-text">
             <h3>Drive another machine</h3>
@@ -568,7 +637,7 @@ const ogImage = 'https://luvus.dev/og.png';
         <a href="/docs/extend/writing-modules/">modules in any language</a> ·
         <a href="/docs/reference/keybindings/">remappable keys</a> ·
         <a href="/docs/guides/layout/">movable panels and themes</a> ·
-        <a href="/docs/guides/bar/">a composable status bar</a>
+        <a href="/docs/guides/search/">global fuzzy search</a>
       </p>
     </section>
 
@@ -1354,7 +1423,8 @@ const ogImage = 'https://luvus.dev/og.png';
       .nav-links a:hover { color: var(--text); }
       .gh {
         display: inline-flex; align-items: center; justify-content: center;
-        border: 1px solid var(--line); padding: 0.4rem;
+        width: 33px; height: 33px; flex: 0 0 33px; box-sizing: border-box;
+        border: 1px solid var(--line); padding: 0;
         transition: border-color 0.15s, color 0.15s;
       }
       .gh:hover { border-color: var(--accent); color: var(--accent); }
@@ -1923,6 +1993,106 @@ const ogImage = 'https://luvus.dev/og.png';
       .fm-row .g { width: 3px; height: 0.75rem; border-radius: 2px; background: var(--line); flex: none; }
       .fm-row .g.m { background: var(--amber); }
       .fm-row .g.a { background: var(--green); }
+
+      /* Native DIFF mock. Paired rows keep old and new source aligned while
+         the colored edge, background, and +/- symbol mirror the three marker
+         options in Settings. The note occupies its own row just like the real
+         review surface, so it never covers source text. */
+      .diff-mock { gap: 0; }
+      .diff-mock .fm-head b { font-weight: 600; }
+      .fd-add { color: var(--mint); }
+      .fd-del { color: var(--coral); }
+      .fd-hunk {
+        padding: 0.22rem 0.35rem; color: var(--amber);
+        background: rgb(from var(--amber) r g b / 0.07);
+        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      }
+      .fd-labels, .fd-row { display: grid; grid-template-columns: 1fr 1fr; gap: 2px; }
+      .fd-labels {
+        color: var(--overlay1); font-size: 0.55rem; letter-spacing: 0.09em;
+        padding: 0.24rem 0 0.12rem;
+      }
+      .fd-labels span { padding-left: 0.35rem; }
+      .fd-code {
+        display: grid; grid-template-columns: 2.35rem minmax(0, 1fr); gap: 0.25rem;
+        min-width: 0; padding: 0.16rem 0.25rem; border-left: 3px solid transparent;
+      }
+      .fd-code i { font-style: normal; color: var(--overlay1); text-align: right; }
+      .fd-code code {
+        min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+        color: var(--sub2); font: inherit;
+      }
+      .fd-code.del {
+        border-color: var(--coral); background: rgb(from var(--coral) r g b / 0.14);
+      }
+      .fd-code.add {
+        border-color: var(--mint); background: rgb(from var(--mint) r g b / 0.14);
+      }
+      .fd-code.gap {
+        background: repeating-linear-gradient(
+          -45deg,
+          transparent 0 5px,
+          rgb(from var(--line) r g b / 0.42) 5px 6px
+        );
+      }
+      .fd-code.del i { color: var(--coral); }
+      .fd-code.add i { color: var(--mint); }
+      .fd-note {
+        margin: 0.42rem 0.1rem 0.1rem; padding: 0.42rem 0.5rem;
+        border: 1px solid rgb(from var(--accent) r g b / 0.7);
+        background: rgb(from var(--accent) r g b / 0.07);
+      }
+      .fd-note > span { display: flex; justify-content: space-between; gap: 0.5rem; }
+      .fd-note b { color: var(--accent); font-size: 0.58rem; letter-spacing: 0.06em; }
+      .fd-note em { color: var(--overlay1); font-style: normal; font-size: 0.58rem; }
+      .fd-note p { margin: 0.25rem 0; color: var(--sub2); line-height: 1.45; }
+      .fd-note > i { display: block; color: var(--mint); font-style: normal; text-align: right; }
+
+      /* Luvus Bar mock. The shell protects the three pieces real clients
+         protect: tabs on top, prefix help at bottom-left, and the clickable
+         version at bottom-right. Module content lives only in the remaining
+         space and therefore cannot change pane geometry. */
+      .fm.bar-mock { padding: 0; border: 0; background: none; }
+      .fb-shell { border: 1px solid var(--line); background: var(--bg2); overflow: hidden; }
+      .fb-top {
+        display: flex; align-items: center; gap: 0.22rem; min-width: 0;
+        padding: 0.3rem 0.38rem; border-bottom: 1px solid var(--line);
+      }
+      .fb-tab {
+        min-width: 0; padding: 0.08rem 0.3rem; color: var(--overlay1);
+        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      }
+      .fb-tab.on { color: var(--text); border-bottom: 1px solid var(--accent); }
+      .fb-tab.add { flex: none; color: var(--accent); }
+      .fb-widget {
+        display: inline-flex; align-items: center; gap: 0.28rem;
+        flex: none; margin-left: auto; padding: 0.1rem 0.34rem;
+        color: var(--sub2); border: 1px solid rgb(from var(--mint) r g b / 0.45);
+        background: rgb(from var(--mint) r g b / 0.08);
+      }
+      .fb-widget i { width: 5px; height: 5px; border-radius: 50%; background: var(--mint); }
+      .fb-widget b { color: var(--mint); font-weight: 600; }
+      .fb-pane {
+        min-height: 6.7rem; display: flex; flex-direction: column; justify-content: center;
+        gap: 0.34rem; padding: 0.75rem 0.8rem; color: var(--sub2);
+      }
+      .fb-pane span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .fb-pane i { color: var(--accent); font-style: normal; }
+      .fb-pane .dim { color: var(--overlay1); }
+      .fb-pane .pass { color: var(--mint); }
+      .fb-bottom {
+        display: flex; align-items: center; gap: 0.5rem; min-width: 0;
+        padding: 0.28rem 0.42rem; border-top: 1px solid var(--line);
+        color: var(--overlay1); font-size: 0.59rem;
+      }
+      .fb-prefix, .fb-version { flex: none; }
+      .fb-runtime {
+        min-width: 0; margin-left: auto; overflow: hidden;
+        text-overflow: ellipsis; white-space: nowrap; color: var(--sub2);
+      }
+      .fb-version { color: var(--accent); }
+      .bar-mock .fm-foot { display: flex; justify-content: flex-end; gap: 0.25rem; }
+      .bar-mock .fm-foot b { color: var(--sub2); font-weight: 500; margin-right: auto; }
 
       .fm .d { width: 6px; height: 6px; border-radius: 50%; flex: none; background: var(--overlay0); }
       .fm .d.run { background: var(--accent); }

--- a/website/src/pages/modules.astro
+++ b/website/src/pages/modules.astro
@@ -22,9 +22,11 @@ import '@fontsource/ibm-plex-mono/600.css';
 import '@fontsource/ibm-plex-mono/700.css';
 import '@fontsource/orbit/400.css'; // the wordmark face
 import Logo from '../components/Logo.astro';
+import XLogo from '../components/XLogo.astro';
 import { NAV_MARK } from '../lib/mark';
 
 const GITHUB = 'https://github.com/RizRiyz/luvus';
+const X = 'https://x.com/luvusdev';
 const TOPIC = 'luvus-module';
 const TOPIC_URL = `https://github.com/topics/${TOPIC}`;
 const SEARCH_API = `https://api.github.com/search/repositories?q=topic:${TOPIC}&sort=stars&order=desc&per_page=60`;
@@ -232,6 +234,7 @@ const examples = [
               ></path></svg
             >
             </a>
+          <a href={X} class="gh" aria-label="Luvus on X" title="X"><XLogo /></a>
         </div>
       </div>
     </nav>
@@ -644,7 +647,8 @@ const examples = [
       .nav-links a[aria-current='page'] { color: var(--accent); }
       .gh {
         display: inline-flex; align-items: center; justify-content: center;
-        border: 1px solid var(--line); padding: 0.4rem;
+        width: 33px; height: 33px; flex: 0 0 33px; box-sizing: border-box;
+        border: 1px solid var(--line); padding: 0;
         transition: border-color 0.15s, color 0.15s;
       }
       .gh:hover { border-color: var(--accent); color: var(--accent); }

--- a/website/src/pages/themes.astro
+++ b/website/src/pages/themes.astro
@@ -9,6 +9,7 @@ import '../styles/themes.css';
 import { NAV_MARK } from '../lib/mark';
 import { THEMES, DEFAULT_THEME } from '../lib/themes';
 import { MAKER_THEMES, THEME_FIELDS, THEME_GROUPS, THEME_FILE_VERSION, THEME_MIN_LUVUS } from '../lib/theme-schema';
+import XLogo from '../components/XLogo.astro';
 
 const makerStyle = (theme: (typeof MAKER_THEMES)[number]) =>
   THEME_FIELDS.map((field) => `${field.css}:${theme.colors[field.id]}`).join(';');
@@ -16,6 +17,7 @@ const makerStyle = (theme: (typeof MAKER_THEMES)[number]) =>
 const title = 'Luvus Theme Maker';
 const description = 'Choose a Luvus theme, edit every semantic color, preview the real interface instantly, and export a portable TOML theme.';
 const GITHUB = 'https://github.com/RizRiyz/luvus';
+const X = 'https://x.com/luvusdev';
 ---
 
 <!doctype html>
@@ -62,6 +64,7 @@ const GITHUB = 'https://github.com/RizRiyz/luvus';
           <a href={GITHUB} class="gh" aria-label="Luvus on GitHub" title="GitHub">
             <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path></svg>
           </a>
+          <a href={X} class="gh" aria-label="Luvus on X" title="X"><XLogo /></a>
         </div>
       </div>
     </nav>
@@ -587,7 +590,8 @@ const GITHUB = 'https://github.com/RizRiyz/luvus';
   .nav-links a[aria-current='page'] { color: var(--accent); }
   .gh {
     display: inline-flex; align-items: center; justify-content: center;
-    border: 1px solid var(--line); padding: 0.4rem;
+    width: 33px; height: 33px; flex: 0 0 33px; box-sizing: border-box;
+    border: 1px solid var(--line); padding: 0;
     transition: border-color 0.15s, color 0.15s;
   }
   .gh:hover { border-color: var(--accent); color: var(--accent); }


### PR DESCRIPTION
Show the new native review and extension surfaces on the Luvus website and make the in-app updater discoverable.

## Website

- Add DIFF review and Luvus Bar feature showcases to the homepage.
- Add the Luvus X profile to shared site navigation.
- Keep social controls aligned across the public pages.

## In-app updates

- Add the copyable `luvus update` command to the changelog update guide.

## Validation

- `cargo fmt --check`
- `cargo test --locked update_guide_shows_the_copyable_luvus_brew_and_curl_commands`
- `npm run build` in `website/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copyable `luvus update` command to the changelog modal.
  * Added X social links and icon buttons throughout the website.
  * Added homepage highlights for native DIFF review and Luvus Bar widgets.
  * Added global fuzzy search to the homepage.
* **Style**
  * Standardized social navigation icons to consistent square button sizing.
* **Tests**
  * Updated changelog coverage for copying all supported update commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->