### PR TITLE
fix(copy): preserve Unicode terminal cell selections

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4,101 +4,63 @@
 use super::*;
 use crate::files::view_text_w;
 
-/// Last selectable character index on a retained row. Empty rows still expose
-/// one visual cell so vertical navigation and a blank-line selection are stable.
-fn copy_line_end(line: Option<&str>) -> usize {
-    line.map(|line| line.chars().count().saturating_sub(1))
-        .unwrap_or(0)
-}
-
 fn copy_word_forward(
     row_count: usize,
-    mut row_text: impl FnMut(usize) -> Option<String>,
+    mut row_layout: impl FnMut(usize) -> Option<crate::terminal::vt::RetainedRowLayout>,
     mut at: (usize, usize),
 ) -> (usize, usize) {
     while at.0 < row_count {
-        let line = row_text(at.0).unwrap_or_default();
-        let chars: Vec<char> = line.chars().collect();
-        while at.1 < chars.len() && !chars[at.1].is_whitespace() {
+        let Some(layout) = row_layout(at.0) else {
+            at.0 += 1;
+            at.1 = 0;
+            continue;
+        };
+        let last = layout.last_column();
+        while at.1 <= last && !layout.is_whitespace(at.1) {
             at.1 += 1;
         }
-        while at.1 < chars.len() && chars[at.1].is_whitespace() {
+        while at.1 <= last && layout.is_whitespace(at.1) {
             at.1 += 1;
         }
-        if at.1 < chars.len() {
+        if at.1 <= last {
             return at;
         }
         at.0 += 1;
         at.1 = 0;
     }
     let last = row_count.saturating_sub(1);
-    let line = row_text(last);
-    (last, copy_line_end(line.as_deref()))
+    let column = row_layout(last).map_or(0, |layout| layout.last_column());
+    (last, column)
 }
 
 fn copy_word_back(
-    mut row_text: impl FnMut(usize) -> Option<String>,
+    mut row_layout: impl FnMut(usize) -> Option<crate::terminal::vt::RetainedRowLayout>,
     mut at: (usize, usize),
 ) -> (usize, usize) {
     loop {
-        let line = row_text(at.0).unwrap_or_default();
-        let chars: Vec<char> = line.chars().collect();
-        let mut col = at.1.min(chars.len());
-        while col > 0 && chars[col - 1].is_whitespace() {
+        let Some(layout) = row_layout(at.0) else {
+            if at.0 == 0 {
+                return (0, 0);
+            }
+            at.0 -= 1;
+            at.1 = row_layout(at.0).map_or(0, |layout| layout.last_column().saturating_add(1));
+            continue;
+        };
+        let mut col = at.1.min(layout.last_column().saturating_add(1));
+        while col > 0 && layout.is_whitespace(col - 1) {
             col -= 1;
         }
-        while col > 0 && !chars[col - 1].is_whitespace() {
+        while col > 0 && !layout.is_whitespace(col - 1) {
             col -= 1;
         }
-        if col > 0 || !chars.is_empty() {
-            return (at.0, col.min(copy_line_end(Some(&line))));
+        if col > 0 || layout.has_text() {
+            return (at.0, col.min(layout.last_column()));
         }
         if at.0 == 0 {
             return (0, 0);
         }
         at.0 -= 1;
-        let line = row_text(at.0);
-        at.1 = copy_line_end(line.as_deref()).saturating_add(1);
-    }
-}
-
-fn append_selected_row(
-    out: &mut String,
-    appended: &mut bool,
-    line: &str,
-    row: usize,
-    ((start_row, start_col), (end_row, end_col)): ((usize, usize), (usize, usize)),
-) {
-    let chars: Vec<char> = line.chars().collect();
-    // A drag that starts beside the visible text must not grow leftward on
-    // middle rows: that otherwise copies the blank cell between the pane edge
-    // and every list item. Keep the drag's leftmost edge for those rows while
-    // preserving the exact start point on the first row.
-    let middle_left = start_col.min(end_col);
-    let left = if row == start_row {
-        start_col
-    } else {
-        middle_left
-    };
-    let right = if row == end_row {
-        end_col
-    } else {
-        chars.len().saturating_sub(1)
-    };
-    if *appended {
-        out.push('\n');
-    }
-    *appended = true;
-    if left <= right {
-        out.extend(
-            chars
-                .iter()
-                .skip(left)
-                .take(right.saturating_sub(left).saturating_add(1)),
-        );
-    }
-    while out.ends_with(' ') {
-        out.pop();
+        at.1 = row_layout(at.0).map_or(0, |layout| layout.last_column().saturating_add(1));
     }
 }
 
@@ -124,35 +86,6 @@ fn strip_uniform_single_cell_margin(text: String) -> String {
         .map(|line| line.strip_prefix(' ').unwrap_or(line))
         .collect::<Vec<_>>()
         .join("\n")
-}
-
-/// Extract a terminal selection from logical rows. Both mouse and keyboard
-/// selection feed this function, keeping clipboard semantics aligned.
-fn extract_rows_selection(
-    rows: &[String],
-    ((start_row, start_col), (end_row, end_col)): ((usize, usize), (usize, usize)),
-) -> Option<String> {
-    if start_row > end_row || start_row >= rows.len() {
-        return None;
-    }
-    let mut out = String::new();
-    let last_row = end_row.min(rows.len().saturating_sub(1));
-    let mut appended = false;
-    for (row, line) in rows
-        .iter()
-        .enumerate()
-        .take(last_row.saturating_add(1))
-        .skip(start_row)
-    {
-        append_selected_row(
-            &mut out,
-            &mut appended,
-            line,
-            row,
-            ((start_row, start_col), (end_row, end_col)),
-        );
-    }
-    finish_selected_text(out)
 }
 
 impl App {
@@ -2086,22 +2019,11 @@ impl App {
             .status
             .get(&copy.pane)
             .is_some_and(|status| status.agent == "codex");
-        let text = self.panes.get(&copy.pane).and_then(|pane| {
-            let range = copy.ordered();
-            let mut output = String::new();
-            let start_row = (range.0).0;
-            let end_row = (range.1).0;
-            // Hold one engine lock so every selected row comes from the same
-            // terminal snapshot. Rows that disappeared after the selection was
-            // made are skipped instead of discarding the remaining copy.
-            let mut appended = false;
-            pane.for_each_retained_row(&mut |row, _history, _row_count, line| {
-                if (start_row..=end_row).contains(&row) {
-                    append_selected_row(&mut output, &mut appended, line, row, range);
-                }
-            });
-            finish_selected_text(output)
-        });
+        let text = self
+            .panes
+            .get(&copy.pane)
+            .and_then(|pane| pane.retained_selection_text(copy.ordered()))
+            .and_then(finish_selected_text);
         if let Some(text) = text.map(|text| {
             if is_codex {
                 strip_uniform_single_cell_margin(text)
@@ -2154,9 +2076,10 @@ impl App {
         match key.code {
             KeyCode::Left | KeyCode::Char('h') => copy.cursor.1 = copy.cursor.1.saturating_sub(1),
             KeyCode::Right | KeyCode::Char('l') => {
-                copy.cursor.1 = copy.cursor.1.saturating_add(1).min(copy_line_end(
-                    pane.retained_row_text(copy.cursor.0).as_deref(),
-                ));
+                let last = pane
+                    .retained_row_layout(copy.cursor.0)
+                    .map_or(0, |layout| layout.last_column());
+                copy.cursor.1 = copy.cursor.1.saturating_add(1).min(last);
             }
             KeyCode::Up | KeyCode::Char('k') => copy.cursor.0 = copy.cursor.0.saturating_sub(1),
             KeyCode::Down | KeyCode::Char('j') => copy.cursor.0 = (copy.cursor.0 + 1).min(last_row),
@@ -2170,20 +2093,23 @@ impl App {
             KeyCode::End | KeyCode::Char('G') => copy.cursor.0 = last_row,
             KeyCode::Char('0') => copy.cursor.1 = 0,
             KeyCode::Char('$') => {
-                copy.cursor.1 = copy_line_end(pane.retained_row_text(copy.cursor.0).as_deref())
+                copy.cursor.1 = pane
+                    .retained_row_layout(copy.cursor.0)
+                    .map_or(0, |layout| layout.last_column())
             }
             KeyCode::Char('w') => {
                 copy.cursor =
-                    copy_word_forward(row_count, |row| pane.retained_row_text(row), copy.cursor)
+                    copy_word_forward(row_count, |row| pane.retained_row_layout(row), copy.cursor)
             }
             KeyCode::Char('B') => {
-                copy.cursor = copy_word_back(|row| pane.retained_row_text(row), copy.cursor)
+                copy.cursor = copy_word_back(|row| pane.retained_row_layout(row), copy.cursor)
             }
             _ => return true,
         }
-        copy.cursor.1 = copy.cursor.1.min(copy_line_end(
-            pane.retained_row_text(copy.cursor.0).as_deref(),
-        ));
+        copy.cursor.1 = copy.cursor.1.min(
+            pane.retained_row_layout(copy.cursor.0)
+                .map_or(0, |layout| layout.last_column()),
+        );
         self.copy_mode = Some(copy);
         self.reveal_copy_cursor();
         true
@@ -2321,16 +2247,11 @@ impl App {
         }
         if let Some(selection) = sel.retained {
             let range = selection.ordered();
-            let mut output = String::new();
-            let mut appended = false;
-            self.panes
+            let text = self
+                .panes
                 .get(&sel.pane)?
-                .for_each_retained_row(&mut |row, _, _, line| {
-                    if (range.0 .0..=range.1 .0).contains(&row) {
-                        append_selected_row(&mut output, &mut appended, line, row, range);
-                    }
-                });
-            let text = finish_selected_text(output)?;
+                .retained_selection_text(range)
+                .and_then(finish_selected_text)?;
             let is_codex = self
                 .status
                 .get(&sel.pane)
@@ -2341,28 +2262,18 @@ impl App {
                 text
             });
         }
-        let rows = self
-            .panes
-            .get(&sel.pane)?
-            .engine
-            .lock()
-            .ok()?
-            .visible_rows();
         let ((sx, sy), (ex, ey)) = sel.ordered();
         let (cx, cy) = (sel.content.x, sel.content.y);
-        let text = extract_rows_selection(
-            &rows,
+        let text = self.panes.get(&sel.pane)?.visible_selection_text((
             (
-                (
-                    (sy as usize).saturating_sub(cy as usize),
-                    (sx as usize).saturating_sub(cx as usize),
-                ),
-                (
-                    (ey as usize).saturating_sub(cy as usize),
-                    (ex as usize).saturating_sub(cx as usize),
-                ),
+                (sy as usize).saturating_sub(cy as usize),
+                (sx as usize).saturating_sub(cx as usize),
             ),
-        )?;
+            (
+                (ey as usize).saturating_sub(cy as usize),
+                (ex as usize).saturating_sub(cx as usize),
+            ),
+        ))?;
         // A drag may begin in the single blank pane cell before uniformly
         // aligned prose. Codex also emits that one-cell transcript gutter even
         // when the drag starts on its first visible character. It remains
@@ -4178,39 +4089,6 @@ mod link_click_tests {
         assert_eq!(app.pending_open_url.as_deref(), Some(URL));
     }
 
-    /// Copy-mode skips rows that fell out of retention, so the newline
-    /// separator must track appended rows — comparing against the selection's
-    /// start row would make a skipped leading row start the copy with `\n`.
-    #[test]
-    fn skipped_leading_rows_do_not_add_a_leading_newline() {
-        let mut out = String::new();
-        let mut appended = false;
-        let range = ((2, 0), (5, 2));
-        // Rows 2 and 3 were evicted and are skipped; row 4 is appended first.
-        append_selected_row(&mut out, &mut appended, "abc", 4, range);
-        append_selected_row(&mut out, &mut appended, "def", 5, range);
-        assert_eq!(
-            finish_selected_text(out).as_deref(),
-            Some("abc\ndef"),
-            "a skipped first row must not produce a leading newline"
-        );
-    }
-
-    #[test]
-    fn multi_line_copy_keeps_the_drag_left_edge() {
-        // The first column is blank pane-side space before a Markdown list. A
-        // drag beginning on `-` must not add that blank to every middle row.
-        let rows = vec![
-            " - first".to_string(),
-            " - second".to_string(),
-            " - third".to_string(),
-        ];
-        assert_eq!(
-            extract_rows_selection(&rows, ((0, 1), (2, 7))).as_deref(),
-            Some("- first\n- second\n- third")
-        );
-    }
-
     #[test]
     fn mouse_copy_drops_a_uniform_one_cell_pane_margin() {
         assert_eq!(
@@ -4285,6 +4163,89 @@ mod link_click_tests {
                 "Morning arrives without ceremony,\na thin gold line on the edge of the glass.\nThe kettle speaks in its private language,"
             )
         );
+    }
+
+    #[test]
+    fn mouse_auto_copy_preserves_reverse_wide_character_selection() {
+        let _env = crate::persist::test_env("mouse-copy-wide-unicode");
+        let (mut app, _term, _) = fixture_showing("你好，hello.", 0);
+        let pane = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        let (visible_top, row_count) = app
+            .panes
+            .get(&pane)
+            .and_then(|pane| pane.retained_viewport())
+            .expect("retained viewport");
+        let row = (visible_top..row_count)
+            .find(|row| {
+                app.panes
+                    .get(&pane)
+                    .and_then(|pane| pane.retained_row_text(*row))
+                    .as_deref()
+                    == Some("你好，hello.")
+            })
+            .expect("fixture row");
+        let screen_row = content.y + (row - visible_top) as u16;
+        let left = (content.x, screen_row);
+        let right = (content.x + 3, screen_row);
+        app.selection = Some(crate::app::Selection {
+            pane,
+            content,
+            anchor: right,
+            cursor: left,
+            retained: Some(crate::app::RetainedSelection {
+                anchor: (row, 3),
+                cursor: (row, 0),
+            }),
+            scrolled: false,
+            dragging: true,
+        });
+
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            left,
+            KeyModifiers::NONE,
+        ));
+
+        assert_eq!(app.pending_clipboard.as_deref(), Some("你好"));
+    }
+
+    #[test]
+    fn visible_selection_fallback_preserves_wide_characters() {
+        let _env = crate::persist::test_env("mouse-copy-wide-visible-fallback");
+        let (mut app, _term, _) = fixture_showing("你好，hello.", 0);
+        let pane = app.layout().focus;
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("pane content rect");
+        let visible_row = {
+            let pane = app.panes.get(&pane).expect("pane");
+            let engine = pane.engine.lock().expect("engine");
+            engine
+                .visible_rows()
+                .iter()
+                .position(|row| row.trim_end() == "你好，hello.")
+                .expect("visible fixture row")
+        };
+        app.selection = Some(crate::app::Selection {
+            pane,
+            content,
+            anchor: (content.x, content.y + visible_row as u16),
+            cursor: (content.x + 3, content.y + visible_row as u16),
+            retained: None,
+            scrolled: false,
+            dragging: false,
+        });
+
+        assert_eq!(app.selection_text().as_deref(), Some("你好"));
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10669,6 +10669,93 @@ mod tests {
     }
 
     #[test]
+    fn keyboard_copy_mode_navigates_and_yanks_wide_cells() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(40, 8, tx).unwrap();
+        let pane = app.layout().focus;
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .engine
+            .lock()
+            .expect("engine")
+            .advance("\x1b[H\x1b[2J你好，hello.".as_bytes());
+        let mut target_row = None;
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .for_each_retained_row(&mut |row, _, _, text| {
+                if text == "你好，hello." {
+                    target_row = Some(row);
+                }
+            });
+        let row = target_row.expect("fixture row");
+        app.copy_mode = Some(CopyMode {
+            pane,
+            anchor: (row, 0),
+            cursor: (row, 0),
+            saved_scroll: 0,
+        });
+
+        for _ in 0..3 {
+            app.handle_event(AppEvent::Key(KeyEvent::new(
+                KeyCode::Char('l'),
+                KeyModifiers::NONE,
+            )));
+        }
+        assert_eq!(app.copy_mode.expect("copy mode").cursor, (row, 3));
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('y'),
+            KeyModifiers::NONE,
+        )));
+
+        assert_eq!(app.pending_clipboard.as_deref(), Some("你好"));
+    }
+
+    #[test]
+    fn keyboard_copy_word_navigation_uses_visual_columns() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(40, 8, tx).unwrap();
+        let pane = app.layout().focus;
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .engine
+            .lock()
+            .expect("engine")
+            .advance("\x1b[H\x1b[2J你好 world".as_bytes());
+        let mut target_row = None;
+        app.panes
+            .get(&pane)
+            .expect("pane")
+            .for_each_retained_row(&mut |row, _, _, text| {
+                if text == "你好 world" {
+                    target_row = Some(row);
+                }
+            });
+        let row = target_row.expect("fixture row");
+        app.copy_mode = Some(CopyMode {
+            pane,
+            anchor: (row, 0),
+            cursor: (row, 0),
+            saved_scroll: 0,
+        });
+
+        let send = |app: &mut App, character| {
+            app.handle_event(AppEvent::Key(KeyEvent::new(
+                KeyCode::Char(character),
+                KeyModifiers::NONE,
+            )));
+        };
+        send(&mut app, 'w');
+        assert_eq!(app.copy_mode.expect("copy mode").cursor, (row, 5));
+        send(&mut app, 'B');
+        assert_eq!(app.copy_mode.expect("copy mode").cursor, (row, 0));
+        send(&mut app, '$');
+        assert_eq!(app.copy_mode.expect("copy mode").cursor, (row, 9));
+    }
+
+    #[test]
     fn keyboard_copy_trims_a_codex_transcript_gutter() {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(40, 8, tx).unwrap();

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -904,6 +904,7 @@ impl Pane {
     }
 
     /// Read one retained row without allocating every other row.
+    #[cfg(test)]
     pub fn retained_row_text(&self, index: usize) -> Option<String> {
         self.engine.lock().ok()?.retained_row_text(index)
     }
@@ -917,6 +918,44 @@ impl Pane {
             let row_count = engine.retained_row_count();
             engine.for_each_retained_row(&mut |index, line| f(index, history, row_count, line));
         }
+    }
+
+    /// Extract retained terminal text by grid cell rather than string index.
+    /// This keeps wide glyphs and combining sequences aligned with selection
+    /// highlights.
+    pub fn retained_selection_text(
+        &self,
+        range: ((usize, usize), (usize, usize)),
+    ) -> Option<String> {
+        self.engine.lock().ok()?.retained_selection_text(range)
+    }
+
+    /// Extract a selection expressed in the currently visible viewport. This
+    /// is the fallback when a mouse press could not snapshot retained-history
+    /// coordinates, and still preserves terminal cell semantics for Unicode.
+    pub fn visible_selection_text(
+        &self,
+        ((start_row, start_col), (end_row, end_col)): ((usize, usize), (usize, usize)),
+    ) -> Option<String> {
+        let engine = self.engine.lock().ok()?;
+        let visible_top = engine.history_len().saturating_sub(engine.scroll_offset());
+        let row_count = engine.retained_row_count();
+        let last_row = row_count.checked_sub(1)?;
+        engine.retained_selection_text((
+            (
+                visible_top.saturating_add(start_row).min(last_row),
+                start_col,
+            ),
+            (visible_top.saturating_add(end_row).min(last_row), end_col),
+        ))
+    }
+
+    /// Cell geometry used by keyboard copy-mode navigation.
+    pub fn retained_row_layout(
+        &self,
+        index: usize,
+    ) -> Option<crate::terminal::vt::RetainedRowLayout> {
+        self.engine.lock().ok()?.retained_row_layout(index)
     }
 
     /// Jump the scrollback viewport so the row `offset` lines above the live

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -5,14 +5,14 @@ use std::sync::{Arc, Mutex};
 
 use alacritty_terminal::event::{Event, EventListener};
 use alacritty_terminal::grid::{Dimensions, Scroll};
-use alacritty_terminal::index::{Column, Line};
+use alacritty_terminal::index::{Column, Line, Point};
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::{Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{Color as VtColor, Processor};
 
 use ratatui::style::{Color, Modifier};
 
-use super::{CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, VtEngine};
+use super::{CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, RetainedRowLayout, VtEngine};
 use crate::terminal::backend::{CaptureMode, CaptureResult};
 use crate::terminal::pty::InputAction;
 
@@ -667,6 +667,7 @@ impl VtEngine for AlacrittyEngine {
             .saturating_add(self.term.grid().screen_lines())
     }
 
+    #[cfg(test)]
     fn retained_row_text(&self, index: usize) -> Option<String> {
         let mut output = String::with_capacity(self.term.grid().columns());
         self.write_retained_row(index, &mut output)
@@ -680,6 +681,88 @@ impl VtEngine for AlacrittyEngine {
                 f(index, &output);
             }
         }
+    }
+
+    fn retained_selection_text(
+        &self,
+        ((start_row, start_col), (end_row, end_col)): ((usize, usize), (usize, usize)),
+    ) -> Option<String> {
+        if start_row > end_row {
+            return None;
+        }
+        let last_column = self.term.grid().columns().checked_sub(1)?;
+        let middle_left = start_col.min(end_col);
+        let mut output = String::new();
+        let mut appended = false;
+
+        for row_index in start_row..=end_row {
+            let Some(line) = self.retained_line(row_index) else {
+                continue;
+            };
+            let left = if row_index == start_row {
+                start_col
+            } else {
+                middle_left
+            }
+            .min(last_column);
+            let right = if row_index == end_row {
+                end_col
+            } else {
+                last_column
+            }
+            .min(last_column);
+
+            if appended {
+                output.push('\n');
+            }
+            appended = true;
+            if left <= right {
+                let row = self.term.bounds_to_string(
+                    Point::new(line, Column(left)),
+                    Point::new(line, Column(right)),
+                );
+                output.push_str(row.trim_end_matches(' '));
+            }
+        }
+
+        appended.then_some(output)
+    }
+
+    fn retained_row_layout(&self, index: usize) -> Option<RetainedRowLayout> {
+        let line = self.retained_line(index)?;
+        let grid = self.term.grid();
+        let row = &grid[line];
+        let mut whitespace = Vec::with_capacity(grid.columns());
+        let mut previous_whitespace = true;
+        let mut last_content = None;
+
+        for column in 0..grid.columns() {
+            let cell = &row[Column(column)];
+            let wide_spacer = cell.flags.contains(Flags::WIDE_CHAR_SPACER);
+            let leading_spacer = cell.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER);
+            let cell_whitespace = if wide_spacer {
+                previous_whitespace
+            } else if leading_spacer {
+                false
+            } else {
+                cell.c == '\0' || cell.c.is_whitespace()
+            };
+            whitespace.push(cell_whitespace);
+
+            let has_content = leading_spacer
+                || (!wide_spacer && cell.c != '\0' && cell.c != ' ')
+                || (wide_spacer && last_content == column.checked_sub(1));
+            if has_content {
+                last_content = Some(column);
+            }
+            if !wide_spacer && !leading_spacer {
+                previous_whitespace = cell_whitespace;
+            }
+        }
+
+        let has_text = last_content.is_some();
+        whitespace.truncate(last_content.map_or(1, |column| column + 1));
+        Some(RetainedRowLayout::new(whitespace, has_text))
     }
 
     fn scroll_to(&mut self, offset: usize) {
@@ -973,6 +1056,95 @@ mod tests {
         );
         e.advance(b" world");
         assert_eq!(e.output_generation(), 2);
+    }
+
+    #[test]
+    fn retained_selection_preserves_unicode_scripts_and_clusters() {
+        let samples = [
+            "你好，世界",
+            "こんにちは",
+            "안녕하세요",
+            "مرحبا",
+            "שלום",
+            "नमस्ते",
+            "สวัสดี",
+            "cafe\u{301}",
+            "🖥️ coding",
+            "👩‍💻 pair",
+        ];
+
+        for sample in samples {
+            let (tx, _rx) = channel();
+            let mut engine = AlacrittyEngine::new(80, 3, tx, budget_for_rows(80, 20));
+            engine.advance(format!("\x1b[H\x1b[2J{sample}").as_bytes());
+            let row = (0..engine.retained_row_count())
+                .find(|row| engine.retained_row_text(*row).as_deref() == Some(sample))
+                .expect("sample retained row");
+            let layout = engine
+                .retained_row_layout(row)
+                .expect("retained row layout");
+            let selected = engine
+                .retained_selection_text(((row, 0), (row, layout.last_column())))
+                .expect("selected row");
+            assert_eq!(selected, sample, "Unicode selection changed {sample:?}");
+        }
+    }
+
+    #[test]
+    fn retained_selection_uses_visual_columns_for_mixed_cjk_text() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(40, 4, tx, budget_for_rows(40, 20));
+        engine.advance("\x1b[H\x1b[2J你好，hello.\r\nمرحبا world".as_bytes());
+        let first = (0..engine.retained_row_count())
+            .find(|row| engine.retained_row_text(*row).as_deref() == Some("你好，hello."))
+            .expect("first retained row");
+        let second = (0..engine.retained_row_count())
+            .find(|row| engine.retained_row_text(*row).as_deref() == Some("مرحبا world"))
+            .expect("second retained row");
+
+        assert_eq!(
+            engine
+                .retained_selection_text(((first, 0), (first, 3)))
+                .as_deref(),
+            Some("你好")
+        );
+        assert_eq!(
+            engine
+                .retained_selection_text(((first, 1), (first, 2)))
+                .as_deref(),
+            Some("你好"),
+            "starting on a wide spacer still includes its complete glyph"
+        );
+        let second_layout = engine
+            .retained_row_layout(second)
+            .expect("second row layout");
+        assert_eq!(
+            engine
+                .retained_selection_text(((first, 0), (second, second_layout.last_column())))
+                .as_deref(),
+            Some("你好，hello.\nمرحبا world")
+        );
+    }
+
+    #[test]
+    fn retained_selection_keeps_the_drag_left_edge_on_middle_rows() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 20));
+        engine.advance(b"\x1b[H\x1b[2J - first\r\n - second\r\n - third");
+        let mut rows = Vec::new();
+        engine.for_each_retained_row(&mut |row, text| {
+            if text.starts_with(" - ") {
+                rows.push(row);
+            }
+        });
+        assert_eq!(rows.len(), 3);
+
+        assert_eq!(
+            engine
+                .retained_selection_text(((rows[0], 1), (rows[2], 7)))
+                .as_deref(),
+            Some("- first\n- second\n- third")
+        );
     }
 
     #[test]

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -92,6 +92,38 @@ pub struct HistoryMetrics {
     pub exact_bytes: bool,
 }
 
+/// Cell geometry for one retained terminal row.
+///
+/// Copy-mode navigation uses this instead of Unicode scalar counts. A terminal
+/// cell is the only stable unit across narrow scripts, double-width glyphs,
+/// combining marks, and emoji sequences.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetainedRowLayout {
+    whitespace: Vec<bool>,
+    has_text: bool,
+}
+
+impl RetainedRowLayout {
+    pub(crate) fn new(whitespace: Vec<bool>, has_text: bool) -> Self {
+        Self {
+            whitespace,
+            has_text,
+        }
+    }
+
+    pub(crate) fn last_column(&self) -> usize {
+        self.whitespace.len().saturating_sub(1)
+    }
+
+    pub(crate) fn is_whitespace(&self, column: usize) -> bool {
+        self.whitespace.get(column).copied().unwrap_or(true)
+    }
+
+    pub(crate) fn has_text(&self) -> bool {
+        self.has_text
+    }
+}
+
 /// Minimal terminal-emulator surface. Owns the grid + scrollback.
 pub trait VtEngine: Send {
     /// Feed child output. Must never panic on arbitrary bytes.
@@ -125,8 +157,8 @@ pub trait VtEngine: Send {
     /// the user's scroll position.
     fn detection_text(&self, n: u16) -> String;
 
-    /// Every visible row as a plain string (one char per cell, full width,
-    /// untrimmed) — used to copy a mouse text selection.
+    /// Every visible row as normalized plain text. Wide-character spacer cells
+    /// are omitted, so callers must not use string indexes as terminal columns.
     fn visible_rows(&self) -> Vec<String>;
 
     /// Bounded public capture for harnesses. Implementations serialize only
@@ -176,11 +208,23 @@ pub trait VtEngine: Send {
 
     /// Read one retained row by oldest-first index without materializing the
     /// entire history.
+    #[cfg(test)]
     fn retained_row_text(&self, index: usize) -> Option<String>;
 
     /// Visit retained rows oldest-first using one reusable line buffer. The
     /// callback must not retain the borrowed text after it returns.
     fn for_each_retained_row(&self, f: &mut dyn FnMut(usize, &str));
+
+    /// Extract an inclusive retained-row selection using terminal cell
+    /// coordinates. Implementations must preserve complete wide glyphs and
+    /// zero-width marks rather than treating columns as string character
+    /// indexes.
+    fn retained_selection_text(&self, range: ((usize, usize), (usize, usize))) -> Option<String>;
+
+    /// Return copy-mode navigation geometry for one retained row. Trailing
+    /// unused cells are omitted, while wide-character spacer cells remain part
+    /// of the layout.
+    fn retained_row_layout(&self, index: usize) -> Option<RetainedRowLayout>;
 
     /// Jump the viewport so the row `offset` lines above the live bottom sits at
     /// the top (clamped to `history_len()`); `0` is live. Lands on a search match


### PR DESCRIPTION
## Summary

- preserve Unicode text when copying terminal selections that use visual cell columns
- keep double-width characters, combining marks, variation selectors, and emoji sequences intact
- use raw terminal-grid geometry for mouse selection and keyboard copy mode
- retain existing ASCII, scrollback, pane-margin, and Codex gutter behavior

## Why

Terminal selections are measured in visual cells, but the previous copy path converted rows into strings and sliced them by character index. Those coordinates diverge for text such as CJK characters and emoji, which could copy extra characters or the wrong range.

This change keeps selection coordinates in terminal-cell space until the VT engine extracts the final text.

## Validation

- `cargo test --locked copy`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `git diff --check`

The focused copy suite passed with 16 tests, including Unicode mouse selection, reverse selection, keyboard copy mode, scrollback, pane margins, and Codex transcript gutters.

Fixes #129


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-mode selection for wide Unicode characters, including Chinese text and grapheme clusters.
  * Fixed word navigation and end-of-line movement to follow visual terminal columns.
  * Preserved accurate character boundaries and spacing in multi-row selections.
  * Added reliable fallback behavior when selecting visible content.

* **Tests**
  * Added regression coverage for reverse selections, wide characters, and visual-column navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->