### PR TITLE
fix(panes): preserve text selection across scrolling

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1333,6 +1333,7 @@ impl App {
                             anchor: (m.column, m.row),
                             cursor: (m.column, m.row),
                             retained,
+                            scrolled: false,
                             dragging: true,
                         }
                     });
@@ -1603,6 +1604,9 @@ impl App {
                     self.scroll_pane = v;
                 }
                 if scrolled_selection {
+                    if let Some(selection) = self.selection.as_mut() {
+                        selection.scrolled = true;
+                    }
                     self.update_mouse_selection_cursor(m.column, m.row);
                 }
             }
@@ -4337,6 +4341,123 @@ mod link_click_tests {
     }
 
     #[test]
+    fn stationary_click_stays_empty_when_output_advances_history() {
+        let _env = crate::persist::test_env("mouse-selection-output-drift");
+        let source = (0..100)
+            .map(|line| format!("line-{line:03}\r\n"))
+            .collect::<String>();
+        let (mut app, _term, _) = fixture_showing(&source, 0);
+        let pane = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        let at = (content.x + 2, content.bottom().saturating_sub(2));
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert!(app.selection.is_some(), "the press begins a selection");
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .engine
+            .lock()
+            .expect("terminal engine")
+            .advance(b"incoming-output\r\n");
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+
+        assert!(app.pending_clipboard.is_none());
+        assert!(app.toast.is_none());
+        assert!(app.selection.is_none(), "a plain click leaves no highlight");
+    }
+
+    #[test]
+    fn wheel_alone_can_extend_an_active_selection() {
+        let _env = crate::persist::test_env("mouse-selection-wheel-only");
+        let source = (0..100)
+            .map(|line| format!("line-{line:03}\r\n"))
+            .collect::<String>();
+        let (mut app, _term, _) = fixture_showing(&source, 0);
+        let pane = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        let at = (content.x + 2, content.bottom().saturating_sub(4));
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert!(app.selection.is_some(), "the press begins a selection");
+        app.handle_event(mouse(MouseEventKind::ScrollUp, at, KeyModifiers::NONE));
+        let selection = app.selection.expect("active selection");
+        let retained = selection.retained.expect("retained endpoints");
+        assert!(selection.scrolled);
+        assert_ne!(retained.anchor, retained.cursor);
+        let selected = app.selection_text().expect("wheel-extended text");
+
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert_eq!(app.pending_clipboard.as_deref(), Some(selected.as_str()));
+    }
+
+    #[test]
+    fn wheel_returning_to_the_anchor_does_not_copy_one_cell() {
+        let _env = crate::persist::test_env("mouse-selection-wheel-return");
+        let source = (0..100)
+            .map(|line| format!("line-{line:03}\r\n"))
+            .collect::<String>();
+        let (mut app, _term, _) = fixture_showing(&source, 0);
+        let pane = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        let at = (content.x + 2, content.bottom().saturating_sub(4));
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert!(app.selection.is_some(), "the press begins a selection");
+        app.handle_event(mouse(MouseEventKind::ScrollUp, at, KeyModifiers::NONE));
+        app.handle_event(mouse(MouseEventKind::ScrollDown, at, KeyModifiers::NONE));
+        let retained = app
+            .selection
+            .and_then(|selection| selection.retained)
+            .expect("retained endpoints");
+        assert_eq!(retained.anchor, retained.cursor);
+        assert!(app.selection_text().is_none());
+
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert!(app.pending_clipboard.is_none());
+        assert!(app.selection.is_none());
+    }
+
+    #[test]
     fn codex_copy_drops_its_one_cell_transcript_gutter() {
         let _env = crate::persist::test_env("codex-copy-gutter");
         let (mut app, _term, _) = fixture_showing("  hello\r\n  world", 0);
@@ -4356,6 +4477,7 @@ mod link_click_tests {
             anchor: (content.x + 1, content.y),
             cursor: (content.x + 6, content.y + 1),
             retained: None,
+            scrolled: false,
             dragging: false,
         });
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1320,11 +1320,21 @@ impl App {
                 // any old one. Falls through to normal click handling (focus/etc).
                 self.selection = self
                     .pane_content_at(m.column, m.row)
-                    .map(|(pane, content)| Selection {
-                        pane,
-                        content,
-                        anchor: (m.column, m.row),
-                        cursor: (m.column, m.row),
+                    .map(|(pane, content)| {
+                        let retained = self
+                            .retained_selection_point(pane, content, m.column, m.row)
+                            .map(|point| RetainedSelection {
+                                anchor: point,
+                                cursor: point,
+                            });
+                        Selection {
+                            pane,
+                            content,
+                            anchor: (m.column, m.row),
+                            cursor: (m.column, m.row),
+                            retained,
+                            dragging: true,
+                        }
                     });
             }
             MouseEventKind::Down(MouseButton::Middle) => {
@@ -1364,13 +1374,7 @@ impl App {
                     }
                     return;
                 }
-                if let Some(sel) = self.selection.as_mut() {
-                    let c = sel.content;
-                    sel.cursor = (
-                        m.column.clamp(c.x, c.right().saturating_sub(1)),
-                        m.row.clamp(c.y, c.bottom().saturating_sub(1)),
-                    );
-                }
+                self.update_mouse_selection_cursor(m.column, m.row);
                 return;
             }
             MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Up(MouseButton::Middle) => {
@@ -1392,6 +1396,10 @@ impl App {
                 if let Some(g) = self.mouse_grab.take() {
                     self.send_grabbed_mouse(g, MouseSeq::Release, m.column, m.row);
                     return;
+                }
+                self.update_mouse_selection_cursor(m.column, m.row);
+                if let Some(selection) = self.selection.as_mut() {
+                    selection.dragging = false;
                 }
                 // A real drag copies its text + flashes a toast; a plain click
                 // clears the (1-cell) selection so nothing stays highlighted.
@@ -1542,9 +1550,21 @@ impl App {
                 // Forwarding the wheel makes the app repaint; that output is the
                 // user scrolling, not the agent working (docs/07).
                 let mut scrolled_the_app = false;
+                let extending_selection = self.selection.is_some_and(|selection| {
+                    selection.pane == id && selection.dragging && selection.retained.is_some()
+                });
+                let mut scrolled_selection = false;
                 if let Some(pane) = self.panes.get(&id) {
                     let mm = pane.mouse_mode();
-                    if mm.report {
+                    if extending_selection && !pane.alt_screen() {
+                        // The selection gesture owns primary-screen scrolling,
+                        // even when the child reports mouse input. Its endpoints
+                        // are retained-history rows, so the original anchor stays
+                        // attached to the same text while the cursor extends.
+                        pane.scroll(-scroll);
+                        set_scroll = Some((pane.scroll_state().0 > 0).then_some(id));
+                        scrolled_selection = true;
+                    } else if mm.report {
                         // The app tracks the mouse (e.g. a TUI agent like Claude
                         // Code on the alternate screen) — forward the wheel so it
                         // scrolls its own transcript, exactly like a real terminal.
@@ -1581,6 +1601,9 @@ impl App {
                 }
                 if let Some(v) = set_scroll {
                     self.scroll_pane = v;
+                }
+                if scrolled_selection {
+                    self.update_mouse_selection_cursor(m.column, m.row);
                 }
             }
             return;
@@ -2208,6 +2231,54 @@ impl App {
             .map(|(id, r)| (*id, *r))
     }
 
+    /// Map one visible terminal cell into the pane's retained-history space.
+    /// Native file and diff views intentionally stay in screen coordinates.
+    fn retained_selection_point(
+        &self,
+        pane: PaneId,
+        content: Rect,
+        x: u16,
+        y: u16,
+    ) -> Option<(usize, usize)> {
+        if self.views.contains_key(&pane) {
+            return None;
+        }
+        let pane = self.panes.get(&pane)?;
+        let (visible_top, row_count) = pane.retained_viewport()?;
+        if row_count == 0 {
+            return None;
+        }
+        let row = visible_top
+            .saturating_add(y.saturating_sub(content.y) as usize)
+            .min(row_count.saturating_sub(1));
+        let col = x
+            .saturating_sub(content.x)
+            .min(content.width.saturating_sub(1)) as usize;
+        Some((row, col))
+    }
+
+    /// Move the visible cursor endpoint and, for terminal panes, resolve that
+    /// cell against the viewport *now*. The retained anchor is never rewritten.
+    fn update_mouse_selection_cursor(&mut self, x: u16, y: u16) {
+        let Some(selection) = self.selection else {
+            return;
+        };
+        let content = selection.content;
+        let screen = (
+            x.clamp(content.x, content.right().saturating_sub(1)),
+            y.clamp(content.y, content.bottom().saturating_sub(1)),
+        );
+        let retained = selection.retained.and_then(|_| {
+            self.retained_selection_point(selection.pane, content, screen.0, screen.1)
+        });
+        if let Some(selection) = self.selection.as_mut() {
+            selection.cursor = screen;
+            if let (Some(cursor), Some(retained)) = (retained, selection.retained.as_mut()) {
+                retained.cursor = cursor;
+            }
+        }
+    }
+
     /// Extract the current selection's text from the pane's grid (linear, with
     /// trailing blanks trimmed). `None` for a click without a drag or empty text.
     pub(crate) fn selection_text(&self) -> Option<String> {
@@ -2219,6 +2290,28 @@ impl App {
         // its rendered lines instead, so drag-to-copy works just like a pane.
         if let Some(crate::app::ViewKind::File(v)) = self.views.get(&sel.pane) {
             return crate::files::selection_text(v, sel.content, sel.ordered());
+        }
+        if let Some(selection) = sel.retained {
+            let range = selection.ordered();
+            let mut output = String::new();
+            let mut appended = false;
+            self.panes
+                .get(&sel.pane)?
+                .for_each_retained_row(&mut |row, _, _, line| {
+                    if (range.0 .0..=range.1 .0).contains(&row) {
+                        append_selected_row(&mut output, &mut appended, line, row, range);
+                    }
+                });
+            let text = finish_selected_text(output)?;
+            let is_codex = self
+                .status
+                .get(&sel.pane)
+                .is_some_and(|status| status.agent == "codex");
+            return Some(if range.0 .1 == 0 || is_codex {
+                strip_uniform_single_cell_margin(text)
+            } else {
+                text
+            });
         }
         let rows = self
             .panes
@@ -4167,6 +4260,83 @@ mod link_click_tests {
     }
 
     #[test]
+    fn mouse_selection_anchor_survives_scrollback_while_dragging() {
+        let _env = crate::persist::test_env("mouse-selection-scroll-anchor");
+        let source = (0..100)
+            .map(|line| format!("line-{line:03}\r\n"))
+            .collect::<String>();
+        let (mut app, _term, _) = fixture_showing(&source, 0);
+        let pane = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        let start = (
+            content.x + "line-000".len() as u16 - 1,
+            content.bottom().saturating_sub(4),
+        );
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            start,
+            KeyModifiers::NONE,
+        ));
+        let anchor = app
+            .selection
+            .and_then(|selection| selection.retained)
+            .expect("terminal selection uses retained rows")
+            .anchor;
+        let anchor_text = app
+            .panes
+            .get(&pane)
+            .and_then(|pane| pane.retained_row_text(anchor.0))
+            .expect("anchored row")
+            .trim_end()
+            .to_string();
+        assert!(!anchor_text.is_empty(), "fixture anchor contains text");
+
+        // Extend beyond the original viewport. Each wheel event scrolls three
+        // retained rows while the pointer remains part of the active gesture.
+        for _ in 0..8 {
+            app.handle_event(mouse(MouseEventKind::ScrollUp, start, KeyModifiers::NONE));
+        }
+        let end = (content.x, content.y + 1);
+        app.handle_event(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            end,
+            KeyModifiers::NONE,
+        ));
+
+        let retained = app
+            .selection
+            .and_then(|selection| selection.retained)
+            .expect("retained selection after scrolling");
+        assert_eq!(
+            retained.anchor, anchor,
+            "scrolling must never re-anchor the original press"
+        );
+        assert!(
+            retained.cursor.0 < retained.anchor.0,
+            "dragging after wheel scroll extends into older history"
+        );
+        let selected = app.selection_text().expect("selected history text");
+        assert_eq!(
+            selected.lines().last(),
+            Some(anchor_text.as_str()),
+            "the copied range still ends on the row where the drag began"
+        );
+
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            end,
+            KeyModifiers::NONE,
+        ));
+        assert_eq!(app.pending_clipboard.as_deref(), Some(selected.as_str()));
+    }
+
+    #[test]
     fn codex_copy_drops_its_one_cell_transcript_gutter() {
         let _env = crate::persist::test_env("codex-copy-gutter");
         let (mut app, _term, _) = fixture_showing("  hello\r\n  world", 0);
@@ -4185,6 +4355,8 @@ mod link_click_tests {
             content,
             anchor: (content.x + 1, content.y),
             cursor: (content.x + 6, content.y + 1),
+            retained: None,
+            dragging: false,
         });
 
         assert_eq!(app.selection_text().as_deref(), Some("hello\nworld"));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1083,14 +1083,51 @@ pub struct LinkPress {
     pub at: (u16, u16),
 }
 
-/// A drag text-selection inside a pane. Coordinates are **terminal** cells; the
-/// pane's `content` rect maps them to grid positions for extraction/highlight.
+/// A drag text-selection inside a pane. Screen coordinates keep native file
+/// views aligned with their renderer. Terminal panes additionally store stable
+/// retained-history coordinates, so scrolling the viewport cannot move either
+/// endpoint onto different text.
 #[derive(Clone, Copy)]
 pub struct Selection {
     pub pane: PaneId,
     pub content: Rect,
     pub anchor: (u16, u16),
     pub cursor: (u16, u16),
+    pub retained: Option<RetainedSelection>,
+    pub dragging: bool,
+}
+
+/// Mouse-selection endpoints in the same absolute retained-row coordinate
+/// space used by keyboard copy mode (oldest retained row is zero).
+#[derive(Clone, Copy)]
+pub struct RetainedSelection {
+    pub anchor: (usize, usize),
+    pub cursor: (usize, usize),
+}
+
+impl RetainedSelection {
+    pub(crate) fn ordered(&self) -> ((usize, usize), (usize, usize)) {
+        if self.anchor <= self.cursor {
+            (self.anchor, self.cursor)
+        } else {
+            (self.cursor, self.anchor)
+        }
+    }
+
+    pub(crate) fn contains(&self, row: usize, col: usize, width: usize) -> bool {
+        let ((sr, sc), (er, ec)) = self.ordered();
+        if row < sr || row > er {
+            return false;
+        }
+        let middle_left = sc.min(ec);
+        let left = if row == sr { sc } else { middle_left };
+        let right = if row == er {
+            ec
+        } else {
+            width.saturating_sub(1)
+        };
+        col >= left && col <= right
+    }
 }
 
 /// An in-progress pane-divider resize drag (docs/27, RESIZE-2): the split node
@@ -1145,7 +1182,9 @@ impl Selection {
 
     /// True only when the drag actually moved (so a plain click isn't a copy).
     fn has_range(&self) -> bool {
-        self.anchor != self.cursor
+        self.retained
+            .is_some_and(|selection| selection.anchor != selection.cursor)
+            || (self.retained.is_none() && self.anchor != self.cursor)
     }
 }
 
@@ -5834,6 +5873,8 @@ mod tests {
             content,
             anchor: (4, 1),
             cursor: (6, 3),
+            retained: None,
+            dragging: false,
         };
         // First row: from the anchor column to the right edge.
         assert!(sel.contains(4, 1));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1094,6 +1094,10 @@ pub struct Selection {
     pub anchor: (u16, u16),
     pub cursor: (u16, u16),
     pub retained: Option<RetainedSelection>,
+    /// The active gesture deliberately moved the retained endpoint by wheel.
+    /// Incoming PTY output may also remap retained coordinates, but must never
+    /// turn a stationary click into a copied range.
+    pub scrolled: bool,
     pub dragging: bool,
 }
 
@@ -1182,9 +1186,11 @@ impl Selection {
 
     /// True only when the drag actually moved (so a plain click isn't a copy).
     fn has_range(&self) -> bool {
-        self.retained
-            .is_some_and(|selection| selection.anchor != selection.cursor)
-            || (self.retained.is_none() && self.anchor != self.cursor)
+        self.anchor != self.cursor
+            || (self.scrolled
+                && self
+                    .retained
+                    .is_some_and(|selection| selection.anchor != selection.cursor))
     }
 }
 
@@ -5874,6 +5880,7 @@ mod tests {
             anchor: (4, 1),
             cursor: (6, 3),
             retained: None,
+            scrolled: false,
             dragging: false,
         };
         // First row: from the anchor column to the right edge.

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -891,6 +891,18 @@ impl Pane {
             .unwrap_or(0)
     }
 
+    /// `(visible_top, retained_rows)` from one terminal snapshot. Mouse
+    /// selection uses this to bind a screen row to retained history without an
+    /// output burst changing the history length between separate reads.
+    pub(crate) fn retained_viewport(&self) -> Option<(usize, usize)> {
+        self.engine.lock().ok().map(|engine| {
+            (
+                engine.history_len().saturating_sub(engine.scroll_offset()),
+                engine.retained_row_count(),
+            )
+        })
+    }
+
     /// Read one retained row without allocating every other row.
     pub fn retained_row_text(&self, index: usize) -> Option<String> {
         self.engine.lock().ok()?.retained_row_text(index)

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -303,6 +303,9 @@ fn draw_one_pane(
         Ok(engine) => {
             let copy_top =
                 copy.map(|_| engine.history_len().saturating_sub(engine.scroll_offset()));
+            let selection_top = sel
+                .and_then(|selection| selection.retained)
+                .map(|_| engine.history_len().saturating_sub(engine.scroll_offset()));
             {
                 let buf = f.buffer_mut();
                 engine.for_each_cell(&mut |row, col, sym, cell| {
@@ -331,7 +334,20 @@ fn draw_one_pane(
                         style = style.bg(conv(cell.bg));
                     }
                     // Highlight the cell if it's inside the mouse selection.
-                    if sel.is_some_and(|s| s.contains(x, y)) {
+                    if sel.is_some_and(|selection| {
+                        selection.retained.map_or_else(
+                            || selection.contains(x, y),
+                            |retained| {
+                                selection_top.is_some_and(|top| {
+                                    retained.contains(
+                                        top.saturating_add(row as usize),
+                                        col as usize,
+                                        content.width as usize,
+                                    )
+                                })
+                            },
+                        )
+                    }) {
                         style = style.bg(t.sel_bg);
                     }
                     if copy.is_some_and(|copy| {


### PR DESCRIPTION
## Summary

- bind terminal mouse-selection endpoints to absolute retained-history rows
- keep the original mouse anchor attached to the same text while the viewport scrolls
- extend an active selection with mouse-wheel scrolling, including panes whose child reports mouse input
- render and copy the stable retained-history range after viewport changes
- preserve existing screen-coordinate selection for native file views

## Root cause

Mouse selections previously stored only terminal screen coordinates. Scrolling changed which retained rows appeared at those coordinates, so the original anchor silently moved onto different text and the copied range lost part of the selection.

Keyboard copy mode already used retained-history coordinates. This change applies the same stable coordinate model to terminal mouse selection while keeping native view handling separate.

## Behavior

- pressing the mouse creates a retained-history anchor for terminal panes
- dragging resolves only the cursor endpoint against the current viewport
- wheel scrolling on the primary screen extends the active selection instead of forwarding the gesture to a mouse-reporting child
- releasing copies the complete stable range
- completed selection highlighting follows its text as the viewport moves
- alternate-screen applications retain their existing application-owned scrolling behavior

## Verification

- focused regression test selects through 24 rows of scrollback and confirms the original anchor row remains in the clipboard
- `cargo test --locked --bin luvus`: 878 tests passed
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

No polling, background work, or per-frame allocation was added. Retained-coordinate mapping runs only during selection input events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mouse text selections remain anchored while scrolling through terminal history.
  * Scrolling during an active selection extends the selected range.
  * Text can be copied reliably from retained terminal history, including content outside the visible area.
  * Selection highlighting stays accurate as the viewport moves.

* **Bug Fixes**
  * Prevented selection anchors and endpoints from shifting unexpectedly during scrollback navigation or terminal output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->