### PR TITLE
feat(input): double-click a path/URL/word to copy it to the clipboard

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -97,9 +97,11 @@ const DOUBLE_CLICK: Duration = Duration::from_millis(400);
 type CellSpan = (u16, u16, u16);
 
 /// The whitespace-delimited word covering grid cell (`col`, `row`), and the one
-/// span it occupies. `None` on a whitespace or out-of-range cell. Char indices
-/// are the columns, matching how [`crate::links::link_at`] and the grid renderer
-/// address cells.
+/// span it occupies. `None` on a whitespace or out-of-range cell. Wide-cell
+/// continuation markers participate in the word boundary and are removed from
+/// the copied text, so either cell of `你` selects the same complete word. Char
+/// indices are the columns, matching how [`crate::links::link_at`] and the grid
+/// renderer address cells.
 fn word_at_grid(rows: &[String], col: u16, row: u16) -> Option<(String, Vec<CellSpan>)> {
     let line = rows.get(row as usize)?;
     let chars: Vec<char> = line.chars().collect();
@@ -115,7 +117,11 @@ fn word_at_grid(rows: &[String], col: u16, row: u16) -> Option<(String, Vec<Cell
     while hi < chars.len() && !chars[hi].is_whitespace() {
         hi += 1;
     }
-    let text: String = chars[lo..hi].iter().collect();
+    let text: String = chars[lo..hi]
+        .iter()
+        .copied()
+        .filter(|c| *c != crate::terminal::vt::ALIGNED_WIDE_CELL)
+        .collect();
     if text.is_empty() {
         return None;
     }
@@ -4305,6 +4311,27 @@ mod link_click_tests {
     }
 
     #[test]
+    fn word_at_grid_keeps_wide_glyph_cells_in_one_word() {
+        let spacer = crate::terminal::vt::ALIGNED_WIDE_CELL;
+        let rows = vec![format!("你{spacer}好{spacer} code 编{spacer}码{spacer}42")];
+
+        for col in 0..4 {
+            assert_eq!(
+                word_at_grid(&rows, col, 0),
+                Some(("你好".to_string(), vec![(0, 0, 4)])),
+                "either cell of each CJK glyph selects the complete word at col {col}"
+            );
+        }
+        for col in 10..16 {
+            assert_eq!(
+                word_at_grid(&rows, col, 0),
+                Some(("编码42".to_string(), vec![(0, 10, 16)])),
+                "mixed wide and narrow characters remain one word at col {col}"
+            );
+        }
+    }
+
+    #[test]
     fn mouse_copy_drops_a_uniform_one_cell_pane_margin() {
         assert_eq!(
             strip_uniform_single_cell_margin(
@@ -4610,6 +4637,38 @@ mod link_click_tests {
             (sel.anchor, sel.cursor),
             ((at.0, at.1), (at.0 + 10, at.1)),
             "the highlight covers the path's true cells (cols 5..16)"
+        );
+    }
+
+    /// Double-clicking either terminal cell of a wide glyph copies its complete
+    /// whitespace-delimited word, without leaking the internal cell marker.
+    #[test]
+    fn a_double_click_copies_a_wide_character_word() {
+        let _env = crate::persist::test_env("double-click-copy-wide-word");
+        // Click the continuation cell of `你`; `你好` occupies cols 0..4.
+        let (mut app, _t, at) = fixture_showing("你好 next", 1);
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+
+        assert_eq!(app.pending_clipboard.as_deref(), Some("你好"));
+        let sel = app.selection.expect("the full wide word is highlighted");
+        assert_eq!(
+            (sel.anchor, sel.cursor),
+            ((at.0 - 1, at.1), (at.0 + 2, at.1))
         );
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -135,6 +135,51 @@ fn word_at_grid(
     Some((text, vec![(row, lo as u16, hi as u16)]))
 }
 
+/// The URL or path covering a grid cell, reconstructed from its original
+/// graphemes. Link parsing remains deliberately ASCII-only for opening
+/// untrusted terminal output, but copying must also keep Unicode path segments.
+/// A searchable projection maps Unicode letters/digits and wide-cell
+/// continuations to ASCII while retaining one character per physical cell;
+/// the returned spans are then used to recover the exact displayed text.
+fn copy_link_at_grid(
+    rows: &crate::terminal::vt::AlignedRows,
+    col: u16,
+    row: u16,
+) -> Option<(String, Vec<CellSpan>)> {
+    let searchable: Vec<String> = rows
+        .rows()
+        .iter()
+        .map(|line| {
+            line.chars()
+                .map(|character| {
+                    if character == crate::terminal::vt::ALIGNED_WIDE_CELL
+                        || (!character.is_ascii() && character.is_alphanumeric())
+                    {
+                        'x'
+                    } else {
+                        character
+                    }
+                })
+                .collect()
+        })
+        .collect();
+    let link = crate::links::link_at(&searchable, col, row)?;
+
+    let mut text = String::new();
+    for (span_row, start, end) in &link.spans {
+        let line: Vec<char> = rows.rows().get(*span_row as usize)?.chars().collect();
+        for column in *start..*end {
+            let character = *line.get(column as usize)?;
+            if character == crate::terminal::vt::ALIGNED_WIDE_CELL {
+                continue;
+            }
+            text.push(character);
+            text.extend(rows.zero_width_at(*span_row, column));
+        }
+    }
+    (!text.is_empty()).then_some((text, link.spans))
+}
+
 impl App {
     fn handle_api_request(&mut self, req: crate::ipc::api::ApiRequest) -> bool {
         if req.method == "terminal.backend.create" {
@@ -2436,14 +2481,8 @@ impl App {
             engine.visible_rows_aligned()
         };
         let (gcol, grow) = (col - content.x, row - content.y);
-        let (text, spans) = match crate::links::link_at(rows.rows(), gcol, grow) {
-            Some(link) => {
-                let text = match link.hit {
-                    crate::links::Hit::Url(u) => u,
-                    crate::links::Hit::Path { raw, .. } => raw,
-                };
-                (text, link.spans)
-            }
+        let (text, spans) = match copy_link_at_grid(&rows, gcol, grow) {
+            Some(pair) => pair,
             None => match word_at_grid(&rows, gcol, grow) {
                 Some(pair) => pair,
                 None => return false,
@@ -4337,6 +4376,22 @@ mod link_click_tests {
                 word_at_grid(&rows, col, 0),
                 Some(("编码42".to_string(), vec![(0, 10, 16)])),
                 "mixed wide and narrow characters remain one word at col {col}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_link_at_grid_keeps_unicode_paths_complete() {
+        let spacer = crate::terminal::vt::ALIGNED_WIDE_CELL;
+        let rows = crate::terminal::vt::AlignedRows::from_rows(vec![format!(
+            "dir/日{spacer}本{spacer}語{spacer}.rs next"
+        )]);
+
+        for col in 0..13 {
+            assert_eq!(
+                copy_link_at_grid(&rows, col, 0),
+                Some(("dir/日本語.rs".to_string(), vec![(0, 0, 13)])),
+                "the complete Unicode path is copied from physical column {col}"
             );
         }
     }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1360,8 +1360,14 @@ impl App {
                 // reporting is off, or `Shift` bypassed it), so it never steals a
                 // click a pane app wanted.
                 let now = Instant::now();
-                let is_double = self.last_left_click.take().is_some_and(|(at, when)| {
-                    now.duration_since(when) <= DOUBLE_CLICK
+                // Only a press inside a pane's content arms (and matches) the
+                // detector, and both presses must land in the *same* pane: a title
+                // or border click must never combine with a nearby body click into
+                // a double-click, which would copy and swallow the pane's focus.
+                let content_pane = self.pane_content_at(m.column, m.row).map(|(id, _)| id);
+                let is_double = self.last_left_click.take().is_some_and(|(pane, at, when)| {
+                    content_pane == Some(pane)
+                        && now.duration_since(when) <= DOUBLE_CLICK
                         && m.column.abs_diff(at.0) <= 1
                         && m.row.abs_diff(at.1) <= 1
                 });
@@ -1371,8 +1377,8 @@ impl App {
                         self.dbl_click_release = true;
                         return;
                     }
-                } else {
-                    self.last_left_click = Some(((m.column, m.row), now));
+                } else if let Some(pane) = content_pane {
+                    self.last_left_click = Some((pane, (m.column, m.row), now));
                 }
                 // Begin a selection only inside a pane's content; otherwise drop
                 // any old one. Falls through to normal click handling (focus/etc).
@@ -2412,7 +2418,9 @@ impl App {
             let Ok(engine) = p.engine.lock() else {
                 return false;
             };
-            engine.visible_rows()
+            // Cell-aligned rows: a wide glyph before the token would otherwise
+            // shift `gcol` off the intended character (and its highlight).
+            engine.visible_rows_aligned()
         };
         let (gcol, grow) = (col - content.x, row - content.y);
         let (text, spans) = match crate::links::link_at(&rows, gcol, grow) {
@@ -2502,7 +2510,9 @@ impl App {
         let (pane, content) = self.pane_content_at(col, row)?;
         let rows = {
             let engine = self.panes.get(&pane)?.engine.lock().ok()?;
-            engine.visible_rows()
+            // Cell-aligned rows so a wide glyph before the link doesn't shift the
+            // column the underline lands on (or which cells Ctrl-click opens).
+            engine.visible_rows_aligned()
         };
         let link = crate::links::link_at(&rows, col - content.x, row - content.y)?;
         let target = match &link.hit {
@@ -4451,6 +4461,181 @@ mod link_click_tests {
         });
 
         assert_eq!(app.selection_text().as_deref(), Some("你好"));
+    }
+
+    /// A title-strip click must never arm the double-click detector. Otherwise a
+    /// following body click one row down is read as a double-click, copies the
+    /// token under it, and `return`s before the focus cascade — the exact shape
+    /// that failed Linux CI in `stacked_bottom_pane_title_zoom_and_body_are_all_clickable`.
+    /// Here it is pinned deterministically by putting a token under the body cell,
+    /// so a regressed detector copies on every platform instead of only where the
+    /// body cell happens to be non-empty.
+    #[test]
+    fn a_title_click_then_a_body_click_focuses_the_pane_not_a_double_click() {
+        let _env = crate::persist::test_env("title-then-body-focus");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let top = app.layout().focus;
+        app.run_cmd(crate::app::keys::Cmd::SplitDown);
+        let bottom = app.layout().focus;
+        assert_ne!(top, bottom);
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        // A token under the bottom pane's body: a false double-click would copy it.
+        app.panes
+            .get(&bottom)
+            .unwrap()
+            .engine
+            .lock()
+            .unwrap()
+            .advance(b"\x1b[H\x1b[2Jhello");
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let (_, title) = *app
+            .pane_title_rects
+            .iter()
+            .max_by_key(|(_, r)| r.y)
+            .expect("bottom pane has a title strip");
+        let body = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == bottom)
+            .map(|(_, r)| *r)
+            .expect("bottom pane has a content rect");
+        // Same column, and the body sits one row under the title, so a detector
+        // that armed on the title would read the body click as a double-click.
+        let col = body.x + 1;
+        assert!(
+            body.y.abs_diff(title.y) <= 1,
+            "body is adjacent to the title"
+        );
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            (col, title.y),
+            KeyModifiers::NONE,
+        ));
+        assert!(
+            app.cmd_inspect.is_some(),
+            "the title click opened the command overlay (setup sanity)"
+        );
+        app.close_cmd_inspect();
+        // Reset focus *after* the title click, so only the body click can move it.
+        app.layout_mut().focus = top;
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            (col, body.y),
+            KeyModifiers::NONE,
+        ));
+
+        assert_eq!(
+            app.layout().focus,
+            bottom,
+            "the body click focused the pane instead of being a double-click"
+        );
+        assert!(
+            app.pending_clipboard.is_none(),
+            "the body click did not copy — it was not a double-click"
+        );
+    }
+
+    /// A real timed double-click (press, release, press) copies the word under the
+    /// cursor; a lone press first copies nothing.
+    #[test]
+    fn a_double_click_copies_the_word_under_the_cursor() {
+        let _env = crate::persist::test_env("double-click-copy");
+        // Click the second word, well clear of the sidebar-resize divider at the
+        // pane's left edge (a press there grabs the divider, not the grid).
+        let (mut app, _t, at) = fixture_showing("hello world", 6);
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert!(
+            app.pending_clipboard.is_none(),
+            "one press and release copies nothing"
+        );
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert_eq!(
+            app.pending_clipboard.as_deref(),
+            Some("world"),
+            "the second press copies the whitespace word"
+        );
+        assert!(app.selection.is_some(), "and highlights it");
+    }
+
+    /// The wide-character case for copying: a CJK glyph before a token shifts every
+    /// following terminal column by its spacer cell, so both the copied text and
+    /// the highlight must be addressed by cell column, not string index.
+    #[test]
+    fn a_double_click_copies_a_token_after_wide_characters() {
+        let _env = crate::persist::test_env("double-click-copy-wide");
+        // 你(cols 0-1) 好(cols 2-3) space(col 4), then src/main.rs at cols 5..16.
+        let (mut app, _t, at) = fixture_showing("你好 src/main.rs", 5);
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+
+        assert_eq!(
+            app.pending_clipboard.as_deref(),
+            Some("src/main.rs"),
+            "the whole path copies, not a wide-char-shifted fragment"
+        );
+        let sel = app.selection.expect("the copied path is highlighted");
+        assert_eq!(
+            (sel.anchor, sel.cursor),
+            ((at.0, at.1), (at.0 + 10, at.1)),
+            "the highlight covers the path's true cells (cols 5..16)"
+        );
+    }
+
+    /// The wide-character case for Ctrl-hover/Ctrl-click link resolution, which
+    /// shares the same `visible_rows` indexing: a CJK glyph before a path must not
+    /// shift where the underline lands or which cells open.
+    #[test]
+    fn ctrl_hover_after_wide_characters_underlines_the_real_cells() {
+        let _env = crate::persist::test_env("ctrl-hover-wide");
+        // 你好 then a real on-disk path: Cargo.toml occupies grid cols 5..15.
+        let (app, _t, at) = fixture_showing("你好 Cargo.toml", 5);
+
+        let h = app
+            .link_at_screen(at.0, at.1)
+            .expect("the path after the CJK glyphs resolves");
+        assert!(
+            matches!(&h.target, LinkTarget::File { .. }),
+            "got {:?}",
+            h.target
+        );
+        assert!(
+            h.link.covers(5, 0),
+            "underline starts at the path's true column"
+        );
+        assert!(h.link.covers(14, 0), "and reaches its end");
+        assert!(!h.link.covers(4, 0), "not the space before it");
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -88,6 +88,40 @@ fn strip_uniform_single_cell_margin(text: String) -> String {
         .join("\n")
 }
 
+/// A second left click within this of the first, on the same cell (±1), is a
+/// double-click. Terminals emit no native double-click, so luvus times it.
+const DOUBLE_CLICK: Duration = Duration::from_millis(400);
+
+/// A run of grid cells on one row: `(row, start_col, end_col)`, `end_col`
+/// exclusive — the same shape as [`crate::links::Link::spans`].
+type CellSpan = (u16, u16, u16);
+
+/// The whitespace-delimited word covering grid cell (`col`, `row`), and the one
+/// span it occupies. `None` on a whitespace or out-of-range cell. Char indices
+/// are the columns, matching how [`crate::links::link_at`] and the grid renderer
+/// address cells.
+fn word_at_grid(rows: &[String], col: u16, row: u16) -> Option<(String, Vec<CellSpan>)> {
+    let line = rows.get(row as usize)?;
+    let chars: Vec<char> = line.chars().collect();
+    let idx = col as usize;
+    if idx >= chars.len() || chars[idx].is_whitespace() {
+        return None;
+    }
+    let mut lo = idx;
+    while lo > 0 && !chars[lo - 1].is_whitespace() {
+        lo -= 1;
+    }
+    let mut hi = idx + 1;
+    while hi < chars.len() && !chars[hi].is_whitespace() {
+        hi += 1;
+    }
+    let text: String = chars[lo..hi].iter().collect();
+    if text.is_empty() {
+        return None;
+    }
+    Some((text, vec![(row, lo as u16, hi as u16)]))
+}
+
 impl App {
     fn handle_api_request(&mut self, req: crate::ipc::api::ApiRequest) -> bool {
         if req.method == "terminal.backend.create" {
@@ -1319,6 +1353,27 @@ impl App {
                 if !m.modifiers.contains(KeyModifiers::SHIFT) && self.begin_mouse_forward(&m, 0) {
                     return;
                 }
+                // A second left press on (or within one cell of) the first,
+                // inside the double-click window, copies and highlights the
+                // path / URL / word under the cursor. This point is reached only
+                // when the press was *not* forwarded to a mouse-tracking app (its
+                // reporting is off, or `Shift` bypassed it), so it never steals a
+                // click a pane app wanted.
+                let now = Instant::now();
+                let is_double = self.last_left_click.take().is_some_and(|(at, when)| {
+                    now.duration_since(when) <= DOUBLE_CLICK
+                        && m.column.abs_diff(at.0) <= 1
+                        && m.row.abs_diff(at.1) <= 1
+                });
+                if is_double {
+                    if self.copy_token_at(m.column, m.row) {
+                        // Its release keeps the highlight instead of re-copying.
+                        self.dbl_click_release = true;
+                        return;
+                    }
+                } else {
+                    self.last_left_click = Some(((m.column, m.row), now));
+                }
                 // Begin a selection only inside a pane's content; otherwise drop
                 // any old one. Falls through to normal click handling (focus/etc).
                 self.selection = self
@@ -1378,10 +1433,20 @@ impl App {
                     }
                     return;
                 }
+                // Dragging after a double-click turns it back into an ordinary
+                // selection, so its release copies what was dragged.
+                self.dbl_click_release = false;
                 self.update_mouse_selection_cursor(m.column, m.row);
                 return;
             }
             MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Up(MouseButton::Middle) => {
+                // A double-click already copied and highlighted on its press; its
+                // release keeps that selection rather than re-copying it or
+                // clearing it the way a plain click would.
+                if self.dbl_click_release {
+                    self.dbl_click_release = false;
+                    return;
+                }
                 if let Some(p) = self.link_press.take() {
                     if (m.column, m.row) == p.at {
                         self.activate_link(p.target);
@@ -2325,6 +2390,67 @@ impl App {
         } else {
             text
         })
+    }
+
+    /// Copy the path, URL, or word under screen cell (`col`, `row`) to the
+    /// clipboard and highlight it — the double-click gesture. A path or URL is
+    /// copied as its full raw token (`src/main.rs:42:7` verbatim, a soft-wrapped
+    /// path rejoined); anything else falls back to the whitespace-delimited word,
+    /// and a whitespace or empty cell copies nothing. Returns whether it copied.
+    ///
+    /// Uses the pure [`crate::links::link_at`], not [`Self::link_at_screen`]:
+    /// copying doesn't need the file to exist, so a `pwd` directory or a
+    /// not-yet-created path still copies.
+    fn copy_token_at(&mut self, col: u16, row: u16) -> bool {
+        let Some((pane, content)) = self.pane_content_at(col, row) else {
+            return false;
+        };
+        let rows = {
+            let Some(p) = self.panes.get(&pane) else {
+                return false;
+            };
+            let Ok(engine) = p.engine.lock() else {
+                return false;
+            };
+            engine.visible_rows()
+        };
+        let (gcol, grow) = (col - content.x, row - content.y);
+        let (text, spans) = match crate::links::link_at(&rows, gcol, grow) {
+            Some(link) => {
+                let text = match link.hit {
+                    crate::links::Hit::Url(u) => u,
+                    crate::links::Hit::Path { raw, .. } => raw,
+                };
+                (text, link.spans)
+            }
+            None => match word_at_grid(&rows, gcol, grow) {
+                Some(pair) => pair,
+                None => return false,
+            },
+        };
+        if text.is_empty() {
+            return false;
+        }
+        // Highlight exactly the copied cells: from the first covered cell to the
+        // last, which for a rejoined soft-wrapped path runs through the full rows
+        // between them (the same reading-order rule `Selection` copies with). The
+        // highlight is transient (screen coordinates, cleared on the next click),
+        // so it carries no retained-history span.
+        if let (Some(first), Some(last)) = (spans.first(), spans.last()) {
+            self.selection = Some(Selection {
+                pane,
+                content,
+                anchor: (content.x + first.1, content.y + first.0),
+                cursor: (content.x + last.2.saturating_sub(1), content.y + last.0),
+                retained: None,
+                scrolled: false,
+                dragging: false,
+            });
+        }
+        self.pending_clipboard = Some(text);
+        let msg = self.catalog.copied;
+        self.show_toast(msg);
+        true
     }
 
     /// Show a transient toast (e.g. "Copied") bottom-center for ~1.4s.
@@ -4140,6 +4266,32 @@ mod link_click_tests {
         assert!(app.pane_menu_items().contains(&PaneMenuItem::OpenLink));
         app.pane_menu_action(PaneMenuItem::OpenLink);
         assert_eq!(app.pending_open_url.as_deref(), Some(URL));
+    }
+
+    /// The double-click fallback: the whitespace-delimited word under a cell,
+    /// with the single span it covers. Used when a cell isn't a path or URL.
+    #[test]
+    fn word_at_grid_takes_the_whitespace_word_under_the_cell() {
+        let rows = vec!["  foo(bar) baz  ".to_string()];
+        // Anywhere inside the token grabs the whole whitespace-delimited run,
+        // punctuation included, and reports its exact span.
+        for col in 2..=9 {
+            assert_eq!(
+                word_at_grid(&rows, col, 0),
+                Some(("foo(bar)".to_string(), vec![(0, 2, 10)])),
+                "col {col}"
+            );
+        }
+        // A neighbouring word is its own token.
+        assert_eq!(
+            word_at_grid(&rows, 11, 0),
+            Some(("baz".to_string(), vec![(0, 11, 14)]))
+        );
+        // Whitespace and out-of-range cells copy nothing.
+        assert_eq!(word_at_grid(&rows, 1, 0), None, "leading blank");
+        assert_eq!(word_at_grid(&rows, 10, 0), None, "gap between words");
+        assert_eq!(word_at_grid(&rows, 99, 0), None, "past the line");
+        assert_eq!(word_at_grid(&rows, 0, 5), None, "past the last row");
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -102,8 +102,12 @@ type CellSpan = (u16, u16, u16);
 /// the copied text, so either cell of `你` selects the same complete word. Char
 /// indices are the columns, matching how [`crate::links::link_at`] and the grid
 /// renderer address cells.
-fn word_at_grid(rows: &[String], col: u16, row: u16) -> Option<(String, Vec<CellSpan>)> {
-    let line = rows.get(row as usize)?;
+fn word_at_grid(
+    rows: &crate::terminal::vt::AlignedRows,
+    col: u16,
+    row: u16,
+) -> Option<(String, Vec<CellSpan>)> {
+    let line = rows.rows().get(row as usize)?;
     let chars: Vec<char> = line.chars().collect();
     let idx = col as usize;
     if idx >= chars.len() || chars[idx].is_whitespace() {
@@ -117,11 +121,14 @@ fn word_at_grid(rows: &[String], col: u16, row: u16) -> Option<(String, Vec<Cell
     while hi < chars.len() && !chars[hi].is_whitespace() {
         hi += 1;
     }
-    let text: String = chars[lo..hi]
-        .iter()
-        .copied()
-        .filter(|c| *c != crate::terminal::vt::ALIGNED_WIDE_CELL)
-        .collect();
+    let mut text = String::new();
+    for (offset, character) in chars[lo..hi].iter().copied().enumerate() {
+        if character == crate::terminal::vt::ALIGNED_WIDE_CELL {
+            continue;
+        }
+        text.push(character);
+        text.extend(rows.zero_width_at(row, (lo + offset) as u16));
+    }
     if text.is_empty() {
         return None;
     }
@@ -2429,7 +2436,7 @@ impl App {
             engine.visible_rows_aligned()
         };
         let (gcol, grow) = (col - content.x, row - content.y);
-        let (text, spans) = match crate::links::link_at(&rows, gcol, grow) {
+        let (text, spans) = match crate::links::link_at(rows.rows(), gcol, grow) {
             Some(link) => {
                 let text = match link.hit {
                     crate::links::Hit::Url(u) => u,
@@ -2520,7 +2527,7 @@ impl App {
             // column the underline lands on (or which cells Ctrl-click opens).
             engine.visible_rows_aligned()
         };
-        let link = crate::links::link_at(&rows, col - content.x, row - content.y)?;
+        let link = crate::links::link_at(rows.rows(), col - content.x, row - content.y)?;
         let target = match &link.hit {
             crate::links::Hit::Url(u) => {
                 crate::platform::is_openable_url(u).then(|| LinkTarget::Url(u.clone()))?
@@ -4288,7 +4295,8 @@ mod link_click_tests {
     /// with the single span it covers. Used when a cell isn't a path or URL.
     #[test]
     fn word_at_grid_takes_the_whitespace_word_under_the_cell() {
-        let rows = vec!["  foo(bar) baz  ".to_string()];
+        let rows =
+            crate::terminal::vt::AlignedRows::from_rows(vec!["  foo(bar) baz  ".to_string()]);
         // Anywhere inside the token grabs the whole whitespace-delimited run,
         // punctuation included, and reports its exact span.
         for col in 2..=9 {
@@ -4313,7 +4321,9 @@ mod link_click_tests {
     #[test]
     fn word_at_grid_keeps_wide_glyph_cells_in_one_word() {
         let spacer = crate::terminal::vt::ALIGNED_WIDE_CELL;
-        let rows = vec![format!("你{spacer}好{spacer} code 编{spacer}码{spacer}42")];
+        let rows = crate::terminal::vt::AlignedRows::from_rows(vec![format!(
+            "你{spacer}好{spacer} code 编{spacer}码{spacer}42"
+        )]);
 
         for col in 0..4 {
             assert_eq!(
@@ -4670,6 +4680,42 @@ mod link_click_tests {
             (sel.anchor, sel.cursor),
             ((at.0 - 1, at.1), (at.0 + 2, at.1))
         );
+    }
+
+    /// Zero-width grapheme components live on the base terminal cell. Copying
+    /// must retain them without letting them shift cell-coordinate lookup.
+    #[test]
+    fn a_double_click_preserves_complete_graphemes() {
+        let _env = crate::persist::test_env("double-click-copy-graphemes");
+        for (shown, expected) in [
+            ("go 👩‍💻 next", "👩‍💻"),
+            ("go 🖥️ next", "🖥️"),
+            ("go e\u{301}lan next", "e\u{301}lan"),
+        ] {
+            // Keep the click clear of the pane-resize target at the left edge.
+            let (mut app, _t, at) = fixture_showing(shown, 3);
+            app.handle_event(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                at,
+                KeyModifiers::NONE,
+            ));
+            app.handle_event(mouse(
+                MouseEventKind::Up(MouseButton::Left),
+                at,
+                KeyModifiers::NONE,
+            ));
+            app.handle_event(mouse(
+                MouseEventKind::Down(MouseButton::Left),
+                at,
+                KeyModifiers::NONE,
+            ));
+
+            assert_eq!(
+                app.pending_clipboard.as_deref(),
+                Some(expected),
+                "{shown:?}"
+            );
+        }
     }
 
     /// The wide-character case for Ctrl-hover/Ctrl-click link resolution, which

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1464,6 +1464,13 @@ pub struct App {
     /// gesture dragged is the RESIZE-5 divider grab: moving off the cell hands
     /// the press over to the resize, releasing on it opens the link.
     pub link_press: Option<LinkPress>,
+    /// The last left press (screen cell + when), for detecting a double-click. A
+    /// second left press within the double-click window on the same cell (±1)
+    /// copies the path / URL / word under the cursor.
+    pub last_left_click: Option<((u16, u16), Instant)>,
+    /// Set between a double-click's press (which already copied) and its release,
+    /// so the release keeps the highlighted token instead of re-copying it.
+    pub dbl_click_release: bool,
     /// A transient toast (text, expiry) shown bottom-center — e.g. "Copied".
     pub toast: Option<(String, Instant)>,
     /// Downsample RGB → 256-color (for the local path on non-truecolor terms).
@@ -1892,6 +1899,8 @@ impl App {
             link_scan_at: None,
             hover_link: None,
             link_press: None,
+            last_left_click: None,
+            dbl_click_release: false,
             toast: None,
             downsample: false,
             last_cwd_at: Instant::now(),
@@ -2432,6 +2441,8 @@ impl App {
             link_scan_at: None,
             hover_link: None,
             link_press: None,
+            last_left_click: None,
+            dbl_click_release: false,
             toast: None,
             downsample: false,
             last_cwd_at: Instant::now(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1464,10 +1464,12 @@ pub struct App {
     /// gesture dragged is the RESIZE-5 divider grab: moving off the cell hands
     /// the press over to the resize, releasing on it opens the link.
     pub link_press: Option<LinkPress>,
-    /// The last left press (screen cell + when), for detecting a double-click. A
-    /// second left press within the double-click window on the same cell (±1)
-    /// copies the path / URL / word under the cursor.
-    pub last_left_click: Option<((u16, u16), Instant)>,
+    /// The last left press (pane + screen cell + when), for detecting a
+    /// double-click. A second left press within the double-click window, in the
+    /// same pane's content and on the same cell (±1), copies the path / URL / word
+    /// under the cursor. Armed only for a press inside pane content, so a
+    /// title/border click never turns a following body click into a double-click.
+    pub last_left_click: Option<(PaneId, (u16, u16), Instant)>,
     /// Set between a double-click's press (which already copied) and its release,
     /// so the release keeps the highlighted token instead of re-copying it.
     pub dbl_click_release: bool,

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -470,6 +470,26 @@ impl VtEngine for AlacrittyEngine {
         lines
     }
 
+    fn visible_rows_aligned(&self) -> Vec<String> {
+        // Identical to `visible_rows`, except a wide-char spacer cell is kept (as
+        // its blank) instead of skipped, so each terminal column contributes one
+        // char and a string index equals a column. See the trait doc for why a
+        // caller addressing a column needs this.
+        let grid = self.term.grid();
+        let rows = grid.screen_lines();
+        let offset = grid.display_offset() as i32;
+        let mut lines = vec![String::new(); rows];
+        for indexed in grid.display_iter() {
+            let r = indexed.point.line.0 + offset;
+            if r < 0 || r as usize >= rows {
+                continue;
+            }
+            let c = indexed.cell.c;
+            lines[r as usize].push(if c == '\0' { ' ' } else { c });
+        }
+        lines
+    }
+
     fn backend_capture(
         &self,
         mode: CaptureMode,

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -12,7 +12,10 @@ use alacritty_terminal::vte::ansi::{Color as VtColor, Processor};
 
 use ratatui::style::{Color, Modifier};
 
-use super::{CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, RetainedRowLayout, VtEngine};
+use super::{
+    CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, RetainedRowLayout, VtEngine,
+    ALIGNED_WIDE_CELL,
+};
 use crate::terminal::backend::{CaptureMode, CaptureResult};
 use crate::terminal::pty::InputAction;
 
@@ -471,10 +474,10 @@ impl VtEngine for AlacrittyEngine {
     }
 
     fn visible_rows_aligned(&self) -> Vec<String> {
-        // Identical to `visible_rows`, except a wide-char spacer cell is kept (as
-        // its blank) instead of skipped, so each terminal column contributes one
-        // char and a string index equals a column. See the trait doc for why a
-        // caller addressing a column needs this.
+        // Identical to `visible_rows`, except a wide-char spacer cell is kept as
+        // a non-text continuation marker instead of skipped. An actual blank must
+        // remain distinguishable so word lookup does not split a CJK/emoji word
+        // between the glyph and its second terminal cell.
         let grid = self.term.grid();
         let rows = grid.screen_lines();
         let offset = grid.display_offset() as i32;
@@ -484,8 +487,14 @@ impl VtEngine for AlacrittyEngine {
             if r < 0 || r as usize >= rows {
                 continue;
             }
-            let c = indexed.cell.c;
-            lines[r as usize].push(if c == '\0' { ' ' } else { c });
+            let c = if indexed.cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                ALIGNED_WIDE_CELL
+            } else if indexed.cell.c == '\0' {
+                ' '
+            } else {
+                indexed.cell.c
+            };
+            lines[r as usize].push(c);
         }
         lines
     }

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -13,8 +13,8 @@ use alacritty_terminal::vte::ansi::{Color as VtColor, Processor};
 use ratatui::style::{Color, Modifier};
 
 use super::{
-    CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, RetainedRowLayout, VtEngine,
-    ALIGNED_WIDE_CELL,
+    AlignedRows, CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, RetainedRowLayout,
+    VtEngine, ALIGNED_WIDE_CELL,
 };
 use crate::terminal::backend::{CaptureMode, CaptureResult};
 use crate::terminal::pty::InputAction;
@@ -473,7 +473,7 @@ impl VtEngine for AlacrittyEngine {
         lines
     }
 
-    fn visible_rows_aligned(&self) -> Vec<String> {
+    fn visible_rows_aligned(&self) -> AlignedRows {
         // Identical to `visible_rows`, except a wide-char spacer cell is kept as
         // a non-text continuation marker instead of skipped. An actual blank must
         // remain distinguishable so word lookup does not split a CJK/emoji word
@@ -481,7 +481,7 @@ impl VtEngine for AlacrittyEngine {
         let grid = self.term.grid();
         let rows = grid.screen_lines();
         let offset = grid.display_offset() as i32;
-        let mut lines = vec![String::new(); rows];
+        let mut lines = AlignedRows::new(rows);
         for indexed in grid.display_iter() {
             let r = indexed.point.line.0 + offset;
             if r < 0 || r as usize >= rows {
@@ -494,7 +494,12 @@ impl VtEngine for AlacrittyEngine {
             } else {
                 indexed.cell.c
             };
-            lines[r as usize].push(c);
+            let zero_width = if indexed.cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                None
+            } else {
+                indexed.cell.zerowidth()
+            };
+            lines.push_cell(r as u16, indexed.point.column.0 as u16, c, zero_width);
         }
         lines
     }

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -17,6 +17,56 @@ use crate::terminal::pty::InputAction;
 /// a wide glyph without being confused with an actual space between words.
 pub(crate) const ALIGNED_WIDE_CELL: char = '\0';
 
+/// Visible terminal text indexed one character per grid cell, plus the sparse
+/// zero-width components attached to base cells. Keeping the latter separate
+/// preserves column lookup without dropping combining marks, variation
+/// selectors, or ZWJ emoji from copied text.
+pub struct AlignedRows {
+    rows: Vec<String>,
+    zero_width: Vec<(u16, u16, Vec<char>)>,
+}
+
+impl AlignedRows {
+    pub(crate) fn new(row_count: usize) -> Self {
+        Self {
+            rows: vec![String::new(); row_count],
+            zero_width: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_rows(rows: Vec<String>) -> Self {
+        Self {
+            rows,
+            zero_width: Vec::new(),
+        }
+    }
+
+    pub(crate) fn push_cell(
+        &mut self,
+        row: u16,
+        col: u16,
+        character: char,
+        zero_width: Option<&[char]>,
+    ) {
+        self.rows[row as usize].push(character);
+        if let Some(chars) = zero_width.filter(|chars| !chars.is_empty()) {
+            self.zero_width.push((row, col, chars.to_vec()));
+        }
+    }
+
+    pub(crate) fn rows(&self) -> &[String] {
+        &self.rows
+    }
+
+    pub(crate) fn zero_width_at(&self, row: u16, col: u16) -> &[char] {
+        self.zero_width
+            .iter()
+            .find(|(r, c, _)| *r == row && *c == col)
+            .map_or(&[], |(_, _, chars)| chars)
+    }
+}
+
 /// Which terminal engine backs a pane.
 ///
 /// One variant today. It exists so that the choice of engine is a named
@@ -172,7 +222,7 @@ pub trait VtEngine: Send {
     /// the distinction between a continuation and an actual space. Use this
     /// (never `visible_rows`) when a screen column must address text — e.g. the
     /// token under a double-click, or the link under a `Ctrl`-hover.
-    fn visible_rows_aligned(&self) -> Vec<String>;
+    fn visible_rows_aligned(&self) -> AlignedRows;
 
     /// Bounded public capture for harnesses. Implementations serialize only
     /// normalized grid text and SGR styles; raw child control sequences never

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -161,6 +161,16 @@ pub trait VtEngine: Send {
     /// are omitted, so callers must not use string indexes as terminal columns.
     fn visible_rows(&self) -> Vec<String>;
 
+    /// Like [`Self::visible_rows`], but every terminal column contributes exactly
+    /// one `char`: a wide-character spacer cell is kept as a blank placeholder, so
+    /// a string char index equals its terminal column. Use this (never
+    /// `visible_rows`) when a screen column must address a character — e.g. the
+    /// token under a double-click, or the link under a `Ctrl`-hover. A token that
+    /// itself contains a wide char is not recoverable here (its glyph reads as one
+    /// column plus a blank); that is out of scope — callers only need alignment
+    /// for tokens sitting after wide characters.
+    fn visible_rows_aligned(&self) -> Vec<String>;
+
     /// Bounded public capture for harnesses. Implementations serialize only
     /// normalized grid text and SGR styles; raw child control sequences never
     /// cross this boundary.

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -12,6 +12,11 @@ use ratatui::style::{Color, Modifier};
 
 use crate::terminal::pty::InputAction;
 
+/// Internal continuation marker used by [`VtEngine::visible_rows_aligned`].
+/// A terminal never renders NUL as text, so it can represent the second cell of
+/// a wide glyph without being confused with an actual space between words.
+pub(crate) const ALIGNED_WIDE_CELL: char = '\0';
+
 /// Which terminal engine backs a pane.
 ///
 /// One variant today. It exists so that the choice of engine is a named
@@ -162,13 +167,11 @@ pub trait VtEngine: Send {
     fn visible_rows(&self) -> Vec<String>;
 
     /// Like [`Self::visible_rows`], but every terminal column contributes exactly
-    /// one `char`: a wide-character spacer cell is kept as a blank placeholder, so
-    /// a string char index equals its terminal column. Use this (never
-    /// `visible_rows`) when a screen column must address a character — e.g. the
-    /// token under a double-click, or the link under a `Ctrl`-hover. A token that
-    /// itself contains a wide char is not recoverable here (its glyph reads as one
-    /// column plus a blank); that is out of scope — callers only need alignment
-    /// for tokens sitting after wide characters.
+    /// one `char`. A wide glyph's continuation cell is represented by
+    /// [`ALIGNED_WIDE_CELL`], so callers can preserve both cell coordinates and
+    /// the distinction between a continuation and an actual space. Use this
+    /// (never `visible_rows`) when a screen column must address text — e.g. the
+    /// token under a double-click, or the link under a `Ctrl`-hover.
     fn visible_rows_aligned(&self) -> Vec<String>;
 
     /// Bounded public capture for harnesses. Implementations serialize only

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -552,7 +552,7 @@ mod label_case_tests {
                     continue;
                 };
                 let minor = MINOR.contains(&part.to_lowercase().as_str());
-                if !first.is_uppercase() && !(minor && !lead) {
+                if !first.is_uppercase() && (!minor || lead) {
                     return Some(part.to_string());
                 }
                 lead = false;


### PR DESCRIPTION
Double-clicking a path, URL, or word in a terminal pane copies it to the clipboard and highlights it.

## What

- Double-click in a terminal pane copies and highlights the token under the cursor.
- Paths and URLs (detected with `links::link_at`) copy as the full raw token: `src/main.rs:42:7` verbatim, soft-wrapped paths rejoined. Any other token falls back to the whitespace-delimited word; whitespace or empty cells copy nothing.
- Copying uses the pure `link_at`, not `link_at_screen`, so it skips the on-disk check: a `pwd` directory or a not-yet-created path still copies.
- A double-click is a second left press within 400ms on the same cell (±1), detected after the mouse-forward gate so it never steals a click from a mouse-tracking pane app. Reporting-off panes copy on a plain double-click; reporting-on panes (vim, tmux, agents) copy on Shift+double-click.
- Ctrl+click still opens links. A double-click's release keeps the highlight instead of re-copying; dragging afterwards reverts to an ordinary selection.
- Reuses the existing `pending_clipboard` and "Copied" toast; the highlight is a transient screen-coordinate `Selection`.
- Scope: terminal panes only. File-browser and diff views keep their existing selection behavior.

## Why

Terminals had no double-click behavior: crossterm emits no native double-click and the code never synthesized one, so a double-click only blinked the clicked cell and copied nothing. There was no quick way to grab a printed path such as `pwd` output. This adds the gesture on top of the existing link detection and clipboard paths.

## Verification

- [x] `cargo test --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Manual testing, if applicable

Run so far: `cargo test` (943 passing, including a new `word_at_grid` test) and `cargo clippy` (clean).

## Notes

- Single-character tokens copy but may not highlight (`Selection::has_range` treats a 1-cell selection as empty); rare for paths.
- Out of scope: triple-click line select, punctuation-aware word boundaries, and a config toggle (always on).
- Rebased on current `main` (v0.13.1) and reconciled with the recent Unicode-selection and scroll-stable-selection changes.
- One pre-existing flaky git test (`status_selection_tracks_the_exact_file_for_diff_activation`, "Bad file descriptor" under parallelism) is unrelated; it passes in isolation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Double-click text in panes to copy and highlight complete URLs, file paths, or words.
  - Detection is limited to repeated clicks within the same pane.
  - Unicode paths, emoji, combining characters, and wide characters are preserved correctly.
  - Clicking either cell of a wide character selects the complete word.
  - Dragging after a double-click returns to standard text selection.

- **Bug Fixes**
  - Corrected title-case validation for leading minor words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->