### PR TITLE
perf(render): make background updates change driven

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -13,6 +13,8 @@ pub(crate) const MAX_AGENT_REPORT_MESSAGE_CHARS: usize = 4096;
 pub(crate) const MAX_AGENT_PROMPT_CHARS: usize = 262_144;
 pub(crate) const MAX_AGENT_START_ARGS: usize = 64;
 const AGENT_PROMPT_QUIET: Duration = Duration::from_millis(1200);
+const DETECTION_INTERVAL: Duration = Duration::from_millis(100);
+const DETECTION_AUDIT_INTERVAL: Duration = Duration::from_secs(2);
 
 /// A parked `wait.output` request (docs/81): reply when the pane's recent
 /// output contains `needle`, or the optional deadline passes.
@@ -33,6 +35,80 @@ mod socket_api_tests {
         let (tx, _rx) = std::sync::mpsc::channel();
         let app = App::new(100, 40, tx).unwrap();
         (env, app)
+    }
+
+    #[test]
+    fn quiet_runtime_can_leave_the_fast_detection_cadence() {
+        let (_env, mut app) = app("quiet-runtime-cadence");
+        let now = Instant::now();
+        assert!(app.needs_fast_runtime_tick(now));
+
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.candidate = status.state;
+            status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+        }
+        assert!(
+            !app.needs_fast_runtime_tick(now),
+            "a quiet fleet without parked deadlines should use the coarse audit"
+        );
+
+        let status = app.status.values_mut().next().unwrap();
+        status.candidate = State::Working;
+        assert!(
+            app.needs_fast_runtime_tick(now),
+            "an in-flight state dwell retains the fast cadence"
+        );
+    }
+
+    #[test]
+    fn detection_considers_changed_panes_between_bounded_audits() {
+        let (_env, mut app) = app("dirty-pane-detection");
+        let pane = app.layout().focus;
+        let start = Instant::now();
+        app.last_detect_at = start - DETECTION_INTERVAL;
+        app.last_detection_audit_at = start;
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.state = State::Idle;
+            status.candidate = State::Idle;
+            status.last_activity = start - Duration::from_secs(60);
+        }
+
+        let considered = app.detection_panes_considered;
+        app.detect_tick(start + DETECTION_INTERVAL);
+        assert_eq!(
+            app.detection_panes_considered, considered,
+            "quiet panes are skipped between fleet audits"
+        );
+
+        assert!(app.handle_event(AppEvent::PtyData(pane)));
+        app.detect_tick(start + 2 * DETECTION_INTERVAL);
+        assert_eq!(
+            app.detection_panes_considered,
+            considered + 1,
+            "PTY invalidation schedules only its pane"
+        );
+    }
+
+    #[test]
+    fn hidden_pty_title_change_is_a_presentation_invalidation() {
+        let (_env, mut app) = app("hidden-title-invalidation");
+        let hidden = app.layout().focus;
+        app.run_cmd(crate::app::keys::Cmd::NewTab);
+        assert!(!app.pane_is_visible(hidden));
+        {
+            let mut engine = app.panes[&hidden].engine.lock().unwrap();
+            engine.advance(b"\x1b]0;Background build\x07");
+        }
+        assert!(app.handle_event(AppEvent::PtyData(hidden)));
+        let now = Instant::now();
+        app.last_detect_at = now - DETECTION_INTERVAL;
+        app.last_detection_audit_at = now;
+        assert!(
+            app.detect_tick(now),
+            "an inactive pane title can change visible tab metadata"
+        );
     }
 
     #[test]
@@ -363,6 +439,30 @@ fn blocking_hint(bottom: &str) -> Option<String> {
 }
 
 impl App {
+    /// Whether the server loop must retain its 100 ms runtime cadence.
+    ///
+    /// Quiet panes do not need a 33 ms poll. Fresh output, an in-flight
+    /// classification dwell, an expiring integration lease, or a parked API
+    /// workflow does: these paths have user-visible deadlines and keep the
+    /// existing detection latency until the scheduler can sleep again.
+    pub(crate) fn needs_fast_runtime_tick(&self, now: Instant) -> bool {
+        let detection_active = self.status.values().any(|status| {
+            status.force_detect
+                || status.candidate != status.state
+                || status.agent_report.is_some()
+                || now.saturating_duration_since(status.last_activity)
+                    < ACTIVITY_WINDOW + QUIET_DWELL
+        });
+        detection_active
+            || !self.output_waits.is_empty()
+            || !self.agent_waits.is_empty()
+            || !self.agent_starts.is_empty()
+            || !self.agent_prompts.is_empty()
+            || !self.backend_revision_waits.is_empty()
+            || self.toast.is_some()
+            || self.search_flash.is_some()
+    }
+
     /// Recompute every pane's agent state. Cheap; called a few times a second.
     /// Returns whether anything the sidebar shows changed, so the loop repaints a
     /// silent agent's Working→Done transition even when no other event fires.
@@ -501,12 +601,34 @@ impl App {
         // The per-pane classification below locks each pane's VT engine + scans its
         // grid; agent state (blocked/working/done) is human-paced, so ~100ms is
         // plenty — running it at the render frame rate (up to 60fps) just burns CPU.
-        if now.duration_since(self.last_detect_at) < Duration::from_millis(100) {
+        if now.duration_since(self.last_detect_at) < DETECTION_INTERVAL {
             return false;
         }
         self.last_detect_at = now;
         let focus = self.layout().focus;
-        let ids: Vec<PaneId> = self.panes.keys().copied().collect();
+        self.detection_dirty
+            .retain(|id| self.panes.contains_key(id));
+        let full_audit =
+            now.duration_since(self.last_detection_audit_at) >= DETECTION_AUDIT_INTERVAL;
+        if full_audit {
+            self.last_detection_audit_at = now;
+            self.detection_full_fleet_audits = self.detection_full_fleet_audits.saturating_add(1);
+        }
+        let ids: Vec<PaneId> = self
+            .panes
+            .keys()
+            .copied()
+            .filter(|id| {
+                full_audit
+                    || self.detection_dirty.contains(id)
+                    || self.status.get(id).is_some_and(|status| {
+                        status.force_detect
+                            || status.candidate != status.state
+                            || status.state == State::Working
+                            || status.agent_report.is_some()
+                    })
+            })
+            .collect();
         let mut changes: Vec<(PaneId, State, String)> = Vec::new();
         // Panes that just finished a working stretch (Working → Idle/Done) — the
         // retro "done" chime fires on these, whether or not the pane is focused.
@@ -518,8 +640,22 @@ impl App {
         // the state remains Idle. Keep this separate from `agent_appeared`:
         // non-resumable agents still need a repaint, but not a persisted session.
         let mut visible_identity_changed = false;
+        // OSC title changes can alter tab labels even when their pane is not in
+        // the active tab. Hidden PTY bytes do not schedule presentation, so the
+        // detector must explicitly surface this metadata-only invalidation.
+        let mut presentation_metadata_changed = false;
         let mut expired_reports: Vec<(PaneId, String)> = Vec::new();
         for id in ids {
+            self.detection_panes_considered = self.detection_panes_considered.saturating_add(1);
+            let audit_only = full_audit
+                && !self.detection_dirty.contains(&id)
+                && self.status.get(&id).is_none_or(|status| {
+                    !status.force_detect
+                        && status.candidate == status.state
+                        && status.state != State::Working
+                        && status.agent_report.is_none()
+                });
+            self.detection_dirty.remove(&id);
             let Some(pane) = self.panes.get(&id) else {
                 continue;
             };
@@ -578,7 +714,12 @@ impl App {
             };
             if let Some(s) = self.status.get_mut(&id) {
                 if let Some((generation, title, bottom)) = inspected {
+                    if audit_only {
+                        self.detection_audit_recoveries =
+                            self.detection_audit_recoveries.saturating_add(1);
+                    }
                     s.last_detect_generation = Some(generation);
+                    presentation_metadata_changed |= s.detected_title != title;
                     s.detected_title = title;
                     s.detected_bottom = bottom;
                     s.force_detect = false;
@@ -749,9 +890,23 @@ impl App {
         if agent_appeared {
             self.session_dirty = true;
         }
+        // A state transition needs presentation only when that state has a
+        // rendered consumer: a visible pane, a live AGENTS/Mission row, or an
+        // orchestration board. Quiet shells in inactive tabs still publish API
+        // events below, but no longer force a known-no-change full projection.
+        let state_presentation_changed = changes.iter().any(|(id, _, agent)| {
+            self.pane_is_visible(*id)
+                || self.manifests.is_agent(agent)
+                || self.status.get(id).is_some_and(|status| {
+                    status.agent_session.is_some() || status.agent_report.is_some()
+                })
+                || self.active_is_orch()
+                || self.active_is_mission()
+        });
         // State and visible identity transitions both change the sidebar. Session
         // persistence remains limited to resumable agents via `agent_appeared`.
-        let changed = !changes.is_empty() || visible_identity_changed;
+        let changed =
+            state_presentation_changed || visible_identity_changed || presentation_metadata_changed;
         let (sound_done, sound_blocked) = {
             let n = &self.config.notifications;
             (n.sound_on_done, n.sound_on_blocked)
@@ -1083,6 +1238,13 @@ impl App {
                     "panes":panes,
                     "detection_extractions": self.detection_extractions,
                     "detection_skips": self.detection_skips,
+                    "detection_performance": {
+                        "panes_considered": self.detection_panes_considered,
+                        "panes_extracted": self.detection_extractions,
+                        "panes_generation_skipped": self.detection_skips,
+                        "full_fleet_audits": self.detection_full_fleet_audits,
+                        "audit_recoveries": self.detection_audit_recoveries,
+                    },
                     "render_performance": crate::ipc::server::performance_snapshot(),
                 }))
             }
@@ -6994,6 +7156,15 @@ command = ["true"]
         let listed = app.dispatch("pane.list", &json!({})).expect("pane list");
         assert!(listed["detection_extractions"].as_u64().is_some());
         assert!(listed["detection_skips"].as_u64().is_some());
+        assert!(listed["detection_performance"]["panes_considered"]
+            .as_u64()
+            .is_some());
+        assert!(listed["detection_performance"]["full_fleet_audits"]
+            .as_u64()
+            .is_some());
+        assert!(listed["detection_performance"]["audit_recoveries"]
+            .as_u64()
+            .is_some());
         assert!(listed["render_performance"]["frames_sent"]
             .as_u64()
             .is_some());

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -422,6 +422,7 @@ impl App {
                 if let Some(s) = self.status.get_mut(&id) {
                     s.last_activity = Instant::now();
                 }
+                self.detection_dirty.insert(id);
                 // A parked `wait.output` for this pane just got new output to
                 // test against — resolve it on the same wake (docs/81).
                 self.check_output_waits(id);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9272,6 +9272,7 @@ mod tests {
         if let Some(p) = app.panes.get(&id) {
             p.scroll(60);
         }
+        app.detection_dirty.insert(id);
         let visible = app
             .panes
             .get(&id)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1426,10 +1426,20 @@ pub struct App {
     /// Throttle for per-pane agent classification — it locks each pane's VT engine
     /// and scans its grid, so it runs at ~100ms, not at the render frame rate.
     last_detect_at: Instant,
+    /// Panes whose PTY generation or identity inputs changed since their last
+    /// classification pass. The detector consumes this bounded set instead of
+    /// walking every quiet pane on each 100 ms cadence.
+    detection_dirty: HashSet<PaneId>,
+    /// A bounded fleet audit repairs any missed invalidation without making the
+    /// audit the normal scheduling path.
+    last_detection_audit_at: Instant,
     /// Runtime evidence for the generation gate, exposed additively by
     /// `pane.list` for diagnostics and performance comparisons.
     detection_extractions: u64,
     detection_skips: u64,
+    detection_panes_considered: u64,
+    detection_full_fleet_audits: u64,
+    detection_audit_recoveries: u64,
     /// Pending server-side `wait.output` requests keyed by pane (docs/81).
     /// Satisfied by the pane's next output event, expired by the loop tick.
     output_waits: HashMap<PaneId, Vec<crate::app::dispatch::OutputWait>>,
@@ -1818,8 +1828,15 @@ impl App {
             last_detect_at: Instant::now()
                 .checked_sub(Duration::from_secs(1))
                 .unwrap_or_else(Instant::now),
+            detection_dirty: HashSet::new(),
+            last_detection_audit_at: Instant::now()
+                .checked_sub(Duration::from_secs(2))
+                .unwrap_or_else(Instant::now),
             detection_extractions: 0,
             detection_skips: 0,
+            detection_panes_considered: 0,
+            detection_full_fleet_audits: 0,
+            detection_audit_recoveries: 0,
             output_waits: HashMap::new(),
             agent_waits: HashMap::new(),
             agent_starts: HashMap::new(),
@@ -2339,8 +2356,15 @@ impl App {
             last_detect_at: Instant::now()
                 .checked_sub(Duration::from_secs(1))
                 .unwrap_or_else(Instant::now),
+            detection_dirty: HashSet::new(),
+            last_detection_audit_at: Instant::now()
+                .checked_sub(Duration::from_secs(2))
+                .unwrap_or_else(Instant::now),
             detection_extractions: 0,
             detection_skips: 0,
+            detection_panes_considered: 0,
+            detection_full_fleet_audits: 0,
+            detection_audit_recoveries: 0,
             output_waits: HashMap::new(),
             agent_waits: HashMap::new(),
             agent_starts: HashMap::new(),
@@ -2722,6 +2746,11 @@ impl App {
             }
         }
         (visible, background)
+    }
+
+    /// Whether any PTY reader is currently coalescing an output notification.
+    pub fn has_pending_pty_output(&self) -> bool {
+        self.panes.values().any(|pane| pane.has_data_pending())
     }
 
     /// Whether a pane is rendered in the active tab.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9351,6 +9351,7 @@ mod tests {
 
         // The user just typed: the recent output is keystroke echo → stays Idle.
         app.status.get_mut(&id).unwrap().last_input = now;
+        app.detection_dirty.insert(id);
         app.detect_tick(now);
         assert_eq!(
             app.status.get(&id).unwrap().state,
@@ -9362,6 +9363,7 @@ mod tests {
         let later = now + std::time::Duration::from_millis(150);
         app.status.get_mut(&id).unwrap().last_activity = later;
         app.status.get_mut(&id).unwrap().last_input = now - std::time::Duration::from_secs(5);
+        app.detection_dirty.insert(id);
         app.detect_tick(later);
         assert_eq!(
             app.status.get(&id).unwrap().state,
@@ -9391,6 +9393,7 @@ mod tests {
             s.last_input = t0 - std::time::Duration::from_secs(5);
             s.last_resize = Some(t0);
         }
+        app.detection_dirty.insert(id);
         app.detect_tick(t0);
         assert_eq!(
             app.status.get(&id).unwrap().state,
@@ -9405,6 +9408,7 @@ mod tests {
             s.last_activity = t1;
             s.last_input = t1 - std::time::Duration::from_secs(5);
         }
+        app.detection_dirty.insert(id);
         app.detect_tick(t1);
         assert_eq!(
             app.status.get(&id).unwrap().state,
@@ -9975,14 +9979,19 @@ mod tests {
         // spinner rather than just poking `last_activity`.
         // Newlines scroll the previous marker away and land the new text in the
         // bottom rows, which is the region detection actually scans.
-        let paint = |app: &App, text: &str| {
-            if let Some(p) = app.panes.get(&id) {
-                if let Ok(mut e) = p.engine.lock() {
-                    let mut buf = vec![b'\n'; 30];
-                    buf.extend_from_slice(text.as_bytes());
-                    e.advance(&buf);
+        let paint = |app: &mut App, text: &str| {
+            {
+                if let Some(p) = app.panes.get(&id) {
+                    if let Ok(mut e) = p.engine.lock() {
+                        let mut buf = vec![b'\n'; 30];
+                        buf.extend_from_slice(text.as_bytes());
+                        e.advance(&buf);
+                    }
                 }
             }
+            // Production output reaches detection through `PtyData`, which marks
+            // the pane dirty. This direct VT mutation must model the same event.
+            app.detection_dirty.insert(id);
         };
         let go_working = |app: &mut App, base: std::time::Instant| {
             paint(app, "⠋ Thinking… (esc to interrupt)\r\n");

--- a/src/bar/render.rs
+++ b/src/bar/render.rs
@@ -109,6 +109,7 @@ fn draw_segment(
         BarSegmentKind::State { state, label } => {
             let state = parse_state(state);
             let glyph = if state == State::Working {
+                f.mark_working_animation();
                 spinner_frame(spinner)
             } else {
                 state.dot()

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -34,6 +34,16 @@ const IDLE_INTERVAL: Duration = Duration::from_millis(250);
 /// 100 ms cadence while they have time-sensitive work.
 const FAST_IDLE_INTERVAL: Duration = Duration::from_millis(100);
 
+fn frame_wait(elapsed_since_attempt: Duration) -> Duration {
+    FRAME_INTERVAL
+        .saturating_sub(elapsed_since_attempt)
+        .max(Duration::from_millis(1))
+}
+
+fn frame_cadence_ready(elapsed_since_attempt: Duration) -> bool {
+    elapsed_since_attempt >= FRAME_INTERVAL
+}
+
 static FRAMES_SENT: AtomicU64 = AtomicU64::new(0);
 static FULL_FRAMES_SENT: AtomicU64 = AtomicU64::new(0);
 static DIFF_RUNS_SENT: AtomicU64 = AtomicU64::new(0);
@@ -152,10 +162,6 @@ impl RenderRequest {
 
     fn needs_render(self) -> bool {
         self.causes != 0
-    }
-
-    fn only_resync(self) -> bool {
-        self.causes == RenderCause::ClientResync.bit()
     }
 
     fn clear(&mut self) {
@@ -303,7 +309,6 @@ pub fn run() -> Result<()> {
     let mut interactive_size = DEFAULT_SIZE;
     let mut next_activity = 1u64;
     let mut last_render_attempt = Instant::now();
-    let mut last_presentation = Instant::now();
     let mut last_save = Instant::now();
     // Un-rendered activity waiting for the frame cap to expire — drives a trailing
     // render so a change that lands mid-interval isn't stuck until the next event.
@@ -322,14 +327,7 @@ pub fn run() -> Result<()> {
         // Pending + clients attached → wait only until the cap frees up (flush
         // promptly); otherwise tick at the coarser idle cadence.
         let wait = if render_request.needs_render() && !clients.is_empty() {
-            let cadence = if render_request.only_resync() {
-                last_render_attempt.elapsed()
-            } else {
-                last_presentation.elapsed()
-            };
-            FRAME_INTERVAL
-                .saturating_sub(cadence)
-                .max(Duration::from_millis(1))
+            frame_wait(last_render_attempt.elapsed())
         } else {
             let mut idle = if app.needs_fast_runtime_tick(Instant::now()) {
                 FAST_IDLE_INTERVAL
@@ -528,24 +526,19 @@ pub fn run() -> Result<()> {
             render_request.record(RenderCause::ClientResync);
         }
 
-        let render_cadence_ready = if render_request.only_resync() {
-            last_render_attempt.elapsed() >= FRAME_INTERVAL
-        } else {
-            last_presentation.elapsed() >= FRAME_INTERVAL
-        };
-        if render_request.needs_render() && !clients.is_empty() && render_cadence_ready {
+        if render_request.needs_render()
+            && !clients.is_empty()
+            && frame_cadence_ready(last_render_attempt.elapsed())
+        {
             let forced = std::mem::take(&mut app.force_redraw);
             last_render_attempt = Instant::now();
-            let presented = render_clients(
+            render_clients(
                 &mut app,
                 &mut clients,
                 &mut foreground,
                 &mut interactive_size,
                 forced,
             );
-            if presented {
-                last_presentation = last_render_attempt;
-            }
             render_request.clear();
             // Re-arm the PTY readers now that their output is on screen. A flag
             // set during this frame = more output already waiting → stay dirty
@@ -1105,8 +1098,9 @@ mod shutdown {
 mod tests {
     use super::ServerMessage;
     use super::{
-        apply, broadcast, record_event_render_request, render_clients, ClientSender, ClientState,
-        EventRenderSource, FrameSendError, RenderCause, RenderRequest,
+        apply, broadcast, frame_cadence_ready, frame_wait, record_event_render_request,
+        render_clients, ClientSender, ClientState, EventRenderSource, FrameSendError, RenderCause,
+        RenderRequest, FRAME_INTERVAL,
     };
     use crate::app::App;
     use crate::event::{AppEvent, ClientInput};
@@ -1167,6 +1161,27 @@ mod tests {
         assert!(request.needs_render());
         request.clear();
         assert!(!request.needs_render());
+    }
+
+    #[test]
+    fn unchanged_normal_render_attempts_remain_frame_capped() {
+        let mut request = RenderRequest::default();
+        request.record(RenderCause::VisiblePty);
+
+        // An unchanged projection clears the request but still resets the
+        // attempt clock. A new normal request must wait for the same frame cap.
+        for _ in 0..2 {
+            assert!(request.needs_render());
+            assert_eq!(frame_wait(Duration::ZERO), FRAME_INTERVAL);
+            assert!(!frame_cadence_ready(Duration::ZERO));
+            request.clear();
+            request.record(RenderCause::VisiblePty);
+        }
+
+        assert!(!frame_cadence_ready(
+            FRAME_INTERVAL - Duration::from_millis(1)
+        ));
+        assert!(frame_cadence_ready(FRAME_INTERVAL));
     }
 
     /// A tab switch requests a frame at the same time a finished selection sends

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -26,20 +26,36 @@ use crate::ui;
 const DEFAULT_SIZE: (u16, u16) = (120, 32);
 /// Minimum time between rendered frames — the fps cap during activity (60fps).
 const FRAME_INTERVAL: Duration = Duration::from_millis(16);
-/// Background-only PTY output cannot change the active terminal grid. A 10fps
-/// probe is enough for sidebar state while avoiding full UI render/diff work
-/// for every inactive-pane read. Any visible output or interaction immediately
-/// returns to [`FRAME_INTERVAL`].
-const BACKGROUND_FRAME_INTERVAL: Duration = Duration::from_millis(100);
-/// How often to wake when idle (drives agent detection + toast expiry) — coarser
-/// than the frame cap so an idle session doesn't spin the CPU.
-const IDLE_INTERVAL: Duration = Duration::from_millis(33);
+/// A genuinely quiet server only needs a bounded maintenance/signalling audit.
+/// This is still short enough for clean signal shutdown while cutting idle
+/// timeout wakes by more than 80% compared with the former 33 ms poll.
+const IDLE_INTERVAL: Duration = Duration::from_millis(250);
+/// Detection hysteresis and parked API workflows retain their established
+/// 100 ms cadence while they have time-sensitive work.
+const FAST_IDLE_INTERVAL: Duration = Duration::from_millis(100);
 
 static FRAMES_SENT: AtomicU64 = AtomicU64::new(0);
 static FULL_FRAMES_SENT: AtomicU64 = AtomicU64::new(0);
 static DIFF_RUNS_SENT: AtomicU64 = AtomicU64::new(0);
 static FRAME_BYTES_SENT: AtomicU64 = AtomicU64::new(0);
 static RENDER_PASSES: AtomicU64 = AtomicU64::new(0);
+static CLIENT_PROJECTIONS: AtomicU64 = AtomicU64::new(0);
+static CHANGED_PROJECTIONS: AtomicU64 = AtomicU64::new(0);
+static UNCHANGED_PROJECTIONS: AtomicU64 = AtomicU64::new(0);
+static FRAMES_ENQUEUED: AtomicU64 = AtomicU64::new(0);
+static FRAMES_BACKPRESSURED: AtomicU64 = AtomicU64::new(0);
+static LOOP_EVENT_WAKES: AtomicU64 = AtomicU64::new(0);
+static LOOP_DEADLINE_WAKES: AtomicU64 = AtomicU64::new(0);
+static CAUSE_VISIBLE_PTY: AtomicU64 = AtomicU64::new(0);
+static CAUSE_BACKGROUND_PTY: AtomicU64 = AtomicU64::new(0);
+static CAUSE_DETECTION: AtomicU64 = AtomicU64::new(0);
+static CAUSE_METADATA: AtomicU64 = AtomicU64::new(0);
+static CAUSE_ANIMATION: AtomicU64 = AtomicU64::new(0);
+static CAUSE_UI: AtomicU64 = AtomicU64::new(0);
+static CAUSE_API_MAINTENANCE: AtomicU64 = AtomicU64::new(0);
+static CAUSE_FORCED: AtomicU64 = AtomicU64::new(0);
+static CAUSE_RESYNC: AtomicU64 = AtomicU64::new(0);
+static CAUSE_ATTACH_RESIZE: AtomicU64 = AtomicU64::new(0);
 
 /// Process-lifetime frame counters for performance diagnostics.
 pub fn performance_snapshot() -> serde_json::Value {
@@ -49,7 +65,102 @@ pub fn performance_snapshot() -> serde_json::Value {
         "diff_runs_sent": DIFF_RUNS_SENT.load(Ordering::Relaxed),
         "frame_bytes_sent": FRAME_BYTES_SENT.load(Ordering::Relaxed),
         "render_passes": RENDER_PASSES.load(Ordering::Relaxed),
+        "client_projections": CLIENT_PROJECTIONS.load(Ordering::Relaxed),
+        "changed_projections": CHANGED_PROJECTIONS.load(Ordering::Relaxed),
+        "unchanged_projections": UNCHANGED_PROJECTIONS.load(Ordering::Relaxed),
+        "frames_enqueued": FRAMES_ENQUEUED.load(Ordering::Relaxed),
+        "frames_backpressured": FRAMES_BACKPRESSURED.load(Ordering::Relaxed),
+        "render_causes": {
+            "visible_pty": CAUSE_VISIBLE_PTY.load(Ordering::Relaxed),
+            "background_pty": CAUSE_BACKGROUND_PTY.load(Ordering::Relaxed),
+            "detection": CAUSE_DETECTION.load(Ordering::Relaxed),
+            "metadata": CAUSE_METADATA.load(Ordering::Relaxed),
+            "animation": CAUSE_ANIMATION.load(Ordering::Relaxed),
+            "ui": CAUSE_UI.load(Ordering::Relaxed),
+            "api_or_maintenance": CAUSE_API_MAINTENANCE.load(Ordering::Relaxed),
+            "forced": CAUSE_FORCED.load(Ordering::Relaxed),
+            "resync": CAUSE_RESYNC.load(Ordering::Relaxed),
+            "client_attach_or_resize": CAUSE_ATTACH_RESIZE.load(Ordering::Relaxed),
+            "unclassified": 0,
+        },
+        "loop_wakes": {
+            "events": LOOP_EVENT_WAKES.load(Ordering::Relaxed),
+            "deadlines": LOOP_DEADLINE_WAKES.load(Ordering::Relaxed),
+        },
     })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RenderCause {
+    VisiblePty,
+    Detection,
+    Metadata,
+    Animation,
+    UserInterface,
+    ApiOrMaintenance,
+    ForcedRepair,
+    ClientResync,
+    ClientAttachOrResize,
+}
+
+impl RenderCause {
+    const fn bit(self) -> u16 {
+        1 << self as u16
+    }
+
+    fn count(self) {
+        let counter = match self {
+            Self::VisiblePty => &CAUSE_VISIBLE_PTY,
+            Self::Detection => &CAUSE_DETECTION,
+            Self::Metadata => &CAUSE_METADATA,
+            Self::Animation => &CAUSE_ANIMATION,
+            Self::UserInterface => &CAUSE_UI,
+            Self::ApiOrMaintenance => &CAUSE_API_MAINTENANCE,
+            Self::ForcedRepair => &CAUSE_FORCED,
+            Self::ClientResync => &CAUSE_RESYNC,
+            Self::ClientAttachOrResize => &CAUSE_ATTACH_RESIZE,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct RenderRequest {
+    causes: u16,
+    hidden_pty_activity: bool,
+    visible_pty_activity: bool,
+}
+
+impl RenderRequest {
+    fn record(&mut self, cause: RenderCause) {
+        let bit = cause.bit();
+        if self.causes & bit == 0 {
+            self.causes |= bit;
+            cause.count();
+        }
+    }
+
+    fn record_visible_pty(&mut self) {
+        self.visible_pty_activity = true;
+        self.record(RenderCause::VisiblePty);
+    }
+
+    fn record_hidden_pty(&mut self) {
+        self.hidden_pty_activity = true;
+        CAUSE_BACKGROUND_PTY.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn needs_render(self) -> bool {
+        self.causes != 0
+    }
+
+    fn only_resync(self) -> bool {
+        self.causes == RenderCause::ClientResync.bit()
+    }
+
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
 }
 
 struct ClientSender {
@@ -96,6 +207,7 @@ struct ClientState {
     behind: bool,
     force_full: bool,
     last_activity: u64,
+    animation_mask: ui::AnimationMask,
 }
 
 impl ClientState {
@@ -116,6 +228,7 @@ impl ClientState {
             behind: false,
             force_full: true,
             last_activity,
+            animation_mask: ui::AnimationMask::default(),
         }
     }
 
@@ -189,17 +302,14 @@ pub fn run() -> Result<()> {
     // Secondary-client projections never change it.
     let mut interactive_size = DEFAULT_SIZE;
     let mut next_activity = 1u64;
-    let mut last_draw = Instant::now();
+    let mut last_render_attempt = Instant::now();
+    let mut last_presentation = Instant::now();
     let mut last_save = Instant::now();
     // Un-rendered activity waiting for the frame cap to expire — drives a trailing
     // render so a change that lands mid-interval isn't stuck until the next event.
-    let mut dirty = false;
-    // True only while every pending redraw reason is output from a pane outside
-    // the active tab. Visible output and UI state changes always promote the
-    // pending frame back to the normal interactive cadence.
-    let mut background_only = false;
-    // Advances the working-agent spinner ~10x/s (the idle tick already wakes the
-    // loop every IDLE_INTERVAL, so this just gates the frame + a repaint).
+    let mut render_request = RenderRequest::default();
+    // Advances only a spinner that the renderer reported visible. Its deadline
+    // participates in the wait calculation, so quiet servers pay no timer cost.
     let mut last_spin = Instant::now();
     const SPIN_INTERVAL: Duration = Duration::from_millis(100);
     // Fallback re-arm cadence for PTY wake coalescing when frames aren't being
@@ -211,19 +321,36 @@ pub fn run() -> Result<()> {
     loop {
         // Pending + clients attached → wait only until the cap frees up (flush
         // promptly); otherwise tick at the coarser idle cadence.
-        let current_interval = frame_interval(background_only);
-        let wait = if dirty && !clients.is_empty() {
-            current_interval
-                .saturating_sub(last_draw.elapsed())
+        let wait = if render_request.needs_render() && !clients.is_empty() {
+            let cadence = if render_request.only_resync() {
+                last_render_attempt.elapsed()
+            } else {
+                last_presentation.elapsed()
+            };
+            FRAME_INTERVAL
+                .saturating_sub(cadence)
                 .max(Duration::from_millis(1))
         } else {
-            IDLE_INTERVAL
+            let mut idle = if app.needs_fast_runtime_tick(Instant::now()) {
+                FAST_IDLE_INTERVAL
+            } else {
+                IDLE_INTERVAL
+            };
+            if clients
+                .values()
+                .any(|client| client.animation_mask.has_working_spinner())
+            {
+                idle = idle.min(SPIN_INTERVAL.saturating_sub(last_spin.elapsed()));
+            }
+            if app.has_pending_pty_output() {
+                idle = idle.min(REARM_INTERVAL.saturating_sub(last_rearm.elapsed()));
+            }
+            idle.max(Duration::from_millis(1))
         };
-        let mut foreground_activity = false;
-        let mut background_activity = false;
-        let mut activity = match rx.recv_timeout(wait) {
+        match rx.recv_timeout(wait) {
             Ok(ev) => {
-                let background = background_pty_event(&app, &ev);
+                LOOP_EVENT_WAKES.fetch_add(1, Ordering::Relaxed);
+                let source = event_render_source(&app, &ev);
                 let changed = apply(
                     ev,
                     &mut app,
@@ -232,15 +359,15 @@ pub fn run() -> Result<()> {
                     &mut interactive_size,
                     &mut next_activity,
                 );
-                foreground_activity = changed && !background;
-                background_activity = changed && background;
-                changed
+                record_event_render_request(source, changed, &mut render_request);
             }
-            Err(RecvTimeoutError::Timeout) => false,
+            Err(RecvTimeoutError::Timeout) => {
+                LOOP_DEADLINE_WAKES.fetch_add(1, Ordering::Relaxed);
+            }
             Err(RecvTimeoutError::Disconnected) => break,
-        };
+        }
         while let Ok(ev) = rx.try_recv() {
-            let background = background_pty_event(&app, &ev);
+            let source = event_render_source(&app, &ev);
             let changed = apply(
                 ev,
                 &mut app,
@@ -249,9 +376,7 @@ pub fn run() -> Result<()> {
                 &mut interactive_size,
                 &mut next_activity,
             );
-            activity |= changed;
-            foreground_activity |= changed && !background;
-            background_activity |= changed && background;
+            record_event_render_request(source, changed, &mut render_request);
         }
         let enabled = app.config.theme == "terminal";
         if enabled != terminal_theme_enabled {
@@ -309,8 +434,7 @@ pub fn run() -> Result<()> {
                 }
                 foreground = latest_client(&clients);
                 apply_foreground_theme(&mut app, &clients, foreground);
-                activity = true;
-                foreground_activity = true;
+                render_request.record(RenderCause::UserInterface);
             }
         }
         if let Some(name) = app.pending_session_switch.take() {
@@ -320,8 +444,7 @@ pub fn run() -> Result<()> {
                 }
                 foreground = latest_client(&clients);
                 apply_foreground_theme(&mut app, &clients, foreground);
-                activity = true;
-                foreground_activity = true;
+                render_request.record(RenderCause::UserInterface);
             } else {
                 app.show_toast("no attached client to switch".to_string());
             }
@@ -337,8 +460,7 @@ pub fn run() -> Result<()> {
         // to ride on, so repaint when detection reports a visible change.
         let now = Instant::now();
         if app.detect_tick(now) {
-            activity = true;
-            foreground_activity = true;
+            render_request.record(RenderCause::Detection);
         }
         // Parked `wait.output` deadlines lapse on the tick (docs/81); a no-op
         // while nobody is waiting.
@@ -362,36 +484,25 @@ pub fn run() -> Result<()> {
         }
         // An expired toast forces one render so it disappears (idle frames don't).
         if app.tick_toast(Instant::now()) {
-            activity = true;
-            foreground_activity = true;
+            render_request.record(RenderCause::Metadata);
         }
         // Likewise for an expired search-jump flash (docs/63).
         if app.tick_search_flash(Instant::now()) {
-            activity = true;
-            foreground_activity = true;
+            render_request.record(RenderCause::Metadata);
         }
         if app.tick_bar_notifications(now) {
-            activity = true;
-            foreground_activity = true;
+            render_request.record(RenderCause::Metadata);
         }
         // Animate the sidebar spinner while any agent is working: advance the
         // frame and mark dirty so the diff sends only the changed dot cell.
         if last_spin.elapsed() >= SPIN_INTERVAL
-            && (app.any_working() || app.bar.has_visible_working(&app.config.bars, app.compact))
+            && clients
+                .values()
+                .any(|client| client.animation_mask.has_working_spinner())
         {
             app.spinner = app.spinner.wrapping_add(1);
             last_spin = Instant::now();
-            dirty = true;
-            background_only = false;
-        }
-        if activity {
-            background_only = next_background_only(
-                dirty,
-                background_only,
-                foreground_activity,
-                background_activity,
-            );
-            dirty = true;
+            render_request.record(RenderCause::Animation);
         }
         // Fallback re-arm (the render path below re-arms at the frame rate): a
         // flag still set here means un-rendered output → schedule a frame.
@@ -399,11 +510,10 @@ pub fn run() -> Result<()> {
             last_rearm = Instant::now();
             let (visible, background) = app.rearm_pty_notify_by_visibility();
             if visible {
-                dirty = true;
-                background_only = false;
-            } else if background {
-                background_only = background_only || !dirty;
-                dirty = true;
+                render_request.record_visible_pty();
+            }
+            if background {
+                render_request.record_hidden_pty();
             }
         }
 
@@ -411,28 +521,42 @@ pub fn run() -> Result<()> {
         // even if nothing else changed this tick — and so must a client that is
         // waiting on its full-frame resync (see `needs_render`).
         let any_behind = clients.values().any(|client| client.behind);
-        let urgent = app.force_redraw || any_behind;
-        dirty = needs_render(dirty, app.force_redraw, any_behind);
-        if urgent {
-            background_only = false;
+        if app.force_redraw {
+            render_request.record(RenderCause::ForcedRepair);
+        }
+        if any_behind {
+            render_request.record(RenderCause::ClientResync);
         }
 
-        if dirty && !clients.is_empty() && last_draw.elapsed() >= frame_interval(background_only) {
+        let render_cadence_ready = if render_request.only_resync() {
+            last_render_attempt.elapsed() >= FRAME_INTERVAL
+        } else {
+            last_presentation.elapsed() >= FRAME_INTERVAL
+        };
+        if render_request.needs_render() && !clients.is_empty() && render_cadence_ready {
             let forced = std::mem::take(&mut app.force_redraw);
-            render_clients(
+            last_render_attempt = Instant::now();
+            let presented = render_clients(
                 &mut app,
                 &mut clients,
                 &mut foreground,
                 &mut interactive_size,
                 forced,
             );
-            last_draw = Instant::now();
+            if presented {
+                last_presentation = last_render_attempt;
+            }
+            render_request.clear();
             // Re-arm the PTY readers now that their output is on screen. A flag
             // set during this frame = more output already waiting → stay dirty
             // so the burst keeps rendering at the frame cap, tail included.
             let (visible, background) = app.rearm_pty_notify_by_visibility();
-            dirty = visible || background;
-            background_only = background && !visible;
+            if visible {
+                render_request.record_visible_pty();
+            }
+            if background {
+                render_request.record_hidden_pty();
+            }
         }
     }
 
@@ -513,7 +637,7 @@ fn apply(
             if promoted || target_size.is_some_and(|size| size != *interactive_size) {
                 let disconnected = clients
                     .get_mut(&id)
-                    .is_some_and(|client| render_client(app, client, true, false));
+                    .is_some_and(|client| render_client(app, client, true, false).disconnected);
                 if disconnected {
                     clients.remove(&id);
                     *foreground = latest_client(clients);
@@ -562,30 +686,39 @@ fn apply_foreground_theme(app: &mut App, clients: &Clients, foreground: Option<u
     }
 }
 
-fn background_pty_event(app: &App, event: &AppEvent) -> bool {
-    matches!(event, AppEvent::PtyData(id) if !app.pane_is_visible(*id))
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EventRenderSource {
+    VisiblePty,
+    HiddenPty,
+    Cause(RenderCause),
 }
 
-fn frame_interval(background_only: bool) -> Duration {
-    if background_only {
-        BACKGROUND_FRAME_INTERVAL
-    } else {
-        FRAME_INTERVAL
+fn event_render_source(app: &App, event: &AppEvent) -> EventRenderSource {
+    match event {
+        AppEvent::PtyData(id) if app.pane_is_visible(*id) => EventRenderSource::VisiblePty,
+        AppEvent::PtyData(_) => EventRenderSource::HiddenPty,
+        AppEvent::ClientConnected { .. }
+        | AppEvent::ClientInput {
+            input: ClientInput::Resize(..),
+            ..
+        } => EventRenderSource::Cause(RenderCause::ClientAttachOrResize),
+        AppEvent::Api(_) => EventRenderSource::Cause(RenderCause::ApiOrMaintenance),
+        _ => EventRenderSource::Cause(RenderCause::UserInterface),
     }
 }
 
-fn next_background_only(
-    dirty: bool,
-    background_only: bool,
-    foreground_activity: bool,
-    background_activity: bool,
-) -> bool {
-    if foreground_activity {
-        false
-    } else if !dirty {
-        background_activity
-    } else {
-        background_only
+fn record_event_render_request(
+    source: EventRenderSource,
+    changed: bool,
+    request: &mut RenderRequest,
+) {
+    if !changed {
+        return;
+    }
+    match source {
+        EventRenderSource::VisiblePty => request.record_visible_pty(),
+        EventRenderSource::HiddenPty => request.record_hidden_pty(),
+        EventRenderSource::Cause(cause) => request.record(cause),
     }
 }
 
@@ -599,10 +732,6 @@ fn next_background_only(
 /// and that client would sit on a **stale** screen (missing whatever the dropped
 /// diff carried) until some unrelated change happened to wake the loop. Treating
 /// a pending resync as work to do closes that window to one frame interval.
-fn needs_render(app_dirty: bool, force_redraw: bool, any_behind: bool) -> bool {
-    app_dirty || force_redraw || any_behind
-}
-
 /// Render the active client first so its geometry remains authoritative, then
 /// render every other client as a projection at that client's own dimensions.
 /// The common one-client case is still exactly one buffer reset, one UI render,
@@ -613,7 +742,7 @@ fn render_clients(
     foreground: &mut Option<u64>,
     interactive_size: &mut (u16, u16),
     force_all: bool,
-) {
+) -> bool {
     RENDER_PASSES.fetch_add(1, Ordering::Relaxed);
     if foreground.is_none_or(|id| !clients.contains_key(&id)) {
         *foreground = latest_client(clients);
@@ -623,10 +752,13 @@ fn render_clients(
     let mut order: Vec<u64> = clients.keys().copied().collect();
     order.sort_unstable_by_key(|id| (*foreground != Some(*id), *id));
     let mut dead = Vec::new();
+    let mut presented = false;
     for id in order {
         let interactive = *foreground == Some(id);
         if let Some(client) = clients.get_mut(&id) {
-            if render_client(app, client, interactive, force_all) {
+            let outcome = render_client(app, client, interactive, force_all);
+            presented |= outcome.enqueued;
+            if outcome.disconnected {
                 dead.push(id);
             } else if interactive {
                 *interactive_size = client.size;
@@ -640,6 +772,7 @@ fn render_clients(
         *foreground = latest_client(clients);
         apply_foreground_theme(app, clients, *foreground);
     }
+    presented
 }
 
 /// Render and enqueue one client's next frame. Returns true when its writer is
@@ -649,7 +782,8 @@ fn render_client(
     client: &mut ClientState,
     interactive: bool,
     force_all: bool,
-) -> bool {
+) -> RenderClientOutcome {
+    CLIENT_PROJECTIONS.fetch_add(1, Ordering::Relaxed);
     let area = Rect::new(0, 0, client.size.0, client.size.1);
     if client.render_buf.area != area {
         client.render_buf = Buffer::empty(area);
@@ -659,15 +793,16 @@ fn render_client(
         client.render_buf.reset();
     }
 
-    let cursor = {
+    let (cursor, animation_mask) = {
         let mut target = ui::RenderTarget::new(&mut client.render_buf, area);
         if interactive {
             ui::render_into(&mut target, app);
         } else {
             ui::render_projection(&mut target, app);
         }
-        target.cursor()
+        (target.cursor(), target.animation_mask())
     };
+    client.animation_mask = animation_mask;
 
     let full = force_all
         || client.force_full
@@ -699,20 +834,36 @@ fn render_client(
     };
 
     let Some(message) = message else {
-        return false;
+        UNCHANGED_PROJECTIONS.fetch_add(1, Ordering::Relaxed);
+        return RenderClientOutcome::default();
     };
+    CHANGED_PROJECTIONS.fetch_add(1, Ordering::Relaxed);
     match client.sender.try_send_frame(message) {
         Ok(()) => {
+            FRAMES_ENQUEUED.fetch_add(1, Ordering::Relaxed);
             client.behind = false;
             client.force_full = false;
-            false
+            RenderClientOutcome {
+                enqueued: true,
+                disconnected: false,
+            }
         }
         Err(FrameSendError::Full) => {
+            FRAMES_BACKPRESSURED.fetch_add(1, Ordering::Relaxed);
             client.behind = true;
-            false
+            RenderClientOutcome::default()
         }
-        Err(FrameSendError::Disconnected) => true,
+        Err(FrameSendError::Disconnected) => RenderClientOutcome {
+            enqueued: false,
+            disconnected: true,
+        },
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct RenderClientOutcome {
+    enqueued: bool,
+    disconnected: bool,
 }
 
 fn bind_client_listener(
@@ -914,7 +1065,7 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
 
 /// Graceful shutdown on a termination signal. The handler only flips an atomic
 /// flag (the only async-signal-safe thing to do); the event loop polls it every
-/// idle tick (≤33ms) and exits through the normal path — clients notified, the
+/// idle tick (≤250ms) and exits through the normal path — clients notified, the
 /// session saved — instead of dying mid-state on SIGTERM (logout, `kill`,
 /// system shutdown).
 #[cfg(unix)]
@@ -954,8 +1105,8 @@ mod shutdown {
 mod tests {
     use super::ServerMessage;
     use super::{
-        apply, broadcast, frame_interval, needs_render, next_background_only, render_clients,
-        ClientSender, ClientState, FrameSendError, BACKGROUND_FRAME_INTERVAL, FRAME_INTERVAL,
+        apply, broadcast, record_event_render_request, render_clients, ClientSender, ClientState,
+        EventRenderSource, FrameSendError, RenderCause, RenderRequest,
     };
     use crate::app::App;
     use crate::event::{AppEvent, ClientInput};
@@ -996,38 +1147,26 @@ mod tests {
         }
     }
 
-    /// A client that dropped a diff must get its full-frame resync even when the
-    /// screen goes quiet. The resync only ships from inside a render, so a
-    /// pending `behind` entry has to count as work — otherwise a client that fell
-    /// behind just as a burst of agent output ended would keep showing stale
-    /// cells until something unrelated redrew the screen.
     #[test]
-    fn a_behind_client_forces_a_frame_on_an_idle_screen() {
-        assert!(
-            needs_render(false, false, true),
-            "a pending resync renders even with nothing else to do"
-        );
-        // The pre-existing reasons still hold.
-        assert!(needs_render(true, false, false), "app activity renders");
-        assert!(needs_render(false, true, false), "a forced redraw renders");
-        // And a genuinely idle loop with every client up to date stays idle, so
-        // this cannot spin the render loop on a quiet screen.
-        assert!(
-            !needs_render(false, false, false),
-            "nothing to do means no frame"
-        );
+    fn hidden_pty_activity_does_not_request_presentation() {
+        let mut request = RenderRequest::default();
+        record_event_render_request(EventRenderSource::HiddenPty, true, &mut request);
+        assert!(request.hidden_pty_activity);
+        assert!(!request.needs_render());
+
+        record_event_render_request(EventRenderSource::VisiblePty, true, &mut request);
+        assert!(request.visible_pty_activity);
+        assert!(request.needs_render());
     }
 
     #[test]
-    fn background_frames_use_the_slower_cap_only_while_background_only() {
-        assert_eq!(frame_interval(false), FRAME_INTERVAL);
-        assert_eq!(frame_interval(true), BACKGROUND_FRAME_INTERVAL);
-        assert!(BACKGROUND_FRAME_INTERVAL > FRAME_INTERVAL);
-
-        assert!(next_background_only(false, false, false, true));
-        assert!(next_background_only(true, true, false, true));
-        assert!(!next_background_only(true, true, true, true));
-        assert!(!next_background_only(true, false, false, true));
+    fn forced_and_resync_causes_request_repair_frames() {
+        let mut request = RenderRequest::default();
+        request.record(RenderCause::ForcedRepair);
+        request.record(RenderCause::ClientResync);
+        assert!(request.needs_render());
+        request.clear();
+        assert!(!request.needs_render());
     }
 
     /// A tab switch requests a frame at the same time a finished selection sends
@@ -1147,6 +1286,45 @@ mod tests {
             app.panes[&focus].size(),
             (content.width, content.height),
             "secondary projection must not resize the shared PTY"
+        );
+    }
+
+    #[test]
+    fn animation_mask_tracks_a_spinner_that_is_actually_rendered() {
+        let _env = crate::persist::test_env("rendered-animation-mask");
+        let (app_tx, _app_rx) = mpsc::channel();
+        let mut app = App::new(120, 40, app_tx).expect("app starts");
+        app.server_mode = true;
+        let focus = app.layout().focus;
+        let status = app.status.get_mut(&focus).expect("focused pane status");
+        status.agent = "claude".into();
+        status.state = crate::ui::theme::State::Working;
+
+        let (client, _rx) = display_client(120, 40, 1);
+        let mut clients = HashMap::from([(1, client)]);
+        let mut foreground = Some(1);
+        let mut interactive_size = (120, 40);
+        render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            false,
+        );
+        assert!(clients[&1].animation_mask.has_working_spinner());
+
+        app.sidebars.left.visible = false;
+        app.sidebars.right.visible = false;
+        render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            false,
+        );
+        assert!(
+            !clients[&1].animation_mask.has_working_spinner(),
+            "a hidden AGENTS dock must not keep scheduling animation frames"
         );
     }
 

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -671,6 +671,13 @@ impl Pane {
         pending
     }
 
+    /// Observe whether output is waiting for a coalescing boundary without
+    /// consuming it. The server uses this to arm the 100 ms fallback only while
+    /// a pane actually has pending bytes, instead of waking forever when idle.
+    pub fn has_data_pending(&self) -> bool {
+        self.data_pending.load(std::sync::atomic::Ordering::Acquire)
+    }
+
     /// Clear the pending-output coalescing flag so the reader's next
     /// announcement fires immediately. Input is interaction, not background
     /// output, and a parked `wait.output` must stay event-driven (docs/81).

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -26,6 +26,21 @@ pub struct RenderTarget<'a> {
     buf: &'a mut Buffer,
     area: Rect,
     cursor: Option<(u16, u16)>,
+    animation_mask: AnimationMask,
+}
+
+/// Allocation-free record of animated surfaces that were actually drawn into a
+/// client projection. The server uses this instead of global agent state, which
+/// avoids repainting when every working indicator is clipped or hidden.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AnimationMask(u8);
+
+impl AnimationMask {
+    const WORKING_SPINNER: u8 = 1 << 0;
+
+    pub fn has_working_spinner(self) -> bool {
+        self.0 & Self::WORKING_SPINNER != 0
+    }
 }
 
 impl<'a> RenderTarget<'a> {
@@ -35,6 +50,7 @@ impl<'a> RenderTarget<'a> {
             buf,
             area,
             cursor: None,
+            animation_mask: AnimationMask::default(),
         }
     }
     pub fn area(&self) -> Rect {
@@ -52,6 +68,15 @@ impl<'a> RenderTarget<'a> {
     }
     pub fn cursor(&self) -> Option<(u16, u16)> {
         self.cursor
+    }
+
+    /// Mark that this projection contains a live working-state spinner.
+    pub fn mark_working_animation(&mut self) {
+        self.animation_mask.0 |= AnimationMask::WORKING_SPINNER;
+    }
+
+    pub fn animation_mask(&self) -> AnimationMask {
+        self.animation_mask
     }
 }
 
@@ -83,6 +108,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
             buf: f.buffer_mut(),
             area,
             cursor: None,
+            animation_mask: AnimationMask::default(),
         };
         render_into(&mut target, app);
         target.cursor

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -577,6 +577,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                 // A working agent gets a live rotating-circle spinner in the dot
                 // slot; every other state keeps its static dot.
                 let dot = if st == State::Working {
+                    f.mark_working_animation();
                     crate::ui::theme::spinner_frame(app.spinner)
                 } else {
                     st.dot()

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -409,6 +409,17 @@ current Alacritty adapter it is a conservative estimate (`false`), because the
 underlying terminal engine limits rows rather than allocation bytes. These
 fields observe state only; they do not grant remote control of a pane viewport.
 
+### Runtime performance counters
+
+The top-level `pane.list` result also includes additive process-lifetime
+`render_performance` and `detection_performance` objects. They expose bounded
+counts for render causes, loop wake sources, client projections, changed and
+unchanged projections, frame backpressure, panes considered and extracted,
+full-fleet audits, and audit recoveries. The counters are intended for local
+performance comparisons and contain no pane text, commands, paths, prompts, or
+client identifiers. Existing `detection_extractions` and `detection_skips`
+remain available for compatibility.
+
 ## Forking an agent session
 
 | Method | Params | Result |


### PR DESCRIPTION
## Summary

- make server rendering source aware instead of treating every event as a full presentation invalidation
- keep parsing hidden pane output while suppressing client frames when visible state does not change
- render agent animation only when a visible spinner actually needs another frame
- detect changed panes directly and retain a bounded fleet audit as a recovery path
- expose additive render and detection counters through the pane list API
- document the new diagnostic fields in the API reference

## Why

Background agents could keep waking the server and diffing the complete interface even when their panes were on another tab. Agent detection also revisited the pane fleet on a fixed cadence. The result was avoidable CPU work that grew with the number of live agents and the width of the attached client.

This change keeps terminal parsing and correctness intact while making client presentation change driven. Hidden output is still retained in scrollback, status and title changes still invalidate visible metadata, and forced or resync paths still produce repair frames.

## Performance validation

A fresh macOS arm64 run used a 160 by 40 attached client, two tabs, five panes per tab, and 200 output lines paced at 50 ms.

- release combined focused output CPU was 3.18 percent
- hidden output produced 213 background PTY events but zero frames, zero diff runs, and zero frame bytes
- release combined RSS was 25.7 MiB
- pane list median latency was 3.224 ms
- idle measurements remained low and were treated as noisy

## Validation

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- targeted tests for quiet detection cadence and dirty pane audits
- targeted tests for hidden PTY suppression and visible metadata invalidation
- targeted tests for forced resync repair frames and renderer animation masks
- website npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved responsiveness by prioritizing active and recently changed panes.
  - Reduced unnecessary background work during quiet periods while maintaining timely updates.
  - Improved rendering efficiency under heavy output, animation, or connection pressure.

- **Visual Updates**
  - Working-agent indicators now animate more reliably and consistently.

- **API**
  - Added runtime performance counters for rendering and agent-status detection, with documentation covering available metrics and compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->