### PR TITLE
fix(input): restore fullscreen TUI wheel scrolling

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1529,10 +1529,12 @@ impl App {
                         let base = content.unwrap_or(Rect::new(0, 0, 1, 1));
                         let col = m.column.saturating_sub(base.x) + 1;
                         let row = m.row.saturating_sub(base.y) + 1;
-                        let seq = mouse_wheel_seq(up, col, row, mm.sgr);
-                        for _ in 0..3 {
-                            pane.send(&seq);
-                        }
+                        // Preserve the terminal protocol's one-event/one-report
+                        // boundary. In particular, Windows ConPTY may coalesce
+                        // rapid writes; sending duplicates here can make a TUI
+                        // receive several concatenated SGR reports as one input
+                        // record and reject the entire wheel action.
+                        pane.send(&mouse_wheel_seq(up, col, row, mm.sgr));
                         scrolled_the_app = true;
                     } else if !pane.alt_screen() {
                         // Primary screen with real history: scroll luvus's
@@ -3430,6 +3432,8 @@ mod tests {
 
     #[test]
     fn sgr_wheel_encodes_button_and_coords() {
+        // Each physical wheel event produces exactly one complete report.
+        // Fullscreen TUIs may reject multiple reports coalesced into one read.
         // Wheel up = button 64, down = 65; coords are 1-based, pane-local.
         assert_eq!(mouse_wheel_seq(true, 5, 3, true), b"\x1b[<64;5;3M".to_vec());
         assert_eq!(

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -1417,6 +1417,20 @@ mod tests {
     }
 
     #[test]
+    fn pi_fullscreen_mouse_modes_are_detected() {
+        let (tx, _rx) = channel();
+        let mut e = AlacrittyEngine::new(20, 5, tx, budget_for_rows(20, 2_000));
+
+        // Pi fullscreen enters the alternate screen, disables autowrap, and
+        // enables normal, button-motion, focus, and SGR mouse reporting.
+        e.advance(b"\x1b[?1049h\x1b[?7l\x1b[?1000h\x1b[?1002h\x1b[?1004h\x1b[?1006h");
+
+        assert!(e.alt_screen());
+        assert!(e.mouse_report());
+        assert!(e.sgr_mouse());
+    }
+
+    #[test]
     fn codex_composer_region_finds_the_real_default_background_layout() {
         let (tx, _rx) = channel();
         let mut e = AlacrittyEngine::new(40, 8, tx, budget_for_rows(40, 2_000));


### PR DESCRIPTION
## Summary

- forward exactly one terminal mouse report for each host wheel event
- preserve existing pane-local coordinates and SGR or legacy mouse encoding
- add regression coverage for the exact alternate-screen and mouse modes enabled by Pi fullscreen

## Why

Luvus currently duplicates every application-owned wheel event three times. On Windows, ConPTY may deliver those rapid writes together. Fullscreen TUIs that parse one complete SGR mouse report per input record can then reject the concatenated input, leaving PageUp and PageDown functional while mouse-wheel scrolling does nothing.

The fix restores the terminal protocol boundary of one input event to one mouse report. Primary-screen Luvus scrollback, selection scrolling, alternate-scroll fallback, clicks, dragging, and hover reporting retain their existing paths.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked`
- 925 unit tests passed, plus CLI, named-session, and theme integration tests
- focused Pi fullscreen mode and SGR wheel encoding regressions passed

Windows CI will validate the branch build and platform test surface. Manual confirmation in Windows Terminal with Pi fullscreen remains the final environment-specific check.

Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mouse-wheel input is now delivered once per physical wheel event, preventing duplicate reports in fullscreen terminal applications.
  - Improved compatibility with fullscreen terminal applications using advanced mouse and focus reporting.

- **Tests**
  - Added coverage confirming correct mouse-wheel event behavior.
  - Added regression coverage for fullscreen terminal configuration, including alternate-screen mode, mouse reporting, focus reporting, SGR encoding, and autowrap settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->