### PR TITLE
feat(keys): support safe non-Ctrl prefix bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ exclude = [
     "/.github",
     "/assets",
     "/community",
+    "/plugins",
     "/preview.html",
     "/preview.ans",
     "/MODULE-GUIDE.md",

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2574,11 +2574,16 @@ impl App {
         match self.mode {
             Mode::Prefix => {
                 self.mode = Mode::Normal;
-                // Pressing the prefix twice sends a literal prefix chord into the
-                // pane (Ctrl+Space → NUL; Ctrl+b → 0x02; etc).
+                // Pressing the prefix twice sends that exact key to the pane.
+                // Use the normal PTY encoder so F-keys and modifiers retain the
+                // same cross-platform escape sequence as ordinary input.
                 if self.prefix.matches(&key) {
-                    let bytes = self.prefix.literal_bytes();
-                    if let Some(p) = self.focused() {
+                    let prefix = self.prefix.key_event();
+                    let newline = self.config.shift_enter_bytes().to_vec();
+                    let app_cursor = self.focused().is_some_and(|p| p.application_cursor());
+                    if let (Some(p), Some(bytes)) =
+                        (self.focused(), encode_key(&prefix, &newline, app_cursor))
+                    {
                         p.send(&bytes);
                     }
                     return true; // left prefix mode → the status bar updates
@@ -2788,7 +2793,11 @@ fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8
                     '_' => 0x1f,
                     _ => return None,
                 };
-                vec![b]
+                if alt {
+                    vec![0x1b, b]
+                } else {
+                    vec![b]
+                }
             } else {
                 let mut s = c.to_string().into_bytes();
                 if alt {
@@ -3136,6 +3145,23 @@ mod tests {
         // Plain Enter ignores the newline sequence and always submits.
         let plain = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
         assert_eq!(encode_key(&plain, b"\n", false), Some(b"\r".to_vec()));
+    }
+
+    #[test]
+    fn character_keys_preserve_alt_with_control() {
+        let key = |modifiers| {
+            encode_key(
+                &KeyEvent::new(KeyCode::Char('a'), modifiers),
+                b"\x1b\r",
+                false,
+            )
+        };
+        assert_eq!(key(KeyModifiers::CONTROL), Some(vec![0x01]));
+        assert_eq!(key(KeyModifiers::ALT), Some(b"\x1ba".to_vec()));
+        assert_eq!(
+            key(KeyModifiers::CONTROL | KeyModifiers::ALT),
+            Some(vec![0x1b, 0x01])
+        );
     }
 
     #[test]

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1,4 +1,4 @@
-//! Keybindings — the prefix-mode command registry. After `Ctrl+Space`, a key
+//! Keybindings — the prefix-mode command registry. After the configured prefix, a key
 //! triggers a [`Cmd`]. Defaults are listed here; users can rebind any command to
 //! a different key in Settings → Keys (persisted to `config.keybindings`). A few
 //! fixed aliases (vim `hjkl`, `Tab`/`⇧Tab`, `q`) are always available too.
@@ -279,7 +279,7 @@ pub const KEY_REFERENCE: &[(&str, &[(&str, &str)])] = &[
             ("X", "close pane"),
             ("-", "split down"),
             ("⇥ / ⇧⇥", "next / previous tab"),
-            ("⌃Space ⌃Space", "send a literal Ctrl+Space"),
+            ("prefix ×2", "send the literal configured prefix"),
         ],
     ),
     (
@@ -305,7 +305,7 @@ pub const KEY_REFERENCE: &[(&str, &[(&str, &str)])] = &[
         ],
     ),
     (
-        "Resize mode  (⌃Space r)",
+        "Resize mode  (after prefix + r)",
         &[
             ("arrows  hjkl", "resize the focused pane"),
             ("Shift+arrow", "bigger step"),
@@ -314,7 +314,7 @@ pub const KEY_REFERENCE: &[(&str, &[(&str, &str)])] = &[
         ],
     ),
     (
-        "Git tab  (⌃Space g)",
+        "Git tab  (after prefix + g)",
         &[
             ("1–6", "Commits Flow Branches PRs Issues Status"),
             ("⇥ / ⇧⇥", "next / previous view"),
@@ -327,7 +327,7 @@ pub const KEY_REFERENCE: &[(&str, &[(&str, &str)])] = &[
         ],
     ),
     (
-        "Task board  (⌃Space o)",
+        "Task board  (after prefix + o)",
         &[
             ("a", "new task"),
             ("s  d  m", "start / done / merge"),
@@ -338,7 +338,7 @@ pub const KEY_REFERENCE: &[(&str, &[(&str, &str)])] = &[
         ],
     ),
     (
-        "Folder picker  (⌃Space n)",
+        "Folder picker  (after prefix + N)",
         &[
             ("j / k", "move"),
             ("→ / ←", "enter folder / go up"),
@@ -380,8 +380,8 @@ pub fn key_reference_rows() -> usize {
     KEY_REFERENCE.iter().map(|(_, rows)| rows.len()).sum()
 }
 
-/// Canonical string for a key in prefix mode (the opening `Ctrl` is already
-/// consumed). Used both to match presses and to display/store bindings.
+/// Canonical string for a command key after the prefix has been consumed.
+/// Used both to match presses and to display/store bindings.
 pub fn key_string(key: &KeyEvent) -> Option<String> {
     Some(match key.code {
         KeyCode::Char(c) => c.to_string(),
@@ -395,110 +395,153 @@ pub fn key_string(key: &KeyEvent) -> Option<String> {
     })
 }
 
-/// The prefix chord that opens command mode (docs/64). Parsed from
-/// `config.prefix` (e.g. `"ctrl+space"`, `"ctrl+b"`). Always carries Ctrl so it
-/// can never be mistaken for a plain typed key; extra modifiers are optional.
+/// The prefix chord that opens command mode (docs/64). Safe single-key
+/// prefixes are F1-F12. Character/Space prefixes must carry Ctrl or Alt so a
+/// plain typed key can never disappear into command mode. Shift is supported
+/// on function keys, where terminals can preserve it reliably.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrefixSpec {
-    alt: bool,
-    shift: bool,
-    /// The base key. `KeyCode::Char(' ')` is `Ctrl+Space`.
+    modifiers: KeyModifiers,
     code: KeyCode,
 }
 
 impl Default for PrefixSpec {
     fn default() -> Self {
-        // The historical default: Ctrl+Space.
-        PrefixSpec {
-            alt: false,
-            shift: false,
+        Self {
+            modifiers: KeyModifiers::CONTROL,
             code: KeyCode::Char(' '),
         }
     }
 }
 
 impl PrefixSpec {
-    /// Parse a spec like `"ctrl+space"` / `"ctrl+b"` / `"ctrl+alt+a"`. Returns
-    /// `None` for anything that does not carry Ctrl or names an unknown key, so a
-    /// bad value is rejected and the caller keeps the previous prefix.
-    pub fn parse(s: &str) -> Option<PrefixSpec> {
-        let mut ctrl = false;
-        let mut alt = false;
-        let mut shift = false;
-        let mut code: Option<KeyCode> = None;
-        for part in s.split('+') {
-            match part.trim().to_ascii_lowercase().as_str() {
+    const RELEVANT_MODIFIERS: KeyModifiers = KeyModifiers::CONTROL
+        .union(KeyModifiers::ALT)
+        .union(KeyModifiers::SHIFT);
+
+    /// Parse canonical specs such as `ctrl+space`, `alt+\`, `shift+f12`, or
+    /// plain `f12`. Bare text remains invalid because it would swallow typing.
+    pub fn parse(s: &str) -> Option<Self> {
+        let mut modifiers = KeyModifiers::NONE;
+        let mut code = None;
+        for raw in s.split('+') {
+            let part = raw.trim().to_ascii_lowercase();
+            match part.as_str() {
                 "" => {}
-                "ctrl" | "control" => ctrl = true,
-                "alt" | "option" | "opt" | "meta" => alt = true,
-                "shift" => shift = true,
-                "space" | "spc" => code = Some(KeyCode::Char(' ')),
-                other if other.chars().count() == 1 => {
-                    code = Some(KeyCode::Char(other.chars().next().unwrap()))
+                "ctrl" | "control" => modifiers.insert(KeyModifiers::CONTROL),
+                // `meta` was historically treated as an Alt alias in config.
+                "alt" | "option" | "opt" | "meta" => modifiers.insert(KeyModifiers::ALT),
+                "shift" => modifiers.insert(KeyModifiers::SHIFT),
+                "space" | "spc" if code.is_none() => code = Some(KeyCode::Char(' ')),
+                "plus" if code.is_none() => code = Some(KeyCode::Char('+')),
+                other if code.is_none() => {
+                    if let Some(number) = other
+                        .strip_prefix('f')
+                        .and_then(|value| value.parse::<u8>().ok())
+                        .filter(|number| (1..=12).contains(number))
+                    {
+                        code = Some(KeyCode::F(number));
+                    } else if other.chars().count() == 1 && other.is_ascii() {
+                        code = Some(KeyCode::Char(other.chars().next()?));
+                    } else {
+                        return None;
+                    }
                 }
                 _ => return None,
             }
         }
-        // Must carry Ctrl (so it can't swallow a plain key) and name a base key.
-        if !ctrl {
+        let code = code?;
+        let is_function = matches!(code, KeyCode::F(1..=12));
+        let carries_non_text_modifier =
+            modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT);
+        if !is_function && (!carries_non_text_modifier || modifiers.contains(KeyModifiers::SHIFT)) {
             return None;
         }
-        Some(PrefixSpec {
-            alt,
-            shift,
-            code: code?,
-        })
+        Some(Self { modifiers, code })
     }
 
-    /// Does this key event match the prefix chord? Handles the terminal quirks of
-    /// `Ctrl+Space`: many emulators send `Ctrl+@` or a raw `NUL` for it.
+    /// Canonical persisted representation.
+    pub fn spec(&self) -> String {
+        let mut parts = Vec::new();
+        if self.modifiers.contains(KeyModifiers::CONTROL) {
+            parts.push("ctrl".to_string());
+        }
+        if self.modifiers.contains(KeyModifiers::ALT) {
+            parts.push("alt".to_string());
+        }
+        if self.modifiers.contains(KeyModifiers::SHIFT) {
+            parts.push("shift".to_string());
+        }
+        parts.push(match self.code {
+            KeyCode::Char(' ') => "space".to_string(),
+            KeyCode::Char('+') => "plus".to_string(),
+            KeyCode::Char(character) => character.to_ascii_lowercase().to_string(),
+            KeyCode::F(number) => format!("f{number}"),
+            _ => unreachable!("PrefixSpec only stores supported keys"),
+        });
+        parts.join("+")
+    }
+
+    /// The normalized event used when a double prefix forwards the literal key
+    /// through the same PTY encoder as ordinary input.
+    pub fn key_event(&self) -> KeyEvent {
+        KeyEvent::new(self.code, self.modifiers)
+    }
+
+    /// Match the exact configured chord. Ctrl+Space keeps its NUL/Ctrl+@ legacy
+    /// compatibility because those encodings cannot carry complete modifiers.
     pub fn matches(&self, key: &KeyEvent) -> bool {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let alt = key.modifiers.contains(KeyModifiers::ALT);
-        if self.alt != alt {
+        if key
+            .modifiers
+            .intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META)
+        {
             return false;
         }
-        // Ctrl+Space: accept the three encodings terminals use for it.
-        if self.code == KeyCode::Char(' ') {
-            if matches!(key.code, KeyCode::Null) {
-                return true;
+        if self.code == KeyCode::Char(' ') && self.modifiers == KeyModifiers::CONTROL {
+            if key.code == KeyCode::Null {
+                return key.modifiers.is_empty() || key.modifiers == KeyModifiers::CONTROL;
             }
-            return ctrl && matches!(key.code, KeyCode::Char(' ') | KeyCode::Char('@'));
+            let modifiers = key.modifiers & Self::RELEVANT_MODIFIERS;
+            if matches!(key.code, KeyCode::Char(' ')) {
+                return modifiers == KeyModifiers::CONTROL;
+            }
+            // Some terminals spell Ctrl+Space as Ctrl+@ and may retain the
+            // physical Shift needed to type `@`; both encodings are NUL.
+            if matches!(key.code, KeyCode::Char('@')) {
+                return modifiers == KeyModifiers::CONTROL
+                    || modifiers == (KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+            }
         }
-        ctrl && key.code == self.code
+        if key.modifiers & Self::RELEVANT_MODIFIERS != self.modifiers {
+            return false;
+        }
+        match (self.code, key.code) {
+            (KeyCode::Char(expected), KeyCode::Char(actual)) => {
+                expected.eq_ignore_ascii_case(&actual)
+            }
+            (expected, actual) => expected == actual,
+        }
     }
 
-    /// The raw byte(s) a terminal sends for this chord, so pressing the prefix
-    /// twice can forward a literal prefix into the focused pane. `Ctrl+<letter>`
-    /// is `letter & 0x1f` (Space/`@` → `0x00`).
-    pub fn literal_bytes(&self) -> Vec<u8> {
-        match self.code {
-            KeyCode::Char(c) if c.is_ascii() => {
-                let upper = c.to_ascii_uppercase() as u8;
-                vec![upper & 0x1f]
-            }
-            _ => vec![0x00],
-        }
-    }
-
-    /// A human label for Settings (e.g. `"Ctrl+Space"`, `"Ctrl+B"`).
+    /// Human label used by Settings and the status line.
     pub fn label(&self) -> String {
-        let mut s = String::from("Ctrl");
-        if self.alt {
-            s.push_str("+Alt");
+        let mut parts = Vec::new();
+        if self.modifiers.contains(KeyModifiers::CONTROL) {
+            parts.push("Ctrl".to_string());
         }
-        if self.shift {
-            s.push_str("+Shift");
+        if self.modifiers.contains(KeyModifiers::ALT) {
+            parts.push("Alt".to_string());
         }
-        match self.code {
-            KeyCode::Char(' ') => s.push_str("+Space"),
-            KeyCode::Char(c) => {
-                s.push('+');
-                s.push(c.to_ascii_uppercase());
-            }
-            _ => {}
+        if self.modifiers.contains(KeyModifiers::SHIFT) {
+            parts.push("Shift".to_string());
         }
-        s
+        parts.push(match self.code {
+            KeyCode::Char(' ') => "Space".to_string(),
+            KeyCode::Char(character) => character.to_ascii_uppercase().to_string(),
+            KeyCode::F(number) => format!("F{number}"),
+            _ => unreachable!("PrefixSpec only stores supported keys"),
+        });
+        parts.join("+")
     }
 }
 
@@ -556,6 +599,12 @@ pub fn presets() -> &'static [Preset] {
             id: "default",
             label: "luvus (default)",
             prefix: "ctrl+space",
+            binds: &[],
+        },
+        Preset {
+            id: "function",
+            label: "no-Ctrl (F12)",
+            prefix: "f12",
             binds: &[],
         },
         Preset {
@@ -617,15 +666,14 @@ impl App {
         crate::config::save(&self.config);
     }
 
-    /// Set the command-mode prefix chord from a spec like `"ctrl+b"` (docs/64).
-    /// Rejects anything that does not carry Ctrl (so a plain key can never become
-    /// the prefix and swallow typing), keeping the current prefix and returning
-    /// `false`. On success it applies live, persists, and returns `true`.
+    /// Set the command-mode prefix from a safe spec such as `ctrl+b`, `alt+\`,
+    /// or `f12` (docs/64). Plain text keys are rejected so normal typing cannot
+    /// disappear into command mode. On success it applies live and persists.
     pub fn set_prefix(&mut self, spec: &str) -> bool {
         match PrefixSpec::parse(spec) {
             Some(p) => {
+                self.config.prefix = p.spec();
                 self.prefix = p;
-                self.config.prefix = spec.trim().to_ascii_lowercase();
                 crate::config::save(&self.config);
                 true
             }
@@ -811,39 +859,53 @@ mod tests {
     }
 
     #[test]
-    fn prefix_parse_requires_ctrl_and_accepts_letters() {
+    fn prefix_parse_accepts_safe_function_keys_and_modified_characters() {
         assert_eq!(PrefixSpec::parse("ctrl+space"), Some(PrefixSpec::default()));
-        assert_eq!(
-            PrefixSpec::parse("ctrl+b"),
-            Some(PrefixSpec {
-                alt: false,
-                shift: false,
-                code: KeyCode::Char('b'),
-            })
-        );
-        // A bare key (no Ctrl) is rejected so it can't swallow typing.
+        assert_eq!(PrefixSpec::parse("control+b").unwrap().spec(), "ctrl+b");
+        assert_eq!(PrefixSpec::parse("f12").unwrap().label(), "F12");
+        assert_eq!(PrefixSpec::parse("shift+f12").unwrap().label(), "Shift+F12");
+        assert_eq!(PrefixSpec::parse("option+\\").unwrap().spec(), "alt+\\");
+        assert_eq!(PrefixSpec::parse("ctrl+plus").unwrap().label(), "Ctrl++");
+        // Bare text and Shift-only text are rejected so they cannot swallow typing.
         assert_eq!(PrefixSpec::parse("b"), None);
         assert_eq!(PrefixSpec::parse("space"), None);
+        assert_eq!(PrefixSpec::parse("shift+b"), None);
+        assert_eq!(PrefixSpec::parse("f13"), None);
         assert_eq!(PrefixSpec::parse("nonsense"), None);
     }
 
     #[test]
-    fn prefix_matches_the_configured_chord() {
+    fn prefix_matches_the_exact_configured_chord() {
         let ctrl = KeyModifiers::CONTROL;
         // Ctrl+Space accepts all three terminal encodings.
         let sp = PrefixSpec::default();
         assert!(sp.matches(&KeyEvent::new(KeyCode::Char(' '), ctrl)));
         assert!(sp.matches(&KeyEvent::new(KeyCode::Char('@'), ctrl)));
         assert!(sp.matches(&KeyEvent::new(KeyCode::Null, KeyModifiers::NONE)));
+        assert!(!sp.matches(&KeyEvent::new(KeyCode::Char(' '), ctrl | KeyModifiers::ALT)));
         assert!(!sp.matches(&KeyEvent::new(KeyCode::Char('b'), ctrl)));
-        // Ctrl+b matches only Ctrl+b.
+
         let cb = PrefixSpec::parse("ctrl+b").unwrap();
         assert!(cb.matches(&KeyEvent::new(KeyCode::Char('b'), ctrl)));
         assert!(!cb.matches(&KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE)));
-        assert!(!cb.matches(&KeyEvent::new(KeyCode::Char(' '), ctrl)));
-        // The literal byte a double-press forwards: Ctrl+b → 0x02, Space → NUL.
-        assert_eq!(cb.literal_bytes(), vec![0x02]);
-        assert_eq!(sp.literal_bytes(), vec![0x00]);
+        assert!(!cb.matches(&KeyEvent::new(
+            KeyCode::Char('b'),
+            ctrl | KeyModifiers::SHIFT
+        )));
+
+        assert_eq!(PrefixSpec::parse("ctrl+shift+b"), None);
+
+        let shifted = PrefixSpec::parse("shift+f12").unwrap();
+        assert!(shifted.matches(&KeyEvent::new(KeyCode::F(12), KeyModifiers::SHIFT)));
+        assert!(!shifted.matches(&KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE)));
+
+        let f12 = PrefixSpec::parse("f12").unwrap();
+        assert!(f12.matches(&KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE)));
+        assert!(!f12.matches(&KeyEvent::new(KeyCode::F(12), KeyModifiers::SHIFT)));
+        assert_eq!(
+            f12.key_event(),
+            KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE)
+        );
     }
 
     #[test]
@@ -851,6 +913,10 @@ mod tests {
         let _env = crate::persist::test_env("tmux-preset");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
+        assert!(app.apply_preset("function"));
+        assert_eq!(app.prefix, PrefixSpec::parse("f12").unwrap());
+        assert_eq!(app.current_preset(), Some(1));
+
         assert!(app.apply_preset("tmux"));
         assert_eq!(app.prefix, PrefixSpec::parse("ctrl+b").unwrap());
         assert_eq!(app.keymap.get("%"), Some(&Cmd::SplitRight));
@@ -870,15 +936,16 @@ mod tests {
     }
 
     #[test]
-    fn set_prefix_rejects_a_modifierless_chord() {
+    fn set_prefix_accepts_function_keys_but_rejects_plain_text() {
         let _env = crate::persist::test_env("set-prefix");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
-        assert!(app.set_prefix("ctrl+a"));
-        assert_eq!(app.prefix, PrefixSpec::parse("ctrl+a").unwrap());
-        // A bad spec is refused and the previous prefix is kept.
+        assert!(app.set_prefix("f12"));
+        assert_eq!(app.prefix, PrefixSpec::parse("f12").unwrap());
+        assert_eq!(app.config.prefix, "f12");
+        // A plain text spec is refused and the previous prefix is kept.
         assert!(!app.set_prefix("x"));
-        assert_eq!(app.prefix, PrefixSpec::parse("ctrl+a").unwrap());
+        assert_eq!(app.prefix, PrefixSpec::parse("f12").unwrap());
     }
 
     #[test]
@@ -1006,6 +1073,26 @@ mod tests {
             tabs + 1,
             "Ctrl+Space no longer opens command mode"
         );
+    }
+
+    #[test]
+    fn function_key_prefix_drives_command_mode() {
+        let _env = crate::persist::test_env("function-prefix");
+        use crate::event::AppEvent;
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        assert!(app.set_prefix("f12"));
+        let tabs = app.ws().tabs.len();
+
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::F(12),
+            KeyModifiers::NONE,
+        )));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::NONE,
+        )));
+        assert_eq!(app.ws().tabs.len(), tabs + 1, "F12 prefix opens a tab");
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -40,7 +40,7 @@ mod switcher;
 
 pub use search::{GlobalSearch, SearchFlash};
 
-pub use keys::{key_reference_rows, presets, Cmd, KEY_REFERENCE};
+pub use keys::{key_reference_rows, presets, Cmd, PrefixSpec, KEY_REFERENCE};
 pub use modules::ModuleMenuAction;
 pub use picker::{FolderPicker, PickerHit, Row};
 pub use settings::{
@@ -5268,6 +5268,7 @@ mod tests {
 
     #[test]
     fn prefix_chord_variants() {
+        let _env = crate::persist::test_env("prefix-chord-variants");
         // Ctrl+Space arrives in different forms across terminals/OSes; each must
         // enter prefix mode and the next key (here `v`) must then split.
         let chords = [
@@ -9486,6 +9487,7 @@ mod tests {
         app.settings = Some(SettingsUi {
             tab: SettingsTab::Layout,
             cursor: idx,
+            prefix_candidate: None,
             layout_scroll: 0,
             capturing: false,
         });

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -72,6 +72,9 @@ impl SettingsTab {
 pub struct SettingsUi {
     pub tab: SettingsTab,
     pub cursor: usize,
+    /// Candidate prefix captured once and waiting for the same chord again.
+    /// Nothing is persisted until confirmation succeeds.
+    pub prefix_candidate: Option<String>,
     /// First visual row shown in the Layout tab. Persisting this while the modal
     /// is open prevents a visible dock/bar button click from re-anchoring the
     /// list around its newly selected row.
@@ -232,6 +235,7 @@ impl App {
         self.settings = Some(SettingsUi {
             tab: SettingsTab::General,
             cursor: 0,
+            prefix_candidate: None,
             layout_scroll: 0,
             capturing: false,
         });
@@ -274,12 +278,10 @@ impl App {
     }
 
     pub fn handle_settings_key(&mut self, key: KeyEvent) {
-        let Some(&SettingsUi {
-            tab,
-            cursor,
-            capturing,
-            ..
-        }) = self.settings.as_ref()
+        let Some((tab, cursor, capturing, prefix_candidate)) = self
+            .settings
+            .as_ref()
+            .map(|ui| (ui.tab, ui.cursor, ui.capturing, ui.prefix_candidate.clone()))
         else {
             return;
         };
@@ -287,22 +289,43 @@ impl App {
         // (Esc cancels). This must intercept before the normal handling so keys
         // like Tab / digits can themselves be bound.
         if capturing {
-            if key.code != KeyCode::Esc {
-                if cursor == KEYS_PREFIX_ROW {
-                    // Capturing the prefix chord needs the modifiers, not just the
-                    // key. Refuse anything without Ctrl and keep the old prefix.
-                    match Self::prefix_spec_from_key(&key) {
-                        Some(spec) if self.set_prefix(&spec) => {}
-                        _ => self.show_toast("Prefix must include Ctrl"),
+            if cursor == KEYS_PREFIX_ROW {
+                if key.code == KeyCode::Esc {
+                    if let Some(ui) = self.settings.as_mut() {
+                        ui.capturing = false;
+                        ui.prefix_candidate = None;
                     }
-                } else if let (Some(cmd), Some(s)) =
-                    (Self::keys_cmd_at(cursor), keys::key_string(&key))
-                {
+                    return;
+                }
+                let Some(spec) = Self::prefix_spec_from_key(&key) else {
+                    self.show_toast("Use F1-F12 or a Ctrl/Alt chord");
+                    return;
+                };
+                if prefix_candidate.as_deref() == Some(spec.as_str()) {
+                    self.set_prefix(&spec);
+                    if let Some(ui) = self.settings.as_mut() {
+                        ui.capturing = false;
+                        ui.prefix_candidate = None;
+                    }
+                } else {
+                    let label = keys::PrefixSpec::parse(&spec)
+                        .map(|prefix| prefix.label())
+                        .unwrap_or(spec.clone());
+                    if let Some(ui) = self.settings.as_mut() {
+                        ui.prefix_candidate = Some(spec);
+                    }
+                    self.show_toast(format!("Press {label} again to confirm"));
+                }
+                return;
+            }
+            if key.code != KeyCode::Esc {
+                if let (Some(cmd), Some(s)) = (Self::keys_cmd_at(cursor), keys::key_string(&key)) {
                     self.rebind(cmd, s);
                 }
             }
             if let Some(ui) = self.settings.as_mut() {
                 ui.capturing = false;
+                ui.prefix_candidate = None;
             }
             return;
         }
@@ -436,7 +459,9 @@ impl App {
         if let Some(ui) = self.settings.as_mut() {
             ui.tab = tab;
             ui.cursor = cursor;
+            ui.prefix_candidate = None;
             ui.layout_scroll = 0;
+            ui.capturing = false;
         }
     }
 
@@ -496,6 +521,10 @@ impl App {
         let Some(tab) = self.settings.as_ref().map(|u| u.tab) else {
             return;
         };
+        if let Some(ui) = self.settings.as_mut() {
+            ui.capturing = false;
+            ui.prefix_candidate = None;
+        }
         match tab {
             SettingsTab::Theme => {
                 let index = cursor.min(self.theme_registry.entries().len().saturating_sub(1));
@@ -526,12 +555,14 @@ impl App {
                 KEYS_PREFIX_ROW => {
                     if let Some(ui) = self.settings.as_mut() {
                         ui.capturing = true;
+                        ui.prefix_candidate = None;
                     }
                 }
                 _ => {
                     if Self::keys_cmd_at(cursor).is_some() {
                         if let Some(ui) = self.settings.as_mut() {
                             ui.capturing = true;
+                            ui.prefix_candidate = None;
                         }
                     }
                 }
@@ -549,28 +580,52 @@ impl App {
             .and_then(|i| crate::app::Cmd::ALL.get(i).copied())
     }
 
-    /// Build a prefix spec string (e.g. `"ctrl+b"`) from a captured key event, or
-    /// `None` if it doesn't carry Ctrl. `Ctrl+Space` arrives as `Char(' ')`/`'@'`
-    /// with Ctrl or a bare `Null`; both normalize to `"ctrl+space"`.
+    /// Convert a captured event to one canonical safe prefix. Function keys can
+    /// stand alone; character and Space prefixes require Ctrl or Alt. Super,
+    /// Hyper, and Meta are rejected because desktop environments commonly keep
+    /// them before the terminal can report them consistently.
     fn prefix_spec_from_key(key: &KeyEvent) -> Option<String> {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let alt = key.modifiers.contains(KeyModifiers::ALT);
-        let base = match key.code {
-            KeyCode::Null | KeyCode::Char(' ') | KeyCode::Char('@') => "space".to_string(),
-            KeyCode::Char(c) if c.is_ascii() => c.to_ascii_lowercase().to_string(),
-            _ => return None,
-        };
-        // Ctrl is required. A bare `Null` already implies Ctrl+Space.
-        if !ctrl && !matches!(key.code, KeyCode::Null) {
+        if key
+            .modifiers
+            .intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META)
+        {
             return None;
         }
-        let mut s = String::from("ctrl");
-        if alt {
-            s.push_str("+alt");
+        if key.code == KeyCode::Null {
+            return Some("ctrl+space".to_string());
         }
-        s.push('+');
-        s.push_str(&base);
-        Some(s)
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let mut shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        let base = match key.code {
+            KeyCode::Char('@') if ctrl => {
+                // Ctrl+Space may arrive as the physical Ctrl+Shift+2 (`@`). The
+                // resulting terminal key is still NUL, so persist Ctrl+Space.
+                shift = false;
+                "space".to_string()
+            }
+            KeyCode::Char(' ') if ctrl => "space".to_string(),
+            KeyCode::Char(' ') => "space".to_string(),
+            KeyCode::Char('+') => "plus".to_string(),
+            KeyCode::Char(character) if character.is_ascii() => {
+                character.to_ascii_lowercase().to_string()
+            }
+            KeyCode::F(number @ 1..=12) => format!("f{number}"),
+            _ => return None,
+        };
+        let mut parts = Vec::new();
+        if ctrl {
+            parts.push("ctrl");
+        }
+        if alt {
+            parts.push("alt");
+        }
+        if shift {
+            parts.push("shift");
+        }
+        parts.push(&base);
+        let candidate = parts.join("+");
+        keys::PrefixSpec::parse(&candidate).map(|prefix| prefix.spec())
     }
 
     /// The index of the preset that exactly matches the current config, or `None`
@@ -1210,6 +1265,62 @@ fn lang_cursor(code: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prefix_capture_accepts_safe_non_ctrl_keys_and_exact_modifiers() {
+        assert_eq!(
+            App::prefix_spec_from_key(&KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE)),
+            Some("f12".to_string())
+        );
+        assert_eq!(
+            App::prefix_spec_from_key(&KeyEvent::new(
+                KeyCode::Char('\\'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            )),
+            Some("ctrl+alt+\\".to_string())
+        );
+        assert_eq!(
+            App::prefix_spec_from_key(&KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE,)),
+            None
+        );
+        assert_eq!(
+            App::prefix_spec_from_key(&KeyEvent::new(
+                KeyCode::Char('@'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            )),
+            Some("ctrl+space".to_string())
+        );
+        assert_eq!(
+            App::prefix_spec_from_key(&KeyEvent::new(KeyCode::F(12), KeyModifiers::SUPER,)),
+            None
+        );
+    }
+
+    #[test]
+    fn prefix_capture_requires_the_same_chord_twice_before_persisting() {
+        let _env = crate::persist::test_env("prefix-capture-confirm");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        app.open_settings();
+        app.settings_set_tab(SettingsTab::Keys);
+        app.settings_activate(KEYS_PREFIX_ROW);
+
+        let f12 = KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE);
+        app.handle_settings_key(f12);
+        assert_eq!(app.config.prefix, "ctrl+space");
+        assert!(app.settings.as_ref().is_some_and(|ui| ui.capturing));
+        assert_eq!(
+            app.settings
+                .as_ref()
+                .and_then(|ui| ui.prefix_candidate.as_deref()),
+            Some("f12")
+        );
+
+        app.handle_settings_key(f12);
+        assert_eq!(app.config.prefix, "f12");
+        assert_eq!(app.prefix, keys::PrefixSpec::parse("f12").unwrap());
+        assert!(app.settings.as_ref().is_some_and(|ui| !ui.capturing));
+    }
 
     #[test]
     fn sidebar_widths_are_grouped_in_the_docks_section() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,9 +62,9 @@ pub struct Config {
     /// An empty value means the command is explicitly unbound.
     #[serde(default)]
     pub keybindings: std::collections::HashMap<String, String>,
-    /// The `Ctrl+Space`-style prefix chord that opens command mode (docs/64).
-    /// A string like `"ctrl+space"` / `"ctrl+b"`; parsed by `keys::PrefixSpec`.
-    /// Must carry Ctrl so it can never swallow a plain typed key.
+    /// The safe prefix that opens command mode (docs/64): an F1-F12 key or a
+    /// Ctrl/Alt character chord such as `ctrl+space`, `ctrl+b`, or `alt+\\`.
+    /// Plain text keys are rejected so normal terminal typing is never swallowed.
     #[serde(default = "default_prefix")]
     pub prefix: String,
     /// Mission Control cost overrides (docs/54, MC-5): model-id substring →

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -773,6 +773,12 @@ fn draw_content(
             // so pressing Down eventually reaches every block; notes and headings
             // scroll along but aren't landed on.
             let capturing = app.settings.as_ref().is_some_and(|u| u.capturing);
+            let prefix_candidate = app
+                .settings
+                .as_ref()
+                .and_then(|ui| ui.prefix_candidate.as_deref())
+                .and_then(crate::app::PrefixSpec::parse)
+                .map(|prefix| prefix.label());
             let all = crate::app::Cmd::ALL;
             let dim = |s: &'static str| Span::styled(s, Style::new().fg(t.overlay0));
             let acc = |s: &'static str| Span::styled(s, Style::new().fg(t.accent).bold());
@@ -812,13 +818,16 @@ fn draw_content(
                 KV::Note(vec![
                     dim("Press the prefix ("),
                     Span::styled(prefix_label.clone(), Style::new().fg(t.accent).bold()),
-                    dim("), then a key below. Hold or release Ctrl, both work."),
+                    dim("), then a key below. Command-key modifiers are optional."),
                 ]),
                 KV::Note(vec![
                     dim("Move with arrows or "),
                     acc("h j k l"),
                     dim(".  "),
-                    acc("Ctrl+Space ?"),
+                    Span::styled(
+                        format!("{prefix_label} ?"),
+                        Style::new().fg(t.accent).bold(),
+                    ),
                     dim(" shows the cheat-sheet."),
                 ]),
                 KV::Note(vec![
@@ -919,7 +928,10 @@ fn draw_content(
                         // The prefix row shows a capture prompt while capturing;
                         // the preset row shows `‹ value ›`.
                         let txt = if is_sel && capturing {
-                            "press a chord…".to_string()
+                            prefix_candidate
+                                .as_ref()
+                                .map(|candidate| format!("press {candidate} again…"))
+                                .unwrap_or_else(|| "press F1-F12 or a Ctrl/Alt chord…".to_string())
                         } else if *chooser {
                             format!("‹ {value} ›")
                         } else {

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -8,8 +8,10 @@ description: Quick answers to the macOS Ctrl+Space conflict, stale servers, Wind
 macOS grabs `Ctrl+Space` for input-source switching. Either untick *Select the
 previous input source* in **System Settings → Keyboard → Keyboard Shortcuts…
 → Input Sources**, or just change the prefix: open Settings from the **Menu**
-button, go to **Keys**, and set the **Prefix** row to another chord such as
-`Ctrl+b` (see [Keybindings](/docs/reference/keybindings/)). Meanwhile:
+button, go to **Keys**, and set the **Prefix** row to `F12`, `Ctrl+b`, or
+another supported key. The **no-Ctrl (F12)** preset avoids the macOS input-source
+shortcut entirely (on media-key keyboards, press `Fn+F12`). See
+[Keybindings](/docs/reference/keybindings/). Meanwhile:
 everything is mouse-driven, and `Shift+↑` scroll mode needs no prefix.
 
 ## I upgraded but see no changes

--- a/website/src/content/docs/docs/guides/settings.mdx
+++ b/website/src/content/docs/docs/guides/settings.mdx
@@ -44,7 +44,8 @@ red/green change colors, and live refresh. See
 
 Keybinding notes: arrows and `hjkl` both work for focus, `Tab`/`Shift+Tab`
 cycle tabs, and every prefix command is remappable, including the vim aliases.
-The **Prefix** row changes the prefix chord (e.g. to `Ctrl+b`), and the
-**Preset** row applies a bundle such as **tmux** in one click. `Ctrl+Space ?`
-always shows the current map. See
+The **Prefix** row captures a safe function key or `Ctrl`/`Alt` chord and asks
+you to press it again before saving. The **Preset** row provides **luvus
+(default)**, **no-Ctrl (F12)**, and **tmux** bundles. Press the configured prefix
+and then `?` to show the current map. See
 [Keybindings](/docs/reference/keybindings/) for the full list.

--- a/website/src/content/docs/docs/reference/configuration.mdx
+++ b/website/src/content/docs/docs/reference/configuration.mdx
@@ -38,7 +38,7 @@ cleanly across versions because unknown fields get defaults.
 | `layout.diff_marker_style` | changed-line indicator: `symbols` (default), `bars`, or `both` |
 | `layout.diff_color_mode` | changed-line palette: `theme` (default) follows the active theme, while `standard` uses fixed red and green review colors |
 | `layout.diff_live_refresh` | refresh visible diff views when the shared FILES status scan changes |
-| `prefix` | the command-mode prefix chord (default `ctrl+space`; e.g. `ctrl+b`). Must include `Ctrl` (see [Keybindings](/docs/reference/keybindings/)) |
+| `prefix` | the command-mode prefix (default `ctrl+space`). Accepts `f1`–`f12` as safe single keys, or a character/Space chord containing `Ctrl` or `Alt`, such as `ctrl+b`, `alt+\`, or `shift+f12` (see [Keybindings](/docs/reference/keybindings/)) |
 | `keybindings` | command id → key, overriding the defaults |
 | `bars.top_right` / `bars.bottom_right` / `bars.off` | canonical widget ids (`module:id`) in each Luvus Bar placement. `core:runtime-status` defaults to Bottom. Live content and notifications are never persisted. |
 

--- a/website/src/content/docs/docs/reference/keybindings.mdx
+++ b/website/src/content/docs/docs/reference/keybindings.mdx
@@ -26,12 +26,21 @@ the live cheat-sheet. Remap anything, change the prefix, or apply a preset in
 ## The prefix and presets
 
 The prefix is **configurable**. From the **Prefix** row at the top of
-Settings → Keys, press a new chord to set it (it must include `Ctrl`, so it can
-never swallow a typed key). Pressing the prefix twice sends the literal chord to
-the focused pane.
+Settings → Keys, press a safe key, then press it again to confirm. You can use a
+single function key (`F1`–`F12`) or a character/Space chord containing `Ctrl` or
+`Alt`, such as `Ctrl+b`, `Alt+\`, or `Ctrl+Alt+Space`. Bare text keys are
+rejected so Luvus can never swallow normal typing. Super/Cmd, Hyper, and Meta
+are rejected because desktop environments do not report them consistently.
+Pressing the configured prefix twice sends that literal key to the focused pane.
 
-The **Preset** row below it applies a whole bundle at once. The **tmux** preset
-switches the prefix to `Ctrl+b` and maps the tmux keys onto luvus:
+The **no-Ctrl (F12)** preset is the most portable single-key option. On a Mac
+keyboard configured to use media controls, press `Fn+F12`; Luvus still receives
+it as `F12`. Luvus asks you to confirm any captured prefix before saving it, so
+an operating-system or terminal shortcut cannot silently lock you out.
+
+The **Preset** row below it applies a whole bundle at once. Available presets
+are **luvus (default)** (`Ctrl+Space`), **no-Ctrl (F12)**, and **tmux**. The tmux
+preset switches the prefix to `Ctrl+b` and maps the tmux keys onto luvus:
 
 | tmux | luvus command |
 |------|---------------|
@@ -85,6 +94,6 @@ read-only or in an editor (plus new / rename / delete). See
 
 Custom bindings persist in `config.json`: `prefix` holds the prefix chord, and
 `keybindings` maps each command id to a key (an empty value unbinds it).
-`Ctrl+Space ?` shows the current map, and every command is editable in
+Pressing the configured prefix and then `?` shows the current map, and every command is editable in
 **Settings → Keys** (the vim `hjkl` and `Tab` aliases included, since nothing is
 bound behind your back).


### PR DESCRIPTION
Users can now choose safe function-key or Ctrl/Alt command prefixes from Settings → Keys instead of being limited to Ctrl-only chords.

## What

- Accept standalone `F1`–`F12`, Shift-modified function keys, and character/Space chords carrying Ctrl or Alt
- Keep bare text and Super/Cmd/Meta prefixes invalid so normal terminal typing and OS shortcuts are not swallowed
- Require the same custom prefix twice before persisting it, and add a **no-Ctrl (F12)** preset
- Match modifiers exactly and forward a doubled prefix through the normal PTY encoder
- Preserve Alt when encoding Ctrl+Alt character input
- Make Settings guidance, the key reference, FAQ, and configuration docs follow the configured prefix
- Exclude the merged `plugins/` source from Cargo packages

## Why

The existing parser and Settings capture path required Ctrl, preventing portable single-key prefixes such as F12. Prefix rendering was partly hardcoded to Ctrl+Space, Shift was parsed but not matched, and forwarding Ctrl+Alt characters discarded Alt.

## Verification

- [x] `cargo test --locked` (830 unit tests and 12 integration tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cd website && npm run build` (42 pages)
- [ ] Manual testing on macOS, Linux, and Windows terminals

## Notes

PR #102 introduces a Socket API error message that still describes prefixes as Ctrl-only. If #102 merges after this PR, that message should be updated to mention `F1`–`F12` and Ctrl/Alt chords; the validation itself delegates to `PrefixSpec` and will support the new forms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure command prefixes using F1–F12 or Ctrl/Alt key chords, including Shift-modified function keys.
  * Prefix capture now requires confirmation and provides clearer guidance for supported formats.
  * Added a no-Ctrl F12 preset alongside existing prefix presets.
  * Key forwarding preserves modifiers, function keys, and application-cursor behavior.

* **Documentation**
  * Updated configuration, keybinding, settings, and FAQ documentation for the expanded prefix options.
  * Added macOS guidance for F12 and media-key keyboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->