### PR TITLE
feat(skill): expand Luvus skill installation and guidance

### DIFF
--- a/plugins/luvus/.codex-plugin/plugin.json
+++ b/plugins/luvus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "luvus",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Control Luvus agents, workspaces, and UHP automation from Codex.",
   "author": {
     "name": "Riz",

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: luvus
-description: "Control Luvus through its local CLI and UHP. Use only for a line beginning with `=target message`, an explicit request naming Luvus, a request to delegate to a named live Luvus agent or pane, or an explicit Luvus operation involving sessions, workspaces, tabs, panes, agents, files, Git, DIFF, worktrees, tasks, leases, modules, themes, Luvus Bar, UI, integrations, or Luvus UHP. Do not use for ordinary coding, file edits, Git operations, tests, task planning, generic agent work, or parallelization unless the user explicitly connects the request to Luvus. Being inside Luvus does not trigger this skill by itself. Inside Luvus use the inherited session; outside use the installed production Luvus command and configured session."
+description: "Control Luvus through its local CLI and UHP. Use only for a line beginning with `=target message`, an explicit request naming Luvus, a request to delegate to a named live Luvus agent or pane, or an explicit Luvus operation involving sessions, workspaces, tabs, panes, agents, files, Git, DIFF, worktrees, tasks, leases, modules, themes, Luvus Bar, configuration, UI, integrations, or Luvus UHP. Do not use for ordinary coding, file edits, Git operations, tests, task planning, generic agent work, or parallelization unless the user explicitly connects the request to Luvus. Being inside Luvus does not trigger this skill by itself. Inside Luvus use the inherited session; outside use the installed production Luvus command and configured session."
 ---
 
 # Luvus
@@ -366,6 +366,21 @@ surface:
   user explicitly requests that lifecycle integration.
 - Subscribe to events only for a live monitoring request. Stop when its
   condition is satisfied and never retain an unbounded stream.
+
+## Learn configuration and unfamiliar surfaces
+
+Use `luvus help <topic>` for the installed command grammar and
+`luvus uhp capabilities` plus `luvus uhp schema` for a selected server's live
+automation contract. For configuration, installation, concepts, or a surface
+not covered here, read https://luvus.dev/agent-readme.md first and use
+https://luvus.dev/llms.txt to open only the relevant documentation page.
+
+Luvus preferences live in `config.json` under `~/.luvus/`, or under the
+explicit `LUVUS_HOME`. Debug builds use `~/.luvus-dev/`. Prefer the Settings
+screen for validated live changes, preserve unknown fields during a manual
+edit, and never substitute production, development, or named-session paths.
+The installed binary and selected running server remain authoritative when the
+website describes a newer release.
 
 ## Safety
 

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: luvus
-description: "Control Luvus through its local CLI and UHP. Use only for a line beginning with `=target message`, an explicit request naming Luvus, a request to delegate to a named live Luvus agent or pane, or an explicit Luvus operation involving sessions, workspaces, tabs, panes, agents, files, Git, DIFF, worktrees, tasks, leases, modules, themes, Luvus Bar, UI, integrations, or Luvus UHP. Do not use for ordinary coding, file edits, Git operations, tests, task planning, generic agent work, or parallelization unless the user explicitly connects the request to Luvus. Being inside Luvus does not trigger this skill by itself. Inside Luvus use the inherited session; outside use the installed production Luvus command and configured session."
+description: "Control Luvus through its local CLI and UHP. Use only for a line beginning with `=target message`, an explicit request naming Luvus, a request to delegate to a named live Luvus agent or pane, or an explicit Luvus operation involving sessions, workspaces, tabs, panes, agents, files, Git, DIFF, worktrees, tasks, leases, modules, themes, Luvus Bar, configuration, UI, integrations, or Luvus UHP. Do not use for ordinary coding, file edits, Git operations, tests, task planning, generic agent work, or parallelization unless the user explicitly connects the request to Luvus. Being inside Luvus does not trigger this skill by itself. Inside Luvus use the inherited session; outside use the installed production Luvus command and configured session."
 ---
 
 # Luvus
@@ -366,6 +366,21 @@ surface:
   user explicitly requests that lifecycle integration.
 - Subscribe to events only for a live monitoring request. Stop when its
   condition is satisfied and never retain an unbounded stream.
+
+## Learn configuration and unfamiliar surfaces
+
+Use `luvus help <topic>` for the installed command grammar and
+`luvus uhp capabilities` plus `luvus uhp schema` for a selected server's live
+automation contract. For configuration, installation, concepts, or a surface
+not covered here, read https://luvus.dev/agent-readme.md first and use
+https://luvus.dev/llms.txt to open only the relevant documentation page.
+
+Luvus preferences live in `config.json` under `~/.luvus/`, or under the
+explicit `LUVUS_HOME`. Debug builds use `~/.luvus-dev/`. Prefer the Settings
+screen for validated live changes, preserve unknown fields during a manual
+edit, and never substitute production, development, or named-session paths.
+The installed binary and selected running server remain authoritative when the
+website describes a newer release.
 
 ## Safety
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1684,10 +1684,8 @@ fn skill_cmd(rest: &[String]) -> Result<i32> {
             } else {
                 "disabled"
             };
-            println!(
-                "luvus\t{}\t{summary}",
-                crate::skill::bundled_release()
-            );
+            println!("bundled\t{}\tavailable", crate::skill::bundled_release());
+            println!("installations\t{summary}");
             for status in statuses {
                 println!(
                     "{}\t{}\t{}\t{}",
@@ -4179,6 +4177,9 @@ mod tests {
         assert!(!HELP_BUG.contains("https://luvus.dev/llms.txt"));
         assert!(readme.starts_with("# Luvus README for AI agents\n"));
         assert!(readme.contains("luvus uhp capabilities"));
+        assert!(readme.contains("luvus skill enable"));
+        assert!(readme.contains("User preferences live in `config.json`, not TOML"));
+        assert!(readme.contains("https://luvus.dev/llms.txt as the task router"));
         assert!(llms.starts_with("# Luvus knowledge map for language models\n"));
         assert!(llms.contains("https://luvus.dev/docs/reference/api/"));
     }

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -53,18 +53,47 @@ static INSTALL_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 #[serde(rename_all = "lowercase")]
 pub enum SkillHost {
     Claude,
-    Codex,
+    /// The open `~/.agents/skills` location shared by Codex, Copilot, Gemini,
+    /// Pi, Cursor, Amp, Droid, and fx.
+    Shared,
     Opencode,
+    Kimi,
+    Grok,
+    Qwen,
+    Kiro,
 }
 
 impl SkillHost {
-    const ALL: [Self; 3] = [Self::Claude, Self::Codex, Self::Opencode];
+    const ALL: [Self; 7] = [
+        Self::Shared,
+        Self::Claude,
+        Self::Opencode,
+        Self::Kimi,
+        Self::Grok,
+        Self::Qwen,
+        Self::Kiro,
+    ];
 
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Claude => "claude",
-            Self::Codex => "codex",
+            Self::Shared => "shared",
             Self::Opencode => "opencode",
+            Self::Kimi => "kimi",
+            Self::Grok => "grok",
+            Self::Qwen => "qwen",
+            Self::Kiro => "kiro",
+        }
+    }
+
+    /// Preserve the schema-1 `codex` ownership key for the shared destination.
+    /// Older Luvus releases already managed the same `~/.agents/skills` path,
+    /// so changing the key would orphan their ownership record.
+    fn state_key(self) -> &'static str {
+        if self == Self::Shared {
+            "codex"
+        } else {
+            self.as_str()
         }
     }
 }
@@ -151,7 +180,7 @@ impl DestinationState {
             Self::Modified => "modified",
             Self::ExternalCurrent => "external-current",
             Self::External => "external",
-            Self::Available => "available",
+            Self::Available => "not-installed",
             Self::NotDetected => "not-detected",
         }
     }
@@ -220,7 +249,7 @@ fn bundled_files(host: SkillHost) -> Vec<BundledFile> {
             content: BUNDLED_UHP_CONTROL,
         },
     ];
-    if host == SkillHost::Codex {
+    if host == SkillHost::Shared {
         files.push(BundledFile {
             path: "agents/openai.yaml",
             content: BUNDLED_OPENAI_METADATA,
@@ -340,13 +369,17 @@ fn atomic_replace_file(tmp: &Path, path: &Path) -> Result<()> {
 fn target_dir_at(host: SkillHost, home: &Path, xdg_config: Option<&Path>) -> PathBuf {
     match host {
         SkillHost::Claude => home.join(".claude").join("skills").join("luvus"),
-        SkillHost::Codex => home.join(".agents").join("skills").join("luvus"),
+        SkillHost::Shared => home.join(".agents").join("skills").join("luvus"),
         SkillHost::Opencode => xdg_config
             .map(Path::to_path_buf)
             .unwrap_or_else(|| home.join(".config"))
             .join("opencode")
             .join("skills")
             .join("luvus"),
+        SkillHost::Kimi => home.join(".kimi-code").join("skills").join("luvus"),
+        SkillHost::Grok => home.join(".grok").join("skills").join("luvus"),
+        SkillHost::Qwen => home.join(".qwen").join("skills").join("luvus"),
+        SkillHost::Kiro => home.join(".kiro").join("skills").join("luvus"),
     }
 }
 
@@ -354,6 +387,11 @@ fn target_dir(host: SkillHost) -> Result<PathBuf> {
     let home = crate::platform::home_dir().ok_or_else(|| anyhow!("home directory not found"))?;
     if host == SkillHost::Claude {
         if let Some(config) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+            return Ok(PathBuf::from(config).join("skills").join("luvus"));
+        }
+    }
+    if host == SkillHost::Kimi {
+        if let Some(config) = std::env::var_os("KIMI_CODE_HOME") {
             return Ok(PathBuf::from(config).join("skills").join("luvus"));
         }
     }
@@ -467,36 +505,90 @@ fn command_on_path(name: &str) -> bool {
     })
 }
 
+fn any_command_on_path(names: &[&str]) -> bool {
+    names.iter().any(|name| command_on_path(name))
+}
+
+fn any_dir(paths: &[PathBuf]) -> bool {
+    paths.iter().any(|path| path.is_dir())
+}
+
+fn host_commands(host: SkillHost) -> &'static [&'static str] {
+    match host {
+        SkillHost::Claude => &["claude"],
+        SkillHost::Shared => &[
+            "codex",
+            "copilot",
+            "gemini",
+            "pi-coding-agent",
+            "cursor-agent",
+            "amp",
+            "droid",
+            "fx",
+        ],
+        SkillHost::Opencode => &["opencode"],
+        SkillHost::Kimi => &["kimi"],
+        SkillHost::Grok => &["grok"],
+        SkillHost::Qwen => &["qwen"],
+        SkillHost::Kiro => &["kiro", "kiro-cli"],
+    }
+}
+
+fn host_config_dirs(
+    host: SkillHost,
+    home: &Path,
+    xdg_config: Option<&Path>,
+    claude_config: Option<&Path>,
+    codex_home: Option<&Path>,
+    kimi_home: Option<&Path>,
+) -> Vec<PathBuf> {
+    let xdg = xdg_config
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| home.join(".config"));
+    match host {
+        SkillHost::Claude => vec![claude_config
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| home.join(".claude"))],
+        SkillHost::Shared => vec![
+            codex_home
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| home.join(".codex")),
+            home.join(".agents"),
+            home.join(".copilot"),
+            home.join(".gemini"),
+            home.join(".pi").join("agent"),
+            home.join(".cursor"),
+            xdg.join("amp"),
+            home.join(".factory"),
+            home.join(".fx"),
+        ],
+        SkillHost::Opencode => vec![xdg.join("opencode")],
+        SkillHost::Kimi => vec![kimi_home
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| home.join(".kimi-code"))],
+        SkillHost::Grok => vec![home.join(".grok")],
+        SkillHost::Qwen => vec![home.join(".qwen")],
+        SkillHost::Kiro => vec![home.join(".kiro")],
+    }
+}
+
 fn host_detected(host: SkillHost, state: &SkillState, target: &Path) -> Result<bool> {
-    if state.agents.contains_key(host.as_str()) || target.exists() {
+    if state.agents.contains_key(host.state_key()) || target.exists() {
         return Ok(true);
     }
     let home = crate::platform::home_dir().ok_or_else(|| anyhow!("home directory not found"))?;
-    Ok(match host {
-        SkillHost::Claude => {
-            std::env::var_os("CLAUDE_CONFIG_DIR")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| home.join(".claude"))
-                .is_dir()
-                || command_on_path("claude")
-        }
-        SkillHost::Codex => {
-            std::env::var_os("CODEX_HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| home.join(".codex"))
-                .is_dir()
-                || home.join(".agents").is_dir()
-                || command_on_path("codex")
-        }
-        SkillHost::Opencode => {
-            std::env::var_os("XDG_CONFIG_HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| home.join(".config"))
-                .join("opencode")
-                .is_dir()
-                || command_on_path("opencode")
-        }
-    })
+    let xdg = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+    let claude = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
+    let codex = std::env::var_os("CODEX_HOME").map(PathBuf::from);
+    let kimi = std::env::var_os("KIMI_CODE_HOME").map(PathBuf::from);
+    Ok(any_dir(&host_config_dirs(
+        host,
+        &home,
+        xdg.as_deref(),
+        claude.as_deref(),
+        codex.as_deref(),
+        kimi.as_deref(),
+    )) || any_command_on_path(host_commands(host)))
 }
 
 fn stage_bundle(target: &Path, host: SkillHost) -> Result<(PathBuf, Vec<ManagedFile>)> {
@@ -553,7 +645,7 @@ fn stage_bundle(target: &Path, host: SkillHost) -> Result<(PathBuf, Vec<ManagedF
 }
 
 fn install_one_at(state: &mut SkillState, host: SkillHost, target: PathBuf) -> Result<SkillChange> {
-    let key = host.as_str();
+    let key = host.state_key();
     let previous = state.agents.get(key).cloned();
     let previous_integrity = previous.as_ref().map(integrity).transpose()?;
 
@@ -720,7 +812,7 @@ pub fn enable() -> Result<Vec<SkillChange>> {
     }
     if selected.is_empty() {
         bail!(
-            "no supported skill host detected; install Claude Code, Codex, or OpenCode, then run `luvus skill enable`"
+            "no native Agent Skills host detected; use `luvus skill show` for this session or install a supported skill-capable agent, then run `luvus skill enable`"
         );
     }
 
@@ -737,7 +829,7 @@ fn disable_one_at(
     host: SkillHost,
     external_target: PathBuf,
 ) -> Result<SkillChange> {
-    let Some(record) = state.agents.get(host.as_str()).cloned() else {
+    let Some(record) = state.agents.get(host.state_key()).cloned() else {
         return Ok(SkillChange {
             host,
             action: if external_target.exists() {
@@ -769,12 +861,12 @@ fn disable_one_at(
         fs::rename(&record.target, &backup)
             .with_context(|| format!("staging removal of {}", record.target.display()))?;
     }
-    state.agents.remove(host.as_str());
+    state.agents.remove(host.state_key());
     if let Err(err) = save_state(state) {
         if backup.exists() {
             let _ = fs::rename(&backup, &record.target);
         }
-        state.agents.insert(host.as_str().to_string(), record);
+        state.agents.insert(host.state_key().to_string(), record);
         return Err(err).context("saving disabled skill state; removal rolled back");
     }
     if backup.exists() {
@@ -807,7 +899,7 @@ pub fn status() -> Result<Vec<DestinationStatus>> {
         .map(|host| {
             let target = target_dir(host)?;
             let detected = host_detected(host, &state, &target)?;
-            let record = state.agents.get(host.as_str());
+            let record = state.agents.get(host.state_key());
             let (state_value, managed_release) = match record {
                 Some(record) => {
                     let integrity = integrity(record)?;
@@ -992,15 +1084,59 @@ mod tests {
     fn native_targets_are_internal_adapters_not_agents_md() {
         let home = Path::new("/home/tester");
         assert_eq!(
-            target_dir_at(SkillHost::Codex, home, None),
+            target_dir_at(SkillHost::Shared, home, None),
             PathBuf::from("/home/tester/.agents/skills/luvus")
         );
-        assert!(!target_dir_at(SkillHost::Codex, home, None).ends_with("AGENTS.md"));
+        assert!(!target_dir_at(SkillHost::Shared, home, None).ends_with("AGENTS.md"));
         assert!(!target_dir_at(SkillHost::Opencode, home, None).ends_with("AGENTS.md"));
         assert_eq!(
             target_dir_at(SkillHost::Opencode, home, Some(Path::new("/xdg/config"))),
             PathBuf::from("/xdg/config/opencode/skills/luvus")
         );
+        assert_eq!(
+            target_dir_at(SkillHost::Kimi, home, None),
+            PathBuf::from("/home/tester/.kimi-code/skills/luvus")
+        );
+        assert_eq!(
+            target_dir_at(SkillHost::Grok, home, None),
+            PathBuf::from("/home/tester/.grok/skills/luvus")
+        );
+        assert_eq!(
+            target_dir_at(SkillHost::Qwen, home, None),
+            PathBuf::from("/home/tester/.qwen/skills/luvus")
+        );
+        assert_eq!(
+            target_dir_at(SkillHost::Kiro, home, None),
+            PathBuf::from("/home/tester/.kiro/skills/luvus")
+        );
+        assert_eq!(SkillHost::Shared.state_key(), "codex");
+    }
+
+    #[test]
+    fn every_native_skill_host_has_detection_markers() {
+        for host in SkillHost::ALL {
+            assert!(!host_commands(host).is_empty());
+            assert!(
+                !host_config_dirs(host, Path::new("/home/tester"), None, None, None, None)
+                    .is_empty()
+            );
+        }
+        let shared = host_commands(SkillHost::Shared);
+        for agent in [
+            "codex",
+            "copilot",
+            "gemini",
+            "pi-coding-agent",
+            "cursor-agent",
+            "amp",
+            "droid",
+            "fx",
+        ] {
+            assert!(
+                shared.contains(&agent),
+                "missing shared host detection for {agent}"
+            );
+        }
     }
 
     #[test]
@@ -1009,10 +1145,10 @@ mod tests {
         let target = crate::persist::skills_dir().join("agent-home/skills/luvus");
         let mut state = SkillState::default();
 
-        let installed = install_one_at(&mut state, SkillHost::Codex, target.clone()).unwrap();
+        let installed = install_one_at(&mut state, SkillHost::Shared, target.clone()).unwrap();
         assert_eq!(installed.action, ChangeAction::Installed);
         assert_eq!(
-            install_one_at(&mut state, SkillHost::Codex, target.clone())
+            install_one_at(&mut state, SkillHost::Shared, target.clone())
                 .unwrap()
                 .action,
             ChangeAction::Current
@@ -1020,7 +1156,7 @@ mod tests {
 
         state.agents.get_mut("codex").unwrap().release = "0.1.0".into();
         assert_eq!(
-            install_one_at(&mut state, SkillHost::Codex, target.clone())
+            install_one_at(&mut state, SkillHost::Shared, target.clone())
                 .unwrap()
                 .action,
             ChangeAction::Refreshed
@@ -1028,13 +1164,13 @@ mod tests {
 
         fs::write(target.join("SKILL.md"), "user changed this skill").unwrap();
         assert_eq!(
-            install_one_at(&mut state, SkillHost::Codex, target.clone())
+            install_one_at(&mut state, SkillHost::Shared, target.clone())
                 .unwrap()
                 .action,
             ChangeAction::PreservedModified
         );
         assert_eq!(
-            disable_one_at(&mut state, SkillHost::Codex, target.clone())
+            disable_one_at(&mut state, SkillHost::Shared, target.clone())
                 .unwrap()
                 .action,
             ChangeAction::PreservedModified
@@ -1054,9 +1190,9 @@ mod tests {
         let blocked_target = root.join("blocked/luvus");
         let mut state = SkillState::default();
 
-        install_one_at(&mut state, SkillHost::Codex, old_target.clone()).unwrap();
+        install_one_at(&mut state, SkillHost::Shared, old_target.clone()).unwrap();
         assert_eq!(
-            install_one_at(&mut state, SkillHost::Codex, new_target.clone())
+            install_one_at(&mut state, SkillHost::Shared, new_target.clone())
                 .unwrap()
                 .action,
             ChangeAction::Refreshed
@@ -1067,7 +1203,7 @@ mod tests {
         fs::create_dir_all(&blocked_target).unwrap();
         fs::write(blocked_target.join("SKILL.md"), "external replacement").unwrap();
         assert_eq!(
-            install_one_at(&mut state, SkillHost::Codex, blocked_target.clone())
+            install_one_at(&mut state, SkillHost::Shared, blocked_target.clone())
                 .unwrap()
                 .action,
             ChangeAction::External
@@ -1081,7 +1217,7 @@ mod tests {
         let later_target = root.join("later/luvus");
         fs::write(new_target.join("SKILL.md"), "managed copy was edited").unwrap();
         assert_eq!(
-            install_one_at(&mut state, SkillHost::Codex, later_target.clone())
+            install_one_at(&mut state, SkillHost::Shared, later_target.clone())
                 .unwrap()
                 .action,
             ChangeAction::PreservedModified

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -32,6 +32,70 @@ luvus uhp snapshot
 The website documents the current release. A development build or older server
 can differ. Report the version and follow its live help for exact behavior.
 
+If the `luvus` command is unavailable, do not imply that Luvus or its skill is
+installed. Tell the human that the client is required and point them to the
+supported installation page at https://luvus.dev/docs/getting-started/installation/.
+Offer a platform command only after this specific missing-client failure:
+
+```sh
+# macOS or Linux
+curl -fsSL https://luvus.dev/install.sh | sh
+
+# Homebrew
+brew install RizRiyz/luvus/luvus
+```
+
+On Windows, the supported PowerShell installer is:
+
+```powershell
+irm https://luvus.dev/install.ps1 | iex
+```
+
+Do not show installation guidance preemptively or for an unrelated command,
+server, session, authentication, or permission failure.
+
+## Load or install the Luvus skill
+
+The Luvus binary contains a release-matched Agent Skill. There are three ways
+for an agent to receive it:
+
+1. For one conversation, read the canonical skill directly from the installed
+   binary:
+
+   ```sh
+   luvus skill show
+   ```
+
+2. For persistent discovery in installed coding agents, ask the human before
+   writing to agent configuration, then run:
+
+   ```sh
+   luvus skill enable
+   luvus skill status
+   ```
+
+3. In Codex, the official Luvus marketplace plugin already includes the skill.
+   Do not install a second copy merely because `luvus skill status` cannot see
+   Codex's private plugin cache.
+
+`luvus skill enable` makes no network request. It installs the same bundled
+skill into detected native skill locations without overwriting external or
+modified content. The shared `~/.agents/skills/luvus/` copy serves Codex,
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx. Dedicated
+adapters serve Claude Code, OpenCode, Kimi Code CLI, Grok Build, Qwen Code,
+and Kiro. Aider has no native Agent Skills installation surface, so use
+`luvus skill show` when an Aider conversation needs the instructions.
+
+Start a new agent conversation after installation, or use that agent's skill
+reload command when it provides one. To remove unchanged Luvus-managed copies:
+
+```sh
+luvus skill disable
+```
+
+Disabling the skill does not stop Luvus, change a session, or remove a plugin
+or externally managed copy.
+
 ## What Luvus is
 
 Luvus is mission control for AI coding agents. It combines persistent terminal
@@ -75,6 +139,32 @@ remote, and default sessions isolated. Do not replace the endpoint with a
 hardcoded path. Do not launch another interactive Luvus client inside a pane
 unless the human explicitly requests it. Use CLI commands to control the
 inherited session.
+
+## How Luvus configuration works
+
+The default state root is `~/.luvus/`. Debug builds use `~/.luvus-dev/`, and
+`LUVUS_HOME` selects an explicit isolated root. Never substitute one root for
+another or copy state between them unless the human requests a migration.
+
+User preferences live in `config.json`, not TOML. It contains the theme,
+language, shell, layout, notifications, keybindings, sidebars, and Luvus Bar
+placement. Prefer the in-app Settings screen because it validates changes,
+applies supported settings live, and writes the file. Hand edits are loaded on
+restart. Preserve unknown keys and do not rewrite the file just to change one
+setting.
+
+The default session stores runtime files directly under the state root. Named
+sessions keep their server-specific runtime files under
+`~/.luvus/sessions/<name>/`, while preferences, skill ownership, manifests,
+themes, modules, worktrees, and reviews remain shared. `session.json` is a
+saved restoration snapshot, not proof that its processes are currently alive.
+Do not edit sockets, locks, or a live session snapshot by hand.
+
+Every managed pane receives `LUVUS_ENV`, `LUVUS_PANE_ID`, and
+`LUVUS_SOCKET_PATH`. `LUVUS_SHELL` overrides the configured shell for new
+panes. Consult https://luvus.dev/docs/reference/configuration/ before changing
+paths, environment variables, scrollback limits, keybindings, DIFF behavior,
+or bar placement.
 
 ## Choose the right interface
 
@@ -234,6 +324,20 @@ have consumed it; use `luvus doctor` and the keybinding reference.
 - Give commands appropriate to the user's OS and installation.
 - Prefer one safe path over speculative alternatives.
 - Say when facts were not verified against the running server.
+
+## Learn the rest of Luvus
+
+Do not expand this guide into a guessed product manual. Use
+https://luvus.dev/llms.txt as the task router, then read only the relevant
+documentation page. It maps installation, concepts, layout, files, scrollback,
+agents, Git, DIFF, worktrees, orchestration, modules, themes, Luvus Bar,
+remote sessions, security, CLI, UHP, and terminal backend behavior.
+
+For an exact command, start with `luvus help <topic>`. For automation, start
+with `luvus uhp capabilities` and `luvus uhp schema`. For product concepts or a
+human workflow, use https://luvus.dev/docs/. The installed binary and selected
+running server remain authoritative when published documentation describes a
+newer release.
 
 ## Canonical resources
 

--- a/website/src/content/docs/docs/guides/codex-plugin.mdx
+++ b/website/src/content/docs/docs/guides/codex-plugin.mdx
@@ -40,9 +40,11 @@ luvus skill enable
 
 The command makes no network request. It detects supported coding-agent
 environments and installs the one bundled Luvus skill through their native
-skill directories. For Codex that directory is `~/.agents/skills/luvus/`. It
-does not add an always-on pointer to `~/.codex/AGENTS.md`, and it never
-overwrites an installation it does not own.
+skill directories. The shared `~/.agents/skills/luvus/` destination serves
+Codex, GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx.
+Claude Code, OpenCode, Kimi Code CLI, Grok Build, Qwen Code, and Kiro use their
+native dedicated destinations. It does not add an always-on pointer to
+`~/.codex/AGENTS.md`, and it never overwrites an installation it does not own.
 
 Start a new Codex thread after enabling the skill. Confirm its release, path,
 and integrity at any time with:
@@ -50,6 +52,10 @@ and integrity at any time with:
 ```sh
 luvus skill status
 ```
+
+The status command reports Luvus-managed filesystem installations. A Codex
+marketplace plugin lives in Codex's private plugin cache, so it is intentionally
+not reported there even though its bundled Luvus skill is available to Codex.
 
 ## Connect to Luvus
 

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -48,3 +48,21 @@ recognize it, as described in
 [Custom detection rules](/docs/guides/agents/#custom-detection-rules). If you
 would like it built in,
 [open an issue](https://github.com/RizRiyz/luvus/issues) or a PR.
+
+## Agent Skill availability
+
+Agent detection is built into Luvus and does not require an Agent Skill. The
+optional bundled skill teaches a coding agent how to control Luvus itself.
+Print the release-matched instructions for one conversation with
+`luvus skill show`, or install them persistently with `luvus skill enable`.
+
+The shared `~/.agents/skills/luvus/` destination is understood by Codex,
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx. Luvus uses
+dedicated native destinations for Claude Code, OpenCode, Kimi Code CLI, Grok
+Build, Qwen Code, and Kiro. Aider does not expose a native Agent Skills
+installation directory, so use `luvus skill show` when an Aider conversation
+needs the instructions.
+
+`luvus skill status` reports the bundled release separately from its managed
+filesystem installations. Codex marketplace plugins are managed by Codex and
+are not visible to this command.


### PR DESCRIPTION
## Summary

- expand `luvus skill enable`, `status`, and `disable` across supported native Agent Skills hosts
- use the shared `~/.agents/skills/luvus` destination for Codex, Copilot, Gemini, Pi, Cursor, Amp, Droid, and fx
- add dedicated destinations for Claude, OpenCode, Kimi, Grok, Qwen, and Kiro while preserving older Codex-managed state
- document the `luvus skill show` fallback for Aider, which has no native Agent Skills installation directory
- explain Luvus installation, `config.json`, `LUVUS_HOME`, session state, CLI discovery, UHP, and documentation routing in the public agent guide
- update the bundled and Codex plugin skill guidance and bump the plugin version to 0.4.2

## Safety

The installer continues to avoid network access, preserves externally managed or modified skill directories, and only removes installations it owns. The end-to-end test used an isolated repository-local home and did not modify production Luvus state or real agent configuration.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked skill::tests`
- focused CLI documentation and bundled skill tests
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo build --locked`
- canonical and plugin skill validation
- Codex plugin validation
- `cargo package --list --allow-dirty`
- website production build, 42 pages
- isolated enable, status, and disable flow across all seven installation destinations
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agent Skills support for Kimi, Grok, Qwen, and Kiro, alongside existing environments.
  * Added host-specific installation, detection, and configuration guidance.
  * Improved skill status reporting to distinguish bundled releases from installed skills.

* **Documentation**
  * Expanded guidance for configuration, session storage, troubleshooting, installation destinations, and live help.
  * Documented shared skill installation, ownership safeguards, and marketplace plugin handling.

* **Chores**
  * Updated the Luvus plugin version to 0.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->