### PR TITLE
fix(api): describe supported prefix keys

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -4855,7 +4855,7 @@ impl App {
         let prefix = keys::PrefixSpec::parse(&next.prefix).ok_or_else(|| {
             (
                 "invalid_request".to_string(),
-                "config prefix must be a valid Ctrl chord".to_string(),
+                "config prefix must be F1-F12 or a valid Ctrl/Alt chord".to_string(),
             )
         })?;
         if self.theme_registry.get(&next.theme).is_none() && next.theme != "terminal" {


### PR DESCRIPTION
The Socket API now reports the complete set of safe command-prefix forms introduced by #104.

## What

- Update config validation guidance from Ctrl-only prefixes to `F1`–`F12` and Ctrl/Alt chords

## Why

PR #104 expanded `PrefixSpec`, so the validation behavior already accepts these forms, but the error text added by #102 still described the old Ctrl-only contract.

## Verification

- [x] `cargo test config_patch --locked`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [ ] Manual testing, not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `config.prefix` validation message to accurately indicate support for F1–F12 keys and Ctrl/Alt key combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->