### PR TITLE
test(terminal): pin cell-level VT engine behaviour

### DIFF
--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -246,3 +246,103 @@ mod tests {
         assert_eq!(engine.cursor().x, 2);
     }
 }
+
+#[cfg(test)]
+mod conformance {
+    //! Characterisation of the `VtEngine` contract at the cell level.
+    //!
+    //! These assert *where each grapheme cluster lands*, not just the text a
+    //! row renders to. A text comparison cannot see the difference between a
+    //! cluster held in one wide cell and the same codepoints split across two,
+    //! yet that difference moves every column after it on the line — so it is
+    //! exactly what a text-level test misses and a pane visibly gets wrong.
+    //!
+    //! They are written against the trait rather than any engine, so they hold
+    //! for whatever backs `create_engine`.
+
+    use super::*;
+    use std::sync::mpsc;
+
+    /// Visible grid as one `"col:CODEPOINT+CODEPOINT"` token per occupied cell,
+    /// row by row. Blank cells are omitted, so a token's column is the
+    /// assertion: a cluster that grew wider shows up as a gap.
+    fn cell_dump(input: &[u8], cols: u16, rows: u16) -> Vec<String> {
+        let (tx, _rx) = mpsc::channel();
+        let engine = create_engine(VtEngineKind::default(), cols, rows, tx, 64 * 1024);
+        let mut engine = engine.lock().expect("engine lock");
+        engine.advance(input);
+
+        let mut out: Vec<Vec<String>> = vec![Vec::new(); rows as usize];
+        engine.for_each_cell(&mut |row, col, symbol, _style| {
+            if symbol == " " {
+                return;
+            }
+            let points: Vec<String> = symbol
+                .chars()
+                .map(|ch| format!("{:X}", ch as u32))
+                .collect();
+            out[row as usize].push(format!("{}:{}", col, points.join("+")));
+        });
+        out.into_iter().map(|row| row.join(" ")).collect()
+    }
+
+    #[test]
+    fn ascii_lands_one_cell_per_column() {
+        assert_eq!(cell_dump(b"ab", 4, 3)[0], "0:61 1:62");
+    }
+
+    #[test]
+    fn wide_characters_occupy_two_columns() {
+        // U+65E5, U+672C: the spacer cell is not reported, so the second
+        // character starting at column 2 is what proves the first took two.
+        assert_eq!(
+            cell_dump("\u{65E5}\u{672C}".as_bytes(), 4, 3)[0],
+            "0:65E5 2:672C"
+        );
+    }
+
+    #[test]
+    fn combining_marks_stay_with_their_base_cell() {
+        // "e" + U+0301 is one cell carrying both codepoints, one column wide.
+        assert_eq!(cell_dump("e\u{301}x".as_bytes(), 4, 3)[0], "0:65+301 1:78");
+    }
+
+    #[test]
+    fn variation_selector_16_stays_narrow() {
+        // U+2764 U+FE0F occupies a single column: the "x" follows at column 1.
+        assert_eq!(
+            cell_dump("\u{2764}\u{FE0F}x".as_bytes(), 4, 3)[0],
+            "0:2764+FE0F 1:78"
+        );
+    }
+
+    #[test]
+    fn emoji_zwj_sequence_spans_two_wide_cells() {
+        // U+1F469 U+200D U+1F4BB is one grapheme cluster, but the engine keeps
+        // the joiner with the first emoji and gives the second its own wide
+        // cell - four columns in total, which fills this row and pushes the
+        // trailing "x" onto the next one. UTS #51 treats the sequence as a
+        // single width-2 cluster, so an engine following that rule would place
+        // "x" at column 2 of row 0 instead. Pinned deliberately: a swap in
+        // either direction reflows every line carrying emoji.
+        let dump = cell_dump("\u{1F469}\u{200D}\u{1F4BB}x".as_bytes(), 4, 3);
+        assert_eq!(dump[0], "0:1F469+200D 2:1F4BB");
+        assert_eq!(dump[1], "0:78");
+    }
+
+    #[test]
+    fn emoji_modifier_sequence_spans_two_wide_cells() {
+        // U+1F44D U+1F3FD, same shape as the ZWJ case: the skin-tone modifier
+        // takes its own wide cell rather than joining the base cluster.
+        let dump = cell_dump("\u{1F44D}\u{1F3FD}x".as_bytes(), 4, 3);
+        assert_eq!(dump[0], "0:1F44D 2:1F3FD");
+        assert_eq!(dump[1], "0:78");
+    }
+
+    #[test]
+    fn text_soft_wraps_at_the_right_margin() {
+        let dump = cell_dump(b"abcdefgh", 4, 3);
+        assert_eq!(dump[0], "0:61 1:62 2:63 3:64");
+        assert_eq!(dump[1], "0:65 1:66 2:67 3:68");
+    }
+}


### PR DESCRIPTION
> **Stacked on #109.** Until that merges this PR shows both commits; the one to
> review here is `test(terminal): pin cell-level VT engine behaviour`. GitHub
> will narrow the diff automatically once #109 lands.

## Problem

The existing engine tests assert rendered *text*. That cannot distinguish a
grapheme cluster held in one wide cell from the same codepoints split across two
cells — both render the same string. But the two place every following column
differently, so the difference is invisible to the tests and plainly visible in a
pane.

It is also easy to change by accident: a bump of `alacritty_terminal`, a
`unicode-width` update, or any future engine work can move a cluster's width
without touching a line of Luvus.

## Change

Seven characterisation tests over `for_each_cell`, asserting *where each cluster
lands* rather than what the row reads as. The helper dumps the visible grid as
`col:CODEPOINT+CODEPOINT` tokens and omits blanks, so a cluster that grew wider
shows up as a gap in the column numbers.

Covered: ASCII placement, wide characters, combining marks, VS16, emoji ZWJ
sequences, emoji modifier sequences, and soft wrap at the right margin.

They are written against `VtEngine`, not against `AlacrittyEngine`, so they hold
for whatever `create_engine` returns.

## What they pin

Three of these are worth knowing about, because they are decisions the engine
makes on Luvus's behalf and agent CLIs emit these characters constantly:

| input | current behaviour |
|---|---|
| `👩‍💻` `U+1F469 U+200D U+1F4BB` | joiner stays with the first emoji, second emoji gets its own wide cell — **4 columns** |
| `👍🏽` `U+1F44D U+1F3FD` | modifier takes its own wide cell — **4 columns** |
| `❤️` `U+2764 U+FE0F` | **1 column** |

UTS #51 treats an emoji ZWJ sequence and an emoji-modifier sequence as single
width-2 clusters, so a strictly conforming engine would place these differently.
I am not proposing a change — the tests pin what Luvus does today, with the
divergence noted in a comment so the choice is visible rather than accidental.

## Relationship to #49

#49 asks for a shared backend conformance suite before a second engine can be
called equivalent. This is the smallest useful piece of it, contributed with no
engine attached: it works today as regression protection for the engine already
here, and any future engine has to match it or explain why.

## Tests

- `cargo fmt --package luvus --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --locked` — 841 passed, 0 failed (834 before, 7 added)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for restoring terminal screens, including saved content and paste state.
  * Improved deferred terminal launches with fallback working directories and clearer startup status.
  * Added support for detecting pending terminal output without consuming it.

* **Bug Fixes**
  * Improved terminal rendering for wide characters, combining marks, variation selectors, and emoji sequences.
  * Fixed edge cases involving soft wrapping and character placement.
  * Improved terminal pane initialization for more consistent behavior across launch paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->