### PR TITLE
feat(mission): redesign Mission Control beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +490,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +539,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"
@@ -646,6 +674,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -788,6 +825,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +896,7 @@ dependencies = [
  "luvus-alacritty-terminal",
  "portable-pty",
  "ratatui",
+ "rusqlite",
  "semver",
  "serde",
  "serde_json",
@@ -1207,6 +1256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1502,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1755,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1974,6 +2072,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ unicode-width = "0.2"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# OpenCode 1.18+ stores per-session token and cost aggregates in SQLite.  Read
+# it in-process and read-only: spawning the OpenCode/Bun runtime every Mission
+# Control refresh is both slower and substantially heavier.
+rusqlite = { version = "0.40", features = ["bundled"] }
 # Agent skills are distributed separately from the runtime. Manifests are
 # authenticated with Ed25519, artifact/package hashes use SHA-256, and semver
 # keeps independently released skills inside their declared Luvus range.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -9,6 +9,9 @@
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+mod usage;
+pub use usage::{session_mtime, session_usage};
+
 /// A resumable agent session discovered on disk.
 #[derive(Clone)]
 pub struct SessionInfo {
@@ -130,6 +133,39 @@ static SOURCES: &[SessionSource] = &[
         // Pi's session model is a branching tree; `--fork` forks by id (docs/23).
         fork: Some(|q| format!("pi --fork {q}\r")),
     },
+    SessionSource {
+        name: "gemini",
+        discover: Some(Discovery {
+            base: gemini_base,
+            recent: gemini_recent,
+            latest: gemini_latest,
+            list: Some(gemini_list),
+        }),
+        resume: |q| format!("gemini --resume {q}\r"),
+        fork: None,
+    },
+    SessionSource {
+        name: "qwen",
+        discover: Some(Discovery {
+            base: qwen_base,
+            recent: qwen_recent,
+            latest: qwen_latest,
+            list: Some(qwen_list),
+        }),
+        resume: |q| format!("qwen --resume {q}\r"),
+        fork: None,
+    },
+    SessionSource {
+        name: "fx",
+        discover: Some(Discovery {
+            base: fx_base,
+            recent: fx_recent,
+            latest: fx_latest,
+            list: Some(fx_list),
+        }),
+        resume: |q| format!("fx session resume {q}\r"),
+        fork: None,
+    },
     // Resume-only (no readable session store): usable when a hook reports the id.
     SessionSource {
         name: "cursor",
@@ -177,82 +213,6 @@ pub fn recent_sessions(limit: usize) -> Vec<SessionInfo> {
 pub fn latest_session(agent: &str, cwd: &Path) -> Option<String> {
     let d = source(agent)?.discover.as_ref()?;
     (d.latest)(&(d.base)(), cwd)
-}
-
-/// Best-effort token/context/cost usage for an agent's session, read from its own
-/// on-disk transcript (docs/54 §5, MC-2). Only agents whose store records usage
-/// are supported (Claude today); others return `None`, and the dashboard shows
-/// "—". Bounded IO — a single file read — so callers run it off the render loop.
-pub fn session_usage(
-    agent: &str,
-    cwd: &Path,
-    session_id: &str,
-) -> Option<crate::mission::AgentUsage> {
-    match agent {
-        "claude" => claude_session_usage(&claude_base(), cwd, session_id),
-        _ => None,
-    }
-}
-
-/// The last-modified time of a session's transcript, for the usage-scan cache
-/// (docs/54): a cheap `stat` so an unchanged (idle) transcript is skipped instead
-/// of being re-read and re-parsed each scan. `None` if there's no such file.
-pub fn session_mtime(agent: &str, cwd: &Path, session_id: &str) -> Option<SystemTime> {
-    let path = match agent {
-        "claude" => claude_project_dir(&claude_base(), cwd).join(format!("{session_id}.jsonl")),
-        _ => return None,
-    };
-    std::fs::metadata(&path).and_then(|m| m.modified()).ok()
-}
-
-/// Sum a Claude session's `.jsonl` transcript into an [`AgentUsage`]: cumulative
-/// input/output/cache tokens (for cost) and the *latest* turn's input-side total
-/// (for the live context %). Model comes from the newest assistant line. Tolerant
-/// of shape drift — missing fields count as zero and a bad line is skipped.
-fn claude_session_usage(
-    base: &Path,
-    cwd: &Path,
-    session_id: &str,
-) -> Option<crate::mission::AgentUsage> {
-    use crate::mission::{context_frac, estimate_cost, AgentUsage};
-    let path = claude_project_dir(base, cwd).join(format!("{session_id}.jsonl"));
-    let text = std::fs::read_to_string(&path).ok()?;
-    let field = |u: &serde_json::Value, k: &str| u.get(k).and_then(|x| x.as_u64()).unwrap_or(0);
-    let mut u = AgentUsage::default();
-    let mut context_tokens = 0u64;
-    for line in text.lines() {
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        let msg = v.get("message");
-        // `usage` lives under `message.usage` (assistant turns) or top-level.
-        if let Some(us) = msg.and_then(|m| m.get("usage")).or_else(|| v.get("usage")) {
-            let cin =
-                field(us, "cache_read_input_tokens") + field(us, "cache_creation_input_tokens");
-            u.tokens_in += field(us, "input_tokens");
-            u.tokens_out += field(us, "output_tokens");
-            u.cache += cin;
-            // The current context ≈ this (latest) turn's whole input side.
-            context_tokens = field(us, "input_tokens") + cin;
-        }
-        if let Some(model) = msg
-            .and_then(|m| m.get("model"))
-            .or_else(|| v.get("model"))
-            .and_then(|x| x.as_str())
-        {
-            if !model.is_empty() {
-                u.model = model.to_string();
-            }
-        }
-    }
-    if u.model.is_empty() && u.total_tokens() == 0 {
-        return None; // nothing usable in this transcript
-    }
-    u.cost = estimate_cost(&u.model, u.tokens_in, u.tokens_out, u.cache);
-    if context_tokens > 0 {
-        u.context = Some(context_frac(&u.model, context_tokens));
-    }
-    Some(u)
 }
 
 /// Every session for `agent` in `cwd`, **newest first**.
@@ -453,6 +413,24 @@ fn opencode_base() -> PathBuf {
         .join("share")
         .join("opencode")
         .join("storage")
+}
+
+fn gemini_base() -> PathBuf {
+    std::env::var_os("GEMINI_CLI_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home().join(".gemini"))
+}
+
+fn qwen_base() -> PathBuf {
+    std::env::var_os("QWEN_CODE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home().join(".qwen"))
+}
+
+fn fx_base() -> PathBuf {
+    std::env::var_os("FX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home().join(".fx"))
 }
 
 // ── Claude Code ─────────────────────────────────────────────────────────────
@@ -1205,6 +1183,208 @@ fn pi_recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
     out
 }
 
+// ── Gemini CLI and Qwen Code ────────────────────────────────────────────────
+// Both keep project-scoped JSONL chats under `<base>/tmp/<project>/chats/` and
+// write the original project path to the sibling `.project_root` file. The
+// full session id lives in the JSONL header, so filenames remain an optimization
+// rather than an identity guess.
+
+fn chat_project_dirs(base: &Path) -> Vec<(PathBuf, PathBuf)> {
+    let Ok(projects) = std::fs::read_dir(base.join("tmp")) else {
+        return Vec::new();
+    };
+    projects
+        .flatten()
+        .filter_map(|entry| {
+            let dir = entry.path();
+            let cwd = std::fs::read_to_string(dir.join(".project_root")).ok()?;
+            Some((PathBuf::from(cwd.trim()), dir.join("chats")))
+        })
+        .collect()
+}
+
+fn chat_files_in_dir(chats: &Path) -> Vec<(SystemTime, PathBuf)> {
+    let mut out = Vec::new();
+    let Ok(files) = std::fs::read_dir(chats) else {
+        return out;
+    };
+    for entry in files.flatten() {
+        let path = entry.path();
+        let supported = matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("json" | "jsonl")
+        ) && path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("session-"));
+        if !supported {
+            continue;
+        }
+        if let Ok(updated) = entry.metadata().and_then(|m| m.modified()) {
+            out.push((updated, path));
+        }
+    }
+    out.sort_by_key(|(updated, _)| std::cmp::Reverse(*updated));
+    out
+}
+
+fn chat_session_files(base: &Path, cwd: &Path) -> Vec<(SystemTime, PathBuf)> {
+    chat_project_dirs(base)
+        .into_iter()
+        .find(|(project, _)| crate::platform::same_path(project, cwd))
+        .map(|(_, chats)| chat_files_in_dir(&chats))
+        .unwrap_or_default()
+}
+
+fn read_chat_session_id(path: &Path) -> Option<String> {
+    use std::io::{BufRead, Read};
+    let file = std::fs::File::open(path).ok()?;
+    for line in std::io::BufReader::new(file)
+        .take(256 * 1024)
+        .lines()
+        .take(40)
+        .map_while(Result::ok)
+    {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if let Some(id) = value.get("sessionId").and_then(|v| v.as_str()) {
+            return Some(id.to_string());
+        }
+    }
+    None
+}
+
+fn chat_list(base: &Path, cwd: &Path) -> Vec<String> {
+    chat_session_files(base, cwd)
+        .into_iter()
+        .filter_map(|(_, path)| read_chat_session_id(&path))
+        .collect()
+}
+
+fn chat_latest(base: &Path, cwd: &Path) -> Option<String> {
+    chat_session_files(base, cwd)
+        .into_iter()
+        .find_map(|(_, path)| read_chat_session_id(&path))
+}
+
+fn chat_recent(base: &Path, limit: usize, agent: &str) -> Vec<SessionInfo> {
+    let mut out = Vec::new();
+    for (cwd, chats) in chat_project_dirs(base) {
+        let Some((updated, path)) = chat_files_in_dir(&chats).into_iter().next() else {
+            continue;
+        };
+        let Some(session_id) = read_chat_session_id(&path) else {
+            continue;
+        };
+        out.push(SessionInfo {
+            agent: agent.to_string(),
+            session_id,
+            cwd,
+            updated,
+        });
+    }
+    out.sort_by_key(|s| std::cmp::Reverse(s.updated));
+    out.truncate(limit);
+    out
+}
+
+fn gemini_list(base: &Path, cwd: &Path) -> Vec<String> {
+    chat_list(base, cwd)
+}
+
+fn gemini_latest(base: &Path, cwd: &Path) -> Option<String> {
+    chat_latest(base, cwd)
+}
+
+fn gemini_recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    chat_recent(base, limit, "gemini")
+}
+
+fn qwen_list(base: &Path, cwd: &Path) -> Vec<String> {
+    chat_list(base, cwd)
+}
+
+fn qwen_latest(base: &Path, cwd: &Path) -> Option<String> {
+    chat_latest(base, cwd)
+}
+
+fn qwen_recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    chat_recent(base, limit, "qwen")
+}
+
+// ── fx ──────────────────────────────────────────────────────────────────────
+// fx stores one small metadata document and one aggregate usage snapshot per
+// session. Reading `session.json` avoids spawning the CLI during Luvus's regular
+// background session scan.
+
+fn read_fx_session(path: &Path) -> Option<(String, PathBuf, SystemTime)> {
+    let raw: serde_json::Value = serde_json::from_reader(std::fs::File::open(path).ok()?).ok()?;
+    let id = raw.get("id").and_then(|v| v.as_str())?.to_string();
+    let cwd = raw
+        .get("workspace_root")
+        .or_else(|| raw.get("origin_workspace_root"))
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)?;
+    let updated = raw
+        .get("updated_at_ms")
+        .and_then(|v| v.as_u64())
+        .map(|ms| SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(ms))
+        .or_else(|| std::fs::metadata(path).and_then(|m| m.modified()).ok())?;
+    Some((id, cwd, updated))
+}
+
+fn fx_session_files(base: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(base.join("sessions")) else {
+        return Vec::new();
+    };
+    let mut out: Vec<_> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path().join("session.json");
+            Some((std::fs::metadata(&path).ok()?.modified().ok()?, path))
+        })
+        .collect();
+    out.sort_by_key(|(updated, _)| std::cmp::Reverse(*updated));
+    out.into_iter().map(|(_, path)| path).collect()
+}
+
+fn fx_session(path: &Path) -> Option<SessionInfo> {
+    let (session_id, cwd, updated) = read_fx_session(path)?;
+    Some(SessionInfo {
+        agent: "fx".to_string(),
+        session_id,
+        cwd,
+        updated,
+    })
+}
+
+fn fx_list(base: &Path, cwd: &Path) -> Vec<String> {
+    fx_session_files(base)
+        .into_iter()
+        .filter_map(|path| fx_session(&path))
+        .filter(|s| crate::platform::same_path(&s.cwd, cwd))
+        .map(|s| s.session_id)
+        .collect()
+}
+
+fn fx_latest(base: &Path, cwd: &Path) -> Option<String> {
+    fx_session_files(base).into_iter().find_map(|path| {
+        let session = fx_session(&path)?;
+        crate::platform::same_path(&session.cwd, cwd).then_some(session.session_id)
+    })
+}
+
+fn fx_recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    let mut seen = std::collections::HashSet::new();
+    fx_session_files(base)
+        .into_iter()
+        .filter_map(|path| fx_session(&path))
+        .filter(|s| seen.insert(s.cwd.clone()))
+        .take(limit)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1216,36 +1396,6 @@ mod tests {
         let _ = fs::remove_dir_all(&d);
         fs::create_dir_all(&d).unwrap();
         d
-    }
-
-    // docs/54 MC-2: sum a Claude transcript's usage into tokens/context/cost.
-    #[test]
-    fn claude_usage_sums_tokens_context_and_cost() {
-        let base = tmp("claude-usage");
-        let cwd = PathBuf::from("/tmp/some/proj");
-        let dir = claude_project_dir(&base, &cwd);
-        fs::create_dir_all(&dir).unwrap();
-        let jsonl = concat!(
-            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1000,"output_tokens":500,"cache_read_input_tokens":200}}}"#,
-            "\n",
-            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":3000,"output_tokens":700,"cache_creation_input_tokens":100}}}"#,
-            "\n",
-            "definitely not json — must be skipped\n",
-        );
-        fs::write(dir.join("sess-1.jsonl"), jsonl).unwrap();
-
-        let u = claude_session_usage(&base, &cwd, "sess-1").expect("usage read");
-        assert_eq!(u.model, "claude-opus-4-8");
-        assert_eq!(u.tokens_in, 4000, "cumulative input");
-        assert_eq!(u.tokens_out, 1200, "cumulative output");
-        assert_eq!(u.cache, 300, "cache read + creation");
-        // Context ≈ the last turn's input side (3000 + 100) / 200k window.
-        let c = u.context.expect("context");
-        assert!((c - (3100.0 / 200_000.0)).abs() < 1e-4, "context {c}");
-        // Cost estimate (opus): in*15 + out*75 + cache*1.5 per million.
-        let want = (4000.0 * 15.0 + 1200.0 * 75.0 + 300.0 * 1.5) / 1_000_000.0;
-        assert!((u.cost.expect("cost") - want).abs() < 1e-9);
-        let _ = fs::remove_dir_all(&base);
     }
 
     #[test]
@@ -1279,10 +1429,65 @@ mod tests {
             .unwrap()
             .contains("cursor-agent --resume"));
         assert!(is_resumable("opencode") && is_resumable("cursor-agent"));
-        assert!(!is_resumable("gemini")); // detectable, but no resume path
+        assert_eq!(
+            resume_command("gemini", "g1").as_deref(),
+            Some("gemini --resume 'g1'\r")
+        );
+        assert_eq!(
+            resume_command("qwen", "q1").as_deref(),
+            Some("qwen --resume 'q1'\r")
+        );
+        assert_eq!(
+            resume_command("fx", "f1").as_deref(),
+            Some("fx session resume 'f1'\r")
+        );
         assert!(resume_command("unknown", "x").is_none());
         assert!(resume_command("claude", "").is_none()); // empty id
         assert!(resume_command("claude", "a b").is_none()); // unsafe char
+    }
+
+    #[test]
+    fn gemini_style_sessions_are_scoped_by_project_root() {
+        let base = tmp("gemini-session");
+        let project = base.join("tmp/hash-one");
+        fs::create_dir_all(project.join("chats")).unwrap();
+        fs::write(project.join(".project_root"), "/work/app\n").unwrap();
+        fs::write(
+            project.join("chats/session-2026-08-25-gem12345.jsonl"),
+            "{\"sessionId\":\"gem12345-full\"}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            gemini_latest(&base, Path::new("/work/app")).as_deref(),
+            Some("gem12345-full")
+        );
+        assert!(gemini_latest(&base, Path::new("/work/other")).is_none());
+        let recent = qwen_recent(&base, 5);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].agent, "qwen");
+        assert_eq!(recent[0].cwd, Path::new("/work/app"));
+    }
+
+    #[test]
+    fn fx_sessions_use_native_workspace_metadata() {
+        let base = tmp("fx-session");
+        let session = base.join("sessions/fx-1");
+        fs::create_dir_all(&session).unwrap();
+        fs::write(
+            session.join("session.json"),
+            r#"{"id":"fx-1","workspace_root":"/work/app","created_at_ms":1000,"updated_at_ms":2000}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fx_latest(&base, Path::new("/work/app")).as_deref(),
+            Some("fx-1")
+        );
+        let recent = fx_recent(&base, 5);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].session_id, "fx-1");
+        assert_eq!(recent[0].cwd, Path::new("/work/app"));
     }
 
     #[test]

--- a/src/agent/usage.rs
+++ b/src/agent/usage.rs
@@ -1,0 +1,1028 @@
+//! Native agent usage readers for Mission Control.
+//!
+//! Every adapter consumes counters the agent already persists.  Missing or
+//! ambiguous data stays missing: this module never derives tokens from text,
+//! invokes a model, or treats an all-zero/incomplete ledger as free usage.
+
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
+use serde_json::Value;
+
+use super::*;
+use crate::mission::{context_frac, estimate_cost, AgentUsage};
+
+/// A single persisted JSONL event can contain an arbitrarily large tool result
+/// or inline image. Usage records are tiny, so skip oversized records without
+/// ever allocating their full payload. This replaces the old whole-transcript
+/// read and keeps a malicious/corrupt transcript from becoming an OOM vector.
+const MAX_USAGE_LINE: usize = 2 * 1024 * 1024;
+
+/// Codex persists cumulative token counters, so the newest counter is enough.
+/// Keep refresh work independent of the total rollout size: large tool results
+/// can make a long-lived transcript hundreds of MiB, but Mission Control should
+/// only inspect a small tail plus the session's bounded metadata prefix.
+const CODEX_USAGE_TAIL_BYTES: u64 = 8 * 1024 * 1024;
+const CODEX_MODEL_HEAD_BYTES: u64 = 256 * 1024;
+
+/// Read JSONL with a strict per-record allocation ceiling. Invalid and
+/// oversized records are skipped; an unreadable file fails the whole read.
+fn for_each_json_line(path: &Path, mut visit: impl FnMut(&Value)) -> Option<()> {
+    let file = File::open(path).ok()?;
+    let mut reader = BufReader::with_capacity(64 * 1024, file);
+    let mut line = Vec::with_capacity(4096);
+    let mut oversized = false;
+
+    loop {
+        let (take, ended, eof) = {
+            let available = reader.fill_buf().ok()?;
+            if available.is_empty() {
+                (0, false, true)
+            } else if let Some(at) = available.iter().position(|b| *b == b'\n') {
+                (at + 1, true, false)
+            } else {
+                (available.len(), false, false)
+            }
+        };
+
+        if eof {
+            if !line.is_empty() && !oversized {
+                if let Ok(value) = serde_json::from_slice::<Value>(&line) {
+                    visit(&value);
+                }
+            }
+            return Some(());
+        }
+
+        if !oversized {
+            let available = reader.fill_buf().ok()?;
+            if line.len().saturating_add(take) <= MAX_USAGE_LINE {
+                line.extend_from_slice(&available[..take]);
+            } else {
+                line.clear();
+                oversized = true;
+            }
+        }
+        reader.consume(take);
+
+        if ended {
+            if !oversized {
+                while matches!(line.last(), Some(b'\n' | b'\r')) {
+                    line.pop();
+                }
+                if let Ok(value) = serde_json::from_slice::<Value>(&line) {
+                    visit(&value);
+                }
+            }
+            line.clear();
+            oversized = false;
+        }
+    }
+}
+
+fn read_window(path: &Path, start: u64, limit: u64) -> Option<Vec<u8>> {
+    let mut file = File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let start = start.min(len);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::with_capacity(len.saturating_sub(start).min(limit) as usize);
+    file.take(limit).read_to_end(&mut bytes).ok()?;
+    Some(bytes)
+}
+
+fn for_each_json_slice(bytes: &[u8], skip_partial_first: bool, mut visit: impl FnMut(&Value)) {
+    let bytes = if skip_partial_first {
+        bytes
+            .iter()
+            .position(|b| *b == b'\n')
+            .map_or(&[][..], |at| &bytes[at + 1..])
+    } else {
+        bytes
+    };
+    for raw in bytes.split(|b| *b == b'\n') {
+        let raw = raw.strip_suffix(b"\r").unwrap_or(raw);
+        if raw.is_empty() || raw.len() > MAX_USAGE_LINE {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_slice::<Value>(raw) {
+            visit(&value);
+        }
+    }
+}
+
+fn n(v: &Value, key: &str) -> u64 {
+    v.get(key)
+        .and_then(|x| {
+            x.as_u64()
+                .or_else(|| x.as_i64().and_then(|n| u64::try_from(n).ok()))
+        })
+        .unwrap_or(0)
+}
+
+fn f(v: &Value, key: &str) -> Option<f64> {
+    v.get(key).and_then(Value::as_f64).filter(|x| x.is_finite())
+}
+
+fn add(dst: &mut u64, value: u64) {
+    *dst = dst.saturating_add(value);
+}
+
+fn non_cache_input(full: u64, cache_read: u64, cache_write: u64) -> u64 {
+    full.saturating_sub(cache_read.saturating_add(cache_write))
+}
+
+fn finish(mut usage: AgentUsage) -> Option<AgentUsage> {
+    if usage.model.is_empty()
+        && usage.total_tokens() == 0
+        && usage.cache == 0
+        && usage.cost.is_none()
+    {
+        return None;
+    }
+    if usage.cost.is_none() {
+        usage.cost = estimate_cost(&usage.model, usage.tokens_in, usage.tokens_out, usage.cache);
+    }
+    Some(usage)
+}
+
+fn modified(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Best-effort native-store usage for a precise agent session. Every recognized
+/// name is handled deliberately: adapters with a stable structured store read
+/// it, while agents without one return `None` rather than guessed counters.
+pub fn session_usage(agent: &str, cwd: &Path, session_id: &str) -> Option<AgentUsage> {
+    match canonical(agent) {
+        "claude" => claude_usage(&claude_path(&claude_base(), cwd, session_id)),
+        "codex" => codex_usage(&codex_path(&codex_base(), session_id)?),
+        "copilot" => copilot_usage(&copilot_path(&copilot_base(), session_id)),
+        "opencode" => opencode_usage(&opencode_db_path(&opencode_base()), session_id, cwd),
+        "kimi" => kimi_usage(&kimi_dir(&kimi_base(), session_id)?),
+        "grok" => grok_usage(&grok_dir(&grok_base(), cwd, session_id)?),
+        "pi" => pi_usage(&pi_path(&pi_base(), session_id)?),
+        "gemini" => gemini_usage(&chat_path(&gemini_base(), session_id)?),
+        "qwen" => gemini_usage(&chat_path(&qwen_base(), session_id)?),
+        "fx" => fx_usage(&fx_dir(&fx_base(), session_id)),
+        // These agents currently expose identity/state but no stable,
+        // structured, per-session usage store Luvus can read safely.
+        "aider" | "kiro" | "cursor" | "amp" | "droid" => None,
+        _ => None, // manifest-defined agents degrade honestly too.
+    }
+}
+
+/// Last modification time of the authoritative usage source. Mission Control
+/// uses this as a cheap idle-session cache key before invoking the parser.
+pub fn session_mtime(agent: &str, cwd: &Path, session_id: &str) -> Option<SystemTime> {
+    let path = match canonical(agent) {
+        "claude" => claude_path(&claude_base(), cwd, session_id),
+        "codex" => codex_path(&codex_base(), session_id)?,
+        "copilot" => copilot_path(&copilot_base(), session_id),
+        "opencode" => opencode_db_path(&opencode_base()),
+        "kimi" => kimi_dir(&kimi_base(), session_id)?.join("agents/main/wire.jsonl"),
+        "grok" => grok_dir(&grok_base(), cwd, session_id)?.join("updates.jsonl"),
+        "pi" => pi_path(&pi_base(), session_id)?,
+        "gemini" => chat_path(&gemini_base(), session_id)?,
+        "qwen" => chat_path(&qwen_base(), session_id)?,
+        "fx" => fx_dir(&fx_base(), session_id).join("usage-v2.json"),
+        _ => return None,
+    };
+    modified(&path)
+}
+
+fn canonical(agent: &str) -> &str {
+    match agent {
+        "cursor-agent" => "cursor",
+        other => other,
+    }
+}
+
+fn claude_path(base: &Path, cwd: &Path, session_id: &str) -> PathBuf {
+    claude_project_dir(base, cwd).join(format!("{session_id}.jsonl"))
+}
+
+fn copilot_path(base: &Path, session_id: &str) -> PathBuf {
+    base.join("session-state")
+        .join(session_id)
+        .join("events.jsonl")
+}
+
+fn opencode_db_path(storage: &Path) -> PathBuf {
+    storage.parent().unwrap_or(storage).join("opencode.db")
+}
+
+fn kimi_dir(base: &Path, session_id: &str) -> Option<PathBuf> {
+    kimi_index(base)
+        .into_iter()
+        .find(|e| e.id == session_id)
+        .map(|e| e.session_dir)
+}
+
+fn grok_dir(base: &Path, cwd: &Path, session_id: &str) -> Option<PathBuf> {
+    grok_cwd_dirs(base)
+        .into_iter()
+        .map(|(_, p)| p)
+        .find(|p| grok_decode_cwd(p).as_deref() == Some(cwd))
+        .map(|p| p.join(session_id))
+        .filter(|p| p.is_dir())
+}
+
+fn codex_path(base: &Path, session_id: &str) -> Option<PathBuf> {
+    codex_rollout_files(base).into_iter().find_map(|(_, path)| {
+        let name_matches = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.contains(session_id));
+        if name_matches {
+            return Some(path);
+        }
+        read_codex_session(&path)
+            .is_some_and(|(id, _)| id == session_id)
+            .then_some(path)
+    })
+}
+
+fn pi_path(base: &Path, session_id: &str) -> Option<PathBuf> {
+    pi_session_files(base).into_iter().find_map(|(_, path)| {
+        read_pi_session(&path)
+            .is_some_and(|(id, _)| id == session_id)
+            .then_some(path)
+    })
+}
+
+fn gemini_base() -> PathBuf {
+    std::env::var_os("GEMINI_CLI_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home().join(".gemini"))
+}
+
+fn qwen_base() -> PathBuf {
+    std::env::var_os("QWEN_CODE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home().join(".qwen"))
+}
+
+fn fx_base() -> PathBuf {
+    std::env::var_os("FX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home().join(".fx"))
+}
+
+fn fx_dir(base: &Path, session_id: &str) -> PathBuf {
+    base.join("sessions").join(session_id)
+}
+
+/// Gemini and Qwen put the first eight session-id characters in the filename,
+/// then keep the full id in the JSONL header. Filter by the filename first so a
+/// lookup does not parse every chat in a large history.
+fn chat_path(base: &Path, session_id: &str) -> Option<PathBuf> {
+    let needle = session_id.get(..session_id.len().min(8))?;
+    let tmp = base.join("tmp");
+    let projects = std::fs::read_dir(tmp).ok()?;
+    for project in projects.flatten() {
+        let chats = project.path().join("chats");
+        let Ok(files) = std::fs::read_dir(chats) else {
+            continue;
+        };
+        for entry in files.flatten() {
+            let path = entry.path();
+            let candidate = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("session-") && n.contains(needle));
+            if !candidate {
+                continue;
+            }
+            let mut found = false;
+            let _ = for_each_json_line(&path, |v| {
+                if v.get("sessionId").and_then(Value::as_str) == Some(session_id) {
+                    found = true;
+                }
+            });
+            if found {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+fn claude_usage(path: &Path) -> Option<AgentUsage> {
+    let mut usage = AgentUsage::default();
+    let mut context_tokens = 0;
+    let mut seen = HashSet::new();
+    for_each_json_line(path, |v| {
+        let message = v.get("message");
+        let Some(raw) = message
+            .and_then(|m| m.get("usage"))
+            .or_else(|| v.get("usage"))
+        else {
+            return;
+        };
+        // Claude can persist the same assistant message more than once. Its
+        // message id is the API-response identity; count it exactly once.
+        if let Some(id) = message.and_then(|m| m.get("id")).and_then(Value::as_str) {
+            if !seen.insert(id.to_string()) {
+                return;
+            }
+        }
+        let cache =
+            n(raw, "cache_read_input_tokens").saturating_add(n(raw, "cache_creation_input_tokens"));
+        add(&mut usage.tokens_in, n(raw, "input_tokens"));
+        add(&mut usage.tokens_out, n(raw, "output_tokens"));
+        add(&mut usage.cache, cache);
+        context_tokens = n(raw, "input_tokens").saturating_add(cache);
+        if let Some(model) = message
+            .and_then(|m| m.get("model"))
+            .or_else(|| v.get("model"))
+            .and_then(Value::as_str)
+            .filter(|m| !m.is_empty())
+        {
+            usage.model = model.to_string();
+        }
+    })?;
+    if context_tokens > 0 {
+        usage.context = Some(context_frac(&usage.model, context_tokens));
+    }
+    finish(usage)
+}
+
+fn codex_usage(path: &Path) -> Option<AgentUsage> {
+    codex_usage_bounded(path, CODEX_USAGE_TAIL_BYTES, CODEX_MODEL_HEAD_BYTES)
+}
+
+fn codex_usage_bounded(path: &Path, tail_limit: u64, head_limit: u64) -> Option<AgentUsage> {
+    let mut usage = AgentUsage::default();
+    let len = std::fs::metadata(path).ok()?.len();
+    let tail_start = len.saturating_sub(tail_limit);
+    let tail = read_window(path, tail_start, tail_limit)?;
+    for_each_json_slice(&tail, tail_start > 0, |v| {
+        let payload = v.get("payload").unwrap_or(v);
+        if let Some(model) = payload
+            .get("model")
+            .or_else(|| payload.pointer("/state/model"))
+            .or_else(|| payload.pointer("/base_instructions/provenance/model"))
+            .and_then(Value::as_str)
+            .filter(|m| !m.is_empty())
+        {
+            usage.model = model.to_string();
+        }
+        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
+            return;
+        }
+        let Some(info) = payload.get("info").filter(|x| x.is_object()) else {
+            return;
+        };
+        let Some(total) = info.get("total_token_usage") else {
+            return;
+        };
+        let cache =
+            n(total, "cached_input_tokens").saturating_add(n(total, "cache_write_input_tokens"));
+        usage.tokens_in = non_cache_input(n(total, "input_tokens"), cache, 0);
+        usage.tokens_out = n(total, "output_tokens");
+        usage.cache = cache;
+
+        if let (Some(last), window) = (
+            info.get("last_token_usage"),
+            n(info, "model_context_window"),
+        ) {
+            if window > 0 {
+                usage.context =
+                    Some((n(last, "input_tokens") as f64 / window as f64).clamp(0.0, 1.0) as f32);
+            }
+        }
+    });
+    // A model is usually repeated in recent turn-context records. If a very
+    // large active turn pushed that record beyond the tail window, recover it
+    // from the bounded session prefix without walking the whole transcript.
+    if usage.model.is_empty() && tail_start > 0 {
+        let head = read_window(path, 0, head_limit)?;
+        for_each_json_slice(&head, false, |v| {
+            let payload = v.get("payload").unwrap_or(v);
+            if let Some(model) = payload
+                .get("model")
+                .or_else(|| payload.pointer("/state/model"))
+                .or_else(|| payload.pointer("/base_instructions/provenance/model"))
+                .and_then(Value::as_str)
+                .filter(|m| !m.is_empty())
+            {
+                usage.model = model.to_string();
+            }
+        });
+    }
+    finish(usage)
+}
+
+fn copilot_usage(path: &Path) -> Option<AgentUsage> {
+    #[derive(Default)]
+    struct ModelTotal {
+        input: u64,
+        output: u64,
+        cache: u64,
+    }
+    let mut totals: HashMap<String, ModelTotal> = HashMap::new();
+    let mut seen = HashSet::new();
+    for_each_json_line(path, |v| {
+        if v.get("type").and_then(Value::as_str) != Some("session.shutdown") {
+            return;
+        }
+        if let Some(id) = v.get("id").and_then(Value::as_str) {
+            if !seen.insert(id.to_string()) {
+                return;
+            }
+        }
+        let Some(models) = v.pointer("/data/modelMetrics").and_then(Value::as_object) else {
+            return;
+        };
+        for (model, metrics) in models {
+            let Some(raw) = metrics.get("usage") else {
+                continue;
+            };
+            let cache = n(raw, "cacheReadTokens").saturating_add(n(raw, "cacheWriteTokens"));
+            let total = totals.entry(model.clone()).or_default();
+            add(
+                &mut total.input,
+                non_cache_input(n(raw, "inputTokens"), cache, 0),
+            );
+            add(&mut total.output, n(raw, "outputTokens"));
+            add(&mut total.cache, cache);
+        }
+    })?;
+
+    let mut usage = AgentUsage::default();
+    let mut dominant = 0;
+    let mut exact_estimate = Some(0.0);
+    for (model, total) in totals {
+        add(&mut usage.tokens_in, total.input);
+        add(&mut usage.tokens_out, total.output);
+        add(&mut usage.cache, total.cache);
+        let weight = total
+            .input
+            .saturating_add(total.output)
+            .saturating_add(total.cache);
+        if weight > dominant {
+            dominant = weight;
+            usage.model = model.clone();
+        }
+        exact_estimate = match (
+            exact_estimate,
+            estimate_cost(&model, total.input, total.output, total.cache),
+        ) {
+            (Some(sum), Some(cost)) => Some(sum + cost),
+            _ => None,
+        };
+    }
+    usage.cost = exact_estimate.filter(|_| dominant > 0);
+    finish(usage)
+}
+
+fn opencode_usage(db: &Path, session_id: &str, cwd: &Path) -> Option<AgentUsage> {
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX
+        | OpenFlags::SQLITE_OPEN_URI;
+    let conn = Connection::open_with_flags(db, flags).ok()?;
+    let _ = conn.busy_timeout(Duration::from_millis(25));
+    let row = conn
+        .query_row(
+            "SELECT model, cost, tokens_input, tokens_output, \
+                    tokens_cache_read, tokens_cache_write \
+             FROM session WHERE id = ?1 AND directory = ?2 LIMIT 1",
+            (session_id, cwd.to_string_lossy().as_ref()),
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, f64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
+                ))
+            },
+        )
+        .optional()
+        .ok()??;
+
+    let as_u64 = |value: i64| u64::try_from(value).unwrap_or(0);
+    let mut usage = AgentUsage {
+        tokens_in: as_u64(row.2),
+        tokens_out: as_u64(row.3),
+        cache: as_u64(row.4).saturating_add(as_u64(row.5)),
+        ..AgentUsage::default()
+    };
+    if let Some(raw_model) = row.0 {
+        usage.model = serde_json::from_str::<Value>(&raw_model)
+            .ok()
+            .and_then(|v| v.get("id").and_then(Value::as_str).map(str::to_string))
+            .unwrap_or(raw_model);
+    }
+    // OpenCode's custom providers commonly persist `0` when billing data is
+    // unavailable. Treat only a positive value as authoritative, then fall back
+    // to the configured estimate table.
+    usage.cost = (row.1 > 0.0 && row.1.is_finite()).then_some(row.1);
+    finish(usage)
+}
+
+fn kimi_usage(dir: &Path) -> Option<AgentUsage> {
+    let wire = dir.join("agents/main/wire.jsonl");
+    let mut usage = AgentUsage::default();
+    let mut context_tokens = 0;
+    let mut context_limit = 0;
+    for_each_json_line(&wire, |v| {
+        let record = v.get("payload").unwrap_or(v);
+        if let Some(model) = record
+            .get("model")
+            .or_else(|| record.pointer("/agent_config/model"))
+            .and_then(Value::as_str)
+            .filter(|m| !m.is_empty())
+        {
+            usage.model = model.to_string();
+        }
+        context_tokens = n(record, "context_tokens").max(context_tokens);
+        context_limit = n(record, "max_context_tokens").max(context_limit);
+        let Some(raw) = record.get("token_usage") else {
+            return;
+        };
+        add(&mut usage.tokens_in, n(raw, "input_other"));
+        add(&mut usage.tokens_out, n(raw, "output"));
+        add(
+            &mut usage.cache,
+            n(raw, "input_cache_read").saturating_add(n(raw, "input_cache_creation")),
+        );
+    })?;
+    if context_limit > 0 {
+        usage.context = Some((context_tokens as f64 / context_limit as f64).clamp(0.0, 1.0) as f32);
+    }
+    finish(usage)
+}
+
+fn grok_usage(dir: &Path) -> Option<AgentUsage> {
+    let mut usage = AgentUsage::default();
+    let mut seen = HashSet::new();
+    let mut cost_ticks = 0u64;
+    for_each_json_line(&dir.join("updates.jsonl"), |v| {
+        let Some(raw) = v.pointer("/params/update/usage") else {
+            return;
+        };
+        if let Some(id) = v
+            .pointer("/params/update/prompt_id")
+            .and_then(Value::as_str)
+        {
+            if !seen.insert(id.to_string()) {
+                return;
+            }
+        }
+        let cache_read = n(raw, "cachedReadTokens");
+        let cache_write = n(raw, "cacheCreationTokens");
+        add(
+            &mut usage.tokens_in,
+            non_cache_input(n(raw, "inputTokens"), cache_read, cache_write),
+        );
+        add(&mut usage.tokens_out, n(raw, "outputTokens"));
+        add(&mut usage.cache, cache_read.saturating_add(cache_write));
+        add(&mut cost_ticks, n(raw, "costUsdTicks"));
+        if let Some(model) = raw
+            .get("modelUsage")
+            .and_then(Value::as_object)
+            .and_then(|models| models.keys().next())
+        {
+            usage.model = model.clone();
+        }
+    })?;
+    if cost_ticks > 0 {
+        usage.cost = Some(cost_ticks as f64 / 10_000_000_000.0);
+    }
+    finish(usage)
+}
+
+fn pi_usage(path: &Path) -> Option<AgentUsage> {
+    let mut usage = AgentUsage::default();
+    let mut direct_cost = 0.0;
+    let mut has_direct_cost = false;
+    let mut seen = HashSet::new();
+    for_each_json_line(path, |v| {
+        let record = v.get("message").unwrap_or(v);
+        let Some(raw) = record.get("usage") else {
+            return;
+        };
+        if let Some(id) = record
+            .get("responseId")
+            .or_else(|| v.get("id"))
+            .and_then(Value::as_str)
+        {
+            if !seen.insert(id.to_string()) {
+                return;
+            }
+        }
+        add(&mut usage.tokens_in, n(raw, "input"));
+        add(&mut usage.tokens_out, n(raw, "output"));
+        add(
+            &mut usage.cache,
+            n(raw, "cacheRead").saturating_add(n(raw, "cacheWrite")),
+        );
+        if let Some(cost) = raw.pointer("/cost/total").and_then(Value::as_f64) {
+            if cost.is_finite() && cost >= 0.0 {
+                direct_cost += cost;
+                has_direct_cost = true;
+            }
+        }
+        if let Some(model) = record
+            .get("model")
+            .and_then(Value::as_str)
+            .filter(|m| !m.is_empty())
+        {
+            usage.model = model.to_string();
+        }
+    })?;
+    if has_direct_cost {
+        usage.cost = Some(direct_cost);
+    }
+    finish(usage)
+}
+
+fn gemini_usage(path: &Path) -> Option<AgentUsage> {
+    let mut usage = AgentUsage::default();
+    let mut seen = HashSet::new();
+    let mut latest_context = None;
+
+    let mut apply_message = |record: &Value| {
+        let id = record
+            .get("id")
+            .or_else(|| record.get("uuid"))
+            .and_then(Value::as_str);
+        if let Some(id) = id {
+            if !seen.insert(id.to_string()) {
+                return;
+            }
+        }
+        if let Some(model) = record
+            .get("model")
+            .and_then(Value::as_str)
+            .filter(|m| !m.is_empty())
+        {
+            usage.model = model.to_string();
+        }
+        let window = n(record, "contextWindowSize");
+        if let Some(raw) = record.get("tokens") {
+            let cache = n(raw, "cached");
+            let input = n(raw, "input");
+            add(&mut usage.tokens_in, non_cache_input(input, cache, 0));
+            add(&mut usage.tokens_out, n(raw, "output"));
+            add(&mut usage.cache, cache);
+            if window > 0 {
+                latest_context = Some((input as f64 / window as f64).clamp(0.0, 1.0) as f32);
+            }
+        } else if let Some(raw) = record.get("usageMetadata") {
+            let cache = n(raw, "cachedContentTokenCount");
+            let input = n(raw, "promptTokenCount");
+            add(&mut usage.tokens_in, non_cache_input(input, cache, 0));
+            add(&mut usage.tokens_out, n(raw, "candidatesTokenCount"));
+            add(&mut usage.cache, cache);
+            if window > 0 {
+                latest_context = Some((input as f64 / window as f64).clamp(0.0, 1.0) as f32);
+            }
+        }
+    };
+
+    for_each_json_line(path, |v| {
+        apply_message(v);
+        if let Some(messages) = v.pointer("/$set/messages").and_then(Value::as_array) {
+            for message in messages {
+                apply_message(message);
+            }
+        }
+    })?;
+    usage.context = latest_context;
+    finish(usage)
+}
+
+fn fx_usage(dir: &Path) -> Option<AgentUsage> {
+    let raw: Value = serde_json::from_reader(File::open(dir.join("usage-v2.json")).ok()?).ok()?;
+    let snapshot = raw.get("snapshot")?;
+    let cache_read = n(snapshot, "cache_read_tokens");
+    let cache_write = n(snapshot, "cache_write_tokens");
+    let mut usage = AgentUsage {
+        tokens_in: non_cache_input(n(snapshot, "input_tokens"), cache_read, cache_write),
+        tokens_out: n(snapshot, "output_tokens"),
+        cache: cache_read.saturating_add(cache_write),
+        ..AgentUsage::default()
+    };
+    if let Some(model) = snapshot
+        .get("models")
+        .and_then(Value::as_array)
+        .and_then(|models| {
+            models.iter().max_by_key(|m| {
+                n(m, "input_tokens")
+                    .saturating_add(n(m, "output_tokens"))
+                    .saturating_add(n(m, "cache_read_tokens"))
+            })
+        })
+        .and_then(|m| m.get("model"))
+        .and_then(Value::as_str)
+    {
+        usage.model = model.to_string();
+    }
+    if snapshot.get("billing").and_then(Value::as_str) == Some("complete") {
+        usage.cost = f(snapshot, "total_cost").filter(|cost| *cost >= 0.0);
+    }
+    finish(usage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmp(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("luvus-agent-usage-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn claude_deduplicates_replayed_message_ids() {
+        let dir = tmp("claude");
+        let path = dir.join("session.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"message":{"id":"msg-1","model":"claude-sonnet-4","usage":{"input_tokens":100,"output_tokens":20,"cache_read_input_tokens":80}}}"#,
+                "\n",
+                r#"{"message":{"id":"msg-1","model":"claude-sonnet-4","usage":{"input_tokens":100,"output_tokens":20,"cache_read_input_tokens":80}}}"#,
+                "\n",
+                r#"{"message":{"id":"msg-2","model":"claude-sonnet-4","usage":{"input_tokens":50,"output_tokens":10,"cache_creation_input_tokens":5}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let usage = claude_usage(&path).unwrap();
+        assert_eq!(usage.tokens_in, 150);
+        assert_eq!(usage.tokens_out, 30);
+        assert_eq!(usage.cache, 85);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn codex_uses_latest_cumulative_counter_and_real_window() {
+        let dir = tmp("codex");
+        let path = dir.join("rollout.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"type":"turn_context","payload":{"model":"gpt-5.6-sol"}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":800,"cache_write_input_tokens":0,"output_tokens":100},"last_token_usage":{"input_tokens":900},"model_context_window":2000}}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1600,"cached_input_tokens":1200,"cache_write_input_tokens":0,"output_tokens":180},"last_token_usage":{"input_tokens":1000},"model_context_window":2000}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let usage = codex_usage(&path).unwrap();
+        assert_eq!(usage.tokens_in, 400);
+        assert_eq!(usage.tokens_out, 180);
+        assert_eq!(usage.cache, 1200);
+        assert_eq!(usage.context, Some(0.5));
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn codex_usage_is_recovered_from_bounded_head_and_tail_windows() {
+        let dir = tmp("codex-bounded");
+        let path = dir.join("rollout.jsonl");
+        let mut transcript = String::from(
+            r#"{"type":"turn_context","payload":{"model":"gpt-5.6-sol"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10}}}}
+"#,
+        );
+        transcript.push_str(&format!(r#"{{"noise":"{}"}}"#, "x".repeat(512)));
+        transcript.push('\n');
+        transcript.push_str(
+            r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":900,"cached_input_tokens":600,"output_tokens":80},"last_token_usage":{"input_tokens":500},"model_context_window":1000}}}
+"#,
+        );
+        fs::write(&path, transcript).unwrap();
+
+        let usage = codex_usage_bounded(&path, 300, 128).unwrap();
+        assert_eq!(usage.model, "gpt-5.6-sol");
+        assert_eq!(
+            (usage.tokens_in, usage.tokens_out, usage.cache),
+            (300, 80, 600)
+        );
+        assert_eq!(usage.context, Some(0.5));
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn copilot_sums_each_shutdown_ledger_once() {
+        let dir = tmp("copilot");
+        let path = dir.join("events.jsonl");
+        let event = serde_json::json!({
+            "id": "shutdown-1",
+            "type": "session.shutdown",
+            "data": {"modelMetrics": {
+                "gpt-5.4": {"usage": {
+                    "inputTokens": 1000,
+                    "outputTokens": 100,
+                    "cacheReadTokens": 700,
+                    "cacheWriteTokens": 20
+                }}
+            }}
+        })
+        .to_string();
+        fs::write(&path, format!("{event}\n{event}\n")).unwrap();
+
+        let usage = copilot_usage(&path).unwrap();
+        assert_eq!(
+            (usage.tokens_in, usage.tokens_out, usage.cache),
+            (280, 100, 720)
+        );
+        assert_eq!(usage.model, "gpt-5.4");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn opencode_reads_aggregate_session_row_without_writing() {
+        let dir = tmp("opencode");
+        let db = dir.join("opencode.db");
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                model TEXT,
+                cost REAL NOT NULL,
+                tokens_input INTEGER NOT NULL,
+                tokens_output INTEGER NOT NULL,
+                tokens_reasoning INTEGER NOT NULL,
+                tokens_cache_read INTEGER NOT NULL,
+                tokens_cache_write INTEGER NOT NULL
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            rusqlite::params![
+                "ses-1",
+                "/work/app",
+                r#"{"id":"anthropic/claude-sonnet-4"}"#,
+                0.42,
+                300i64,
+                40i64,
+                5i64,
+                600i64,
+                10i64
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let usage = opencode_usage(&db, "ses-1", Path::new("/work/app")).unwrap();
+        assert_eq!(
+            (usage.tokens_in, usage.tokens_out, usage.cache),
+            (300, 40, 610)
+        );
+        assert_eq!(usage.model, "anthropic/claude-sonnet-4");
+        assert_eq!(usage.cost, Some(0.42));
+        assert!(opencode_usage(&db, "ses-1", Path::new("/work/other")).is_none());
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn grok_sums_unique_turn_ledgers_and_exact_ticks() {
+        let dir = tmp("grok");
+        let line = |id: &str, input: u64| {
+            serde_json::json!({
+                "params": {"update": {
+                    "prompt_id": id,
+                    "usage": {
+                        "inputTokens": input,
+                        "outputTokens": 10,
+                        "cachedReadTokens": 80,
+                        "cacheCreationTokens": 5,
+                        "costUsdTicks": 500_000_000u64,
+                        "modelUsage": {"grok-4.6-build": {}}
+                    }
+                }}
+            })
+            .to_string()
+        };
+        fs::write(
+            dir.join("updates.jsonl"),
+            format!(
+                "{}\n{}\n{}\n",
+                line("one", 100),
+                line("one", 100),
+                line("two", 120)
+            ),
+        )
+        .unwrap();
+        let usage = grok_usage(&dir).unwrap();
+        assert_eq!(usage.tokens_in, 50);
+        assert_eq!(usage.tokens_out, 20);
+        assert_eq!(usage.cache, 170);
+        assert_eq!(usage.cost, Some(0.1));
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn kimi_and_pi_map_disjoint_token_buckets() {
+        let kimi = tmp("kimi");
+        fs::create_dir_all(kimi.join("agents/main")).unwrap();
+        fs::write(
+            kimi.join("agents/main/wire.jsonl"),
+            concat!(
+                r#"{"type":"StatusUpdate","payload":{"context_tokens":1000,"max_context_tokens":4000,"token_usage":{"input_other":100,"output":20,"input_cache_read":300,"input_cache_creation":5}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let ku = kimi_usage(&kimi).unwrap();
+        assert_eq!((ku.tokens_in, ku.tokens_out, ku.cache), (100, 20, 305));
+        assert_eq!(ku.context, Some(0.25));
+
+        let pi = tmp("pi");
+        let path = pi.join("session.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"type":"message","message":{"role":"assistant","responseId":"r1","model":"gpt-5.4-mini","usage":{"input":50,"output":20,"cacheRead":100,"cacheWrite":5,"cost":{"total":0.01}}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let pu = pi_usage(&path).unwrap();
+        assert_eq!((pu.tokens_in, pu.tokens_out, pu.cache), (50, 20, 105));
+        assert_eq!(pu.cost, Some(0.01));
+        fs::remove_dir_all(kimi).unwrap();
+        fs::remove_dir_all(pi).unwrap();
+    }
+
+    #[test]
+    fn gemini_and_fx_use_native_aggregate_shapes() {
+        let gemini = tmp("gemini");
+        let path = gemini.join("session.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"sessionId":"s1"}"#,
+                "\n",
+                r#"{"id":"m1","type":"gemini","model":"gemini-3-pro","contextWindowSize":1000,"tokens":{"input":500,"output":40,"cached":300,"total":540}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let gu = gemini_usage(&path).unwrap();
+        assert_eq!((gu.tokens_in, gu.tokens_out, gu.cache), (200, 40, 300));
+        assert_eq!(gu.context, Some(0.5));
+
+        let fx = tmp("fx");
+        fs::write(
+            fx.join("usage-v2.json"),
+            r#"{"snapshot":{"input_tokens":1000,"output_tokens":50,"cache_read_tokens":700,"cache_write_tokens":20,"reasoning_tokens":10,"total_cost":0.12,"billing":"complete","models":[{"model":"zai/glm-5.2","input_tokens":1000,"output_tokens":50,"cache_read_tokens":700}]}}"#,
+        )
+        .unwrap();
+        let fu = fx_usage(&fx).unwrap();
+        assert_eq!((fu.tokens_in, fu.tokens_out, fu.cache), (280, 50, 720));
+        assert_eq!(fu.cost, Some(0.12));
+        assert_eq!(fu.model, "zai/glm-5.2");
+        fs::remove_dir_all(gemini).unwrap();
+        fs::remove_dir_all(fx).unwrap();
+    }
+
+    #[test]
+    fn bounded_jsonl_skips_oversized_records_and_keeps_following_usage() {
+        let dir = tmp("bounded");
+        let path = dir.join("events.jsonl");
+        let mut bytes = vec![b'x'; MAX_USAGE_LINE + 1];
+        bytes.push(b'\n');
+        bytes.extend_from_slice(br#"{"ok":true}"#);
+        bytes.push(b'\n');
+        fs::write(&path, bytes).unwrap();
+        let mut found = false;
+        for_each_json_line(&path, |v| found |= v.get("ok") == Some(&Value::Bool(true))).unwrap();
+        assert!(found);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn unsupported_agents_never_receive_guessed_usage() {
+        for agent in [
+            "aider",
+            "kiro",
+            "cursor",
+            "cursor-agent",
+            "amp",
+            "droid",
+            "custom",
+        ] {
+            assert!(session_usage(agent, Path::new("/work"), "session").is_none());
+            assert!(session_mtime(agent, Path::new("/work"), "session").is_none());
+        }
+    }
+}

--- a/src/agent/usage.rs
+++ b/src/agent/usage.rs
@@ -40,13 +40,22 @@ fn for_each_json_line(path: &Path, mut visit: impl FnMut(&Value)) -> Option<()> 
     loop {
         let (take, ended, eof) = {
             let available = reader.fill_buf().ok()?;
-            if available.is_empty() {
+            let next = if available.is_empty() {
                 (0, false, true)
             } else if let Some(at) = available.iter().position(|b| *b == b'\n') {
                 (at + 1, true, false)
             } else {
                 (available.len(), false, false)
+            };
+            if !oversized && !next.2 {
+                if line.len().saturating_add(next.0) <= MAX_USAGE_LINE {
+                    line.extend_from_slice(&available[..next.0]);
+                } else {
+                    line.clear();
+                    oversized = true;
+                }
             }
+            next
         };
 
         if eof {
@@ -58,15 +67,6 @@ fn for_each_json_line(path: &Path, mut visit: impl FnMut(&Value)) -> Option<()> 
             return Some(());
         }
 
-        if !oversized {
-            let available = reader.fill_buf().ok()?;
-            if line.len().saturating_add(take) <= MAX_USAGE_LINE {
-                line.extend_from_slice(&available[..take]);
-            } else {
-                line.clear();
-                oversized = true;
-            }
-        }
         reader.consume(take);
 
         if ended {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -527,61 +527,39 @@ impl App {
                 let _ = tx.send(AppEvent::ProcScanned(found));
             });
         }
-        // Mission Control usage (docs/54, MC-2): read tokens/context/cost from the
-        // agents' on-disk stores on a worker thread, and only while a mission tab is
-        // open — the default session pays nothing. Targets are gathered here (cheap);
-        // the worker does the file IO and posts the fresh cache back.
-        let mission_open = self
-            .workspaces
-            .iter()
-            .any(|w| w.tabs.iter().any(Tab::is_mission));
-        if mission_open
-            && now.duration_since(self.last_usage_at) >= Duration::from_secs(5)
-            && !self.usage_scan_inflight
-        {
-            self.last_usage_at = now;
+        // Mission Control usage is demand-driven. Opening/focusing the dashboard,
+        // changing scope, or pressing/clicking refresh queues one worker scan;
+        // merely retaining a hidden mission tab performs no usage IO.
+        self.sync_mission_usage_visibility();
+        if self.mission_usage_requested && !self.usage_scan_inflight {
+            self.mission_usage_requested = false;
             self.usage_scan_inflight = true;
-            // Targets: every live pane with a session, plus every resumable session
-            // on disk. Keyed by session id (dedup), so a live pane and its resumable
-            // twin share one read (`(agent, cwd, session_id)`).
-            let mut targets: std::collections::HashMap<String, (String, std::path::PathBuf)> =
-                std::collections::HashMap::new();
-            for (id, p) in self.panes.iter() {
-                if let Some(sess) = self.status.get(id).and_then(|s| s.agent_session.as_ref()) {
-                    targets
-                        .entry(sess.session_id.clone())
-                        .or_insert((sess.agent.clone(), p.cwd.clone()));
-                }
-            }
-            for s in self.resumable.iter() {
-                targets
-                    .entry(s.session_id.clone())
-                    .or_insert((s.agent.clone(), s.cwd.clone()));
-            }
+            let targets = self.mission_usage_targets();
             let overrides = self.config.mission_pricing.clone();
-            // Previous scan's results, so an unchanged transcript is reused instead
-            // of re-read+parsed (the heavy part). Cloned once per scan (every 5s,
-            // only while a mission tab is open) — a handful of small entries.
+            // Previous results let an explicit refresh reuse unchanged transcripts:
+            // one stat per idle session, with no read or parse.
             let prev_usage = self.agent_usage.clone();
             let prev_mtimes = self.usage_mtimes.clone();
             let tx = self.app_tx.clone();
             std::thread::spawn(move || {
                 let mut usage = std::collections::HashMap::new();
                 let mut mtimes = std::collections::HashMap::new();
-                for (sid, (agent, cwd)) in targets {
-                    let mtime = crate::agent::session_mtime(&agent, &cwd, &sid);
+                for (key, cwd) in targets {
+                    let mtime = crate::agent::session_mtime(&key.agent, &cwd, &key.session_id);
                     if let Some(mt) = mtime {
-                        mtimes.insert(sid.clone(), mt);
+                        mtimes.insert(key.clone(), mt);
                     }
                     // Unchanged since last scan → reuse the cached figures (one
                     // `stat`, no read/parse).
-                    if mtime.is_some() && prev_mtimes.get(&sid) == mtime.as_ref() {
-                        if let Some(u) = prev_usage.get(&sid) {
-                            usage.insert(sid, u.clone());
+                    if mtime.is_some() && prev_mtimes.get(&key) == mtime.as_ref() {
+                        if let Some(u) = prev_usage.get(&key) {
+                            usage.insert(key, u.clone());
                             continue;
                         }
                     }
-                    if let Some(mut u) = crate::agent::session_usage(&agent, &cwd, &sid) {
+                    if let Some(mut u) =
+                        crate::agent::session_usage(&key.agent, &cwd, &key.session_id)
+                    {
                         // Re-price with any user overrides (MC-5); empty ⇒ unchanged.
                         if !overrides.is_empty() {
                             u.cost = crate::mission::estimate_cost_with(
@@ -592,7 +570,7 @@ impl App {
                                 &overrides,
                             );
                         }
-                        usage.insert(sid, u);
+                        usage.insert(key, u);
                     }
                 }
                 let _ = tx.send(AppEvent::UsageScanned { usage, mtimes });

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1787,14 +1787,16 @@ impl App {
             if self.mission_detail.take().is_some() || self.mission_answer.take().is_some() {
                 return;
             }
-            let body_top = self.mission_area.y + 2; // header + separator
-            if hit(self.mission_area) && m.row >= body_top {
-                let idx = self.mission_scroll + (m.row - body_top) as usize;
-                if idx < self.mission_rows.len() {
-                    self.mission_cursor = idx;
-                    self.mission_activate(idx);
-                }
+            if self.mission_refresh_rect.is_some_and(hit) {
+                self.request_mission_usage_refresh();
+                return;
             }
+            if let Some((scope, _)) = self.mission_scope_rects.iter().find(|(_, rect)| hit(*rect)) {
+                self.set_mission_scope(*scope);
+                return;
+            }
+            // Agent rows are intentionally keyboard-only for now. A plain click
+            // must never jump away from Mission Control unexpectedly.
             return;
         }
         if let Some((id, _)) = self.pane_rects.iter().find(|(_, rect)| hit(*rect)) {

--- a/src/app/mission.rs
+++ b/src/app/mission.rs
@@ -1,10 +1,10 @@
-//! Mission Control (docs/54): open/close the per-workspace agent dashboard tab,
+//! Mission Control (docs/54): open/close the agent dashboard tab,
 //! build its rows, and its key/mouse handlers. A mission tab carries a
 //! placeholder `TileLayout` leaf (no pane spawned), so every `layout()` path is
 //! untouched; render/input branch on `Tab::is_mission()`, mirroring the git tab.
 
 use super::*;
-use crate::mission::{MissionRow, MissionRowView};
+use crate::mission::{MissionRow, MissionRowView, MissionScope};
 
 impl App {
     /// Open (or focus) the Mission Control tab for `workspace`. Idempotent — one
@@ -16,6 +16,7 @@ impl App {
         self.active_ws = wsi;
         if let Some(i) = self.workspaces[wsi].tabs.iter().position(Tab::is_mission) {
             self.workspaces[wsi].active_tab = i;
+            self.request_mission_usage_refresh();
             return;
         }
         let placeholder = PaneId::alloc(); // never inserted into `panes`
@@ -33,6 +34,7 @@ impl App {
         self.mission_scroll = 0;
         self.mission_cursor = 0;
         self.session_dirty = true;
+        self.request_mission_usage_refresh();
     }
 
     /// True when the focused tab is a Mission Control dashboard.
@@ -59,56 +61,153 @@ impl App {
         }
     }
 
-    /// Build the rows for the active node's Mission Control: every live agent in
-    /// its pane tabs (a recognised agent, or a pane with a resolved session).
-    /// Dashboard tabs (git/orch/mission) hold only a placeholder, which has no
-    /// `status` entry, so they contribute nothing. MC-4 appends resumable sessions.
-    pub fn build_mission_rows(&self) -> Vec<MissionRowView> {
-        let mut rows = Vec::new();
-        let Some(node) = self.workspaces.get(self.active_ws) else {
-            return rows;
-        };
-        // Live agents first.
-        let mut live_sessions = std::collections::HashSet::new();
-        for (ti, tab) in node.tabs.iter().enumerate() {
-            let leaves = tab.layout.leaves();
-            for (pi, id) in leaves.iter().copied().enumerate() {
-                let Some(s) = self.status.get(&id) else {
+    /// Change the dashboard scope without changing the active workspace or any
+    /// pane ownership. Selection-dependent overlays are reset because the row
+    /// identities may change when the scope changes.
+    pub fn set_mission_scope(&mut self, scope: MissionScope) {
+        if self.mission_scope != scope {
+            self.mission_scope = scope;
+            self.mission_scroll = 0;
+            self.mission_cursor = 0;
+            self.mission_detail = None;
+            self.mission_answer = None;
+            self.request_mission_usage_refresh();
+        }
+    }
+
+    /// Queue one asynchronous usage refresh. Repeated requests coalesce while a
+    /// scan is running; after it lands, Mission Control stays idle until another
+    /// explicit request or a later transition into the dashboard.
+    pub fn request_mission_usage_refresh(&mut self) {
+        self.mission_usage_requested = true;
+    }
+
+    pub fn mission_usage_refreshing(&self) -> bool {
+        self.mission_usage_requested || self.usage_scan_inflight
+    }
+
+    /// Detect focus transitions in one central place so mouse, keyboard, API,
+    /// switcher, and restored-session tab activation all share the same policy.
+    pub(crate) fn sync_mission_usage_visibility(&mut self) {
+        let active = self.active_is_mission();
+        if active && !self.mission_was_active {
+            self.request_mission_usage_refresh();
+        }
+        self.mission_was_active = active;
+    }
+
+    /// Usage targets visible in the selected Mission Control scope. Avoid
+    /// opening one workspace's dashboard and scanning every resumable session
+    /// Luvus has ever discovered in unrelated workspaces.
+    pub(crate) fn mission_usage_targets(
+        &self,
+    ) -> std::collections::HashMap<crate::mission::UsageKey, std::path::PathBuf> {
+        let mut targets = std::collections::HashMap::new();
+        if self.workspaces.get(self.active_ws).is_none() {
+            return targets;
+        }
+        let all = self.mission_scope == MissionScope::All;
+        for (wi, workspace) in self.workspaces.iter().enumerate() {
+            if !all && wi != self.active_ws {
+                continue;
+            }
+            for id in workspace.tabs.iter().flat_map(|tab| tab.layout.leaves()) {
+                let Some(session) = self
+                    .status
+                    .get(&id)
+                    .and_then(|status| status.agent_session.as_ref())
+                else {
                     continue;
                 };
-                if self.manifests.is_agent(&s.agent) || s.agent_session.is_some() {
-                    let usage = s
-                        .agent_session
-                        .as_ref()
-                        .and_then(|sess| {
-                            live_sessions.insert(sess.session_id.clone());
-                            self.agent_usage.get(&sess.session_id)
-                        })
-                        .cloned();
-                    // Where the agent lives: the tab (its own name if set, else its
-                    // number) and — when that tab is split — which pane holds it, so
-                    // you can tell two agents in one tab apart. Click still jumps.
-                    let mut location = match &tab.name {
-                        Some(n) => n.clone(),
-                        None => format!("tab {}", ti + 1),
+                if let Some(pane) = self.panes.get(&id) {
+                    targets
+                        .entry(crate::mission::UsageKey::new(
+                            &session.agent,
+                            &session.session_id,
+                        ))
+                        .or_insert_with(|| pane.cwd.clone());
+                }
+            }
+        }
+        for session in &self.resumable {
+            let included = self.workspaces.iter().enumerate().any(|(wi, workspace)| {
+                (all || wi == self.active_ws)
+                    && crate::platform::same_path(&session.cwd, &workspace.cwd)
+            });
+            if included {
+                targets
+                    .entry(crate::mission::UsageKey::new(
+                        &session.agent,
+                        &session.session_id,
+                    ))
+                    .or_insert_with(|| session.cwd.clone());
+            }
+        }
+        targets
+    }
+
+    /// Build Mission Control rows from either the active workspace or every open
+    /// workspace. Dashboard tabs hold placeholder leaves without status entries,
+    /// so they contribute nothing. Resumable sessions are appended once and keep
+    /// their global index, making activation equally safe in both scopes.
+    pub fn build_mission_rows(&self) -> Vec<MissionRowView> {
+        let mut rows = Vec::new();
+        if self.workspaces.get(self.active_ws).is_none() {
+            return rows;
+        }
+        let all = self.mission_scope == MissionScope::All;
+        // Live agents first.
+        let mut live_sessions = std::collections::HashSet::new();
+        for (wi, workspace) in self.workspaces.iter().enumerate() {
+            if !all && wi != self.active_ws {
+                continue;
+            }
+            for (ti, tab) in workspace.tabs.iter().enumerate() {
+                let leaves = tab.layout.leaves();
+                for (pi, id) in leaves.iter().copied().enumerate() {
+                    let Some(s) = self.status.get(&id) else {
+                        continue;
                     };
-                    if leaves.len() > 1 {
-                        location.push_str(&format!(" · p{}/{}", pi + 1, leaves.len()));
+                    if self.manifests.is_agent(&s.agent) || s.agent_session.is_some() {
+                        let usage = s
+                            .agent_session
+                            .as_ref()
+                            .and_then(|sess| {
+                                let key =
+                                    crate::mission::UsageKey::new(&sess.agent, &sess.session_id);
+                                live_sessions.insert(key.clone());
+                                self.agent_usage.get(&key)
+                            })
+                            .cloned();
+                        // In the global scope, the workspace label leads the normal
+                        // tab/pane location so identical tab numbers stay distinct.
+                        let tab_name = match &tab.name {
+                            Some(n) => n.clone(),
+                            None => format!("t{}", ti + 1),
+                        };
+                        let mut location = if all {
+                            format!("{} · {tab_name}", workspace.name)
+                        } else {
+                            tab_name
+                        };
+                        if leaves.len() > 1 {
+                            location.push_str(&format!(" p{}/{}", pi + 1, leaves.len()));
+                        }
+                        if let Some(task) =
+                            self.orch.tasks.iter().find(|t| t.assignee == Some(id.0))
+                        {
+                            location.push_str(&format!(" · {}", task.id));
+                        }
+                        rows.push(MissionRowView {
+                            row: MissionRow::Live(id),
+                            agent: s.agent.clone(),
+                            state: s.state,
+                            resumable: false,
+                            location,
+                            usage,
+                            blocked_hint: s.blocked_hint.clone(),
+                        });
                     }
-                    // If this pane is an orch worker (docs/22), tag its task id, so
-                    // Mission Control links to the board (docs/54 MC-5).
-                    if let Some(task) = self.orch.tasks.iter().find(|t| t.assignee == Some(id.0)) {
-                        location.push_str(&format!(" · {}", task.id));
-                    }
-                    rows.push(MissionRowView {
-                        row: MissionRow::Live(id),
-                        agent: s.agent.clone(),
-                        state: s.state,
-                        resumable: false,
-                        location,
-                        usage,
-                        blocked_hint: s.blocked_hint.clone(),
-                    });
                 }
             }
         }
@@ -123,12 +222,16 @@ impl App {
             _ => 3,
         };
         rows.sort_by_key(|r| rank(r.state));
-        // Then the node's resumable on-disk sessions (docs/54 MC-4) — those whose
-        // cwd is this node's folder and that aren't already live above.
+        // Then resumable sessions belonging to an included workspace and not
+        // already represented by a live pane.
         for (idx, s) in self.resumable.iter().enumerate() {
-            if !crate::platform::same_path(&s.cwd, &node.cwd)
-                || live_sessions.contains(&s.session_id)
-            {
+            let workspace = self.workspaces.iter().enumerate().find(|(wi, workspace)| {
+                (all || *wi == self.active_ws) && crate::platform::same_path(&s.cwd, &workspace.cwd)
+            });
+            let Some((_, workspace)) = workspace else {
+                continue;
+            };
+            if live_sessions.contains(&crate::mission::UsageKey::new(&s.agent, &s.session_id)) {
                 continue;
             }
             rows.push(MissionRowView {
@@ -136,16 +239,25 @@ impl App {
                 agent: s.agent.clone(),
                 state: crate::ui::theme::State::Idle,
                 resumable: true,
-                location: "resumable".into(),
-                usage: self.agent_usage.get(&s.session_id).cloned(),
+                // STATE already says RESUME, so repeating "resumable" in the
+                // location wastes the most valuable horizontal table space.
+                location: if all {
+                    workspace.name.clone()
+                } else {
+                    "—".into()
+                },
+                usage: self
+                    .agent_usage
+                    .get(&crate::mission::UsageKey::new(&s.agent, &s.session_id))
+                    .cloned(),
                 blocked_hint: None,
             });
         }
         rows
     }
 
-    /// The click/`⏎` action for the row at `idx`: jump to a live agent's pane, or
-    /// resume a dead session (MC-4).
+    /// Keyboard activation for the row at `idx`: jump to a live agent's pane, or
+    /// resume a dead session (MC-4). Plain row clicks are intentionally inert.
     pub fn mission_activate(&mut self, idx: usize) {
         let Some(row) = self.mission_rows.get(idx).map(|r| r.row) else {
             return;
@@ -220,6 +332,13 @@ impl App {
         }
         let n = self.mission_rows.len();
         match key.code {
+            KeyCode::Tab | KeyCode::BackTab => {
+                let scope = match self.mission_scope {
+                    MissionScope::Workspace => MissionScope::All,
+                    MissionScope::All => MissionScope::Workspace,
+                };
+                self.set_mission_scope(scope);
+            }
             KeyCode::Char('j') | KeyCode::Down => {
                 if n > 0 {
                     self.mission_cursor = (self.mission_cursor + 1).min(n - 1);
@@ -248,6 +367,7 @@ impl App {
             KeyCode::Char('a') if self.mission_selected_pane().is_some() => {
                 self.mission_answer = Some(String::new());
             }
+            KeyCode::Char('r') => self.request_mission_usage_refresh(),
             KeyCode::Char('q') => self.close_mission_tab(),
             _ => {}
         }

--- a/src/app/mission.rs
+++ b/src/app/mission.rs
@@ -89,11 +89,11 @@ impl App {
     /// Detect focus transitions in one central place so mouse, keyboard, API,
     /// switcher, and restored-session tab activation all share the same policy.
     pub(crate) fn sync_mission_usage_visibility(&mut self) {
-        let active = self.active_is_mission();
-        if active && !self.mission_was_active {
+        let active_workspace = self.active_is_mission().then_some(self.active_ws);
+        if active_workspace.is_some() && active_workspace != self.mission_active_workspace {
             self.request_mission_usage_refresh();
         }
-        self.mission_was_active = active;
+        self.mission_active_workspace = active_workspace;
     }
 
     /// Usage targets visible in the selected Mission Control scope. Avoid

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -317,8 +317,8 @@ pub struct Tab {
     /// -leaf trick as a git tab; mutually exclusive with `git`.
     pub orch: bool,
     /// When `true`, this is the **Mission Control** dashboard (docs/54): the
-    /// per-workspace agent overview. Same placeholder-leaf trick as git/orch;
-    /// mutually exclusive with both.
+    /// workspace or all-workspaces agent overview. Same placeholder-leaf trick
+    /// as git/orch; mutually exclusive with both.
     pub mission: bool,
     /// User-chosen tab name (docs/28). `None` → the tab bar shows its number.
     /// Git/orch/mission tabs keep their fixed label and are never named.
@@ -1319,10 +1319,17 @@ pub struct App {
     /// The board's content rect, for mouse-wheel hit-testing.
     pub orch_area: Rect,
     /// Mission Control (docs/54): scroll + selected row of the active mission tab,
-    /// its content rect (mouse hit-testing), the rows currently displayed (so a
-    /// click/⏎ maps back to a pane or session), and the async token/cost cache.
+    /// its content rect (mouse-wheel hit-testing), the rows currently displayed
+    /// (so keyboard activation maps back to a pane or session), and the async
+    /// token/cost cache.
     pub mission_scroll: usize,
     pub mission_cursor: usize,
+    /// Current workspace only, or every open workspace.
+    pub mission_scope: crate::mission::MissionScope,
+    /// Click targets for the two scope tabs. Agent rows remain keyboard-only.
+    pub mission_scope_rects: Vec<(crate::mission::MissionScope, Rect)>,
+    /// Click target for the explicit Mission Control usage refresh action.
+    pub mission_refresh_rect: Option<Rect>,
     pub mission_area: Rect,
     pub mission_rows: Vec<crate::mission::MissionRowView>,
     /// Row index whose Mission Control detail overlay is open (`o`), if any (MC-5).
@@ -1335,15 +1342,17 @@ pub struct App {
     pub mission_burn: Option<f64>,
     /// Previous (total cost, time) sample, for the burn-rate delta.
     pub mission_last_cost: Option<(f64, std::time::Instant)>,
-    /// Best-effort usage (tokens/context/cost) keyed by **session id**, so both a
-    /// live pane and a resumable on-disk session share one entry. Refreshed
+    /// Best-effort usage (tokens/context/cost) keyed by **agent + session id**, so
+    /// a live pane and its resumable on-disk session share one entry without
+    /// colliding with another agent's local session namespace. Refreshed
     /// off-loop and blitted by the mission render — never computed on the render
     /// path (docs/54 MC-2/MC-4).
-    pub agent_usage: std::collections::HashMap<String, crate::mission::AgentUsage>,
+    pub agent_usage:
+        std::collections::HashMap<crate::mission::UsageKey, crate::mission::AgentUsage>,
     /// Each scanned transcript's mtime, so the next usage scan re-reads a session
     /// only when its file actually changed (docs/54) — an idle session costs one
     /// `stat`, not a full read+parse.
-    pub usage_mtimes: std::collections::HashMap<String, std::time::SystemTime>,
+    pub usage_mtimes: std::collections::HashMap<crate::mission::UsageKey, std::time::SystemTime>,
     /// Cursor position from the last render (for headless frame streaming).
     pub last_cursor: Option<(u16, u16)>,
     /// Foreground client asked to detach (prefix+q). Distinct from quit.
@@ -1419,9 +1428,11 @@ pub struct App {
     /// Throttle for rescanning the agents' on-disk session stores.
     last_sessions_at: Instant,
     last_proc_at: Instant,
-    /// Mission Control usage scan (docs/54, MC-2): throttle + in-flight guard, so
-    /// the token/cost read runs off-loop and only while a mission tab is open.
-    last_usage_at: Instant,
+    /// Mission Control usage is demand-driven: opening/focusing the dashboard,
+    /// changing its scope, or choosing refresh queues one off-loop scan. No
+    /// usage reader runs merely because a hidden Mission Control tab exists.
+    mission_usage_requested: bool,
+    mission_was_active: bool,
     usage_scan_inflight: bool,
     /// Throttle for per-pane agent classification — it locks each pane's VT engine
     /// and scans its grid, so it runs at ~100ms, not at the render frame rate.
@@ -1790,6 +1801,9 @@ impl App {
             orch_area: Rect::ZERO,
             mission_scroll: 0,
             mission_cursor: 0,
+            mission_scope: crate::mission::MissionScope::Workspace,
+            mission_scope_rects: Vec::new(),
+            mission_refresh_rect: None,
             mission_area: Rect::ZERO,
             mission_rows: Vec::new(),
             mission_detail: None,
@@ -1822,7 +1836,8 @@ impl App {
             proc_scan_inflight: false,
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
-            last_usage_at: Instant::now(),
+            mission_usage_requested: false,
+            mission_was_active: false,
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
             last_detect_at: Instant::now()
@@ -2324,6 +2339,9 @@ impl App {
             orch_area: Rect::ZERO,
             mission_scroll: 0,
             mission_cursor: 0,
+            mission_scope: crate::mission::MissionScope::Workspace,
+            mission_scope_rects: Vec::new(),
+            mission_refresh_rect: None,
             mission_area: Rect::ZERO,
             mission_rows: Vec::new(),
             mission_detail: None,
@@ -2356,7 +2374,8 @@ impl App {
             proc_scan_inflight: false,
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
-            last_usage_at: Instant::now(),
+            mission_usage_requested: false,
+            mission_was_active: false,
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
             last_detect_at: Instant::now()
@@ -6743,11 +6762,11 @@ mod tests {
         let mut app = App::new(80, 24, tx).unwrap();
         let focus = app.layout().focus;
         assert!(
-            !crate::agent::is_resumable("gemini"),
+            !crate::agent::is_resumable("aider"),
             "the regression needs an agent whose identity is visible but not persisted"
         );
 
-        app.proc_commands.insert(focus, vec!["gemini".into()]);
+        app.proc_commands.insert(focus, vec!["aider".into()]);
         let now = Instant::now();
         app.last_detect_at = now - Duration::from_secs(1);
         app.last_proc_at = now;
@@ -6758,7 +6777,7 @@ mod tests {
             app.detect_tick(now),
             "an idle identity change adds a sidebar row and must request a frame"
         );
-        assert_eq!(app.status.get(&focus).unwrap().agent, "gemini");
+        assert_eq!(app.status.get(&focus).unwrap().agent, "aider");
         assert!(
             !app.session_dirty,
             "a non-resumable identity repaint does not create persistence work"
@@ -9614,7 +9633,7 @@ mod tests {
     }
 
     // docs/54 MC-1: Mission Control opens as a dashboard tab, lists the node's
-    // live agents, renders them, and ⏎/click jumps back to the agent's pane.
+    // live agents, renders them, and Enter jumps back to the agent's pane.
     #[test]
     /// Every dashboard must survive a hostile terminal. Mission Control lays its
     /// rows out in fixed-width columns, which is exactly the shape that panics on
@@ -9694,6 +9713,7 @@ mod tests {
             text.contains("Mission Control"),
             "the dashboard title shows"
         );
+        assert!(text.contains("BETA"), "the dashboard beta badge shows");
         assert!(text.contains("claude"), "the agent row shows");
 
         // ⏎ jumps back to the agent's pane (leaving the dashboard).
@@ -9701,6 +9721,124 @@ mod tests {
         assert!(!app.active_is_mission(), "jumped off the dashboard");
         assert_eq!(app.ws().active_tab, agent_tab, "landed on the agent's tab");
         assert_eq!(app.layout().focus, agent_pane, "focused the agent's pane");
+    }
+
+    #[test]
+    fn mission_usage_refresh_is_demand_driven() {
+        use ratatui::crossterm::event::{
+            KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+        };
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let _env = crate::persist::test_env("mission-demand-refresh");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let normal_tab = app.ws().active_tab;
+        app.open_mission_control(0);
+        let mission_tab = app.ws().active_tab;
+        assert!(app.mission_usage_requested, "opening requests one refresh");
+
+        app.sync_mission_usage_visibility();
+        app.mission_usage_requested = false; // simulate the worker consuming it
+        app.sync_mission_usage_visibility();
+        assert!(
+            !app.mission_usage_requested,
+            "remaining on Mission Control does not poll"
+        );
+
+        app.handle_mission_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+        assert!(app.mission_usage_requested, "r requests a refresh");
+
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let refresh = app
+            .mission_refresh_rect
+            .expect("wide dashboard exposes refresh button");
+        app.mission_usage_requested = false;
+        app.handle_event(crate::event::AppEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: refresh.x,
+            row: refresh.y,
+            modifiers: KeyModifiers::NONE,
+        }));
+        assert!(app.mission_usage_requested, "click requests a refresh");
+
+        app.mission_usage_requested = false;
+        app.focus_tab(normal_tab).unwrap();
+        app.sync_mission_usage_visibility();
+        app.focus_tab(mission_tab).unwrap();
+        app.sync_mission_usage_visibility();
+        assert!(
+            app.mission_usage_requested,
+            "returning to Mission Control requests one fresh snapshot"
+        );
+    }
+
+    #[test]
+    fn mission_control_scope_tabs_include_every_workspace_without_row_clicks() {
+        use crate::mission::{MissionRow, MissionScope};
+        use ratatui::crossterm::event::{
+            KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+        };
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let _env = crate::persist::test_env("mission-scope");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let first = app.layout().focus;
+        app.workspaces[0].name = "alpha".into();
+        app.status.get_mut(&first).unwrap().agent = "claude".into();
+
+        let second = PaneId::alloc();
+        let mut second_status = PaneStatus::new("codex".into());
+        second_status.agent_session = Some(AgentSession {
+            agent: "codex".into(),
+            session_id: "beta-session".into(),
+        });
+        app.status.insert(second, second_status);
+        app.workspaces.push(Workspace {
+            id: crate::ids::public_id("workspace"),
+            name: "beta".into(),
+            cwd: PathBuf::from("/tmp/luvus-mission-beta"),
+            branch: None,
+            git_ahead_behind: None,
+            worktree: None,
+            tabs: vec![Tab::panes(TileLayout::new(second))],
+            active_tab: 0,
+            pinned: false,
+        });
+
+        app.open_mission_control(0);
+        assert_eq!(app.mission_scope, MissionScope::Workspace);
+        assert_eq!(app.build_mission_rows().len(), 1, "current workspace only");
+
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let all = app
+            .mission_scope_rects
+            .iter()
+            .find(|(scope, _)| *scope == MissionScope::All)
+            .expect("all-workspaces scope tab is rendered")
+            .1;
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: all.x + 1,
+            row: all.y,
+            modifiers: KeyModifiers::NONE,
+        }));
+        assert_eq!(app.mission_scope, MissionScope::All);
+        let rows = app.build_mission_rows();
+        assert_eq!(rows.len(), 2, "both workspaces contribute agents");
+        assert!(rows.iter().any(|row| {
+            row.row == MissionRow::Live(second) && row.location.starts_with("beta · t1")
+        }));
+
+        app.handle_mission_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(
+            app.mission_scope,
+            MissionScope::Workspace,
+            "Tab provides a keyboard equivalent"
+        );
     }
 
     // docs/54 MC-2/MC-4: live rows carry cached usage (tokens/cost/context), and
@@ -9721,9 +9859,10 @@ mod tests {
                 session_id: "live-1".into(),
             });
         }
-        // Seed the usage cache (what the async scan produces), keyed by session id.
+        // Seed the usage cache (what the async scan produces), keyed by agent and
+        // session id.
         app.agent_usage.insert(
-            "live-1".into(),
+            crate::mission::UsageKey::new("claude", "live-1"),
             AgentUsage {
                 model: "claude-opus-4-8".into(),
                 tokens_in: 4000,
@@ -9741,7 +9880,7 @@ mod tests {
             updated: std::time::SystemTime::now(),
         }];
         app.agent_usage.insert(
-            "resume-1".into(),
+            crate::mission::UsageKey::new("claude", "resume-1"),
             AgentUsage {
                 model: "claude-sonnet-4".into(),
                 tokens_in: 1000,
@@ -9751,7 +9890,6 @@ mod tests {
                 cost: Some(0.02),
             },
         );
-
         app.open_mission_control(0);
         let rows = app.build_mission_rows();
 
@@ -9776,8 +9914,8 @@ mod tests {
             "the resumable row carries its historical cost"
         );
 
-        // Render the dashboard and confirm the new layout draws: the column
-        // header, the per-row context gauge, and the bottom cost-by-model chart.
+        // Render the dashboard and confirm the full command deck draws: agent
+        // sessions, selected agent, status summary, and model-spend telemetry.
         {
             use ratatui::{backend::TestBackend, Terminal};
             let mut term = Terminal::new(TestBackend::new(140, 30)).unwrap();
@@ -9789,14 +9927,60 @@ mod tests {
                         .map(move |c| buf.cell((c, r)).map(|x| x.symbol()).unwrap_or(" "))
                 })
                 .collect();
-            assert!(text.contains("status"), "column header row draws");
-            assert!(text.contains("context"), "the context column header draws");
+            assert!(text.contains("AGENT SESSIONS"), "the agent panel draws");
+            assert!(text.contains("LOCATION"), "the table location header draws");
+            assert!(text.contains("TOKENS"), "the table usage header draws");
             assert!(
-                text.contains("cost by model"),
-                "the bottom cost chart draws"
+                text.contains("SELECTED AGENT"),
+                "the selected-agent panel draws"
             );
-            assert!(text.contains('█'), "a bar (context gauge / chart) draws");
+            assert!(
+                text.contains("COST BY MODEL"),
+                "the model-spend panel draws"
+            );
+            assert!(text.contains("AGENT STATUS"), "the state panel draws");
+            assert!(text.contains('█'), "a telemetry bar draws");
         }
+
+        // A narrow terminal falls back to a full-width, single-column agent list.
+        {
+            use ratatui::{backend::TestBackend, Terminal};
+            let mut term = Terminal::new(TestBackend::new(60, 18)).unwrap();
+            term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+            let buf = term.backend().buffer();
+            let text: String = (0..buf.area.height)
+                .flat_map(|r| {
+                    (0..buf.area.width)
+                        .map(move |c| buf.cell((c, r)).map(|x| x.symbol()).unwrap_or(" "))
+                })
+                .collect();
+            assert!(text.contains("AGENT SESSIONS"), "compact agent panel draws");
+        }
+
+        // Plain clicks are intentionally inert: opening a pane is an explicit
+        // keyboard action through Enter, not an accidental dashboard click.
+        let active_tab = app.ws().active_tab;
+        let cursor = app.mission_cursor;
+        app.handle_event(crate::event::AppEvent::Mouse(
+            ratatui::crossterm::event::MouseEvent {
+                kind: ratatui::crossterm::event::MouseEventKind::Down(
+                    ratatui::crossterm::event::MouseButton::Left,
+                ),
+                column: app.mission_area.x.saturating_add(2),
+                row: app.mission_area.y.saturating_add(7),
+                modifiers: KeyModifiers::NONE,
+            },
+        ));
+        assert!(app.active_is_mission(), "click stays in Mission Control");
+        assert_eq!(
+            app.ws().active_tab,
+            active_tab,
+            "click does not open a pane"
+        );
+        assert_eq!(
+            app.mission_cursor, cursor,
+            "click does not change selection"
+        );
 
         // The detail overlay opens on `o` and closes on esc. (`render` publishes
         // `mission_rows`, so it's set now.)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1432,7 +1432,9 @@ pub struct App {
     /// changing its scope, or choosing refresh queues one off-loop scan. No
     /// usage reader runs merely because a hidden Mission Control tab exists.
     mission_usage_requested: bool,
-    mission_was_active: bool,
+    /// Workspace whose Mission Control tab was visible on the previous sync.
+    /// `None` also records transitions away from Mission Control.
+    mission_active_workspace: Option<usize>,
     usage_scan_inflight: bool,
     /// Throttle for per-pane agent classification — it locks each pane's VT engine
     /// and scans its grid, so it runs at ~100ms, not at the render frame rate.
@@ -1837,7 +1839,7 @@ impl App {
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
             mission_usage_requested: false,
-            mission_was_active: false,
+            mission_active_workspace: None,
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
             last_detect_at: Instant::now()
@@ -2375,7 +2377,7 @@ impl App {
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
             mission_usage_requested: false,
-            mission_was_active: false,
+            mission_active_workspace: None,
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
             last_detect_at: Instant::now()
@@ -9771,6 +9773,38 @@ mod tests {
         assert!(
             app.mission_usage_requested,
             "returning to Mission Control requests one fresh snapshot"
+        );
+    }
+
+    #[test]
+    fn mission_usage_refreshes_when_switching_between_workspace_dashboards() {
+        let _env = crate::persist::test_env("mission-workspace-refresh");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let second = PaneId::alloc();
+        app.workspaces.push(Workspace {
+            id: crate::ids::public_id("workspace"),
+            name: "beta".into(),
+            cwd: PathBuf::from("/tmp/luvus-mission-beta"),
+            branch: None,
+            git_ahead_behind: None,
+            worktree: None,
+            tabs: vec![Tab::panes(TileLayout::new(second))],
+            active_tab: 0,
+            pinned: false,
+        });
+
+        app.open_mission_control(0);
+        app.open_mission_control(1);
+        app.sync_mission_usage_visibility();
+        app.mission_usage_requested = false;
+
+        app.active_ws = 0;
+        app.sync_mission_usage_visibility();
+
+        assert!(
+            app.mission_usage_requested,
+            "switching directly to another workspace dashboard requests fresh usage"
         );
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -179,11 +179,11 @@ pub enum AppEvent {
     /// rather than concluding that no agent is running.
     ProcScanned(Option<std::collections::HashMap<u32, Vec<String>>>),
     /// A Mission Control usage scan finished (docs/54, MC-2/MC-4): best-effort
-    /// tokens/context/cost keyed by session id, read off-loop from agents' stores,
-    /// plus each transcript's mtime so the next scan can skip unchanged files.
+    /// tokens/context/cost keyed by agent + session id, read off-loop from native
+    /// agent stores, plus each ledger's mtime so unchanged sessions stay cached.
     UsageScanned {
-        usage: std::collections::HashMap<String, crate::mission::AgentUsage>,
-        mtimes: std::collections::HashMap<String, std::time::SystemTime>,
+        usage: std::collections::HashMap<crate::mission::UsageKey, crate::mission::AgentUsage>,
+        mtimes: std::collections::HashMap<crate::mission::UsageKey, std::time::SystemTime>,
     },
     /// A git-tab fetch finished; apply it to the matching `GitView`.
     GitData {

--- a/src/mission/mod.rs
+++ b/src/mission/mod.rs
@@ -1,4 +1,5 @@
-//! Mission Control (docs/54): the per-workspace agent dashboard. This is the
+//! Mission Control (docs/54): the workspace and all-workspaces agent dashboard.
+//! This is the
 //! **pure model** — the row/usage types here, and the cost estimates in
 //! [`pricing`]. A `Tab.mission` flag makes a tab render this dashboard instead of
 //! panes, exactly like the git tab (docs/17) and the orch board (docs/22): the tab
@@ -13,10 +14,36 @@ pub use pricing::*;
 use crate::ids::PaneId;
 use crate::ui::theme::State;
 
+/// Which workspaces contribute agents to Mission Control. This is ephemeral UI
+/// state: it changes only what the dashboard shows, never pane ownership.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum MissionScope {
+    #[default]
+    Workspace,
+    All,
+}
+
+/// Stable cache identity for a native usage ledger. Session identifiers are
+/// agent-local, so the agent name must be part of the key.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UsageKey {
+    pub agent: String,
+    pub session_id: String,
+}
+
+impl UsageKey {
+    pub fn new(agent: impl Into<String>, session_id: impl Into<String>) -> Self {
+        Self {
+            agent: agent.into(),
+            session_id: session_id.into(),
+        }
+    }
+}
+
 /// Token / context / cost usage for one agent session (docs/54 §5). Every figure
-/// is best-effort from the agent's own on-disk store; **cost is an estimate**
-/// (tokens × a model price table, see [`pricing`]), never a bill. `None` fields
-/// mean "unknown".
+/// is best-effort from the agent's own on-disk store. Cost uses an agent's exact
+/// persisted amount where available, otherwise the model price table in
+/// [`pricing`]; it is still informational, never a bill. `None` means unknown.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AgentUsage {
     pub model: String,
@@ -36,7 +63,7 @@ impl AgentUsage {
     }
 }
 
-/// What a Mission Control row points at, for its click / `⏎` action.
+/// What a Mission Control row points at for keyboard activation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MissionRow {
     /// A live agent pane — jump to it.

--- a/src/ui/mission.rs
+++ b/src/ui/mission.rs
@@ -1,13 +1,12 @@
-//! Mission Control render (docs/54): a per-workspace table of the node's agents —
-//! status, tokens, context and estimated cost, plus a header aggregate. One line
-//! per agent (cursor + scroll like the orch board). Data is precomputed into
-//! `MissionRowView`s by `App::build_mission_rows`, so drawing borrows no `App`.
+//! Mission Control render (docs/54): a full-tab command deck for the workspace's
+//! live and resumable agents. Data is precomputed into `MissionRowView`s by
+//! `App::build_mission_rows`, so the responsive Ratatui grid borrows no `App`.
 
 use std::borrow::Cow;
 
 use super::*;
 use crate::i18n::Catalog;
-use crate::mission::MissionRowView;
+use crate::mission::{MissionRowView, MissionScope};
 
 /// Format a token count compactly: `945`, `12.3k`, `1.2M`.
 fn fmt_tokens(n: u64) -> String {
@@ -27,45 +26,6 @@ fn fill_bg(f: &mut RenderTarget, rect: Rect, color: Color) {
             buf[(x, y)].set_bg(color);
         }
     }
-}
-
-fn hline(f: &mut RenderTarget, x: u16, y: u16, w: u16, t: &Theme) {
-    let buf = f.buffer_mut();
-    for cx in x..x + w {
-        buf[(cx, y)]
-            .set_symbol("─")
-            .set_style(Style::new().fg(t.surface1).bg(t.mantle));
-    }
-}
-
-// ── column layout (shared by the header row and every data row) ──────────────
-const GAP: usize = 2;
-const STATUS_W: usize = 10;
-/// The data columns after the status column: (header, width, right-aligned).
-const DCOLS: &[(&str, usize, bool)] = &[
-    ("agent", 12, false),
-    ("ctx", 5, true),
-    ("room", 6, true),
-    ("tokens", 12, true),
-    ("cost", 11, true),
-    ("model", 8, false),
-    ("where", 12, false),
-];
-
-/// Truncate + pad a value to a fixed-width column cell (right- or left-aligned).
-fn cell(s: &str, w: usize, right: bool) -> String {
-    let s = truncate(s, w);
-    if right {
-        format!("{s:>w$}")
-    } else {
-        format!("{s:<w$}")
-    }
-}
-
-/// The columns occupy this many cells before the trailing context bar: status +
-/// each data column, with a `GAP` after every one (including before the bar).
-fn cols_width() -> usize {
-    STATUS_W + DCOLS.iter().map(|(_, w, _)| GAP + w).sum::<usize>() + GAP
 }
 
 /// Compact USD: `$3.20`, `$1.2k`, `$24.9k`.
@@ -106,140 +66,729 @@ fn short_model(m: &str) -> Cow<'static, str> {
     }
 }
 
-/// The column-header row, aligned to the data columns below it (`context` labels
-/// the bar area).
-fn col_header(w: usize, t: &Theme) -> Line<'static> {
-    let mut s = cell("status", STATUS_W, false);
-    for (h, cw, right) in DCOLS {
-        s.push_str(&" ".repeat(GAP));
-        s.push_str(&cell(h, *cw, *right));
-    }
-    if cols_width() + 8 <= w {
-        s.push_str(&" ".repeat(GAP));
-        s.push_str("context");
-    }
-    Line::from(Span::styled(s, Style::new().fg(t.overlay1).bold()))
+fn deck_block(title: &str, t: &Theme, focus: bool) -> ratatui::widgets::Block<'static> {
+    use ratatui::widgets::{Block, BorderType, Borders};
+    let border = if focus { t.border_focus } else { t.surface1 };
+    Block::new()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::new().fg(border).bg(t.mantle))
+        .title(Span::styled(
+            format!(" {title} "),
+            Style::new()
+                .fg(if focus { t.accent } else { t.overlay1 })
+                .bold(),
+        ))
+        .style(Style::new().bg(t.mantle))
 }
 
-/// One agent row: status (dot + label) + the data columns, then a context gauge
-/// filling the rest of the width — or, for a blocked agent, the line it's waiting
-/// on (so you can answer it without opening the pane, docs/54).
-fn row_line(r: &MissionRowView, w: usize, t: &Theme) -> Line<'static> {
-    let u = r.usage.as_ref();
-    let ctx_frac = u.and_then(|x| x.context);
-    let near = ctx_frac.is_some_and(|c| c >= crate::mission::COMPACT_AT);
-    let warn = if near { t.coral } else { t.subtext0 };
-    // Status is one colour: a live state dot+label, or a dim "○ resume" cue (MC-4).
-    let (dot, word, scolor) = if r.resumable {
-        ("○", "resume", t.overlay1)
+fn pad_right(text: &str, width: usize) -> String {
+    let text = truncate(text, width);
+    format!(
+        "{text}{}",
+        " ".repeat(width.saturating_sub(display_width(&text)))
+    )
+}
+
+fn pad_left(text: &str, width: usize) -> String {
+    let text = truncate(text, width);
+    format!(
+        "{}{text}",
+        " ".repeat(width.saturating_sub(display_width(&text)))
+    )
+}
+
+fn meter(value: f32, width: usize) -> (String, String) {
+    let width = width.max(1);
+    let fill = ((value.clamp(0.0, 1.0) * width as f32).round() as usize).min(width);
+    ("█".repeat(fill), "░".repeat(width - fill))
+}
+
+fn draw_header(
+    f: &mut RenderTarget,
+    area: Rect,
+    rows: &[MissionRowView],
+    scope: MissionScope,
+    cat: &Catalog,
+    t: &Theme,
+) {
+    if area.height == 0 {
+        return;
+    }
+    let working = rows.iter().filter(|r| r.state == State::Working).count();
+    let blocked = rows.iter().filter(|r| r.state == State::Blocked).count();
+    let signal = if blocked > 0 {
+        ("ATTENTION", t.coral)
+    } else if working > 0 {
+        ("ACTIVE", t.mint)
     } else {
-        (r.state.dot(), r.state.label(), r.state.color(t))
+        ("STANDBY", t.overlay1)
     };
-    let ctx = ctx_frac
-        .map(|c| format!("{}%", (c * 100.0).round() as u32))
-        .unwrap_or_else(|| "—".into());
-    let room = ctx_frac
-        .map(|c| {
-            format!(
-                "→{}%",
-                ((crate::mission::COMPACT_AT - c) * 100.0).max(0.0).round() as u32
-            )
-        })
-        .unwrap_or_default();
-    let tokens = u
-        .map(|x| format!("{} tok", fmt_tokens(x.total_tokens())))
-        .unwrap_or_else(|| "—".into());
-    let cost = u
-        .and_then(|x| x.cost)
-        .map(fmt_cost)
-        .unwrap_or_else(|| "—".into());
-    let model = u.map(|x| short_model(&x.model)).unwrap_or_default();
-    let vals: [(&str, Color); 7] = [
-        (r.agent.as_str(), t.subtext1),
-        (ctx.as_str(), warn),
-        (room.as_str(), warn),
-        (tokens.as_str(), t.subtext0),
-        (cost.as_str(), t.green),
-        (model.as_ref(), t.mint),
-        (r.location.as_str(), t.overlay1),
-    ];
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    spans.push(Span::styled(
-        cell(&format!("{dot} {word}"), STATUS_W, false),
-        Style::new().fg(scolor),
-    ));
-    for ((v, color), (_, cw, right)) in vals.iter().zip(DCOLS) {
-        spans.push(Span::raw(" ".repeat(GAP)));
-        spans.push(Span::styled(cell(v, *cw, *right), Style::new().fg(*color)));
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(" ◉ ", Style::new().fg(signal.1).bold()),
+            Span::styled(cat.mc_title, Style::new().fg(t.text).bold()),
+            Span::raw("  "),
+            Span::styled(" BETA ", Style::new().fg(t.crust).bg(t.accent).bold()),
+            Span::styled(
+                match scope {
+                    MissionScope::Workspace => "  //  CURRENT WORKSPACE",
+                    MissionScope::All => "  //  ALL WORKSPACES",
+                },
+                Style::new().fg(t.overlay1),
+            ),
+        ])),
+        Rect::new(area.x, area.y, area.width, 1),
+    );
+    let status = if area.width >= 72 {
+        format!(
+            "STATE {0}  ·  AGENTS {1:02}  ·  BLOCKED {2:02}",
+            signal.0,
+            rows.len(),
+            blocked
+        )
+    } else {
+        signal.0.to_string()
+    };
+    let sw = status.chars().count().min(area.width as usize) as u16;
+    f.render_widget(
+        Paragraph::new(Span::styled(status, Style::new().fg(signal.1))),
+        Rect::new(area.right().saturating_sub(sw + 1), area.y, sw, 1),
+    );
+    if area.height > 1 {
+        let scan = "─".repeat(area.width.saturating_sub(2) as usize);
+        f.render_widget(
+            Paragraph::new(Span::styled(scan, Style::new().fg(t.surface1))),
+            Rect::new(area.x + 1, area.y + 1, area.width.saturating_sub(2), 1),
+        );
     }
-    // Trailing: what a blocked agent is waiting on, else a context gauge.
-    let used = cols_width().saturating_sub(GAP); // width of the spans built above
-    if let Some(hint) = &r.blocked_hint {
-        if w > used + GAP + 4 {
-            spans.push(Span::raw(" ".repeat(GAP)));
-            spans.push(Span::styled(
-                truncate(hint, w - used - GAP),
-                Style::new().fg(t.coral),
-            ));
-        }
-    } else if let Some(c) = ctx_frac {
-        let bar_w = w.saturating_sub(cols_width());
-        if bar_w >= 4 {
-            let fill = ((c * bar_w as f32).round() as usize).min(bar_w);
-            let bcolor = if near { t.coral } else { t.mint };
-            spans.push(Span::raw(" ".repeat(GAP)));
-            spans.push(Span::styled("█".repeat(fill), Style::new().fg(bcolor)));
-            spans.push(Span::styled(
-                "░".repeat(bar_w - fill),
-                Style::new().fg(t.surface1),
-            ));
-        }
-    }
-    Line::from(spans)
 }
 
-/// The bottom graphic: horizontal bars of total cost per model, so you can see at
-/// a glance where the spend goes (docs/54). Cheap — a small aggregate over the
-/// already-built rows, drawn only while the tab is open.
-fn draw_cost_chart(f: &mut RenderTarget, area: Rect, rows: &[MissionRowView], t: &Theme) {
-    let mut map: Vec<(Cow<'static, str>, f64)> = Vec::new();
-    for r in rows {
-        if let Some(c) = r.usage.as_ref().and_then(|u| u.cost) {
-            let m = short_model(&r.usage.as_ref().unwrap().model);
-            match map.iter_mut().find(|(k, _)| *k == m) {
-                Some(e) => e.1 += c,
-                None => map.push((m, c)),
+fn draw_scope_tabs(
+    f: &mut RenderTarget,
+    area: Rect,
+    scope: MissionScope,
+    refreshing: bool,
+    cat: &Catalog,
+    t: &Theme,
+) -> (Vec<(MissionScope, Rect)>, Option<Rect>) {
+    if area.height == 0 || area.width < 8 {
+        return (Vec::new(), None);
+    }
+    let labels = [
+        (MissionScope::Workspace, cat.workspace.to_uppercase()),
+        (
+            MissionScope::All,
+            format!(
+                "{} {}",
+                cat.all.to_uppercase(),
+                cat.workspaces.to_uppercase()
+            ),
+        ),
+    ];
+    let mut x = area.x.saturating_add(1);
+    let mut hits = Vec::with_capacity(labels.len());
+    for (kind, label) in labels {
+        let text = format!(" {label} ");
+        let width = display_width(&text).min(area.right().saturating_sub(x) as usize) as u16;
+        if width == 0 {
+            break;
+        }
+        let rect = Rect::new(x, area.y, width, 1);
+        let selected = kind == scope;
+        f.render_widget(
+            Paragraph::new(Span::styled(
+                truncate(&text, width as usize),
+                Style::new()
+                    .fg(if selected { t.base } else { t.overlay1 })
+                    .bg(if selected { t.accent } else { t.mantle })
+                    .bold(),
+            )),
+            rect,
+        );
+        hits.push((kind, rect));
+        x = x.saturating_add(width).saturating_add(1);
+        if x >= area.right() {
+            break;
+        }
+    }
+    let refresh_text = if refreshing {
+        " REFRESHING "
+    } else {
+        " REFRESH "
+    };
+    let refresh_width = display_width(refresh_text) as u16;
+    let refresh_rect = area
+        .width
+        .checked_sub(refresh_width)
+        .map(|offset| Rect::new(area.x + offset, area.y, refresh_width, 1))
+        .filter(|rect| rect.x > x);
+    if let Some(rect) = refresh_rect {
+        f.render_widget(
+            Paragraph::new(Span::styled(
+                refresh_text,
+                Style::new()
+                    .fg(if refreshing { t.base } else { t.overlay1 })
+                    .bg(if refreshing { t.accent } else { t.mantle })
+                    .bold(),
+            )),
+            rect,
+        );
+    }
+    (hits, refresh_rect)
+}
+
+fn draw_metric(
+    f: &mut RenderTarget,
+    area: Rect,
+    title: &str,
+    value: String,
+    detail: String,
+    color: Color,
+    t: &Theme,
+) {
+    if area.width < 4 || area.height < 3 {
+        return;
+    }
+    let block = deck_block(title, t, false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    if inner.height == 0 {
+        return;
+    }
+    let mut lines = vec![Line::from(Span::styled(
+        format!(" {value}"),
+        Style::new().fg(color).bold(),
+    ))];
+    if inner.height > 1 {
+        lines.push(Line::from(Span::styled(
+            format!(
+                " {}",
+                truncate(&detail, inner.width.saturating_sub(1) as usize)
+            ),
+            Style::new().fg(t.overlay1),
+        )));
+    }
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_metrics(
+    f: &mut RenderTarget,
+    area: Rect,
+    rows: &[MissionRowView],
+    burn: Option<f64>,
+    budget: Option<f64>,
+    cat: &Catalog,
+    t: &Theme,
+) {
+    if area.height < 3 {
+        return;
+    }
+    let cells: [Rect; 4] = Layout::horizontal([
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+        Constraint::Percentage(25),
+    ])
+    .areas(area);
+    let working = rows.iter().filter(|r| r.state == State::Working).count();
+    let blocked = rows.iter().filter(|r| r.state == State::Blocked).count();
+    let resumable = rows.iter().filter(|r| r.resumable).count();
+    let total_cost: f64 = rows.iter().filter_map(|r| r.usage.as_ref()?.cost).sum();
+    let over_budget = budget.is_some_and(|b| total_cost > b);
+    draw_metric(
+        f,
+        cells[0],
+        &cat.mc_agents.to_uppercase(),
+        format!("{:02}", rows.len()),
+        format!(
+            "{} live · {} {}",
+            rows.len().saturating_sub(resumable),
+            rows.len(),
+            cat.mc_total
+        ),
+        t.accent,
+        t,
+    );
+    draw_metric(
+        f,
+        cells[1],
+        &cat.mc_working.to_uppercase(),
+        format!("{:02}", working),
+        "currently working".into(),
+        if working > 0 { t.mint } else { t.overlay1 },
+        t,
+    );
+    draw_metric(
+        f,
+        cells[2],
+        &cat.mc_blocked.to_uppercase(),
+        format!("{:02}", blocked),
+        if blocked > 0 {
+            "awaiting response"
+        } else {
+            "no blocked agents"
+        }
+        .into(),
+        if blocked > 0 { t.coral } else { t.green },
+        t,
+    );
+    let burn_detail = burn
+        .filter(|r| *r >= 0.005)
+        .map(|r| format!("{}/hr", fmt_cost(r)))
+        .unwrap_or_else(|| "rate unavailable".into());
+    draw_metric(
+        f,
+        cells[3],
+        "SPEND",
+        fmt_cost(total_cost),
+        burn_detail,
+        if over_budget { t.coral } else { t.green },
+        t,
+    );
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AgentColumns {
+    number: usize,
+    agent: usize,
+    state: usize,
+    location: usize,
+    model: usize,
+    tokens: usize,
+    context: usize,
+    cost: usize,
+}
+
+impl AgentColumns {
+    fn for_width(width: usize) -> Self {
+        const MARKER: usize = 2;
+        if width >= 81 {
+            // Wide terminals keep a compact, left-aligned table. Spare space
+            // stays after COST instead of splitting the table in the middle.
+            Self {
+                number: 3,
+                agent: 12,
+                state: 10,
+                location: 18,
+                model: 10,
+                tokens: 9,
+                context: 8,
+                cost: 9,
+            }
+        } else if width >= 73 {
+            // Full table with LOCATION shrinking only when space is constrained.
+            Self {
+                number: 3,
+                agent: 12,
+                state: 10,
+                location: width - 63,
+                model: 10,
+                tokens: 9,
+                context: 8,
+                cost: 9,
+            }
+        } else if width >= 63 {
+            // Keep the most useful usage fields and drop context first.
+            Self {
+                number: 3,
+                agent: 12,
+                state: 10,
+                location: width - 55,
+                model: 10,
+                tokens: 9,
+                context: 0,
+                cost: 9,
+            }
+        } else if width >= 37 {
+            // Narrow table: identity and location remain aligned.
+            Self {
+                number: 3,
+                agent: 12,
+                state: 10,
+                location: width - (MARKER + 3 + 12 + 10),
+                model: 0,
+                tokens: 0,
+                context: 0,
+                cost: 0,
+            }
+        } else {
+            // Tiny fallback: never overflow the terminal.
+            Self {
+                number: 3.min(width.saturating_sub(MARKER)),
+                agent: width.saturating_sub(MARKER + 3),
+                state: 0,
+                location: 0,
+                model: 0,
+                tokens: 0,
+                context: 0,
+                cost: 0,
             }
         }
     }
-    if map.is_empty() || area.height == 0 {
+
+    fn total(self) -> usize {
+        2 + self.number
+            + self.agent
+            + self.state
+            + self.location
+            + self.model
+            + self.tokens
+            + self.context
+            + self.cost
+    }
+}
+
+fn column_right(text: &str, width: usize) -> String {
+    if width == 0 {
+        String::new()
+    } else {
+        format!("{} ", pad_right(text, width - 1))
+    }
+}
+
+fn column_left(text: &str, width: usize) -> String {
+    if width == 0 {
+        String::new()
+    } else {
+        format!("{} ", pad_left(text, width - 1))
+    }
+}
+
+fn draw_agent_header(f: &mut RenderTarget, area: Rect, columns: AgentColumns, t: &Theme) {
+    let mut spans = vec![
+        Span::raw("  "),
+        Span::styled(
+            column_right("#", columns.number),
+            Style::new().fg(t.overlay0),
+        ),
+        Span::styled(
+            column_right("AGENT", columns.agent),
+            Style::new().fg(t.overlay0).bold(),
+        ),
+    ];
+    for (label, width) in [
+        ("STATE", columns.state),
+        ("LOCATION", columns.location),
+        ("MODEL", columns.model),
+    ] {
+        if width > 0 {
+            spans.push(Span::styled(
+                column_right(label, width),
+                Style::new().fg(t.overlay0).bold(),
+            ));
+        }
+    }
+    for (label, width) in [
+        ("TOKENS", columns.tokens),
+        ("CONTEXT", columns.context),
+        ("COST", columns.cost),
+    ] {
+        if width > 0 {
+            spans.push(Span::styled(
+                column_left(label, width),
+                Style::new().fg(t.overlay0).bold(),
+            ));
+        }
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_agent_row(
+    f: &mut RenderTarget,
+    area: Rect,
+    row: &MissionRowView,
+    number: usize,
+    selected: bool,
+    columns: AgentColumns,
+    t: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    if selected {
+        fill_bg(f, area, t.surface1);
+    }
+    let state_color = if row.resumable {
+        t.overlay1
+    } else {
+        row.state.color(t)
+    };
+    let rail = Rect::new(area.x, area.y, 1, 1);
+    fill_bg(f, rail, state_color);
+    let state = if row.resumable {
+        "RESUME"
+    } else {
+        row.state.label()
+    };
+    let usage = row.usage.as_ref();
+    let model = usage
+        .map(|usage| short_model(&usage.model))
+        .unwrap_or(Cow::Borrowed("—"));
+    let tokens = usage
+        .map(|usage| fmt_tokens(usage.total_tokens()))
+        .unwrap_or_else(|| "—".into());
+    let context = usage
+        .and_then(|usage| usage.context)
+        .map(|context| format!("{}%", (context * 100.0).round() as u32))
+        .unwrap_or_else(|| "—".into());
+    let cost = usage
+        .and_then(|usage| usage.cost)
+        .map(fmt_cost)
+        .unwrap_or_else(|| "—".into());
+    let mut spans = vec![
+        Span::styled(
+            if selected { "▸ " } else { "  " },
+            Style::new().fg(t.accent),
+        ),
+        Span::styled(
+            column_left(&format!("{number:02}"), columns.number),
+            Style::new().fg(t.overlay1),
+        ),
+        Span::styled(
+            column_right(&row.agent.to_uppercase(), columns.agent),
+            Style::new().fg(t.text).bold(),
+        ),
+    ];
+    if columns.state > 0 {
+        spans.push(Span::styled(
+            column_right(state, columns.state),
+            Style::new().fg(state_color),
+        ));
+    }
+    if columns.location > 0 {
+        spans.push(Span::styled(
+            column_right(&row.location, columns.location),
+            Style::new().fg(t.overlay1),
+        ));
+    }
+    if columns.model > 0 {
+        spans.push(Span::styled(
+            column_right(model.as_ref(), columns.model),
+            Style::new().fg(t.mint),
+        ));
+    }
+    for (value, width, color) in [
+        (&tokens, columns.tokens, t.subtext1),
+        (&context, columns.context, t.subtext1),
+        (&cost, columns.cost, t.green),
+    ] {
+        if width > 0 {
+            spans.push(Span::styled(
+                column_left(value, width),
+                Style::new().fg(color),
+            ));
+        }
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_roster(
+    f: &mut RenderTarget,
+    area: Rect,
+    rows: &[MissionRowView],
+    cursor: usize,
+    requested_scroll: usize,
+    cat: &Catalog,
+    t: &Theme,
+) -> usize {
+    let block = deck_block("AGENT SESSIONS", t, true);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    if inner.height == 0 {
+        return 0;
+    }
+    let content = Rect::new(
+        inner.x.saturating_add(2),
+        inner.y,
+        inner.width.saturating_sub(2),
+        1,
+    );
+    let columns = AgentColumns::for_width(content.width as usize);
+    debug_assert!(columns.total() <= content.width as usize);
+    draw_agent_header(f, content, columns, t);
+    if rows.is_empty() || inner.height < 2 {
+        f.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled("        ──╂──", Style::new().fg(t.surface1))),
+                Line::from(Span::styled(
+                    format!("      {}", cat.mc_empty.to_uppercase()),
+                    Style::new().fg(t.overlay1).bold(),
+                )),
+            ]),
+            Rect::new(
+                inner.x,
+                inner.y.saturating_add(1),
+                inner.width,
+                inner.height.saturating_sub(1),
+            ),
+        );
+        return 0;
+    }
+    let rows_area = Rect::new(inner.x, inner.y + 1, inner.width, inner.height - 1);
+    let visible = rows_area.height.max(1) as usize;
+    let cursor = cursor.min(rows.len().saturating_sub(1));
+    let mut scroll = requested_scroll.min(rows.len().saturating_sub(1));
+    if cursor < scroll {
+        scroll = cursor;
+    } else if cursor >= scroll + visible {
+        scroll = cursor + 1 - visible;
+    }
+    scroll = scroll.min(rows.len().saturating_sub(visible));
+    for (slot, idx) in (scroll..rows.len().min(scroll + visible)).enumerate() {
+        let rect = Rect::new(rows_area.x, rows_area.y + slot as u16, rows_area.width, 1);
+        draw_agent_row(f, rect, &rows[idx], idx + 1, idx == cursor, columns, t);
+    }
+    scroll
+}
+
+fn draw_selected(f: &mut RenderTarget, area: Rect, row: Option<&MissionRowView>, t: &Theme) {
+    let block = deck_block("SELECTED AGENT", t, false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let Some(row) = row else {
+        return;
+    };
+    let color = if row.resumable {
+        t.overlay1
+    } else {
+        row.state.color(t)
+    };
+    let state = if row.resumable {
+        "RESUMABLE"
+    } else {
+        row.state.label()
+    };
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled(" ◉ ", Style::new().fg(color)),
+            Span::styled(row.agent.to_uppercase(), Style::new().fg(t.text).bold()),
+            Span::styled(format!("  {state}"), Style::new().fg(color)),
+        ]),
+        Line::from(Span::styled(
+            format!(
+                "   WORKSPACE  {}",
+                truncate(&row.location, inner.width.saturating_sub(10) as usize)
+            ),
+            Style::new().fg(t.overlay1),
+        )),
+    ];
+    if let Some(u) = &row.usage {
+        lines.push(Line::from(vec![
+            Span::styled("   MODEL  ", Style::new().fg(t.overlay0)),
+            Span::styled(truncate(&u.model, 24), Style::new().fg(t.mint)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("   I/O    ", Style::new().fg(t.overlay0)),
+            Span::styled(
+                format!(
+                    "{} in · {} out · {} cache",
+                    fmt_tokens(u.tokens_in),
+                    fmt_tokens(u.tokens_out),
+                    fmt_tokens(u.cache)
+                ),
+                Style::new().fg(t.subtext1),
+            ),
+        ]));
+        if let Some(context) = u.context {
+            let meter_w = inner.width.saturating_sub(17).min(18) as usize;
+            let (on, off) = meter(context, meter_w);
+            let warning = context >= crate::mission::COMPACT_AT;
+            lines.push(Line::from(vec![
+                Span::styled("   CONTEXT ", Style::new().fg(t.overlay0)),
+                Span::styled(on, Style::new().fg(if warning { t.coral } else { t.mint })),
+                Span::styled(off, Style::new().fg(t.surface1)),
+                Span::styled(
+                    format!(" {:>3}%", (context * 100.0).round() as u32),
+                    Style::new().fg(if warning { t.coral } else { t.subtext1 }),
+                ),
+            ]));
+        }
+    } else {
+        lines.push(Line::from(Span::styled(
+            "   USAGE  data unavailable",
+            Style::new().fg(t.overlay0),
+        )));
+    }
+    if let Some(hint) = &row.blocked_hint {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "   ALERT  {}",
+                truncate(hint, inner.width.saturating_sub(10) as usize)
+            ),
+            Style::new().fg(t.coral),
+        )));
+    }
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_signal_matrix(f: &mut RenderTarget, area: Rect, rows: &[MissionRowView], t: &Theme) {
+    let block = deck_block("AGENT STATUS", t, false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    let states = [State::Working, State::Blocked, State::Done, State::Idle];
+    let mut spans = Vec::new();
+    for state in states {
+        let count = rows
+            .iter()
+            .filter(|r| !r.resumable && r.state == state)
+            .count();
+        spans.push(Span::styled(
+            format!(" {} {} {:02} ", state.dot(), state.label(), count),
+            Style::new().fg(state.color(t)),
+        ));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), inner);
+}
+
+fn draw_cost_chart(f: &mut RenderTarget, area: Rect, rows: &[MissionRowView], t: &Theme) {
+    let block = deck_block("COST BY MODEL", t, false);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    if inner.height == 0 {
+        return;
+    }
+    let mut map: Vec<(Cow<'static, str>, f64)> = Vec::new();
+    for row in rows {
+        if let Some(cost) = row.usage.as_ref().and_then(|u| u.cost) {
+            let model = short_model(&row.usage.as_ref().unwrap().model);
+            match map.iter_mut().find(|(name, _)| *name == model) {
+                Some(entry) => entry.1 += cost,
+                None => map.push((model, cost)),
+            }
+        }
+    }
+    if map.is_empty() {
+        f.render_widget(
+            Paragraph::new(Span::styled(
+                " cost data unavailable",
+                Style::new().fg(t.overlay0),
+            )),
+            inner,
+        );
         return;
     }
     map.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    let maxc = map[0].1.max(1e-9);
-    f.render_widget(
-        Paragraph::new(Span::styled(
-            "cost by model",
-            Style::new().fg(t.subtext1).bold(),
-        )),
-        Rect::new(area.x, area.y, area.width, 1),
-    );
-    let bar_w = (area.width as usize).saturating_sub(24).max(1); // 10 label + 12 value region
-    for (i, (m, c)) in map
-        .iter()
-        .take(area.height.saturating_sub(1) as usize)
-        .enumerate()
-    {
-        let fill = ((c / maxc * bar_w as f64).round() as usize).min(bar_w);
-        let line = Line::from(vec![
-            Span::styled(format!(" {} ", cell(m, 7, false)), Style::new().fg(t.mint)),
-            Span::styled("█".repeat(fill), Style::new().fg(t.accent)),
-            Span::styled("░".repeat(bar_w - fill), Style::new().fg(t.surface1)),
-            Span::styled(format!("  {}", fmt_cost(*c)), Style::new().fg(t.green)),
-        ]);
+    let max_cost = map[0].1.max(1e-9);
+    // Keep a blank terminal row between bars. Adjacent full-block glyphs merge
+    // visually into one large rectangle, especially when several models are
+    // present. Showing fewer distinct rows is easier to scan than packing them.
+    let row_stride = 2_u16;
+    let visible = inner.height.div_ceil(row_stride) as usize;
+    for (line, (model, cost)) in map.iter().take(visible).enumerate() {
+        let bar_w = inner.width.saturating_sub(18).max(1) as usize;
+        let fill = ((cost / max_cost * bar_w as f64).round() as usize).min(bar_w);
         f.render_widget(
-            Paragraph::new(line),
-            Rect::new(area.x, area.y + 1 + i as u16, area.width, 1),
+            Paragraph::new(Line::from(vec![
+                Span::styled(
+                    format!(" {:<7}", truncate(model, 7)),
+                    Style::new().fg(t.mint),
+                ),
+                Span::styled("█".repeat(fill), Style::new().fg(t.accent)),
+                Span::styled("░".repeat(bar_w - fill), Style::new().fg(t.surface1)),
+                Span::styled(format!(" {:>7}", fmt_cost(*cost)), Style::new().fg(t.green)),
+            ])),
+            Rect::new(inner.x, inner.y + line as u16 * row_stride, inner.width, 1),
         );
     }
 }
@@ -251,73 +800,62 @@ pub(super) fn render(
     rows: &[MissionRowView],
     scroll: usize,
     cursor: usize,
+    scope: MissionScope,
+    refreshing: bool,
     burn: Option<f64>,
     budget: Option<f64>,
     compact: bool,
     cat: &Catalog,
     t: &Theme,
-) -> usize {
+) -> MissionRender {
     if area.height < 4 || area.width < 24 {
-        return 0;
+        return MissionRender {
+            scroll: 0,
+            scope_rects: Vec::new(),
+            refresh_rect: None,
+        };
     }
-    let x = area.x + 1;
-    let w = area.width.saturating_sub(2) as usize;
-    // Header: title + a live aggregate (agents, working, blocked), then the
-    // workspace's total cost, fleet burn rate, and an over-budget warning.
-    let working = rows.iter().filter(|r| r.state == State::Working).count();
-    let blocked = rows.iter().filter(|r| r.state == State::Blocked).count();
-    let total_cost: f64 = rows.iter().filter_map(|r| r.usage.as_ref()?.cost).sum();
-    let over_budget = budget.is_some_and(|b| total_cost > b);
-    let mut header = vec![
-        Span::styled(
-            format!(" {} ", cat.mc_title),
-            Style::new().fg(t.accent).bold(),
-        ),
-        Span::styled(
-            format!(
-                "{} {} · {} {} · {} {}",
-                rows.len(),
-                cat.mc_agents,
-                working,
-                cat.mc_working,
-                blocked,
-                cat.mc_blocked,
-            ),
-            Style::new().fg(t.subtext0),
-        ),
-    ];
-    if total_cost > 0.0 {
-        let mut cost = format!(" · ${total_cost:.2} {}", cat.mc_total);
-        if let Some(b) = budget {
-            cost.push_str(&format!(" / ${b:.2}"));
-        }
-        let color = if over_budget { t.coral } else { t.green };
-        header.push(Span::styled(cost, Style::new().fg(color)));
-    }
-    if let Some(rate) = burn.filter(|r| *r >= 0.005) {
-        header.push(Span::styled(
-            format!(" · ${rate:.2}/hr"),
-            Style::new().fg(t.subtext0),
-        ));
-    }
-    f.render_widget(
-        Paragraph::new(Line::from(header)),
-        Rect::new(area.x, area.y, area.width, 1),
-    );
-    hline(f, area.x, area.y + 1, area.width, t);
-    // Column header row.
-    f.render_widget(
-        Paragraph::new(col_header(w, t)),
-        Rect::new(x, area.y + 2, w as u16, 1),
-    );
+    fill_bg(f, area, t.mantle);
+    let footer_h = u16::from(!compact && area.height >= 10);
+    let [header, scopes, metrics, body, footer]: [Rect; 5] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(if area.height >= 14 { 4 } else { 3 }),
+        Constraint::Min(3),
+        Constraint::Length(footer_h),
+    ])
+    .areas(area);
+    draw_header(f, header, rows, scope, cat, t);
+    let (scope_rects, refresh_rect) = draw_scope_tabs(f, scopes, scope, refreshing, cat, t);
+    draw_metrics(f, metrics, rows, burn, budget, cat, t);
 
-    let footer_h: u16 = if compact { 0 } else { 2 };
-    if !compact {
-        let footer_y = area.bottom().saturating_sub(1);
-        hline(f, area.x, footer_y.saturating_sub(1), area.width, t);
+    let cursor = cursor.min(rows.len().saturating_sub(1));
+    let rendered = if body.width >= 78 && body.height >= 14 {
+        let [roster, telemetry]: [Rect; 2] =
+            Layout::horizontal([Constraint::Percentage(64), Constraint::Percentage(36)])
+                .areas(body);
+        let selected_h = (telemetry.height / 2).clamp(7, 10);
+        let [selected, matrix, chart]: [Rect; 3] = Layout::vertical([
+            Constraint::Length(selected_h),
+            Constraint::Length(3),
+            Constraint::Min(3),
+        ])
+        .areas(telemetry);
+        let rendered = draw_roster(f, roster, rows, cursor, scroll, cat, t);
+        draw_selected(f, selected, rows.get(cursor), t);
+        draw_signal_matrix(f, matrix, rows, t);
+        draw_cost_chart(f, chart, rows, t);
+        rendered
+    } else {
+        draw_roster(f, body, rows, cursor, scroll, cat, t)
+    };
+    if footer_h > 0 {
         f.render_widget(
             Paragraph::new(super::hint_line(
                 &[
+                    ("↑↓", "navigate"),
+                    ("tab", "scope"),
+                    ("r", cat.act_refresh),
                     ("⏎", cat.mc_go),
                     ("a", cat.mc_answer),
                     ("i", cat.mc_stop),
@@ -326,65 +864,20 @@ pub(super) fn render(
                 ],
                 t,
             )),
-            Rect::new(area.x, footer_y, area.width, 1),
+            footer,
         );
     }
+    MissionRender {
+        scroll: rendered,
+        scope_rects,
+        refresh_rect,
+    }
+}
 
-    let top = area.y + 3;
-    let region_h = area.bottom().saturating_sub(top).saturating_sub(footer_h);
-    if region_h == 0 {
-        return 0;
-    }
-    if rows.is_empty() {
-        f.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                format!("  {}", cat.mc_empty),
-                Style::new().fg(t.overlay0),
-            ))),
-            Rect::new(x, top, w as u16, 1),
-        );
-        return 0;
-    }
-
-    // The bottom cost-by-model chart takes a few rows when there's cost + room.
-    let n_models = {
-        let mut s = std::collections::HashSet::new();
-        for r in rows {
-            if let Some(u) = r.usage.as_ref().filter(|u| u.cost.is_some()) {
-                s.insert(short_model(&u.model));
-            }
-        }
-        s.len()
-    };
-    let chart_h: u16 = if total_cost > 0.0 && region_h >= 6 {
-        (1 + n_models.min(3)).min(4) as u16
-    } else {
-        0
-    };
-    let rows_h = region_h.saturating_sub(chart_h);
-
-    let vis = rows_h as usize;
-    let cursor = cursor.min(rows.len().saturating_sub(1));
-    let mut scroll = scroll;
-    if vis > 0 {
-        if cursor < scroll {
-            scroll = cursor;
-        } else if cursor >= scroll + vis {
-            scroll = cursor + 1 - vis;
-        }
-        scroll = scroll.min(rows.len().saturating_sub(vis));
-    }
-    for (row, i) in (scroll..rows.len().min(scroll + vis)).enumerate() {
-        let rect = Rect::new(x, top + row as u16, w as u16, 1);
-        if i == cursor {
-            fill_bg(f, rect, t.surface1);
-        }
-        f.render_widget(Paragraph::new(row_line(&rows[i], w, t)), rect);
-    }
-    if chart_h > 0 {
-        draw_cost_chart(f, Rect::new(x, top + rows_h, w as u16, chart_h), rows, t);
-    }
-    scroll
+pub(super) struct MissionRender {
+    pub scroll: usize,
+    pub scope_rects: Vec<(MissionScope, Rect)>,
+    pub refresh_rect: Option<Rect>,
 }
 
 /// The row-detail overlay (MC-5): a small modal with the selected agent's full
@@ -506,4 +999,32 @@ pub(super) fn draw_answer(f: &mut RenderTarget, area: Rect, text: &str, cat: &Ca
         ]),
         inner,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{display_width, pad_left, pad_right, AgentColumns};
+
+    #[test]
+    fn agent_columns_keep_exact_display_widths() {
+        let short_agent = pad_right("FX", 14);
+        let long_agent = pad_right("A-VERY-LONG-AGENT", 14);
+        let tokens = pad_left("9.3M", 8);
+        let context = pad_left("60%", 4);
+
+        assert_eq!(display_width(&short_agent), 14);
+        assert_eq!(display_width(&long_agent), 14);
+        assert_eq!(display_width(&tokens), 8);
+        assert_eq!(display_width(&context), 4);
+        assert!(tokens.ends_with("9.3M"));
+        assert!(context.ends_with("60%"));
+
+        for width in 20..=160 {
+            assert_eq!(
+                AgentColumns::for_width(width).total(),
+                width.min(81),
+                "the table stays compact without overflowing at {width} columns"
+            );
+        }
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -149,6 +149,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     let orch_area = app.orch_area;
     let mission_scroll = app.mission_scroll;
     let mission_area = app.mission_area;
+    let mission_refresh_rect = app.mission_refresh_rect;
     let changelog_scroll = app.changelog_scroll;
     let file_tree_scroll = app.file_tree.scroll;
 
@@ -181,6 +182,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     let switcher_rects = std::mem::take(&mut app.switcher_rects);
     let switcher_scope_rects = std::mem::take(&mut app.switcher_scope_rects);
     let mission_rows = std::mem::take(&mut app.mission_rows);
+    let mission_scope_rects = std::mem::take(&mut app.mission_scope_rects);
     let bar_hits = std::mem::take(&mut app.bar.hits);
     let bar_overflow_hits = std::mem::take(&mut app.bar.overflow_hits);
     let bar_overflow = app.bar.overflow.clone();
@@ -271,6 +273,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     app.orch_area = orch_area;
     app.mission_scroll = mission_scroll;
     app.mission_area = mission_area;
+    app.mission_refresh_rect = mission_refresh_rect;
     app.changelog_scroll = changelog_scroll;
     app.file_tree.scroll = file_tree_scroll;
     app.pane_rects = pane_rects;
@@ -300,6 +303,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     app.switcher_rects = switcher_rects;
     app.switcher_scope_rects = switcher_scope_rects;
     app.mission_rows = mission_rows;
+    app.mission_scope_rects = mission_scope_rects;
     app.bar.hits = bar_hits;
     app.bar.overflow_hits = bar_overflow_hits;
     app.bar.overflow = bar_overflow;
@@ -594,22 +598,27 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
         None
     } else if app.active_is_mission() {
         // Mission Control (docs/54): rows are precomputed from `App` first (so the
-        // render borrows nothing mutable), stashed for click/⏎ hit-testing, then
+        // render borrows nothing mutable), stashed for keyboard activation, then
         // drawn; the scroll offset is written back.
         app.mission_area = pane_area;
         let rows = app.build_mission_rows();
-        app.mission_scroll = mission::render(
+        let rendered = mission::render(
             f,
             pane_area,
             &rows,
             app.mission_scroll,
             app.mission_cursor,
+            app.mission_scope,
+            app.mission_usage_refreshing(),
             app.mission_burn,
             app.config.mission_budget,
             compact,
             cat,
             &t,
         );
+        app.mission_scroll = rendered.scroll;
+        app.mission_scope_rects = rendered.scope_rects;
+        app.mission_refresh_rect = rendered.refresh_rect;
         app.mission_rows = rows;
         None
     } else if let Some(g) = app.active_git_mut() {

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -10,8 +10,8 @@ back after a restart, all without wrapping or modifying the agents themselves.
 ## The AGENTS sidebar
 
 Every pane running a recognized agent (Claude Code, Copilot, Codex, opencode,
-Kimi, Grok, Pi, Cursor, Gemini, Aider, Amp, Droid) appears in the sidebar with a
-live state:
+Kimi, Grok, Pi, Cursor, Gemini, Qwen, Kiro, Aider, Amp, Droid, or fx) appears in
+the sidebar with a live state:
 
 | State | Meaning | How it's detected |
 |---|---|---|
@@ -39,6 +39,36 @@ idle. That way you never get a false state or a false completion chime.
 
 The **All / Active** toggle in the header switches between live agents only
 (default) and the full resumable history.
+
+## Usage in Mission Control
+
+Mission Control reads the structured usage counters that each agent already
+stores for its own session. It shows input, output, and cache tokens, context
+usage when the agent records its context limit, and cost when the agent records
+one or Luvus has pricing for the model.
+
+| Native usage reader | Data source |
+|---|---|
+| Claude Code | project transcript |
+| Codex | rollout token counters |
+| GitHub Copilot CLI | session shutdown metrics |
+| opencode | read-only session database |
+| Kimi | session status records |
+| Grok | completed-turn usage records |
+| Pi | assistant message usage |
+| Gemini and Qwen | project chat records |
+| fx | session usage snapshot |
+
+Aider, Kiro, Cursor, Amp, Droid, and manifest-defined agents still receive live
+identity and state detection, but show `—` for usage until they expose a stable
+per-session counter or report one through an integration. Luvus never estimates
+tokens from transcript text.
+
+Usage parsing runs off the render path only when Mission Control becomes active,
+its scope changes, or you choose **Refresh**. A hidden dashboard schedules no
+usage work. Unchanged sessions are cached by agent, session ID, and source
+modification time. JSONL readers cap individual records, so an unusually large
+tool result cannot cause an equally large temporary allocation.
 
 ## How luvus knows which agent a pane is running
 
@@ -87,6 +117,9 @@ command for you:
 | Kimi | its session index (`~/.kimi-code/session_index.jsonl`) |
 | Grok | its session directory (`~/.grok/sessions`) |
 | Pi | its session store (`~/.pi/agent/sessions`) |
+| Gemini | its project chat store (`~/.gemini/tmp`) |
+| Qwen | its project chat store (`~/.qwen/tmp`) |
+| fx | its session store (`~/.fx/sessions`) |
 | Cursor | resume command (when the session id is known) |
 
 You'll also see **recent sessions** listed at the bottom of the AGENTS sidebar


### PR DESCRIPTION
## Summary

- Redesigns Mission Control as a full-tab beta dashboard for supervising AI agent sessions.
- Adds current-workspace and all-workspaces fleet views with aligned session, state, location, model, token, context, and cost data.
- Expands native session discovery and usage support while preserving honest missing-data behavior.
- Removes continuous background usage polling and bounds work for very large Codex transcripts.

## Mission Control beta

- Adds a full-screen responsive command-deck layout with compact fallback rendering.
- Adds a visible `BETA` badge and current/all-workspaces scope controls.
- Aligns agent sessions into a single-row table with state-aware ordering.
- Shows fleet metrics, selected-agent details, status distribution, and cost by model.
- Keeps agent rows keyboard-driven to avoid accidental pane activation.
- Supports navigation, scope switching, details, agent actions, and explicit refresh controls.

## Native agent data

- Reads structured per-session usage for Claude Code, Codex, GitHub Copilot CLI, opencode, Kimi, Grok, Pi, Gemini, Qwen, and fx.
- Adds resumable session discovery for Gemini, Qwen, and fx.
- Reads the opencode database in-process and read-only.
- Shows `—` when an agent does not expose a stable usage ledger instead of estimating tokens from transcript text.
- Keeps model pricing overrides and context-pressure reporting.

## Performance and safety

- Refreshes usage only when Mission Control becomes active, its scope changes, or the user presses `r` or clicks `REFRESH`.
- Hidden Mission Control tabs schedule no usage work.
- Coalesces refresh requests and reuses unchanged sessions through modification-time caching.
- Limits Codex parsing to an 8 MiB transcript tail plus a 256 KiB metadata prefix, independent of total rollout size.
- Caps individual JSONL record allocations and performs native-store IO off the render loop.
- Reduced the reproduced debug-server behavior from sustained 71–100% CPU to mostly 0–4% idle CPU. An explicit refresh used about 0.29 CPU-seconds in the tested session.

## Documentation

- Documents supported agents, native usage sources, missing-data behavior, caching, and demand-driven refresh semantics.

## Validation

- `cargo fmt --all --check`
- `cargo test mission_control -- --nocapture`
- `cargo test usage::tests -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- `cd website && npm run build`
- Rebuilt and restarted only the `~/.luvus-dev` server.
- Observed the attached debug server for 20 seconds and manually refreshed Mission Control without a recurring CPU spike.

Production Luvus state was not touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a redesigned Mission Control dashboard with workspace and all-workspaces views, usage metrics, cost details, and responsive layouts.
  - Added support for discovering and resuming Gemini CLI, Qwen Code, and fx sessions.
  - Added native usage reporting for supported agents, including token, cache, context, and cost data.
  - Added explicit refresh controls and keyboard shortcuts.
- **Bug Fixes**
  - Improved usage accuracy across multiple sessions and workspaces while avoiding unnecessary background scans.
- **Documentation**
  - Updated agent support, usage reporting, session locations, and resume guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->