### PR TITLE
fix(windows): detect agents behind npm shims

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,11 @@ windows-sys = { version = "0.61", features = [
     "Win32_Media_Audio",
     "Win32_Security",
     "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Kernel",
     "Win32_System_Threading",
+    "Wdk_System_Threading",
 ] }
 
 [profile.release]

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -988,13 +988,39 @@ impl Manifests {
 
     /// Split a process command line into argv-like tokens, retaining spaces
     /// inside quoted paths such as `"C:\\Program Files\\nodejs\\node.exe"`.
+    /// Apply the Windows backslash-before-quote rules so escaped quotes and
+    /// trailing backslashes survive when launch arguments are replayed.
     fn command_tokens(command: &str) -> Vec<String> {
         let mut tokens = Vec::new();
         let mut token = String::new();
         let mut quoted = false;
         let mut token_started = false;
-        for character in command.chars() {
+        let mut characters = command.chars().peekable();
+        while let Some(character) = characters.next() {
             match character {
+                '\\' => {
+                    let mut backslashes = 1;
+                    while characters.peek().copied() == Some('\\') {
+                        characters.next();
+                        backslashes += 1;
+                    }
+                    token_started = true;
+                    if characters.peek().copied() == Some('"') {
+                        characters.next();
+                        for _ in 0..backslashes / 2 {
+                            token.push('\\');
+                        }
+                        if backslashes % 2 == 1 {
+                            token.push('"');
+                        } else {
+                            quoted = !quoted;
+                        }
+                    } else {
+                        for _ in 0..backslashes {
+                            token.push('\\');
+                        }
+                    }
+                }
                 '"' => {
                     quoted = !quoted;
                     token_started = true;
@@ -1341,6 +1367,21 @@ mod tests {
         assert_eq!(
             m.launch_args_for(&[r#"claude --model "" --yes"#.into()], "claude"),
             Some(vec!["--model".into(), "".into(), "--yes".into()])
+        );
+        // Windows escapes a quote with an odd run of backslashes inside a
+        // quoted argument; the escaped quote must remain part of the value.
+        assert_eq!(
+            m.launch_args_for(
+                &["claude --append-system-prompt \"say \\\"hi\\\"\"".into()],
+                "claude",
+            ),
+            Some(vec!["--append-system-prompt".into(), "say \"hi\"".into()])
+        );
+        // An even run before a closing quote becomes half as many backslashes,
+        // and the quote remains the delimiter.
+        assert_eq!(
+            m.launch_args_for(&["claude --cwd \"C:\\work\\\\\"".into()], "claude"),
+            Some(vec!["--cwd".into(), r#"C:\work\"#.into()])
         );
         // Windows process inspection supplies the full Node command line, so
         // Pi's npm package name in the script slot resolves to the agent.

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -992,18 +992,26 @@ impl Manifests {
         let mut tokens = Vec::new();
         let mut token = String::new();
         let mut quoted = false;
+        let mut token_started = false;
         for character in command.chars() {
             match character {
-                '"' => quoted = !quoted,
+                '"' => {
+                    quoted = !quoted;
+                    token_started = true;
+                }
                 character if character.is_whitespace() && !quoted => {
-                    if !token.is_empty() {
+                    if token_started {
                         tokens.push(std::mem::take(&mut token));
+                        token_started = false;
                     }
                 }
-                character => token.push(character),
+                character => {
+                    token.push(character);
+                    token_started = true;
+                }
             }
         }
-        if !token.is_empty() {
+        if token_started {
             tokens.push(token);
         }
         tokens
@@ -1015,18 +1023,21 @@ impl Manifests {
     fn match_interpreter_script(&self, token: &str) -> Option<String> {
         self.match_binary(binary_name(token)).or_else(|| {
             let normalized = token.to_lowercase().replace('\\', "/");
-            normalized.split('/').rev().find_map(|segment| {
-                let segment = segment
-                    .strip_suffix(".cjs")
-                    .or_else(|| segment.strip_suffix(".mjs"))
-                    .or_else(|| segment.strip_suffix(".js"))
-                    .or_else(|| segment.strip_suffix(".py"))
-                    .unwrap_or(segment);
-                self.agents
-                    .iter()
-                    .find(|agent| agent.distinct.iter().any(|pattern| *pattern == segment))
-                    .map(|agent| agent.name.clone())
-            })
+            let mut segments = normalized.split('/').rev();
+            let script = strip_script_extension(segments.next()?);
+
+            self.agents
+                .iter()
+                .find(|agent| agent.all().any(|pattern| pattern == script))
+                .map(|agent| agent.name.clone())
+                .or_else(|| {
+                    segments.find_map(|segment| {
+                        self.agents
+                            .iter()
+                            .find(|agent| agent.distinct.iter().any(|pattern| pattern == segment))
+                            .map(|agent| agent.name.clone())
+                    })
+                })
         })
     }
 
@@ -1082,6 +1093,16 @@ pub(crate) fn binary_name(token: &str) -> &str {
         .unwrap_or(token)
         .trim_start_matches('-')
         .trim_end_matches(".exe")
+}
+
+/// The basename of a script without the extension used by common interpreters.
+fn strip_script_extension(token: &str) -> &str {
+    token
+        .strip_suffix(".cjs")
+        .or_else(|| token.strip_suffix(".mjs"))
+        .or_else(|| token.strip_suffix(".js"))
+        .or_else(|| token.strip_suffix(".py"))
+        .unwrap_or(token)
 }
 
 /// Runtimes that execute an agent as a script, so the name to look for is the
@@ -1315,6 +1336,12 @@ mod tests {
             m.launch_args_for(&["claude".into()], "claude"),
             Some(vec![])
         );
+        // Empty quoted arguments are real argv entries and must survive so a
+        // relaunch does not silently change the agent's configuration.
+        assert_eq!(
+            m.launch_args_for(&[r#"claude --model "" --yes"#.into()], "claude"),
+            Some(vec!["--model".into(), "".into(), "--yes".into()])
+        );
         // Windows process inspection supplies the full Node command line, so
         // Pi's npm package name in the script slot resolves to the agent.
         assert_eq!(
@@ -1322,6 +1349,12 @@ mod tests {
                 r#""C:\Program Files\nodejs\node.exe" C:\Users\me\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\dist\cli.js"#.into()
             ]),
             Some("pi".into())
+        );
+        // An ambiguous brand name is still deliberate when it is the script
+        // basename in a running interpreter command.
+        assert_eq!(
+            m.agent_in_processes(&[r#"node C:\tools\grok.js"#.into()]),
+            Some("grok".into())
         );
     }
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1043,26 +1043,34 @@ impl Manifests {
         tokens
     }
 
-    /// Match an interpreter's script slot by basename or by a distinctive
-    /// package directory in its path. npm shims commonly execute `cli.js`
-    /// from a directory named after the package (`...\\pi-coding-agent\\...`).
+    /// Match an interpreter's script slot by basename or by a distinctive npm
+    /// package root. npm shims commonly execute `cli.js` from a package path
+    /// such as `...\\node_modules\\pi-coding-agent\\dist\\cli.js`.
     fn match_interpreter_script(&self, token: &str) -> Option<String> {
         self.match_binary(binary_name(token)).or_else(|| {
             let normalized = token.to_lowercase().replace('\\', "/");
-            let mut segments = normalized.split('/').rev();
-            let script = strip_script_extension(segments.next()?);
+            let segments: Vec<&str> = normalized.split('/').collect();
+            let script = strip_script_extension(segments.last().copied()?);
 
             self.agents
                 .iter()
                 .find(|agent| agent.all().any(|pattern| pattern == script))
                 .map(|agent| agent.name.clone())
                 .or_else(|| {
-                    segments.find_map(|segment| {
-                        self.agents
-                            .iter()
-                            .find(|agent| agent.distinct.iter().any(|pattern| pattern == segment))
-                            .map(|agent| agent.name.clone())
-                    })
+                    let node_modules = segments
+                        .iter()
+                        .rposition(|segment| *segment == "node_modules")?;
+                    let package_index = node_modules + 1;
+                    let package = segments.get(package_index).copied()?;
+                    let package = if package.starts_with('@') {
+                        segments.get(package_index + 1).copied()?
+                    } else {
+                        package
+                    };
+                    self.agents
+                        .iter()
+                        .find(|agent| agent.distinct.iter().any(|pattern| pattern == package))
+                        .map(|agent| agent.name.clone())
                 })
         })
     }
@@ -1396,6 +1404,24 @@ mod tests {
         assert_eq!(
             m.agent_in_processes(&[r#"node C:\tools\grok.js"#.into()]),
             Some("grok".into())
+        );
+        // A bare agent name in an unrelated project directory is not an
+        // installed package and must not identify the pane.
+        assert_eq!(
+            m.agent_in_processes(&[r#"node C:\work\claude\build.js"#.into()]),
+            None
+        );
+        // Package-directory matching remains available for npm shim paths.
+        assert_eq!(
+            m.agent_in_processes(&[r#"node C:\work\node_modules\claude\build.js"#.into()]),
+            Some("claude".into())
+        );
+        // Scoped npm packages use the package name after the `@scope` segment.
+        assert_eq!(
+            m.agent_in_processes(&[
+                r#"node C:\work\node_modules\@earendil-works\pi-coding-agent\dist\cli.js"#.into()
+            ]),
+            Some("pi".into())
         );
     }
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -931,22 +931,18 @@ impl Manifests {
     fn agent_in_process_command(&self, cmd: &str) -> Option<String> {
         let low = cmd.to_lowercase();
         let tokens = Self::command_tokens(&low);
-        let mut tokens = tokens.iter().map(String::as_str);
-        let first = binary_name(tokens.next()?);
+        let tokens = unwrap_leading_env(&tokens);
+        let (first, rest) = tokens.split_first()?;
+        let first = binary_name(first);
         if let Some(a) = self.match_binary(first) {
             return Some(a);
         }
         // Several agents ship as a script run by an interpreter, so argv[0]
-        // is `node` / `python` and the real name is the script slot: the first
-        // non-flag argument. Nothing later counts -- `cargo test --example amp`
-        // must not resolve to amp.
+        // is `node` / `python` and the real name is the script slot. Nothing
+        // later counts -- `cargo test --example amp` must not resolve to amp.
         if is_interpreter(first) {
-            for t in tokens {
-                if t.starts_with('-') {
-                    continue;
-                }
-                return self.match_interpreter_script(t);
-            }
+            let i = interpreter_script_slot(rest)?;
+            return self.match_interpreter_script(&rest[i]);
         }
         None
     }
@@ -961,6 +957,7 @@ impl Manifests {
     pub fn launch_args_for(&self, running: &[String], agent: &str) -> Option<Vec<String>> {
         for cmd in running {
             let tokens = Self::command_tokens(cmd);
+            let tokens = unwrap_leading_env(&tokens);
             let Some((first, rest)) = tokens.split_first() else {
                 continue;
             };
@@ -968,18 +965,14 @@ impl Manifests {
             if self.match_binary(binary_name(&first_low)).as_deref() == Some(agent) {
                 return Some(rest.iter().map(|s| s.to_string()).collect());
             }
-            // Interpreter form: the agent token is the first non-flag argument,
-            // and nothing before it is a launch flag.
+            // Interpreter form: the agent token is the script slot, and nothing
+            // before it is a launch flag.
             if is_interpreter(binary_name(&first_low)) {
-                for (i, t) in rest.iter().enumerate() {
-                    if t.starts_with('-') {
-                        continue;
-                    }
-                    let t_low = t.to_lowercase();
+                if let Some(i) = interpreter_script_slot(rest) {
+                    let t_low = rest[i].to_lowercase();
                     if self.match_interpreter_script(&t_low).as_deref() == Some(agent) {
                         return Some(rest[(i + 1)..].iter().map(|s| s.to_string()).collect());
                     }
-                    break; // the first non-flag arg is the script slot; nothing later counts
                 }
             }
         }
@@ -1158,12 +1151,59 @@ pub(crate) fn is_interpreter(base: &str) -> bool {
             | "uvx"
             | "ruby"
             | "perl"
-            | "env"
             | "sh"
             | "bash"
             | "zsh"
             | "fish"
     )
+}
+
+/// Conservatively unwrap `env KEY=value command ...`.
+///
+/// Only that form is unwrapped: a leading `env` followed by zero or more
+/// `KEY=value` assignments, then a command. Flags after `env` are an unknown
+/// wrapper and the original argv is left untouched -- later arguments are not
+/// scanned for an agent-looking path.
+fn unwrap_leading_env(tokens: &[String]) -> &[String] {
+    let Some(first) = tokens.first() else {
+        return tokens;
+    };
+    if binary_name(&first.to_lowercase()) != "env" {
+        return tokens;
+    }
+    let mut i = 1;
+    while i < tokens.len() {
+        let t = &tokens[i];
+        if t.starts_with('-') {
+            return tokens;
+        }
+        if !t.contains('=') {
+            return &tokens[i..];
+        }
+        i += 1;
+    }
+    &tokens[i..]
+}
+
+/// Index of the script an interpreter will run, among the arguments after
+/// argv[0]. Flags are skipped. Values consumed by `-r`, `--require`, and
+/// `--loader` are skipped with their option. The first remaining argument is
+/// the script; later arguments are not scanned.
+fn interpreter_script_slot(args: &[String]) -> Option<usize> {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        if arg.starts_with('-') {
+            if matches!(arg, "-r" | "--require" | "--loader") {
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        return Some(i);
+    }
+    None
 }
 
 /// True when `needle` appears in `hay` as a **standalone word**.
@@ -1422,6 +1462,50 @@ mod tests {
                 r#"node C:\work\node_modules\@earendil-works\pi-coding-agent\dist\cli.js"#.into()
             ]),
             Some("pi".into())
+        );
+    }
+
+    #[test]
+    fn interpreter_script_slot_skips_require_value() {
+        let m = Manifests::builtin();
+        let cmd = r#"node --require C:\hooks\loader.js C:\Users\me\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\dist\cli.js --yes"#;
+        assert_eq!(m.agent_in_processes(&[cmd.into()]), Some("pi".into()));
+        assert_eq!(
+            m.launch_args_for(&[cmd.into()], "pi"),
+            Some(vec!["--yes".into()])
+        );
+    }
+
+    #[test]
+    fn interpreter_script_slot_skips_loader_value() {
+        let m = Manifests::builtin();
+        let cmd = r#"node --loader C:\hooks\loader.js C:\Users\me\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\dist\cli.js --yes"#;
+        assert_eq!(m.agent_in_processes(&[cmd.into()]), Some("pi".into()));
+        assert_eq!(
+            m.launch_args_for(&[cmd.into()], "pi"),
+            Some(vec!["--yes".into()])
+        );
+    }
+
+    #[test]
+    fn interpreter_script_slot_ignores_agent_looking_loader() {
+        let m = Manifests::builtin();
+        assert_eq!(
+            m.agent_in_processes(&[
+                r#"node --require C:\work\node_modules\pi-coding-agent\hooks\loader.js C:\work\build.js"#.into()
+            ]),
+            None
+        );
+    }
+
+    #[test]
+    fn interpreter_script_slot_unwraps_env_key_value() {
+        let m = Manifests::builtin();
+        let cmd = r#"env FOO=bar node C:\work\node_modules\@earendil-works\pi-coding-agent\dist\cli.js --yes"#;
+        assert_eq!(m.agent_in_processes(&[cmd.into()]), Some("pi".into()));
+        assert_eq!(
+            m.launch_args_for(&[cmd.into()], "pi"),
+            Some(vec!["--yes".into()])
         );
     }
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1693,6 +1693,26 @@ mod tests {
         assert_eq!(detection.identity_source, "command_fallback");
     }
 
+    #[test]
+    fn successful_process_scan_replaces_a_stale_identity() {
+        let detection = classify(
+            Some("claude"),
+            "claude prompt",
+            false,
+            false,
+            "cmd.exe",
+            "claude",
+            &[
+                r#"cmd.exe /d /k C:\Users\me\.grok\bin\grok.exe --prompt-file C:\Users\me\task.md"#
+                    .into(),
+                r#"C:\Users\me\.grok\bin\grok.exe --prompt-file C:\Users\me\task.md"#.into(),
+            ],
+            &Manifests::builtin(),
+        );
+        assert_eq!(detection.agent, "grok");
+        assert_eq!(detection.identity_source, "process_tree");
+    }
+
     /// A pane is named after the agent *running in it*, never after a word that
     /// happens to be on screen. `amp` is a substring of "example", "sample",
     /// "stamped" and "implementation", so a Claude pane printing ordinary prose

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -930,7 +930,8 @@ impl Manifests {
 
     fn agent_in_process_command(&self, cmd: &str) -> Option<String> {
         let low = cmd.to_lowercase();
-        let mut tokens = low.split_whitespace();
+        let tokens = Self::command_tokens(&low);
+        let mut tokens = tokens.iter().map(String::as_str);
         let first = binary_name(tokens.next()?);
         if let Some(a) = self.match_binary(first) {
             return Some(a);
@@ -944,7 +945,7 @@ impl Manifests {
                 if t.starts_with('-') {
                     continue;
                 }
-                return self.match_binary(binary_name(t));
+                return self.match_interpreter_script(t);
             }
         }
         None
@@ -959,7 +960,7 @@ impl Manifests {
     /// nothing rather than guessing.
     pub fn launch_args_for(&self, running: &[String], agent: &str) -> Option<Vec<String>> {
         for cmd in running {
-            let tokens: Vec<&str> = cmd.split_whitespace().collect();
+            let tokens = Self::command_tokens(cmd);
             let Some((first, rest)) = tokens.split_first() else {
                 continue;
             };
@@ -975,7 +976,7 @@ impl Manifests {
                         continue;
                     }
                     let t_low = t.to_lowercase();
-                    if self.match_binary(binary_name(&t_low)).as_deref() == Some(agent) {
+                    if self.match_interpreter_script(&t_low).as_deref() == Some(agent) {
                         return Some(rest[(i + 1)..].iter().map(|s| s.to_string()).collect());
                     }
                     break; // the first non-flag arg is the script slot; nothing later counts
@@ -983,6 +984,50 @@ impl Manifests {
             }
         }
         None
+    }
+
+    /// Split a process command line into argv-like tokens, retaining spaces
+    /// inside quoted paths such as `"C:\\Program Files\\nodejs\\node.exe"`.
+    fn command_tokens(command: &str) -> Vec<String> {
+        let mut tokens = Vec::new();
+        let mut token = String::new();
+        let mut quoted = false;
+        for character in command.chars() {
+            match character {
+                '"' => quoted = !quoted,
+                character if character.is_whitespace() && !quoted => {
+                    if !token.is_empty() {
+                        tokens.push(std::mem::take(&mut token));
+                    }
+                }
+                character => token.push(character),
+            }
+        }
+        if !token.is_empty() {
+            tokens.push(token);
+        }
+        tokens
+    }
+
+    /// Match an interpreter's script slot by basename or by a distinctive
+    /// package directory in its path. npm shims commonly execute `cli.js`
+    /// from a directory named after the package (`...\\pi-coding-agent\\...`).
+    fn match_interpreter_script(&self, token: &str) -> Option<String> {
+        self.match_binary(binary_name(token)).or_else(|| {
+            let normalized = token.to_lowercase().replace('\\', "/");
+            normalized.split('/').rev().find_map(|segment| {
+                let segment = segment
+                    .strip_suffix(".cjs")
+                    .or_else(|| segment.strip_suffix(".mjs"))
+                    .or_else(|| segment.strip_suffix(".js"))
+                    .or_else(|| segment.strip_suffix(".py"))
+                    .unwrap_or(segment);
+                self.agents
+                    .iter()
+                    .find(|agent| agent.distinct.iter().any(|pattern| *pattern == segment))
+                    .map(|agent| agent.name.clone())
+            })
+        })
     }
 
     /// The agent whose patterns name exactly this binary.
@@ -1269,6 +1314,14 @@ mod tests {
         assert_eq!(
             m.launch_args_for(&["claude".into()], "claude"),
             Some(vec![])
+        );
+        // Windows process inspection supplies the full Node command line, so
+        // Pi's npm package name in the script slot resolves to the agent.
+        assert_eq!(
+            m.agent_in_processes(&[
+                r#""C:\Program Files\nodejs\node.exe" C:\Users\me\AppData\Roaming\npm\node_modules\@earendil-works\pi-coding-agent\dist\cli.js"#.into()
+            ]),
+            Some("pi".into())
         );
     }
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -451,9 +451,9 @@ fn ps_command_table() -> Option<PsTable> {
 }
 
 /// Process identities running under each of `roots` (the root's own included),
-/// from one platform snapshot: command lines on Unix and executable names on
-/// Windows. This batched form lets agent detection cover every pane without one
-/// process-table operation per pane. `None` means the platform cannot tell.
+/// from one platform snapshot. This batched form lets agent detection cover
+/// every pane without one process-table operation per pane. `None` means the
+/// platform cannot tell.
 #[cfg(unix)]
 pub fn descendant_commands(roots: &[u32]) -> Option<std::collections::HashMap<u32, Vec<String>>> {
     use std::collections::{HashMap, HashSet};

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -4,22 +4,27 @@
 //! contract as macOS/Linux without carrying Windows handles through app state.
 
 use std::collections::{HashMap, HashSet};
+use std::ffi::c_void;
 use std::mem::size_of;
 
+use windows_sys::Wdk::System::Threading::{NtQueryInformationProcess, ProcessBasicInformation};
 use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::Security::{
     EqualSid, GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER,
 };
+use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
 use windows_sys::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
 };
 use windows_sys::Win32::System::Threading::{
-    GetCurrentProcess, GetProcessTimes, OpenProcess, OpenProcessToken,
-    PROCESS_QUERY_LIMITED_INFORMATION,
+    GetCurrentProcess, GetProcessTimes, OpenProcess, OpenProcessToken, PEB,
+    PROCESS_BASIC_INFORMATION, PROCESS_QUERY_INFORMATION, PROCESS_QUERY_LIMITED_INFORMATION,
+    PROCESS_VM_READ, RTL_USER_PROCESS_PARAMETERS,
 };
 
 const MAX_PROCESS_ENTRIES: usize = 16_384;
 const MAX_DESCENDANTS_PER_ROOT: usize = 64;
+const MAX_COMMAND_LINE_BYTES: usize = 64 * 1024;
 
 struct OwnedHandle(HANDLE);
 
@@ -42,6 +47,84 @@ impl Drop for OwnedHandle {
 fn open_process(pid: u32) -> Option<OwnedHandle> {
     // SAFETY: the access mask is read-only and `pid` is passed by value.
     OwnedHandle::new(unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) })
+}
+
+fn read_process_memory<T: Default>(process: HANDLE, address: *const c_void) -> Option<T> {
+    let mut value = T::default();
+    let mut bytes_read = 0;
+    // SAFETY: `address` is supplied by the target process and is only read via
+    // the OS API; `value` is writable storage of the exact requested size.
+    let success = unsafe {
+        ReadProcessMemory(
+            process,
+            address,
+            (&mut value as *mut T).cast(),
+            size_of::<T>(),
+            &mut bytes_read,
+        )
+    } != 0;
+    (success && bytes_read == size_of::<T>()).then_some(value)
+}
+
+/// Read a process's full command line from its PEB.
+///
+/// Windows' ToolHelp snapshot exposes only the executable name. The command
+/// line is needed for runtimes such as `node ...\\pi-coding-agent\\...`, where
+/// the agent identity lives in a script argument rather than the executable.
+/// This is best-effort: protected, exited, or differently-bitness processes
+/// fall back to their executable name at the snapshot caller.
+fn process_command_line(pid: u32) -> Option<String> {
+    let process = OwnedHandle::new(unsafe {
+        OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, 0, pid)
+    })?;
+    let mut basic_info = PROCESS_BASIC_INFORMATION::default();
+    let mut return_length = 0_u32;
+    // SAFETY: `basic_info` is writable storage of the documented result size.
+    let status = unsafe {
+        NtQueryInformationProcess(
+            process.0,
+            ProcessBasicInformation,
+            (&mut basic_info as *mut PROCESS_BASIC_INFORMATION).cast(),
+            size_of::<PROCESS_BASIC_INFORMATION>() as u32,
+            &mut return_length,
+        )
+    };
+    if status < 0 || basic_info.PebBaseAddress.is_null() {
+        return None;
+    }
+    let peb = read_process_memory::<PEB>(process.0, basic_info.PebBaseAddress.cast())?;
+    if peb.ProcessParameters.is_null() {
+        return None;
+    }
+    let parameters = read_process_memory::<RTL_USER_PROCESS_PARAMETERS>(
+        process.0,
+        peb.ProcessParameters.cast(),
+    )?;
+    let command_line = parameters.CommandLine;
+    let length = usize::from(command_line.Length);
+    if length == 0 || length % size_of::<u16>() != 0 || length > MAX_COMMAND_LINE_BYTES {
+        return None;
+    }
+    if command_line.Buffer.is_null() {
+        return None;
+    }
+    let mut buffer = vec![0_u16; length / size_of::<u16>()];
+    let mut bytes_read = 0;
+    // SAFETY: the target buffer and length come from the target's live process
+    // parameters; the destination is allocated for exactly `length` bytes.
+    let success = unsafe {
+        ReadProcessMemory(
+            process.0,
+            command_line.Buffer.cast(),
+            buffer.as_mut_ptr().cast(),
+            length,
+            &mut bytes_read,
+        )
+    } != 0;
+    if !success || bytes_read != length {
+        return None;
+    }
+    String::from_utf16(&buffer).ok()
 }
 
 fn token_user(process: HANDLE) -> Option<Vec<usize>> {
@@ -130,6 +213,7 @@ struct ProcessEntry {
 struct ProcessSnapshot {
     names: HashMap<u32, String>,
     children: HashMap<u32, Vec<u32>>,
+    command_lines: HashMap<u32, String>,
 }
 
 impl ProcessSnapshot {
@@ -177,10 +261,14 @@ impl ProcessSnapshot {
         for child_ids in children.values_mut() {
             child_ids.sort_unstable();
         }
-        Self { names, children }
+        Self {
+            names,
+            children,
+            command_lines: HashMap::new(),
+        }
     }
 
-    fn descendants(&self, root: u32) -> Vec<(u32, u16, String)> {
+    fn descendants(&self, root: u32) -> Vec<(u32, u16)> {
         let mut output = Vec::new();
         let mut pending = vec![(root, 0_u16)];
         let mut visited = HashSet::new();
@@ -188,8 +276,8 @@ impl ProcessSnapshot {
             if !visited.insert(pid) || output.len() >= MAX_DESCENDANTS_PER_ROOT {
                 continue;
             }
-            if let Some(executable) = self.names.get(&pid) {
-                output.push((pid, depth, executable.clone()));
+            if self.names.contains_key(&pid) {
+                output.push((pid, depth));
             }
             if let Some(children) = self.children.get(&pid) {
                 pending.extend(
@@ -203,10 +291,20 @@ impl ProcessSnapshot {
         }
         output
     }
+
+    fn command(&mut self, pid: u32) -> String {
+        if let Some(command) = self.command_lines.get(&pid) {
+            return command.clone();
+        }
+        let fallback = self.names.get(&pid).cloned().unwrap_or_default();
+        let command = process_command_line(pid).unwrap_or(fallback);
+        self.command_lines.insert(pid, command.clone());
+        command
+    }
 }
 
 pub(super) fn descendant_commands(roots: &[u32]) -> Option<HashMap<u32, Vec<String>>> {
-    let snapshot = ProcessSnapshot::capture()?;
+    let mut snapshot = ProcessSnapshot::capture()?;
     Some(
         roots
             .iter()
@@ -215,7 +313,7 @@ pub(super) fn descendant_commands(roots: &[u32]) -> Option<HashMap<u32, Vec<Stri
                 let commands = snapshot
                     .descendants(root)
                     .into_iter()
-                    .map(|(_, _, command)| command)
+                    .map(|(pid, _)| snapshot.command(pid))
                     .collect();
                 (root, commands)
             })
@@ -225,14 +323,14 @@ pub(super) fn descendant_commands(roots: &[u32]) -> Option<HashMap<u32, Vec<Stri
 
 pub(super) fn process_tree(root: u32) -> Vec<super::ProcInfo> {
     ProcessSnapshot::capture()
-        .map(|snapshot| {
+        .map(|mut snapshot| {
             snapshot
                 .descendants(root)
                 .into_iter()
-                .map(|(pid, depth, command)| super::ProcInfo {
+                .map(|(pid, depth)| super::ProcInfo {
                     pid,
                     depth,
-                    command,
+                    command: snapshot.command(pid),
                 })
                 .collect()
         })
@@ -257,7 +355,7 @@ mod tests {
         }));
         let descendants = ProcessSnapshot::from_entries(entries).descendants(1);
         assert_eq!(descendants.len(), MAX_DESCENDANTS_PER_ROOT);
-        assert_eq!(descendants[0], (1, 0, "root.exe".into()));
+        assert_eq!(descendants[0], (1, 0));
     }
 
     #[test]
@@ -272,9 +370,25 @@ mod tests {
     #[test]
     fn process_snapshot_contains_the_current_process() {
         let pid = std::process::id();
-        let snapshot = ProcessSnapshot::capture().expect("Windows ToolHelp snapshot");
+        let mut snapshot = ProcessSnapshot::capture().expect("Windows ToolHelp snapshot");
         let root = snapshot.descendants(pid);
         assert_eq!(root.first().map(|entry| entry.0), Some(pid));
-        assert!(root.first().is_some_and(|entry| !entry.2.is_empty()));
+        assert!(!snapshot.command(pid).is_empty());
+    }
+
+    #[test]
+    fn process_command_line_includes_arguments() {
+        let mut child = std::process::Command::new("cmd")
+            .args(["/C", "ping.exe -n 3 127.0.0.1 > nul"])
+            .spawn()
+            .expect("spawn cmd");
+        let commands = descendant_commands(&[child.id()]).expect("capture process tree");
+        let command = commands
+            .get(&child.id())
+            .and_then(|commands| commands.first())
+            .expect("root command line");
+        assert!(command.to_ascii_lowercase().contains("/c"), "{command:?}");
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }


### PR DESCRIPTION
Closes #141

## Summary

- Read full Windows process command lines from the target process PEB while walking pane descendants.
- Parse quoted Windows executable paths and identify npm-packaged agents from distinctive package directories, including `pi-coding-agent`.
- Keep executable-name fallback when a process is protected, exits, or cannot be queried.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --locked detect::tests -- --nocapture`
- `cargo test --locked platform::windows::tests -- --nocapture`
- `cargo check --locked --target x86_64-pc-windows-msvc`
- `cargo clippy --locked --all-targets --target x86_64-pc-windows-msvc -- -D warnings -A clippy::nonminimal_bool`

The full test suite was also attempted; an unrelated existing `app::cwd_test::pane_cwd_follows_cd_without_moving_its_workspace` failure prevented it from completing cleanly in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows process inspection to capture complete command lines, including launch arguments and quoted executable paths.
  - Added fallback handling when command-line details are unavailable.
  - Improved descendant process traversal and command enumeration.
  - Improved interpreter detection for regular and scoped npm packages while avoiding false matches in unrelated directories.
  - Added support for preserving complex quoted arguments during process relaunch.

- **Documentation**
  - Clarified that process identities are derived from a single platform snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->