### PR TITLE
refactor(terminal): construct VT engines through one factory

### DIFF
--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -16,8 +16,7 @@ use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use crate::event::AppEvent;
 use crate::ids::PaneId;
 use crate::terminal::backend::TerminalRuntime;
-use crate::terminal::vt::alacritty::AlacrittyEngine;
-use crate::terminal::vt::VtEngine;
+use crate::terminal::vt::{create_engine, VtEngine, VtEngineKind};
 
 const CHILD_REAPER_INTERVAL: Duration = Duration::from_millis(50);
 
@@ -475,12 +474,13 @@ impl Pane {
         // All bytes (user input + terminal responses) funnel through one channel
         // to a single writer thread — keeps ordering correct, needs no mutex.
         let (input_tx, input_rx) = mpsc::channel::<InputAction>();
-        let engine: Arc<Mutex<dyn VtEngine>> = Arc::new(Mutex::new(AlacrittyEngine::new(
+        let engine = create_engine(
+            VtEngineKind::default(),
             cols,
             rows,
             input_tx.clone(),
             history_budget_bytes,
-        )));
+        );
         // Replay the saved screen so a restored pane shows its prior content.
         if let Some(screen) = initial {
             if let Ok(mut e) = engine.lock() {
@@ -550,12 +550,13 @@ impl Pane {
         // Everything a caller can observe before the child exists: the engine
         // (pane.read, detection, rendering) and the input queue.
         let (input_tx, input_rx) = mpsc::channel::<InputAction>();
-        let engine: Arc<Mutex<dyn VtEngine>> = Arc::new(Mutex::new(AlacrittyEngine::new(
+        let engine = create_engine(
+            VtEngineKind::default(),
             cols,
             rows,
             input_tx.clone(),
             history_budget_bytes,
-        )));
+        );
         if let Some(screen) = initial {
             if let Ok(mut engine) = engine.lock() {
                 engine.advance(screen.as_bytes());

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -5,7 +5,45 @@
 
 pub mod alacritty;
 
+use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex};
+
 use ratatui::style::{Color, Modifier};
+
+use crate::terminal::pty::InputAction;
+
+/// Which terminal engine backs a pane.
+///
+/// One variant today. It exists so that the choice of engine is a named
+/// decision with one home, rather than a concrete type spelled out at each
+/// construction site.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum VtEngineKind {
+    #[default]
+    Alacritty,
+}
+
+/// Build the engine backing one pane.
+///
+/// Every pane is constructed through here, so engine selection, and any
+/// validation it later needs, live in one place while the rest of the
+/// application keeps talking only to [`VtEngine`].
+pub(crate) fn create_engine(
+    kind: VtEngineKind,
+    cols: u16,
+    rows: u16,
+    resp_tx: Sender<InputAction>,
+    history_budget_bytes: usize,
+) -> Arc<Mutex<dyn VtEngine>> {
+    match kind {
+        VtEngineKind::Alacritty => Arc::new(Mutex::new(alacritty::AlacrittyEngine::new(
+            cols,
+            rows,
+            resp_tx,
+            history_budget_bytes,
+        ))),
+    }
+}
 
 /// A rendered cell's style, already mapped to ratatui colors/modifiers so the
 /// trait surface stays free of engine-specific types. The cell's *symbol* (its
@@ -191,4 +229,20 @@ pub trait VtEngine: Send {
     /// Dump the visible screen as ANSI so it can be replayed into a fresh
     /// engine on restore (session persistence). Trailing blanks are trimmed.
     fn snapshot_ansi(&self) -> String;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[test]
+    fn factory_builds_a_working_default_engine() {
+        let (tx, _rx) = mpsc::channel();
+        let engine = create_engine(VtEngineKind::default(), 20, 3, tx, 64 * 1024);
+        let mut engine = engine.lock().expect("engine lock");
+        engine.advance(b"hi");
+        assert_eq!(engine.visible_rows()[0].trim_end(), "hi");
+        assert_eq!(engine.cursor().x, 2);
+    }
 }


### PR DESCRIPTION
## What

Route VT engine construction through one factory instead of naming the concrete
engine at each call site.

- `VtEngineKind` — one variant, `Alacritty`, and it is the `Default`.
- `create_engine(kind, cols, rows, resp_tx, history_budget_bytes)` — returns
  `Arc<Mutex<dyn VtEngine>>`, which is what both callers already built by hand.

Both production sites in `src/terminal/pty.rs` (pane spawn and deferred pane
construction) now call the factory. The two remaining direct constructions are
in `#[cfg(test)]` code that deliberately drives a concrete engine, so they are
left alone.

## Why

`VtEngine` is already the boundary the rest of the app talks to, but the choice
of engine was spelled out wherever a pane was built. That makes the decision
implicit and duplicated: two identical seven-line constructions that must be
kept in sync, and no single place to put validation, diagnostics or a future
alternative.

#49's architecture section already calls for exactly this — "add an engine kind
and one factory responsible for validation and construction" — so this is that
step, extracted on its own and with no engine attached to it. Doing it
separately keeps the refactor reviewable and keeps the interesting work in #49
free of unrelated churn.

Related: #106, which proposes what the seam could carry once it exists. This PR
takes no position on that; it is a straight refactor either way.

## No behavior change

One kind, every caller passes `VtEngineKind::default()`, and the engine built is
the same `AlacrittyEngine` with the same arguments. Nothing is configurable and
no user-visible surface moves.

## Tests

`terminal::vt::tests::factory_builds_a_working_default_engine` — builds through
the factory, feeds bytes, and asserts the grid and cursor, so the factory is
covered rather than merely compiled.

Full local run against the CI gates:

- `cargo fmt --package luvus --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --locked` — 834 passed, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable terminal engine selection while preserving the default Alacritty-based experience.
  * Restored terminal panes can now replay saved screen content during startup.
  * Added reliable detection of pending terminal data.

* **Bug Fixes**
  * Improved startup reliability by retrying the requested and fallback working directories.
  * Preserved pasted content containing Windows paths, quotation marks, and Unicode characters.
  * Improved terminal output parsing and cursor updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->