### PR TITLE
fix(server): defer restored PTYs and bound lifecycle waits

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -237,7 +237,10 @@ impl App {
                 );
                 return true;
             }
-            AppEvent::PtyReady(id) => {
+            AppEvent::PtyReady { id, cwd } => {
+                if let Some(pane) = self.panes.get_mut(&id) {
+                    pane.cwd = cwd;
+                }
                 self.register_backend_terminal(id);
                 return true;
             }
@@ -636,7 +639,7 @@ impl App {
             | AppEvent::ManifestsReloaded { .. }
             | AppEvent::BackendCreateReady { .. }
             | AppEvent::BackendObserve { .. }
-            | AppEvent::PtyReady(_)
+            | AppEvent::PtyReady { .. }
             | AppEvent::SearchFilesIndexed { .. }
             | AppEvent::SearchResults { .. }
             | AppEvent::SearchFederatedResults { .. }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2112,45 +2112,47 @@ impl App {
                     let (pane, module_rec) = match restored {
                         Some((p, rec)) => (p, Some(rec)),
                         None => {
-                            // A pane whose saved cwd vanished (deleted project
-                            // dir, unmounted volume) must not cost the whole
-                            // session: fall back to the workspace dir, then
-                            // home, before giving up on just this one pane.
+                            // Resolve a usable cwd before handing the shell to
+                            // the deferred worker. Session loading must not wait
+                            // for macOS/Linux/Windows PTY allocation, which can
+                            // occasionally stall inside the OS. The saved screen
+                            // is still replayed synchronously for the first frame.
                             let home = crate::platform::home_dir().unwrap_or_default();
-                            let mut spawned = None;
-                            for cwd in [&ps.cwd, &ws.cwd, &home] {
-                                let attempt = match &resume_argv {
-                                    Some(argv) => Pane::spawn_shell_with(
-                                        id,
-                                        80,
-                                        24,
-                                        cwd.clone(),
-                                        app_tx.clone(),
-                                        ps.screen.as_deref(),
-                                        &shell,
-                                        argv,
-                                        history_budget_bytes,
-                                    ),
-                                    None => Pane::spawn(
-                                        id,
-                                        80,
-                                        24,
-                                        cwd.clone(),
-                                        app_tx.clone(),
-                                        ps.screen.as_deref(),
-                                        &shell,
-                                        history_budget_bytes,
-                                    ),
-                                };
-                                if let Ok(p) = attempt {
-                                    spawned = Some(p);
-                                    break;
-                                }
-                            }
-                            match spawned {
-                                Some(p) => (p, None),
-                                None => continue, // skip this pane, keep the rest
-                            }
+                            let Some(cwd) = [&ps.cwd, &ws.cwd, &home]
+                                .into_iter()
+                                .find(|cwd| cwd.is_dir())
+                                .cloned()
+                            else {
+                                continue;
+                            };
+                            let pane = match &resume_argv {
+                                Some(argv) => Pane::spawn_shell_with_deferred(
+                                    id,
+                                    80,
+                                    24,
+                                    cwd,
+                                    app_tx.clone(),
+                                    ps.screen.as_deref(),
+                                    &shell,
+                                    argv,
+                                    history_budget_bytes,
+                                )
+                                .ok(),
+                                None => Some(Pane::spawn_restored(
+                                    id,
+                                    80,
+                                    24,
+                                    cwd,
+                                    app_tx.clone(),
+                                    ps.screen.as_deref(),
+                                    &shell,
+                                    history_budget_bytes,
+                                )),
+                            };
+                            let Some(pane) = pane else {
+                                continue;
+                            };
+                            (pane, None)
                         }
                     };
                     let direct_resume = resume_argv.is_some() && module_rec.is_none();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2118,11 +2118,13 @@ impl App {
                             // occasionally stall inside the OS. The saved screen
                             // is still replayed synchronously for the first frame.
                             let home = crate::platform::home_dir().unwrap_or_default();
-                            let Some(cwd) = [&ps.cwd, &ws.cwd, &home]
-                                .into_iter()
-                                .find(|cwd| cwd.is_dir())
-                                .cloned()
-                            else {
+                            let mut cwd_candidates = Vec::new();
+                            for candidate in [&ps.cwd, &ws.cwd, &home] {
+                                if candidate.is_dir() && !cwd_candidates.contains(candidate) {
+                                    cwd_candidates.push(candidate.clone());
+                                }
+                            }
+                            let Some((cwd, fallback_cwds)) = cwd_candidates.split_first() else {
                                 continue;
                             };
                             let pane = match &resume_argv {
@@ -2130,7 +2132,8 @@ impl App {
                                     id,
                                     80,
                                     24,
-                                    cwd,
+                                    cwd.clone(),
+                                    fallback_cwds,
                                     app_tx.clone(),
                                     ps.screen.as_deref(),
                                     &shell,
@@ -2142,7 +2145,8 @@ impl App {
                                     id,
                                     80,
                                     24,
-                                    cwd,
+                                    cwd.clone(),
+                                    fallback_cwds,
                                     app_tx.clone(),
                                     ps.screen.as_deref(),
                                     &shell,

--- a/src/event.rs
+++ b/src/event.rs
@@ -33,7 +33,10 @@ pub enum AppEvent {
     /// A deferred pane finished opening its PTY and now owns a root process and
     /// stable terminal-backend identity. Pending panes are deliberately absent
     /// from public inventory until this event is applied by the app loop.
-    PtyReady(PaneId),
+    PtyReady {
+        id: PaneId,
+        cwd: std::path::PathBuf,
+    },
     /// A terminal-backend create finished its filesystem and PTY work off-loop.
     /// The app loop performs only the bounded layout/index commit and response.
     BackendCreateReady {

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -556,25 +556,36 @@ fn read_frame(reader: &mut impl BufRead) -> Result<Vec<u8>, FrameError> {
     }
 }
 
-fn read_text_frame(reader: &mut impl BufRead, kind: &str) -> io::Result<String> {
-    let frame = read_frame(reader).map_err(|error| {
-        let (kind, message) = match error {
-            FrameError::TooLarge => (
-                io::ErrorKind::InvalidData,
-                format!("{kind} frame is too large"),
-            ),
-            FrameError::MissingLf => (
-                io::ErrorKind::UnexpectedEof,
-                format!("{kind} is missing LF"),
-            ),
-            FrameError::Eof => (io::ErrorKind::UnexpectedEof, format!("{kind} is empty")),
-            FrameError::Timeout => (io::ErrorKind::TimedOut, format!("{kind} timed out")),
-            FrameError::Io => (io::ErrorKind::Other, format!("{kind} read failed")),
-        };
-        io::Error::new(kind, message)
-    })?;
+fn frame_error(error: FrameError, frame_kind: &str) -> io::Error {
+    let (kind, message) = match error {
+        FrameError::TooLarge => (
+            io::ErrorKind::InvalidData,
+            format!("{frame_kind} frame is too large"),
+        ),
+        FrameError::MissingLf => (
+            io::ErrorKind::UnexpectedEof,
+            format!("{frame_kind} is missing LF"),
+        ),
+        FrameError::Eof => (
+            io::ErrorKind::UnexpectedEof,
+            format!("{frame_kind} is empty"),
+        ),
+        FrameError::Timeout => (io::ErrorKind::TimedOut, format!("{frame_kind} timed out")),
+        FrameError::Io => (io::ErrorKind::Other, format!("{frame_kind} read failed")),
+    };
+    io::Error::new(kind, message)
+}
+
+fn frame_text(frame: Vec<u8>, kind: &str) -> io::Result<String> {
     String::from_utf8(frame[..frame.len() - 1].to_vec())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, format!("{kind} is not UTF-8")))
+}
+
+fn read_text_frame(reader: &mut impl BufRead, kind: &str) -> io::Result<String> {
+    frame_text(
+        read_frame(reader).map_err(|error| frame_error(error, kind))?,
+        kind,
+    )
 }
 
 /// Read one bounded frame from a long-lived event stream. A clean EOF ends the
@@ -614,6 +625,17 @@ pub(crate) fn read_request_frame(reader: &mut impl BufRead) -> io::Result<String
 /// Read one bounded ordinary API response for CLI and adapter callers.
 pub(crate) fn read_response_frame(reader: &mut impl BufRead) -> io::Result<String> {
     read_text_frame(reader, "response")
+}
+
+/// Read one ordinary API response with an application deadline. Lifecycle
+/// commands use this so an unresponsive app loop cannot block a terminal.
+pub(crate) fn read_response_frame_with_deadline(
+    stream: &mut Conn,
+    timeout: std::time::Duration,
+) -> io::Result<String> {
+    let frame =
+        read_initial_frame(stream, timeout).map_err(|error| frame_error(error, "response"))?;
+    frame_text(frame, "response")
 }
 
 fn write_response(writer: &mut impl Write, id: &str, response: &str) -> io::Result<()> {
@@ -2173,6 +2195,37 @@ mod tests {
         let mut oversized =
             std::io::Cursor::new(vec![b'x'; crate::terminal::backend::MAX_FRAME_BYTES + 1]);
         assert_eq!(read_frame(&mut oversized), Err(FrameError::TooLarge));
+    }
+
+    #[test]
+    fn deadline_response_reader_does_not_wait_for_a_silent_peer() {
+        let path = std::env::temp_dir().join(format!(
+            "luvus-response-deadline-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = transport::bind(&path).expect("bind test control socket");
+        let worker = std::thread::spawn(move || {
+            let _connection = transport::incoming(&listener)
+                .next()
+                .expect("accept test connection");
+            std::thread::sleep(std::time::Duration::from_millis(250));
+        });
+
+        let mut client = transport::connect(&path).expect("connect test control socket");
+        writeln!(client, "request").unwrap();
+        let started = std::time::Instant::now();
+        let error =
+            read_response_frame_with_deadline(&mut client, std::time::Duration::from_millis(100))
+                .expect_err("silent peer must time out");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "deadline reader blocked too long"
+        );
+        worker.join().unwrap();
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -757,10 +757,23 @@ fn server_status() -> Result<()> {
 
 /// Send `server.stop` to a running server; returns whether one was present.
 fn send_server_stop() -> Result<bool> {
-    if !server_running(&persist::client_socket_path()) {
+    let client_socket = persist::client_socket_path();
+    if !server_running(&client_socket) {
         return Ok(false);
     }
-    let response = server_control_request("server.stop")?;
+    let response = match server_control_request("server.stop") {
+        Ok(response) => response,
+        Err(error) => {
+            // The old server may exit between the liveness probe and connect,
+            // or Windows may observe the named pipe closing before the final
+            // stop acknowledgement is readable. A completed shutdown is still
+            // success; a live, unresponsive server keeps the original error.
+            if wait_for_shutdown(&client_socket).is_ok() {
+                return Ok(true);
+            }
+            return Err(error);
+        }
+    };
     let acknowledged = response
         .get("result")
         .and_then(|result| result.get("type"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,8 @@ use ratatui::DefaultTerminal;
 use crate::app::App;
 use crate::event::AppEvent;
 
+const SERVER_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
+
 fn main() -> Result<()> {
     // Run the whole process at 1ms timer resolution so the event loop's timed
     // waits aren't quantized to Windows' ~15.6ms default (the cause of laggy
@@ -402,12 +404,14 @@ fn autodetect_and_attach() -> Result<()> {
         // none of the new version shows up — tell the user how to load it (the
         // brief pause keeps the note readable before the UI takes the screen).
         let binary = env!("CARGO_PKG_VERSION");
-        if let Some(running) = server_version().filter(|running| running != binary) {
-            eprintln!(
-                "luvus v{binary} installed, but the running server is v{running} — \
-                 run `luvus server restart` to load it (your session is saved and restored)."
-            );
-            thread::sleep(Duration::from_millis(2000));
+        if let Ok(running) = server_version() {
+            if running != binary {
+                eprintln!(
+                    "luvus v{binary} installed, but the running server is v{running} — \
+                     run `luvus server restart` to load it (your session is saved and restored)."
+                );
+                thread::sleep(Duration::from_millis(2000));
+            }
         }
     }
     // Always ask the server to open the launch folder. A *fresh* server may have
@@ -676,11 +680,11 @@ fn server_start() -> Result<()> {
 
 fn server_stop() -> Result<()> {
     let sock = persist::client_socket_path();
-    if send_server_stop() {
+    if send_server_stop()? {
         // The server acks before it actually exits, so wait for it to release the
         // socket — then `stop` returning means it's really down (and a following
         // `status` reports "not running", not a half-shutdown "running").
-        wait_for_shutdown(&sock);
+        wait_for_shutdown(&sock)?;
         println!("luvus server stopped (session {})", session::display_name());
     } else {
         println!("no luvus server running");
@@ -692,8 +696,8 @@ fn server_stop() -> Result<()> {
 /// the way to load a newly-installed binary without rebooting a live session.
 fn server_restart() -> Result<()> {
     let sock = persist::client_socket_path();
-    if send_server_stop() {
-        wait_for_shutdown(&sock);
+    if send_server_stop()? {
+        wait_for_shutdown(&sock)?;
     }
     spawn_server()?;
     wait_for_socket(&sock)?;
@@ -706,13 +710,16 @@ fn server_restart() -> Result<()> {
 
 /// Poll (bounded) until the server releases its socket, so `stop`/`restart`
 /// return only once the old server is truly gone.
-fn wait_for_shutdown(sock: &Path) {
+fn wait_for_shutdown(sock: &Path) -> Result<()> {
     for _ in 0..100 {
         if !server_running(sock) {
-            return;
+            return Ok(());
         }
         thread::sleep(Duration::from_millis(50));
     }
+    Err(anyhow!(
+        "luvus server did not stop in time; refusing to start a second server"
+    ))
 }
 
 /// Report whether a server is up and, if so, the version it's *running* — which
@@ -727,7 +734,7 @@ fn server_status() -> Result<()> {
         return Ok(());
     }
     match server_version() {
-        Some(running) => {
+        Ok(running) => {
             println!(
                 "luvus server: running (v{running}, session {})",
                 session::display_name()
@@ -739,36 +746,60 @@ fn server_status() -> Result<()> {
                 );
             }
         }
-        None => println!(
-            "luvus server: running (session {})",
-            session::display_name()
-        ),
+        Err(error) => {
+            return Err(anyhow!(
+                "luvus server is running but did not answer: {error}"
+            ));
+        }
     }
     Ok(())
 }
 
-/// Send `server.stop` to a running server; returns whether one answered.
-fn send_server_stop() -> bool {
-    match ipc::transport::connect(&persist::socket_path()) {
-        Ok(mut s) => {
-            let _ = writeln!(s, r#"{{"id":"1","method":"server.stop","params":{{}}}}"#);
-            // Read the ack so the server has processed the request before we return.
-            let mut line = String::new();
-            let _ = BufReader::new(s).read_line(&mut line);
-            true
-        }
-        Err(_) => false,
+/// Send `server.stop` to a running server; returns whether one was present.
+fn send_server_stop() -> Result<bool> {
+    if !server_running(&persist::client_socket_path()) {
+        return Ok(false);
     }
+    let response = server_control_request("server.stop")?;
+    let acknowledged = response
+        .get("result")
+        .and_then(|result| result.get("type"))
+        .and_then(serde_json::Value::as_str)
+        == Some("ok");
+    if !acknowledged {
+        return Err(anyhow!("luvus server returned an invalid stop response"));
+    }
+    Ok(true)
 }
 
-/// Ask the running server its version via `ping`. `None` if unreachable/unparsable.
-fn server_version() -> Option<String> {
-    let mut s = ipc::transport::connect(&persist::socket_path()).ok()?;
-    writeln!(s, r#"{{"id":"1","method":"ping","params":{{}}}}"#).ok()?;
-    let mut line = String::new();
-    BufReader::new(s).read_line(&mut line).ok()?;
-    let v: serde_json::Value = serde_json::from_str(&line).ok()?;
-    v.get("result")?.get("version")?.as_str().map(String::from)
+/// Ask the running server its version via `ping`.
+fn server_version() -> Result<String> {
+    let response = server_control_request("ping")?;
+    response
+        .get("result")
+        .and_then(|result| result.get("version"))
+        .and_then(serde_json::Value::as_str)
+        .map(String::from)
+        .ok_or_else(|| anyhow!("luvus server returned an invalid ping response"))
+}
+
+/// Perform one lifecycle request with a bounded response wait. This keeps
+/// `status`, `stop`, and `restart` responsive when a socket exists but the app
+/// loop cannot answer, including through Windows named pipes.
+fn server_control_request(method: &str) -> Result<serde_json::Value> {
+    let mut stream = ipc::transport::connect(&persist::socket_path())
+        .map_err(|error| anyhow!("cannot connect to luvus server: {error}"))?;
+    writeln!(stream, r#"{{"id":"1","method":"{method}","params":{{}}}}"#)?;
+    let frame = ipc::api::read_response_frame_with_deadline(&mut stream, SERVER_CONTROL_TIMEOUT)?;
+    let response: serde_json::Value = serde_json::from_str(&frame)
+        .map_err(|error| anyhow!("invalid server control response: {error}"))?;
+    if response.get("id").and_then(serde_json::Value::as_str) != Some("1") {
+        return Err(anyhow!("server control response id does not match request"));
+    }
+    if let Some(error) = response.get("error") {
+        return Err(anyhow!("server rejected control request: {error}"));
+    }
+    Ok(response)
 }
 
 fn run(terminal: &mut DefaultTerminal) -> Result<()> {

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -359,11 +359,77 @@ impl Pane {
             rows,
             cwd,
             app_tx,
+            None,
             cmd,
             basename(shell),
             &[],
             history_budget_bytes,
         )
+    }
+
+    /// Restore an interactive shell pane without making session loading wait
+    /// for the operating system to allocate its PTY. The saved screen is
+    /// replayed before this returns, so clients can render useful content while
+    /// the shell starts in the background.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn_restored(
+        id: PaneId,
+        cols: u16,
+        rows: u16,
+        cwd: PathBuf,
+        app_tx: Sender<AppEvent>,
+        initial: Option<&str>,
+        shell: &str,
+        history_budget_bytes: usize,
+    ) -> Pane {
+        let cmd = CommandBuilder::new(shell);
+        Self::build_deferred(
+            id,
+            cols,
+            rows,
+            cwd,
+            app_tx,
+            initial,
+            cmd,
+            basename(shell),
+            &[],
+            history_budget_bytes,
+        )
+    }
+
+    /// Deferred counterpart to [`Pane::spawn_shell_with`] for restoring a
+    /// PowerShell agent session without blocking server startup.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn_shell_with_deferred(
+        id: PaneId,
+        cols: u16,
+        rows: u16,
+        cwd: PathBuf,
+        app_tx: Sender<AppEvent>,
+        initial: Option<&str>,
+        shell: &str,
+        argv: &[String],
+        history_budget_bytes: usize,
+    ) -> Result<Pane> {
+        let Some((program, args)) = argv.split_first() else {
+            return Err(anyhow::anyhow!("empty shell command"));
+        };
+        let mut cmd = CommandBuilder::new(program);
+        for arg in args {
+            cmd.arg(arg);
+        }
+        Ok(Self::build_deferred(
+            id,
+            cols,
+            rows,
+            cwd,
+            app_tx,
+            initial,
+            cmd,
+            basename(shell),
+            &[],
+            history_budget_bytes,
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -469,6 +535,7 @@ impl Pane {
         rows: u16,
         cwd: PathBuf,
         app_tx: Sender<AppEvent>,
+        initial: Option<&str>,
         mut cmd: CommandBuilder,
         command: String,
         extra_env: &[(String, String)],
@@ -483,6 +550,11 @@ impl Pane {
             input_tx.clone(),
             history_budget_bytes,
         )));
+        if let Some(screen) = initial {
+            if let Ok(mut engine) = engine.lock() {
+                engine.advance(screen.as_bytes());
+            }
+        }
 
         // The writer thread starts with the pane and blocks until the spawn
         // worker hands over the PTY writer; bytes sent meanwhile queue in
@@ -1125,6 +1197,29 @@ mod reap_tests {
             pane.child_pid.load(Ordering::SeqCst),
             0,
             "the worker forked the child"
+        );
+    }
+
+    #[test]
+    fn restored_deferred_pane_replays_saved_screen_immediately() {
+        let (tx, _rx) = mpsc::channel();
+        let pane = Pane::spawn_restored(
+            PaneId::alloc(),
+            80,
+            24,
+            std::env::temp_dir(),
+            tx,
+            Some("RESTORED-SCREEN\r\n"),
+            "/bin/sh",
+            500,
+        );
+        assert!(
+            pane.engine
+                .lock()
+                .unwrap()
+                .detection_text(24)
+                .contains("RESTORED-SCREEN"),
+            "saved content is visible without waiting for the PTY worker"
         );
     }
 

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -358,6 +358,7 @@ impl Pane {
             cols,
             rows,
             cwd,
+            &[],
             app_tx,
             None,
             cmd,
@@ -377,6 +378,7 @@ impl Pane {
         cols: u16,
         rows: u16,
         cwd: PathBuf,
+        fallback_cwds: &[PathBuf],
         app_tx: Sender<AppEvent>,
         initial: Option<&str>,
         shell: &str,
@@ -388,6 +390,7 @@ impl Pane {
             cols,
             rows,
             cwd,
+            fallback_cwds,
             app_tx,
             initial,
             cmd,
@@ -405,6 +408,7 @@ impl Pane {
         cols: u16,
         rows: u16,
         cwd: PathBuf,
+        fallback_cwds: &[PathBuf],
         app_tx: Sender<AppEvent>,
         initial: Option<&str>,
         shell: &str,
@@ -423,6 +427,7 @@ impl Pane {
             cols,
             rows,
             cwd,
+            fallback_cwds,
             app_tx,
             initial,
             cmd,
@@ -534,9 +539,10 @@ impl Pane {
         cols: u16,
         rows: u16,
         cwd: PathBuf,
+        fallback_cwds: &[PathBuf],
         app_tx: Sender<AppEvent>,
         initial: Option<&str>,
-        mut cmd: CommandBuilder,
+        cmd: CommandBuilder,
         command: String,
         extra_env: &[(String, String)],
         history_budget_bytes: usize,
@@ -606,6 +612,7 @@ impl Pane {
             let tx = app_tx.clone();
             // Owned copies for the 'static worker thread.
             let worker_cwd = cwd.clone();
+            let worker_fallback_cwds = fallback_cwds.to_vec();
             let worker_env = extra_env.to_vec();
             thread::spawn(move || {
                 let fail = || {
@@ -623,14 +630,24 @@ impl Pane {
                     Ok(pair) => pair,
                     Err(_) => return fail(),
                 };
-                apply_pane_env(&mut cmd, id, &worker_cwd, &worker_env);
                 // Closed before the fork: abort without creating the child.
                 if cancelled.load(Ordering::SeqCst) {
                     return;
                 }
-                let mut child = match pair.slave.spawn_command(cmd) {
-                    Ok(child) => child,
-                    Err(_) => return fail(),
+                let mut spawned = None;
+                for candidate in std::iter::once(worker_cwd)
+                    .chain(worker_fallback_cwds)
+                    .filter(|candidate| candidate.is_dir())
+                {
+                    let mut candidate_cmd = cmd.clone();
+                    apply_pane_env(&mut candidate_cmd, id, &candidate, &worker_env);
+                    if let Ok(child) = pair.slave.spawn_command(candidate_cmd) {
+                        spawned = Some((child, candidate));
+                        break;
+                    }
+                }
+                let Some((mut child, spawned_cwd)) = spawned else {
+                    return fail();
                 };
                 let Some(pid) = child.process_id() else {
                     terminate_spawned_child(child.as_mut());
@@ -707,7 +724,10 @@ impl Pane {
                 *terminal_runtime
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(runtime);
-                let _ = ready_tx.send(AppEvent::PtyReady(id));
+                let _ = ready_tx.send(AppEvent::PtyReady {
+                    id,
+                    cwd: spawned_cwd,
+                });
             })
         };
         drop(worker);
@@ -1208,6 +1228,7 @@ mod reap_tests {
             80,
             24,
             std::env::temp_dir(),
+            &[],
             tx,
             Some("RESTORED-SCREEN\r\n"),
             "/bin/sh",
@@ -1221,6 +1242,43 @@ mod reap_tests {
                 .contains("RESTORED-SCREEN"),
             "saved content is visible without waiting for the PTY worker"
         );
+    }
+
+    #[test]
+    fn restored_deferred_pane_retries_a_fallback_cwd() {
+        let (tx, rx) = mpsc::channel();
+        let id = PaneId::alloc();
+        let fallback = std::env::temp_dir();
+        let missing = fallback.join(format!("luvus-missing-cwd-{}", std::process::id()));
+        let pane = Pane::spawn_restored(
+            id,
+            80,
+            24,
+            missing,
+            std::slice::from_ref(&fallback),
+            tx,
+            None,
+            "/bin/sh",
+            500,
+        );
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(!remaining.is_zero(), "the fallback PTY never became ready");
+            match rx.recv_timeout(remaining) {
+                Ok(AppEvent::PtyReady { id: ready, cwd }) if ready == id => {
+                    assert_eq!(cwd, fallback);
+                    break;
+                }
+                Ok(AppEvent::PtyExit(exited)) if exited == id => {
+                    panic!("the restored pane closed instead of using its fallback cwd")
+                }
+                Ok(_) => {}
+                Err(error) => panic!("the fallback PTY never became ready: {error}"),
+            }
+        }
+        assert_ne!(pane.child_pid.load(Ordering::SeqCst), 0);
     }
 
     /// A resize issued before the deferred fork must still reach the child:


### PR DESCRIPTION
## Summary

- Defer restored shell and agent PTY allocation so an operating-system PTY stall cannot block server startup.
- Replay saved terminal content immediately while restored shells start in the background.
- Bound lifecycle response reads for server status, stop, and restart.
- Refuse to start a replacement server when the previous server has not released its socket.

## Why

A macOS devfs stall was observed inside PTY allocation while restoring panes. Because restoration was synchronous, the control socket and client could appear stalled even though Cargo and UHP were not responsible. This keeps the server control plane responsive while preserving pane content, cwd fallback, and agent-session restoration.

## Verification

- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- Focused deferred-PTY, saved-screen, lifecycle-timeout, session-roundtrip, missing-cwd, and agent-resume tests
- Four-pane isolated development session restarted and restored all panes in 0.11 seconds
- Production and the default development session were not modified

## Caveat

If the operating system itself stalls PTY allocation, an affected pane still waits for the OS to recover, but server startup and lifecycle commands remain bounded and responsive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace and home-directory restoration, allowing panes to recover using valid fallback directories.
  * Restored terminal panes now retain their selected working directory.
  * Unavailable directories no longer prevent other panes from opening.
  * Server status, stop, restart, and version operations now report connection, timeout, and response errors clearly.
  * Added response timeouts and validation to prevent control operations from hanging or silently masking server failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->