### PR TITLE
fix(codex): report native sessions without clashing with server sessions

### DIFF
--- a/src/integration.rs
+++ b/src/integration.rs
@@ -259,7 +259,24 @@ pub fn install_copilot() -> Result<PathBuf> {
 }
 
 pub fn install_codex() -> Result<PathBuf> {
-    install_shell_hook("codex")
+    let dir = install_shell_hook("codex")?;
+    let cfg_path = dir.join("hooks.json");
+    let script = dir.join("luvus-agent-hook.sh");
+    let mut cfg: Value = fs::read_to_string(&cfg_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| json!({}));
+    // Codex provides the session id to both hooks. SessionStart is the earliest
+    // report, while UserPromptSubmit covers Code mode lifecycles where startup
+    // hooks are delayed or skipped.
+    register_hook(
+        &mut cfg,
+        "UserPromptSubmit",
+        None,
+        &script.to_string_lossy(),
+    );
+    fs::write(&cfg_path, serde_json::to_string_pretty(&cfg)?)?;
+    Ok(dir)
 }
 
 /// Install the opencode plugin (NI-4). No shell hook — write the JS plugin.
@@ -448,7 +465,7 @@ pub fn install(agent: &str) -> Result<()> {
 }
 
 /// Remove luvus's integration for `agent`. Deletes **only what `install` added** —
-/// the `luvus-agent-hook.sh` script + luvus's single hook entry (other entries and
+/// the `luvus-agent-hook.sh` script + luvus's hook entries (other entries and
 /// the config file itself are left intact), or the opencode plugin file. **Never
 /// touches the agent binary, its config, or its sessions.** Idempotent.
 pub fn uninstall(agent: &str) -> Result<()> {
@@ -493,11 +510,13 @@ pub fn uninstall(agent: &str) -> Result<()> {
     let cfg_path = spec.dir.join(spec.file);
     if let Ok(s) = fs::read_to_string(&cfg_path) {
         if let Ok(mut v) = serde_json::from_str::<Value>(&s) {
-            // Strip luvus's entry from the primary event and, for Claude, the
-            // extra lifecycle events installed alongside session detection.
+            // Strip luvus's entry from the primary event and the extra events
+            // installed alongside session detection.
             let mut events = vec![spec.event];
             if agent == "claude" {
                 events.extend(["Notification", "Stop"]);
+            } else if agent == "codex" {
+                events.push("UserPromptSubmit");
             }
             for evt in events {
                 if let Some(arr) = v
@@ -546,11 +565,27 @@ pub fn is_installed(agent: &str) -> bool {
     let Ok(v) = serde_json::from_str::<Value>(&s) else {
         return false;
     };
-    v.get("hooks")
+    let installed = v
+        .get("hooks")
         .and_then(|h| h.get(spec.event))
         .and_then(|a| a.as_array())
         .map(|arr| arr.iter().any(group_mentions_luvus))
-        .unwrap_or(false)
+        .unwrap_or(false);
+    if !installed {
+        return false;
+    }
+    // A previously installed Codex integration can predate the prompt hook.
+    // Treat that as incomplete so Settings offers an in-place refresh instead
+    // of an uninstall.
+    if agent == "codex" {
+        return v
+            .get("hooks")
+            .and_then(|h| h.get("UserPromptSubmit"))
+            .and_then(|a| a.as_array())
+            .map(|arr| arr.iter().any(group_mentions_luvus))
+            .unwrap_or(false);
+    }
+    true
 }
 
 /// Insert a command hook under `hooks.<event>` pointing at `script` (with an
@@ -770,7 +805,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_hook_installs_to_hooks_json_with_matcher() {
+    fn codex_hook_installs_start_and_prompt_session_reporting() {
         let _env = crate::persist::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -783,18 +818,40 @@ mod tests {
 
         let script = fs::read_to_string(tmp.join("luvus-agent-hook.sh")).unwrap();
         assert!(script.contains("--agent codex"), "reports as codex");
-        // Codex writes `hooks.json` (not settings.json), SessionStart with a matcher.
+        // Codex writes `hooks.json` (not settings.json). Keep SessionStart for
+        // immediate binding and UserPromptSubmit for Code mode fallbacks.
         let hooks: Value =
             serde_json::from_str(&fs::read_to_string(tmp.join("hooks.json")).unwrap()).unwrap();
-        let groups = hooks["hooks"]["SessionStart"].as_array().unwrap();
-        let luvus: Vec<&Value> = groups.iter().filter(|g| group_mentions_luvus(g)).collect();
-        assert_eq!(luvus.len(), 1);
-        assert_eq!(luvus[0]["matcher"].as_str(), Some("startup|resume"));
+        let start = hooks["hooks"]["SessionStart"].as_array().unwrap();
+        let start_luvus: Vec<&Value> = start.iter().filter(|g| group_mentions_luvus(g)).collect();
+        assert_eq!(start_luvus.len(), 1);
+        assert_eq!(start_luvus[0]["matcher"].as_str(), Some("startup|resume"));
+        let prompt = hooks["hooks"]["UserPromptSubmit"].as_array().unwrap();
+        assert_eq!(
+            prompt.iter().filter(|g| group_mentions_luvus(g)).count(),
+            1,
+            "one prompt hook remains after an idempotent reinstall"
+        );
         assert!(
             script.contains("LUVUS_BIN_PATH"),
             "the hook uses the exact server binary even when PATH is stale"
         );
         assert!(is_installed("codex"));
+
+        uninstall("codex").unwrap();
+        assert!(!is_installed("codex"));
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(tmp.join("hooks.json")).unwrap()).unwrap();
+        for event in ["SessionStart", "UserPromptSubmit"] {
+            assert!(
+                after["hooks"][event]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|group| !group_mentions_luvus(group)),
+                "uninstall removes only Luvus's {event} hook"
+            );
+        }
 
         std::env::remove_var("CODEX_HOME");
         let _ = fs::remove_dir_all(&tmp);

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -231,6 +231,7 @@ fn install_shell_hook(agent: &str) -> Result<PathBuf> {
         spec.event,
         spec.matcher,
         &script.to_string_lossy(),
+        None,
     );
     fs::write(&cfg_path, serde_json::to_string_pretty(&cfg)?)?;
     let _ = fs::remove_file(spec.dir.join("bohay-agent-hook.sh"));
@@ -248,7 +249,7 @@ pub fn install_claude() -> Result<PathBuf> {
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_else(|| json!({}));
     for evt in ["Notification", "Stop"] {
-        register_hook(&mut cfg, evt, None, &script.to_string_lossy());
+        register_hook(&mut cfg, evt, None, &script.to_string_lossy(), None);
     }
     fs::write(&cfg_path, serde_json::to_string_pretty(&cfg)?)?;
     Ok(dir)
@@ -274,6 +275,7 @@ pub fn install_codex() -> Result<PathBuf> {
         "UserPromptSubmit",
         None,
         &script.to_string_lossy(),
+        Some(5),
     );
     fs::write(&cfg_path, serde_json::to_string_pretty(&cfg)?)?;
     Ok(dir)
@@ -590,7 +592,13 @@ pub fn is_installed(agent: &str) -> bool {
 
 /// Insert a command hook under `hooks.<event>` pointing at `script` (with an
 /// optional group `matcher`), removing any prior luvus entry first.
-fn register_hook(settings: &mut Value, event: &str, matcher: Option<&str>, script: &str) {
+fn register_hook(
+    settings: &mut Value,
+    event: &str,
+    matcher: Option<&str>,
+    script: &str,
+    timeout_seconds: Option<u64>,
+) {
     if !settings.is_object() {
         *settings = json!({});
     }
@@ -613,7 +621,11 @@ fn register_hook(settings: &mut Value, event: &str, matcher: Option<&str>, scrip
     let arr = session_start.as_array_mut().unwrap();
     // Drop any previous luvus entries (idempotent reinstall).
     arr.retain(|group| !group_mentions_luvus(group));
-    let mut group = json!({ "hooks": [ { "type": "command", "command": script } ] });
+    let mut command = json!({ "type": "command", "command": script });
+    if let Some(timeout_seconds) = timeout_seconds {
+        command["timeout"] = json!(timeout_seconds);
+    }
+    let mut group = json!({ "hooks": [command] });
     if let Some(m) = matcher {
         group["matcher"] = json!(m);
     }
@@ -827,10 +839,16 @@ mod tests {
         assert_eq!(start_luvus.len(), 1);
         assert_eq!(start_luvus[0]["matcher"].as_str(), Some("startup|resume"));
         let prompt = hooks["hooks"]["UserPromptSubmit"].as_array().unwrap();
+        let prompt_luvus: Vec<&Value> = prompt.iter().filter(|g| group_mentions_luvus(g)).collect();
         assert_eq!(
-            prompt.iter().filter(|g| group_mentions_luvus(g)).count(),
+            prompt_luvus.len(),
             1,
             "one prompt hook remains after an idempotent reinstall"
+        );
+        assert_eq!(
+            prompt_luvus[0]["hooks"][0]["timeout"].as_u64(),
+            Some(5),
+            "prompt reporting has a bounded hook timeout"
         );
         assert!(
             script.contains("LUVUS_BIN_PATH"),

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -197,8 +197,10 @@ fn switched_args(raw: &[String], name: &str) -> Vec<String> {
             index += 1;
             continue;
         }
-        out.push(raw[index].clone());
-        index += 1;
+        // Only replace an initial global selector. Later flags belong to the
+        // command itself, for example `pane report --session <native-id>`.
+        out.extend_from_slice(&raw[index..]);
+        break;
     }
     out
 }
@@ -719,6 +721,31 @@ mod render_tests {
             ["--session", "new", "--remote", "host", "-p", "2222"]
         );
     }
+
+    #[test]
+    fn session_handoff_preserves_subcommand_session_flags() {
+        let raw = vec![
+            "luvus".to_string(),
+            "--session".to_string(),
+            "old".to_string(),
+            "pane".to_string(),
+            "report".to_string(),
+            "--session".to_string(),
+            "native-rollout".to_string(),
+        ];
+        assert_eq!(
+            switched_args(&raw, "new"),
+            [
+                "--session",
+                "new",
+                "pane",
+                "report",
+                "--session",
+                "native-rollout"
+            ]
+        );
+    }
+
     #[test]
     fn incremental_diff_reconstructs_the_screen() {
         let cell = |s: &str| protocol::CellData {

--- a/src/session.rs
+++ b/src/session.rs
@@ -30,8 +30,10 @@ pub struct SessionInfo {
     pub session_dir: String,
 }
 
-/// Resolve `session attach` and global `--session` flags before normal routing.
-/// The returned argv no longer contains the selector.
+/// Resolve `session attach` and leading global `--session` flags before normal
+/// routing. A subcommand may also own a `--session` flag, such as
+/// `pane report --session <native-agent-id>`, so parsing stops at its command.
+/// The returned argv no longer contains only the global selector.
 pub fn configure_from_args(args: &[String]) -> Result<Vec<String>, String> {
     if args.get(1).map(String::as_str) == Some("session")
         && args.get(2).map(String::as_str) == Some("attach")
@@ -81,8 +83,10 @@ pub fn configure_from_args(args: &[String]) -> Result<Vec<String>, String> {
             index += 1;
             continue;
         }
-        cleaned.push(arg.clone());
-        index += 1;
+        // Global options belong before the command. Do not scan the remaining
+        // argv or a report's native session id would select a server namespace.
+        cleaned.extend_from_slice(&args[index..]);
+        break;
     }
 
     if let Some(name) = requested {
@@ -377,6 +381,24 @@ mod tests {
             crate::persist::cli_socket_path(),
             api_socket_path_for(Some("alpha"))
         );
+    }
+
+    #[test]
+    fn subcommand_session_flag_is_not_a_server_selector() {
+        let _env = crate::persist::test_env("session-subcommand-flag");
+        let raw = argv(&[
+            "luvus",
+            "pane",
+            "report",
+            "--agent",
+            "codex",
+            "--session",
+            "019ffe06-aacc-7131-a377-e66bb39c211b",
+        ]);
+        let cleaned = configure_from_args(&raw).unwrap();
+        assert_eq!(cleaned, raw, "the report owns its native session id");
+        assert_eq!(active_name(), None);
+        assert!(!explicit_session_requested());
     }
 
     #[test]

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -131,8 +131,8 @@ Codex forks require the exact session identity reported by its integration or
 recorded when Luvus resumes a session. Luvus never guesses the newest Codex
 rollout in a shared folder, because that could fork another pane's active
 conversation. Install or refresh the hook with
-`luvus integration install codex`; its SessionStart hook binds both new and
-resumed Codex panes to their exact rollout.
+`luvus integration install codex`; its SessionStart and prompt hooks bind new
+and resumed Codex panes to their exact rollout.
 
 ## Precise events: the integration hook
 


### PR DESCRIPTION
## Summary

- preserve subcommand-owned `--session` flags so native agent session reports reach the active Luvus server
- register Codex session reporting for both `SessionStart` and `UserPromptSubmit`
- identify legacy Codex hook installs as incomplete so Settings can refresh them in place
- preserve native session flags when handing a command to a named session

## Why

Codex session reports use `pane report --session <native-session-id>`. The CLI previously interpreted that flag as a global Luvus server-session selector, redirected the report to a nonexistent socket, and left Codex panes without the exact session binding required for Fork.

## Validation

- `cargo fmt --check`
- focused parser, remote-handoff, Codex integration, and fork-menu tests
- debug client report verified against a running Luvus server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex integration now supports SessionStart and prompt hooks, including resumed sessions, with a five-second timeout.
  * Hooks bind new and resumed Codex panes to their exact rollout.

* **Bug Fixes**
  * Preserved command-specific session selections when processing nested commands.
  * Improved hook installation and cleanup behavior for Codex integrations.

* **Documentation**
  * Updated agent integration guidance to describe the expanded Codex hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->