### PR TITLE
feat(agent): fork Grok Build sessions and isolate CLI family help

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   working, done, or idle state with session titles, tokens, cost, context use,
   and optional sound alerts.
 - **Agent workflows:** Start, name, message, inspect, wait for, resume, and send
-  keys to agents. Fork Claude, Codex, and Pi sessions with their context intact.
+  keys to agents. Fork Claude, Grok, Codex, and Pi sessions with their context intact.
 - **Files and code:** Browse a Git-aware file tree, inspect files and changes,
   reveal paths, and open files in a pane, tab, preview, or external editor.
 - **Git and GitHub:** View status, branches, commits, contributors, pull

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -245,7 +245,7 @@ luvus agent get <target>
 luvus agent fork <target> [--name <alias>] [--no-focus]
 ```
 
-Native forks currently support Claude, Codex, and Pi. Report
+Native forks currently support Claude, Grok, Codex, and Pi. Report
 `unsupported_agent`, `session_unknown`, or `spawn_failed` exactly when returned.
 Do not approximate a failed fork with `pane split`, `agent start`, or `resume`,
 because those paths do not guarantee an independent copy of the conversation.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -115,7 +115,8 @@ static SOURCES: &[SessionSource] = &[
             list: None,
         }),
         resume: |q| format!("grok --resume {q}\r"),
-        fork: None,
+        // Same flag pair as Claude: resume the source transcript into a new id.
+        fork: Some(|q| format!("grok --resume {q} --fork-session\r")),
     },
     SessionSource {
         name: "pi",
@@ -1505,6 +1506,11 @@ mod tests {
             ),
             vec!["--verbose"]
         );
+        // Grok uses the same `--fork-session` resume pair; restore must not re-fork.
+        assert_eq!(
+            f("grok", &["--resume", "old-id", "--fork-session", "--yolo"]),
+            vec!["--yolo"]
+        );
         // Codex selects a session with positional resume/fork subcommands.
         assert_eq!(
             f("codex", &["resume", "sess_9", "--model", "o3"]),
@@ -1610,10 +1616,11 @@ mod tests {
         assert!(fork_command("pi", "0198abcd-uuid")
             .unwrap()
             .contains("pi --fork"));
-        assert!(can_fork("claude") && can_fork("codex") && can_fork("pi"));
+        let grok = fork_command("grok", "g1").unwrap();
+        assert!(grok.contains("grok --resume") && grok.contains("--fork-session"));
+        assert!(can_fork("claude") && can_fork("codex") && can_fork("pi") && can_fork("grok"));
         // Resume-capable, but no native fork (the copy-then-resume tier is future).
-        assert!(fork_command("grok", "g1").is_none());
-        assert!(!can_fork("copilot") && !can_fork("grok"));
+        assert!(!can_fork("copilot"));
         assert!(!can_fork("cursor"));
         // Unknown agent / unsafe / empty id all refuse.
         assert!(fork_command("unknown", "x").is_none());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8471,6 +8471,36 @@ mod tests {
     }
 
     #[test]
+    fn fork_pane_splits_a_grok_session() {
+        let _env = crate::persist::test_env("fork-pane-grok");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let src = app.layout().focus;
+        {
+            let st = app.status.get_mut(&src).unwrap();
+            st.agent = "grok".into();
+            st.agent_session = Some(AgentSession {
+                agent: "grok".into(),
+                session_id: "sess-grok".into(),
+            });
+        }
+        assert!(app.fork_pane(src), "grok sessions fork natively");
+        let new = app.layout().focus;
+        assert_ne!(new, src);
+        assert_eq!(app.status.get(&new).unwrap().agent, "grok");
+        assert_eq!(
+            app.status
+                .get(&src)
+                .unwrap()
+                .agent_session
+                .as_ref()
+                .unwrap()
+                .session_id,
+            "sess-grok"
+        );
+    }
+
+    #[test]
     fn fork_from_mission_control_uses_the_agents_real_tab() {
         let _env = crate::persist::test_env("fork-pane-mission");
         let (tx, _rx) = std::sync::mpsc::channel();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4316,9 +4316,9 @@ mod tests {
         // DETAILED_USAGE ends with a newline the split consumes; compare trimmed.
         assert_eq!(
             block.trim_end(),
-            DETAILED_USAGE.trim_end(),
+            format!("{DETAILED_USAGE}{HELP_BUG}").trim_end(),
             "website/…/reference/cli.mdx has drifted from `luvus help all` — \
-             regenerate the page's txt block from the DETAILED_USAGE text"
+             regenerate the page's txt block from DETAILED_USAGE plus HELP_BUG"
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -320,11 +320,11 @@ pub fn run(args: &[String]) -> Result<i32> {
     if args.get(1).map(String::as_str) == Some("help") {
         return match args.get(2).map(String::as_str) {
             None => {
-                print!("{USAGE}");
+                print!("{USAGE}{HELP_BUG}");
                 Ok(0)
             }
             Some("all") if args.len() == 3 => {
-                print!("{DETAILED_USAGE}");
+                print!("{DETAILED_USAGE}{HELP_BUG}");
                 Ok(0)
             }
             Some(topic) if matches!(args.len(), 3 | 4) => {
@@ -553,6 +553,13 @@ fn normalize_help_topic(topic: &str) -> Option<&str> {
     }
 }
 
+const HELP_BUG: &str = r#"
+\   /
+ \_/
+(o_o)
+/|_|\
+"#;
+
 fn write_topic_help(
     mut output: impl Write,
     requested: &str,
@@ -564,12 +571,13 @@ fn write_topic_help(
     if topic == "session" {
         if let Some(command) = command {
             writeln!(output, "Usage: luvus session <command>\n")?;
-            if !write_command_rows(&mut output, SESSION_USAGE, topic, command)? {
+            if !write_topic_rows(&mut output, SESSION_USAGE, topic, Some(command))? {
                 output.write_all(SESSION_USAGE.as_bytes())?;
             }
         } else {
             output.write_all(SESSION_USAGE.as_bytes())?;
         }
+        output.write_all(HELP_BUG.as_bytes())?;
         return Ok(true);
     }
 
@@ -691,23 +699,24 @@ fn write_topic_help(
     };
 
     writeln!(output, "Usage: {usage}\n")?;
-    if let Some(command) = command {
-        if !write_command_rows(&mut output, section, topic, command)? {
-            output.write_all(section.as_bytes())?;
-        }
-    } else {
+    if !write_topic_rows(&mut output, section, topic, command)? {
         output.write_all(section.as_bytes())?;
     }
+    output.write_all(HELP_BUG.as_bytes())?;
     Ok(true)
 }
 
-fn write_command_rows(
+fn write_topic_rows(
     output: &mut impl Write,
     section: &str,
     topic: &str,
-    command: &str,
+    command: Option<&str>,
 ) -> std::io::Result<bool> {
-    let noun = if topic == "session" { "" } else { topic };
+    let noun = match topic {
+        "session" => "",
+        "remote" | "--remote" => "--remote",
+        _ => topic,
+    };
     let mut matched = false;
     let mut include_continuation = false;
 
@@ -731,9 +740,11 @@ fn write_command_rows(
                 continue;
             };
             let syntax = rest.split("  ").next().unwrap_or(rest);
-            include_continuation = syntax
-                .split(|character: char| character.is_whitespace() || character == '|')
-                .any(|token| token == command);
+            include_continuation = command.is_none_or(|command| {
+                syntax
+                    .split(|character: char| character.is_whitespace() || character == '|')
+                    .any(|token| token == command)
+            });
             if include_continuation {
                 matched = true;
                 writeln!(output, "{line}")?;
@@ -801,7 +812,8 @@ Commands:
 ";
 
 fn write_session_help(mut output: impl Write) -> std::io::Result<()> {
-    output.write_all(SESSION_USAGE.as_bytes())
+    output.write_all(SESSION_USAGE.as_bytes())?;
+    output.write_all(HELP_BUG.as_bytes())
 }
 
 fn session_list(args: &[String]) -> Result<i32> {
@@ -3445,6 +3457,71 @@ mod tests {
 
     fn argv(s: &str) -> Vec<String> {
         s.split_whitespace().map(String::from).collect()
+    }
+
+    fn rendered_topic_help(topic: &str, command: Option<&str>) -> String {
+        let mut output = Vec::new();
+        assert!(write_topic_help(&mut output, topic, command).unwrap());
+        String::from_utf8(output).unwrap()
+    }
+
+    #[test]
+    fn family_help_lists_only_commands_owned_by_that_family() {
+        for (topic, noun) in [
+            ("workspace", "workspace"),
+            ("tab", "tab"),
+            ("pane", "pane"),
+            ("agent", "agent"),
+            ("skill", "skill"),
+            ("wait", "wait"),
+            ("attach", "attach"),
+            ("search", "search"),
+            ("theme", "theme"),
+            ("bar", "bar"),
+            ("ui", "ui"),
+            ("module", "module"),
+            ("git", "git"),
+            ("files", "files"),
+            ("diff", "diff"),
+            ("worktree", "worktree"),
+            ("task", "task"),
+            ("lease", "lease"),
+            ("events", "events"),
+            ("api", "api"),
+            ("remote", "--remote"),
+            ("server", "server"),
+            ("integration", "integration"),
+        ] {
+            let output = rendered_topic_help(topic, None);
+            assert!(output.ends_with(HELP_BUG), "{topic} help lost the bug");
+            let rows: Vec<_> = output
+                .lines()
+                .filter(|line| {
+                    line.starts_with("  ")
+                        && line
+                            .as_bytes()
+                            .get(2)
+                            .is_some_and(|character| *character != b' ')
+                })
+                .collect();
+            assert!(!rows.is_empty(), "{topic} help has no command rows");
+            assert!(
+                rows.iter().all(|line| {
+                    line.trim_start()
+                        .strip_prefix(noun)
+                        .is_some_and(|rest| rest.chars().next().is_some_and(char::is_whitespace))
+                }),
+                "{topic} help contains another family: {rows:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn leaf_help_still_selects_only_the_requested_command() {
+        let output = rendered_topic_help("pane", Some("split"));
+        assert!(output.contains("pane split [<id>]"));
+        assert!(!output.contains("pane list"));
+        assert!(!output.contains("agent start"));
     }
 
     #[test]

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -120,6 +120,7 @@ support it natively:
 | Agent | Forks via |
 |---|---|
 | Claude Code | `claude --resume <id> --fork-session` |
+| Grok Build | `grok --resume <id> --fork-session` |
 | Codex | `codex fork <id>` |
 | Pi | `pi --fork <id>` |
 

--- a/website/src/content/docs/docs/guides/codex-plugin.mdx
+++ b/website/src/content/docs/docs/guides/codex-plugin.mdx
@@ -137,7 +137,7 @@ luvus agent fork reviewer --name experiment --no-focus
 ```
 
 The fork inherits the source conversation and receives its own new session.
-Native forks currently support Claude, Codex, and Pi. If the target is
+Native forks currently support Claude, Grok, Codex, and Pi. If the target is
 unsupported, its session cannot be resolved, or its pane cannot start, the
 skill reports Luvus's structured error instead of substituting a split, new
 agent, or resume operation that could lose or reuse the wrong context.

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -10,7 +10,7 @@ description: What luvus supports per agent, covering live status, session resume
 | Codex | ✓ | ✓ | ✓ | ✓ |
 | opencode | ✓ | ✓ | no | ✓ |
 | Kimi Code CLI | ✓ | ✓ | no | ✓ |
-| Grok Build | ✓ | ✓ | no | ✓ |
+| Grok Build | ✓ | ✓ | ✓ | ✓ |
 | Pi | ✓ | ✓ | ✓ | no |
 | Cursor | ✓ | resume command | no | no |
 | Gemini | ✓ | no | no | no |
@@ -29,8 +29,9 @@ description: What luvus supports per agent, covering live status, session resume
 - **Fork to New Pane** branches the running session into a new pane beside it,
   preserving the original's full context under a new session id while the
   original keeps running. It needs an agent with a native fork command, so today
-  that is **Claude** (`claude --resume <id> --fork-session`), **Codex**
-  (`codex fork <id>`), and **Pi** (`pi --fork <id>`). Right-click the pane and
+  that is **Claude** (`claude --resume <id> --fork-session`), **Grok**
+  (`grok --resume <id> --fork-session`), **Codex** (`codex fork <id>`), and
+  **Pi** (`pi --fork <id>`). Right-click the pane and
   choose **Fork to New Pane**, or press `Ctrl+Space f`. The action only appears
   for agents that can fork.
 - **Hook**, via `luvus integration install <agent>`, makes the agent report its

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -230,4 +230,11 @@ server:
   integration install|uninstall <claude|copilot|codex|opencode|kimi|grok>
                              add/remove luvus's session-resume hook (uninstall
                              removes only luvus's hook, never the agent)
+
+\   /
+ \_/
+(o_o)
+/|_|\
 ```
+
+


### PR DESCRIPTION
Grok Build panes can now fork like Claude: the original session stays running, and a sibling pane continues from a copy under a new session id.

## What

- Native Grok fork uses `grok --resume <id> --fork-session`, so right-click **Fork to New Pane**, `Ctrl+Space f`, and `luvus agent fork` work for Grok the same way they work for Claude.
- Restore still strips `--fork-session`, so a restarted fork resumes its own id instead of forking the parent again.
- Session resolution matches Claude: a hook-reported or already-bound id wins; otherwise Luvus falls back to the newest Grok session in that folder. Codex remains exact-id only.
- `luvus help <family>` now prints only that family's command rows. Focused help still selects a single command.
- Compact help, `help all`, family help, and session help append a small bug footer.

## Why

Grok already ships `--fork-session` with `--resume`. Luvus treated Grok as resume-only, so the fork action never appeared. Family help was leaking other command groups when the topic had no command filter.

## Verification

- [x] `cargo test --locked fork_` (11 passed) and `launch_flag_filter_drops_session_selection`
- [ ] `cargo test --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all --check`

## Notes

For two Grok panes in one project, `luvus integration install grok` still gives each pane an exact session id. Without a binding, fork uses the newest on-disk Grok session for that folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native session forking support for Grok Build, preserving session context when opening a new pane.
  * Updated supported-agent lists and fork guidance to include Grok Build.

* **Documentation**
  * Updated user guides, reference tables, and README content to document Grok Build session forking.
  * Added a Luvus mascot to the CLI reference documentation.

* **Improvements**
  * Improved help output consistency with bug-report markers across help views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->