### PR TITLE
fix(modules): restore discovery and add copyable install commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,14 +90,17 @@ jobs:
           cargo test --locked app::backend::tests
           cargo test --locked terminal::backend::tests
       - name: Validate published protocol fixtures
+        shell: pwsh
         run: |
           python examples/terminal-backend/consumer.py --fixtures
-          python examples/terminal-backend/mock_conformance.py
+          if ($LASTEXITCODE -ne 0) { throw "terminal-backend fixture validation failed" }
           python examples/runtime-api/consumer.py
+          if ($LASTEXITCODE -ne 0) { throw "runtime-api fixture validation failed" }
       - name: Validate named pipes and ConPTY live
         shell: pwsh
         run: |
           cargo build --locked
+          if ($LASTEXITCODE -ne 0) { throw "Windows debug build failed" }
           .\examples\terminal-backend\live_conformance.ps1 `
             -Luvus .\target\debug\luvus.exe
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,32 +91,6 @@ perf(render): avoid repeated frame allocations
 docs: clarify module setup
 ```
 
-### AI assistance and transparency
-
-Disclose substantial use of AI tools when their output or technical direction
-is included in a commit. Add an `Assisted-by:` trailer with the tool name and
-the primary model name and version:
-
-```text
-feat(search): add global fuzzy finder
-
-Assisted-by: OpenAI Codex (GPT-5.6-sol)
-```
-
-An AI-assisted contribution must still be understood, reviewed, and owned by
-the contributor. Check generated code and documentation for correctness,
-security, licensing, performance, and compatibility before submitting it.
-
-`Co-authored-by:` does not replace `Assisted-by:`. If an AI tool substantially
-writes a pull request description or review comment, disclose that assistance
-in the description or comment as well because commit trailers only describe
-the commits.
-
-Standard formatters, deterministic editor actions, and short boilerplate
-autocomplete do not require a trailer. Research, testing, debugging, or private
-review also does not require one when no substantial AI output or technical
-direction is included in the contribution. When uncertain, disclose it.
-
 Luvus squash-merges pull requests, so follow-up commits during review are fine.
 You do not need to rebuild a perfect commit history before submitting changes.
 

--- a/examples/terminal-backend/live_conformance.ps1
+++ b/examples/terminal-backend/live_conformance.ps1
@@ -70,19 +70,20 @@ function Close-PipeConnection {
 function Read-BoundedLine {
     param(
         [Parameter(Mandatory)]$Reader,
-        [int]$TimeoutMs = 5000
+        [int]$TimeoutMs = 5000,
+        [string]$Context = "named-pipe response"
     )
 
     $Task = $Reader.ReadLineAsync()
     if (-not $Task.Wait($TimeoutMs)) {
-        throw "named-pipe response timed out"
+        throw "$Context timed out"
     }
     $Line = $Task.Result
     if ($null -eq $Line) {
-        throw "named-pipe response ended before LF"
+        throw "$Context ended before LF"
     }
     if ([System.Text.Encoding]::UTF8.GetByteCount($Line) + 1 -gt 1MB) {
-        throw "named-pipe response exceeded the protocol frame limit"
+        throw "$Context exceeded the protocol frame limit"
     }
     $Line
 }
@@ -102,7 +103,8 @@ function Send-Request {
         $Connection.Writer.Write($Json + "`n")
         $Connection.Writer.Flush()
         try {
-            $Response = (Read-BoundedLine $Connection.Reader) | ConvertFrom-Json
+            $Response = (Read-BoundedLine -Reader $Connection.Reader `
+                -Context "request '$($Request.id)' response") | ConvertFrom-Json
         } catch {
             throw "named-pipe request '$($Request.id)' failed: $($_.Exception.Message)"
         }
@@ -126,7 +128,8 @@ function Wait-TerminalEvent {
     $Deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
     while ([DateTime]::UtcNow -lt $Deadline) {
         $RemainingMs = [Math]::Max(1, [int]($Deadline - [DateTime]::UtcNow).TotalMilliseconds)
-        $Received = (Read-BoundedLine -Reader $Connection.Reader -TimeoutMs $RemainingMs) | ConvertFrom-Json
+        $Received = (Read-BoundedLine -Reader $Connection.Reader -TimeoutMs $RemainingMs `
+            -Context "event '$Name'") | ConvertFrom-Json
         if ($Received.event -eq "terminal.resync_required") {
             throw "terminal event stream overflowed during conformance"
         }
@@ -222,7 +225,8 @@ try {
         params = @{}
     } | ConvertTo-Json -Compress) + "`n")
     $EventConnection.Writer.Flush()
-    $Subscribed = (Read-BoundedLine $EventConnection.Reader) | ConvertFrom-Json
+    $Subscribed = (Read-BoundedLine -Reader $EventConnection.Reader `
+        -Context "event subscription response") | ConvertFrom-Json
     if ($Subscribed.result.type -ne "subscription_started") {
         throw "terminal event subscription did not start"
     }

--- a/examples/terminal-backend/live_conformance.ps1
+++ b/examples/terminal-backend/live_conformance.ps1
@@ -101,9 +101,13 @@ function Send-Request {
         }
         $Connection.Writer.Write($Json + "`n")
         $Connection.Writer.Flush()
-        $Response = (Read-BoundedLine $Connection.Reader) | ConvertFrom-Json
+        try {
+            $Response = (Read-BoundedLine $Connection.Reader) | ConvertFrom-Json
+        } catch {
+            throw "named-pipe request '$($Request.id)' failed: $($_.Exception.Message)"
+        }
         if ($Response.id -ne $Request.id) {
-            throw "named-pipe response id mismatch"
+            throw "named-pipe request '$($Request.id)' received response id '$($Response.id)'"
         }
         $Response
     } finally {
@@ -177,6 +181,21 @@ try {
         }
     } finally {
         Close-PipeConnection $IdentityProbe
+    }
+
+    # Exercise the one-request-per-connection path immediately after a client
+    # disconnects without sending a frame. This catches response bytes being
+    # lost when Windows named-pipe handlers close rapidly.
+    for ($Attempt = 0; $Attempt -lt 32; $Attempt++) {
+        $RequestId = "rapid-$Attempt"
+        $Rapid = Send-Request $Address @{
+            id = $RequestId
+            method = "terminal.backend.capabilities"
+            params = @{ protocol = @{ name = "luvus-terminal-backend"; major = 1; minor = 0 } }
+        }
+        if ($Rapid.result.protocol.major -ne 1 -or $Rapid.result.protocol.minor -ne 0) {
+            throw "rapid named-pipe request '$RequestId' returned an invalid protocol"
+        }
     }
 
     $Capability = Send-Request $Address @{

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -166,14 +166,15 @@ pub(crate) fn read_response_frame(reader: &mut impl BufRead) -> io::Result<Strin
 
 fn write_response(writer: &mut impl Write, id: &str, response: &str) -> io::Result<()> {
     if response.len().saturating_add(1) <= crate::terminal::backend::MAX_FRAME_BYTES {
-        writeln!(writer, "{response}")
+        writeln!(writer, "{response}")?;
     } else {
         writeln!(
             writer,
             "{}",
             json!({"id":id,"error":{"code":"internal","message":"response exceeded protocol frame limit"}})
-        )
+        )?;
     }
+    writer.flush()
 }
 
 /// Reject duplicate JSON object keys before deserializing into `Value`, which
@@ -784,6 +785,33 @@ fn parse_timeout_s(params: &Value) -> Result<Option<std::time::Duration>, &'stat
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Default)]
+    struct FlushProbe {
+        bytes: Vec<u8>,
+        flushes: usize,
+    }
+
+    impl Write for FlushProbe {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flushes += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn responses_are_lf_framed_and_flushed_before_disconnect() {
+        let mut writer = FlushProbe::default();
+        write_response(&mut writer, "test", r#"{"id":"test","result":{}}"#).unwrap();
+
+        assert_eq!(writer.bytes, b"{\"id\":\"test\",\"result\":{}}\n");
+        assert_eq!(writer.flushes, 1);
+    }
 
     #[test]
     fn bounded_frame_requires_lf_and_stops_after_one_request() {

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -540,12 +540,19 @@ fn handle_conn(stream: Conn, event_tx: Sender<AppEvent>, bus: EventBus) {
         // …while this thread watches the read side: EOF/error = the client is
         // gone, so unsubscribe NOW instead of lingering in the bus until the
         // next publish happens to notice the dead channel.
-        let _ = reader
+        let timeout_mode = reader
             .get_ref()
-            .set_timeouts(std::time::Duration::from_millis(250));
+            .set_timeouts(std::time::Duration::from_millis(250))
+            .ok();
         let mut probe = [0_u8; 1024];
         while active.load(Ordering::Acquire) {
             match reader.read(&mut probe) {
+                Ok(0) if timeout_mode == Some(transport::TimeoutMode::Nonblocking) => {
+                    // Windows byte-mode named pipes can report a zero-byte
+                    // successful read for PIPE_NOWAIT when no data is ready.
+                    // A later write still detects a disconnected subscriber.
+                    thread::sleep(std::time::Duration::from_millis(25));
+                }
                 Ok(0) => break,
                 Ok(_) => {}
                 Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
@@ -746,6 +753,12 @@ fn wait_for_parked_reply(
             Err(TryRecvError::Empty) => {}
         }
         match reader.read(&mut probe) {
+            Ok(0) if timeout_mode == Some(transport::TimeoutMode::Nonblocking) => {
+                // On Windows PIPE_NOWAIT, zero bytes can mean that no input is
+                // ready rather than EOF. The app-owned timeout still bounds
+                // this wait and the response write detects a disconnected peer.
+                thread::sleep(std::time::Duration::from_millis(25));
+            }
             Ok(0) => break,
             Ok(_) => {}
             Err(error)

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -555,8 +555,20 @@ fn handle_conn(stream: Conn, event_tx: Sender<AppEvent>, bus: EventBus) {
                 }
                 Ok(0) => break,
                 Ok(_) => {}
-                Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    if timeout_mode == Some(transport::TimeoutMode::Nonblocking) {
+                        thread::sleep(std::time::Duration::from_millis(25));
+                    }
+                }
+                Err(error)
+                    if timeout_mode == Some(transport::TimeoutMode::Nonblocking)
+                        && transport::nonblocking_read_pending(&error) =>
+                {
                     thread::sleep(std::time::Duration::from_millis(25));
                 }
                 Err(_) => break,
@@ -770,6 +782,12 @@ fn wait_for_parked_reply(
                 if timeout_mode == Some(transport::TimeoutMode::Nonblocking) {
                     thread::sleep(std::time::Duration::from_millis(25));
                 }
+            }
+            Err(error)
+                if timeout_mode == Some(transport::TimeoutMode::Nonblocking)
+                    && transport::nonblocking_read_pending(&error) =>
+            {
+                thread::sleep(std::time::Duration::from_millis(25));
             }
             Err(_) => break,
         }

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -177,6 +177,11 @@ fn write_response(writer: &mut impl Write, id: &str, response: &str) -> io::Resu
     writer.flush()
 }
 
+fn write_event_frame(writer: &mut impl Write, event: &str) -> io::Result<()> {
+    writeln!(writer, "{event}")?;
+    writer.flush()
+}
+
 /// Reject duplicate JSON object keys before deserializing into `Value`, which
 /// would otherwise silently keep the last value and make validation ambiguous.
 fn reject_duplicate_keys(bytes: &[u8]) -> Result<(), serde_json::Error> {
@@ -525,12 +530,13 @@ fn handle_conn(stream: Conn, event_tx: Sender<AppEvent>, bus: EventBus) {
                 if !fwd_active.load(Ordering::Acquire) {
                     let dropped_at = overflow_sequence.load(Ordering::Acquire);
                     if dropped_at > 0 {
-                        let _ = writeln!(fwd_writer, "{}", resync_event(filter, dropped_at));
+                        let _ =
+                            write_event_frame(&mut fwd_writer, &resync_event(filter, dropped_at));
                     }
                     break;
                 }
                 if evt.len().saturating_add(1) > crate::terminal::backend::MAX_FRAME_BYTES
-                    || writeln!(fwd_writer, "{evt}").is_err()
+                    || write_event_frame(&mut fwd_writer, &evt).is_err()
                 {
                     fwd_active.store(false, Ordering::Release);
                     break;
@@ -841,6 +847,15 @@ mod tests {
         write_response(&mut writer, "test", r#"{"id":"test","result":{}}"#).unwrap();
 
         assert_eq!(writer.bytes, b"{\"id\":\"test\",\"result\":{}}\n");
+        assert_eq!(writer.flushes, 1);
+    }
+
+    #[test]
+    fn subscription_events_are_lf_framed_and_flushed_immediately() {
+        let mut writer = FlushProbe::default();
+        write_event_frame(&mut writer, r#"{"event":"terminal.closed"}"#).unwrap();
+
+        assert_eq!(writer.bytes, b"{\"event\":\"terminal.closed\"}\n");
         assert_eq!(writer.flushes, 1);
     }
 

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -138,7 +138,19 @@ impl Write for Conn {
         (&*self.0).write(buf)
     }
     fn flush(&mut self) -> io::Result<()> {
-        (&*self.0).flush()
+        #[cfg(windows)]
+        {
+            // `interprocess` intentionally makes `Write::flush` on its local
+            // socket wrapper a no-op on Windows. Reach the named-pipe stream
+            // so one-shot responses are delivered before this connection is
+            // dropped instead of relying on the crate's deferred drop flush.
+            let Stream::NamedPipe(pipe) = &*self.0;
+            pipe.inner().flush()
+        }
+        #[cfg(not(windows))]
+        {
+            (&*self.0).flush()
+        }
     }
 }
 

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -127,6 +127,23 @@ impl Conn {
     }
 }
 
+/// Whether a nonblocking local-socket read should be retried. Windows reports
+/// `ERROR_NO_DATA` for a connected PIPE_NOWAIT stream with no input available,
+/// and Rust maps that code to `BrokenPipe` rather than `WouldBlock`.
+pub fn nonblocking_read_pending(error: &io::Error) -> bool {
+    if error.kind() == io::ErrorKind::WouldBlock {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        error.raw_os_error() == Some(windows_sys::Win32::Foundation::ERROR_NO_DATA as i32)
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 impl Read for Conn {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (&*self.0).read(buf)
@@ -379,7 +396,8 @@ mod tests {
 
 #[cfg(all(test, windows))]
 mod windows_tests {
-    use super::{legacy_pipe_id, pipe_id};
+    use super::{legacy_pipe_id, nonblocking_read_pending, pipe_id};
+    use std::io;
     use std::path::Path;
 
     #[test]
@@ -404,5 +422,13 @@ mod windows_tests {
             current.strip_prefix("luvus-"),
             legacy.strip_prefix("bohay-")
         );
+    }
+
+    #[test]
+    fn pipe_nowait_no_data_is_retryable_despite_broken_pipe_kind() {
+        let error =
+            io::Error::from_raw_os_error(windows_sys::Win32::Foundation::ERROR_NO_DATA as i32);
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+        assert!(nonblocking_read_pending(&error));
     }
 }

--- a/src/module/discovery.rs
+++ b/src/module/discovery.rs
@@ -26,10 +26,10 @@ pub fn search(query: Option<&str>) -> Result<Vec<RepoHit>> {
 
 /// Build the GitHub search URL (most-starred first, capped at 30 results).
 fn build_url(query: Option<&str>) -> String {
-    // Keep 0.10 modules discoverable during the rename window. GitHub search
-    // treats the explicit OR as a union; duplicate repositories are returned
-    // only once by the API.
-    let mut q = String::from("topic:luvus-module OR topic:bohay-module");
+    // GitHub topic qualifiers are not reliably composable with `OR` and an
+    // additional free-text query. Search the canonical topic only so keyword
+    // filtering keeps the topic constraint attached to every result.
+    let mut q = String::from("topic:luvus-module");
     if let Some(extra) = query.map(str::trim).filter(|s| !s.is_empty()) {
         q.push(' ');
         q.push_str(extra);
@@ -136,16 +136,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn url_encodes_the_topic_query() {
-        let url = build_url(None);
-        assert!(
-            url.contains("q=topic%3Aluvus-module%20OR%20topic%3Abohay-module"),
-            "{url}"
+    fn url_encodes_the_canonical_topic_query() {
+        assert_eq!(
+            build_url(None),
+            "https://api.github.com/search/repositories?q=topic%3Aluvus-module&sort=stars&order=desc&per_page=30"
         );
-        let url = build_url(Some("git status"));
-        assert!(url.contains("topic%3Abohay-module%20git%20status"), "{url}");
-        // No raw spaces or colons leak into the URL.
-        assert!(!url.contains(' ') && !url.contains("q=topic:"));
+        assert_eq!(
+            build_url(Some("git status")),
+            "https://api.github.com/search/repositories?q=topic%3Aluvus-module%20git%20status&sort=stars&order=desc&per_page=30"
+        );
+        assert_eq!(build_url(Some("  ")), build_url(None));
+        assert!(!build_url(Some("media")).contains("bohay-module"));
     }
 
     #[test]

--- a/src/search/federation.rs
+++ b/src/search/federation.rs
@@ -255,10 +255,10 @@ fn request_nonblocking(
     let mut chunk = [0u8; 16 * 1024];
     loop {
         match stream.read(&mut chunk) {
-            Ok(0) if response.is_empty() => {
-                return Err("session returned an empty response".to_string())
-            }
-            Ok(0) => break,
+            // Windows PIPE_NOWAIT can return a successful zero-byte read when
+            // no response data is ready yet. This helper is only used for the
+            // nonblocking timeout fallback, so keep waiting for LF or deadline.
+            Ok(0) => wait_for_io(deadline)?,
             Ok(bytes) => {
                 let room = (MAX_SESSION_RESPONSE_BYTES as usize + 1).saturating_sub(response.len());
                 response.extend_from_slice(&chunk[..bytes.min(room)]);
@@ -311,6 +311,10 @@ mod tests {
 
     struct NeverReady;
 
+    struct ZeroThenResponse {
+        reads: usize,
+    }
+
     impl Read for NeverReady {
         fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
             Err(std::io::ErrorKind::WouldBlock.into())
@@ -320,6 +324,28 @@ mod tests {
     impl Write for NeverReady {
         fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
             Err(std::io::ErrorKind::WouldBlock.into())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Read for ZeroThenResponse {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.reads += 1;
+            if self.reads == 1 {
+                return Ok(0);
+            }
+            let response = b"{\"id\":\"federated-search\",\"result\":{}}\n";
+            buf[..response.len()].copy_from_slice(response);
+            Ok(response.len())
+        }
+    }
+
+    impl Write for ZeroThenResponse {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
         }
 
         fn flush(&mut self) -> std::io::Result<()> {
@@ -340,6 +366,16 @@ mod tests {
             .unwrap_err();
         assert!(error.contains("timed out"));
         assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn nonblocking_fallback_retries_zero_byte_reads() {
+        let mut stream = ZeroThenResponse { reads: 0 };
+        let response =
+            request_nonblocking(&mut stream, b"request\n", Duration::from_millis(100)).unwrap();
+
+        assert!(response.ends_with('\n'));
+        assert_eq!(stream.reads, 2);
     }
 
     #[test]

--- a/src/search/federation.rs
+++ b/src/search/federation.rs
@@ -270,7 +270,7 @@ fn request_nonblocking(
                 }
             }
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            Err(error) if crate::ipc::transport::nonblocking_read_pending(&error) => {
                 wait_for_io(deadline)?;
             }
             Err(error) => return Err(format!("session search timed out or failed: {error}")),

--- a/website/src/pages/modules.astro
+++ b/website/src/pages/modules.astro
@@ -309,39 +309,50 @@ const examples = [
 
       <div id="grid" class="grid">
         {
-          repos.map((r) => (
-            <a class="mod" href={r.url}>
-              <div class="mhead">
-                {r.avatar && (
-                  <img class="avatar" src={r.avatar} alt="" width="26" height="26" loading="lazy" />
-                )}
-                <span class="mname">{r.name}</span>
-                <span class="stars" title={`${r.stars} stars`}>
-                  ★ {r.stars}
-                </span>
-              </div>
-              <span class="mowner">{r.owner}</span>
-              <p class="mdesc">{r.description || 'No description provided.'}</p>
-              <div class="meta">
-                {r.language && (
-                  <span class="mi">
-                    <i class="dot" style={`background:${LANG_COLOR[r.language] ?? 'var(--accent)'}`} />
-                    {r.language}
+          repos.map((r) => {
+            const command = `luvus module install ${r.full_name}`;
+            return (
+              <article class="mod">
+                <div class="mhead">
+                  {r.avatar && (
+                    <img class="avatar" src={r.avatar} alt="" width="26" height="26" loading="lazy" />
+                  )}
+                  <a class="mname" href={r.url}>{r.name}</a>
+                  <span class="stars" title={`${r.stars} stars`}>
+                    ★ {r.stars}
                   </span>
-                )}
-                {r.forks > 0 && <span class="mi">{r.forks} forks</span>}
-                {r.pushed && <span class="mi">updated {rel(r.pushed)}</span>}
-              </div>
-              {r.topics.length > 0 && (
-                <div class="mfoot">
-                  {r.topics.map((t) => (
-                    <span class="chip">{t}</span>
-                  ))}
                 </div>
-              )}
-              <code class="install">luvus module install {r.full_name}</code>
-            </a>
-          ))
+                <span class="mowner">{r.owner}</span>
+                <p class="mdesc">{r.description || 'No description provided.'}</p>
+                <div class="meta">
+                  {r.language && (
+                    <span class="mi">
+                      <i class="dot" style={`background:${LANG_COLOR[r.language] ?? 'var(--accent)'}`} />
+                      {r.language}
+                    </span>
+                  )}
+                  {r.forks > 0 && <span class="mi">{r.forks} forks</span>}
+                  {r.pushed && <span class="mi">updated {rel(r.pushed)}</span>}
+                </div>
+                {r.topics.length > 0 && (
+                  <div class="mfoot">
+                    {r.topics.map((t) => (
+                      <span class="chip">{t}</span>
+                    ))}
+                  </div>
+                )}
+                <div class="install-row">
+                  <code class="install">{command}</code>
+                  <button
+                    type="button"
+                    class="copy-install"
+                    data-command={command}
+                    aria-label={`Copy install command for ${r.full_name}`}
+                  >COPY</button>
+                </div>
+              </article>
+            );
+          })
         }
       </div>
 
@@ -375,12 +386,12 @@ const examples = [
       <div class="grid">
         {
           examples.map((e) => (
-            <a class="mod" href={`${GITHUB}/tree/main/${e.path}`}>
+            <article class="mod">
               <div class="mhead">
                 <span class="avatar ex" aria-hidden="true">
                   ◇
                 </span>
-                <span class="mname">{e.name}</span>
+                <a class="mname" href={`${GITHUB}/tree/main/${e.path}`}>{e.name}</a>
                 <span class="tag">example</span>
               </div>
               <span class="mowner">{e.owner}</span>
@@ -398,8 +409,16 @@ const examples = [
                   <span class="chip">{t}</span>
                 ))}
               </div>
-              <code class="install">{e.install}</code>
-            </a>
+              <div class="install-row">
+                <code class="install">{e.install}</code>
+                <button
+                  type="button"
+                  class="copy-install"
+                  data-command={e.install}
+                  aria-label={`Copy command for ${e.name}`}
+                >COPY</button>
+              </div>
+            </article>
           ))
         }
       </div>
@@ -502,16 +521,20 @@ const examples = [
         const avatar = r.owner?.avatar_url
           ? `<img class="avatar" src="${esc(r.owner.avatar_url)}" alt="" width="26" height="26" loading="lazy">`
           : '';
-        return `<a class="mod" href="${esc(r.html_url)}">
-          <div class="mhead">${avatar}<span class="mname">${esc(r.name)}</span>
+        const command = `luvus module install ${r.full_name}`;
+        return `<article class="mod">
+          <div class="mhead">${avatar}<a class="mname" href="${esc(r.html_url)}">${esc(r.name)}</a>
             <span class="stars" title="${r.stargazers_count ?? 0} stars">★ ${r.stargazers_count ?? 0}</span>
           </div>
           <span class="mowner">${esc(r.owner?.login ?? '')}</span>
           <p class="mdesc">${esc(r.description || 'No description provided.')}</p>
           <div class="meta">${lang}${forks}${upd}</div>
           ${topics ? `<div class="mfoot">${topics}</div>` : ''}
-          <code class="install">luvus module install ${esc(r.full_name)}</code>
-        </a>`;
+          <div class="install-row">
+            <code class="install">${esc(command)}</code>
+            <button type="button" class="copy-install" data-command="${esc(command)}" aria-label="Copy install command for ${esc(r.full_name)}">COPY</button>
+          </div>
+        </article>`;
       };
 
       const paint = () => {
@@ -538,6 +561,51 @@ const examples = [
       };
 
       document.getElementById('sort')?.addEventListener('change', paint);
+
+      const writeClipboard = async (text) => {
+        if (navigator.clipboard?.writeText) {
+          try {
+            await navigator.clipboard.writeText(text);
+            return;
+          } catch {
+            // Older browser policies can expose the API but reject writes;
+            // fall through to the selection-based copy path.
+          }
+        }
+        const input = document.createElement('textarea');
+        input.value = text;
+        input.setAttribute('readonly', '');
+        input.style.position = 'fixed';
+        input.style.opacity = '0';
+        document.body.appendChild(input);
+        input.select();
+        const copied = document.execCommand('copy');
+        input.remove();
+        if (!copied) throw new Error('clipboard unavailable');
+      };
+
+      // Delegation covers both build-time cards and cards replaced by the live
+      // GitHub refresh. The command comes from one value shared by the visible
+      // code and data attribute, so COPY cannot drift from what the card shows.
+      document.addEventListener('click', async (event) => {
+        const button = event.target instanceof Element
+          ? event.target.closest('.copy-install')
+          : null;
+        if (!(button instanceof HTMLButtonElement) || button.disabled) return;
+        const command = button.dataset.command;
+        if (!command) return;
+        button.disabled = true;
+        try {
+          await writeClipboard(command);
+          button.textContent = 'COPIED';
+        } catch {
+          button.textContent = 'FAILED';
+        }
+        window.setTimeout(() => {
+          button.textContent = 'COPY';
+          button.disabled = false;
+        }, 1200);
+      });
 
       // Refresh the index in the browser so it stays current between deploys.
       // Purely additive: if this fails, the build-time markup stands.
@@ -742,9 +810,7 @@ const examples = [
         background: none;
         transition: border-color 0.18s, transform 0.18s, box-shadow 0.18s;
       }
-      .mod:hover {
-        border-color: rgb(from var(--accent) r g b / 0.34); transform: translateY(-2px);
-      }
+      .mod:hover { border-color: rgb(from var(--accent) r g b / 0.34); }
       .mhead { display: flex; align-items: center; gap: 0.5rem; min-width: 0; }
       .mhead > * { min-width: 0; }
       .avatar { border-radius: 50%; border: 1px solid var(--line); flex-shrink: 0; }
@@ -757,6 +823,10 @@ const examples = [
         font-family: 'IBM Plex Mono', monospace; font-weight: 700; font-size: 0.95rem;
         color: var(--accent); letter-spacing: -0.02em;
         overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+      }
+      .mname:hover { text-decoration: underline; }
+      .mname:focus-visible, .copy-install:focus-visible {
+        outline: 2px solid var(--accent); outline-offset: 2px;
       }
       .stars, .tag {
         margin-left: auto; flex-shrink: 0; color: var(--sub); font-size: 0.76rem;
@@ -791,18 +861,31 @@ const examples = [
         border: 1px solid var(--line); color: var(--sub);
         font-family: 'IBM Plex Mono', monospace; line-height: 1.5;
       }
+      .install-row {
+        display: grid; grid-template-columns: minmax(0, 1fr) auto;
+        align-items: stretch; margin-top: 0.75rem; min-width: 0;
+      }
       .install {
-        display: block; margin-top: 0.75rem; background: var(--bg);
-        border: 1px solid var(--line);
+        display: flex; align-items: center; min-width: 0; background: var(--bg);
+        border: 1px solid var(--line); border-right: 0;
         padding: 0.4rem 0.5rem; font-size: 0.68rem; color: var(--accent);
-        line-height: 1.5; min-width: 0;
-        /* Wrap rather than ellipsis: this is the line people copy, so losing
-           the tail of it defeats the point. Breaking at the spaces keeps the
-           command readable, and the card's `flex: 1` description absorbs the
-           extra row so every card in the row still ends level. */
+        line-height: 1.5;
+        /* Wrap rather than ellipsis: the visible command must remain exact. */
         white-space: normal; overflow-wrap: break-word;
       }
-      .mod:hover .install { border-color: rgb(from var(--accent) r g b / 0.22); }
+      .copy-install {
+        min-width: 4.25rem; padding: 0.4rem 0.65rem; cursor: pointer;
+        border: 1px solid var(--line); background: var(--bg2); color: var(--text);
+        font: 600 0.66rem/1.2 'IBM Plex Mono', ui-monospace, monospace;
+        letter-spacing: 0.06em;
+      }
+      .copy-install:hover:not(:disabled) {
+        border-color: var(--accent); color: var(--accent);
+      }
+      .copy-install:disabled { cursor: default; color: var(--sub); }
+      .mod:hover .install, .mod:hover .copy-install {
+        border-color: rgb(from var(--accent) r g b / 0.28);
+      }
 
       /* the two grids are one block: pull them together */
       .index { padding-bottom: 1.5rem; }


### PR DESCRIPTION
Fix module discovery and make module installation commands easier to use from the website.

## Module discovery

- Search only the canonical `luvus-module` GitHub topic.
- Preserve keyword filtering and URL encoding.
- Add exact query-construction regression coverage.

## Install command copying

- Replace linked command rows with dedicated COPY controls.
- Keep repository navigation on module names.
- Support build-time, live-refreshed, and example cards.
- Fall back to selection-based copying when the Clipboard API is unavailable.

## Verification

- `cargo test module::discovery --locked`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cd website && npm run build`
- `git diff --check`
- Live `luvus module search media` query


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Module discovery now uses the canonical module topic for more accurate results.
  - Module and example cards provide separate name and repository/example links.
  - Added install-command copy buttons with clipboard fallback and success/failure feedback.
  - Refined link styling and install-row presentation, and removed card hover animation.
  - Added clearer diagnostics for terminal-backend validation issues.

- **Bug Fixes**
  - Improved response and subscription-event delivery through more reliable flushing.
  - Improved connection reliability, particularly on Windows named-pipe connections.
  - Prevented premature disconnects when temporary empty reads occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->