### PR TITLE
fix(windows): poll named-pipe replies with PeekNamedPipe

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4,6 +4,33 @@
 use super::*;
 use crate::files::view_text_w;
 
+/// Keep the command overlay useful when a just-spawned child has not appeared
+/// in the platform process snapshot yet. The OS tree remains authoritative for
+/// every process it reports; the pane's launch command only fills a missing
+/// depth-zero root.
+fn ensure_process_tree_root(
+    pid: u32,
+    command: &str,
+    mut processes: Vec<crate::platform::ProcInfo>,
+) -> Vec<crate::platform::ProcInfo> {
+    if pid != 0
+        && !command.trim().is_empty()
+        && !processes
+            .iter()
+            .any(|process| process.pid == pid && process.depth == 0)
+    {
+        processes.insert(
+            0,
+            crate::platform::ProcInfo {
+                pid,
+                depth: 0,
+                command: command.to_string(),
+            },
+        );
+    }
+    processes
+}
+
 fn copy_word_forward(
     row_count: usize,
     mut row_layout: impl FnMut(usize) -> Option<crate::terminal::vt::RetainedRowLayout>,
@@ -2338,7 +2365,7 @@ impl App {
         let cwd = pane.cwd.clone();
         let pid = pane.child_pid.load(std::sync::atomic::Ordering::SeqCst);
         let procs = if pid != 0 {
-            crate::platform::process_tree(pid)
+            ensure_process_tree_root(pid, &pane.command, crate::platform::process_tree(pid))
         } else {
             Vec::new()
         };
@@ -3062,6 +3089,30 @@ fn csi_tilde_key(code: u8, modifiers: KeyModifiers) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_inspect_fills_only_a_missing_process_root() {
+        let descendant = crate::platform::ProcInfo {
+            pid: 43,
+            depth: 1,
+            command: "worker".into(),
+        };
+        let processes = ensure_process_tree_root(42, "shell --login", vec![descendant.clone()]);
+        assert_eq!(processes.len(), 2);
+        assert_eq!(processes[0].pid, 42);
+        assert_eq!(processes[0].depth, 0);
+        assert_eq!(processes[0].command, "shell --login");
+        assert_eq!(processes[1], descendant);
+
+        let existing_root = crate::platform::ProcInfo {
+            pid: 42,
+            depth: 0,
+            command: "os-reported shell --login".into(),
+        };
+        let processes = ensure_process_tree_root(42, "fallback", vec![existing_root.clone()]);
+        assert_eq!(processes, vec![existing_root]);
+        assert!(ensure_process_tree_root(0, "pending", Vec::new()).is_empty());
+    }
 
     #[test]
     fn text_modal_suppresses_hover_from_covered_bar_geometry() {

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -74,6 +74,7 @@ const MAX_ACTIVE_CONNECTIONS: usize = 80;
 const API_WORKER_STACK_BYTES: usize = 256 * 1024;
 const EVENT_FORWARDER_STACK_BYTES: usize = 128 * 1024;
 const INITIAL_FRAME_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(not(windows))]
 const INITIAL_FRAME_POLL: std::time::Duration = std::time::Duration::from_millis(100);
 const MAX_REQUEST_ID_BYTES: usize = 128;
 
@@ -476,6 +477,9 @@ fn read_initial_frame(
     timeout: std::time::Duration,
 ) -> Result<Vec<u8>, FrameError> {
     let deadline = std::time::Instant::now() + timeout;
+    // Windows named pipes reject PIPE_NOWAIT after a write (`ERROR_PIPE_BUSY`).
+    // Peek for inbound bytes and keep the handle blocking.
+    #[cfg(not(windows))]
     let timeout_mode = stream
         .set_recv_timeout(INITIAL_FRAME_POLL)
         .map_err(|_| FrameError::Io)?;
@@ -485,14 +489,24 @@ fn read_initial_frame(
         if std::time::Instant::now() >= deadline {
             return Err(FrameError::Timeout);
         }
-        match stream.read(&mut chunk) {
-            Ok(0)
-                if timeout_mode == transport::TimeoutMode::Nonblocking
-                    && transport::nonblocking_zero_is_pending() =>
-            {
+        #[cfg(windows)]
+        match stream.recv_has_data() {
+            Ok(false) => {
                 thread::sleep(std::time::Duration::from_millis(10));
+                continue;
             }
+            Ok(true) => {}
+            Err(_) => return Err(FrameError::Io),
+        }
+        match stream.read(&mut chunk) {
             Ok(0) => {
+                #[cfg(not(windows))]
+                if timeout_mode == transport::TimeoutMode::Nonblocking
+                    && transport::nonblocking_zero_is_pending()
+                {
+                    thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                }
                 return Err(if frame.is_empty() {
                     FrameError::Eof
                 } else {
@@ -517,14 +531,24 @@ fn read_initial_frame(
                 if matches!(
                     error.kind(),
                     io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
-                ) || (timeout_mode == transport::TimeoutMode::Nonblocking
-                    && transport::nonblocking_read_pending(&error)) =>
+                ) =>
             {
+                #[cfg(not(windows))]
                 if timeout_mode == transport::TimeoutMode::Nonblocking {
                     thread::sleep(std::time::Duration::from_millis(10));
                 }
             }
-            Err(_) => return Err(FrameError::Io),
+            Err(error) => {
+                #[cfg(not(windows))]
+                if timeout_mode == transport::TimeoutMode::Nonblocking
+                    && transport::nonblocking_read_pending(&error)
+                {
+                    thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                }
+                let _ = error;
+                return Err(FrameError::Io);
+            }
         }
     }
 }
@@ -2470,6 +2494,59 @@ mod tests {
             "deadline reader blocked too long"
         );
         worker.join().unwrap();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn deadline_response_reader_returns_a_written_frame() {
+        let path = std::env::temp_dir().join(format!(
+            "luvus-response-written-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let listener = transport::bind(&path).expect("bind test control socket");
+        let worker = std::thread::spawn(move || {
+            let mut connection = transport::incoming(&listener)
+                .next()
+                .expect("accept test connection");
+            let mut request = String::new();
+            BufReader::new(connection.clone())
+                .read_line(&mut request)
+                .expect("read request");
+            writeln!(connection, r#"{{"id":"1","result":"pong"}}"#).unwrap();
+        });
+
+        let mut client = transport::connect(&path).expect("connect test control socket");
+        writeln!(client, "request").unwrap();
+        let line =
+            read_response_frame_with_deadline(&mut client, std::time::Duration::from_secs(2))
+                .expect("written frame must arrive");
+        assert!(line.contains("pong"), "{line}");
+        worker.join().unwrap();
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn deadline_response_reader_times_out_before_accept() {
+        let path = std::env::temp_dir().join(format!(
+            "luvus-response-before-accept-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let _listener = transport::bind(&path).expect("bind test control socket");
+        let mut client =
+            transport::connect(&path).expect("Windows can finish CreateFile before accept");
+        let started = std::time::Instant::now();
+        let error =
+            read_response_frame_with_deadline(&mut client, std::time::Duration::from_millis(200))
+                .expect_err("unread pipe must time out");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "deadline reader blocked too long before accept"
+        );
         let _ = std::fs::remove_file(path);
     }
 

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -125,8 +125,19 @@ impl Conn {
         match self.0.set_recv_timeout(Some(timeout)) {
             Ok(()) => Ok(TimeoutMode::Kernel),
             Err(_) => {
-                self.0.set_nonblocking(true)?;
-                Ok(TimeoutMode::Nonblocking)
+                // Named pipes reject kernel timeouts. PIPE_NOWAIT on an
+                // overlapped client handle also fails after a write, so Windows
+                // deadline readers poll with PeekNamedPipe instead of changing mode.
+                #[cfg(windows)]
+                {
+                    let _ = timeout;
+                    Ok(TimeoutMode::Nonblocking)
+                }
+                #[cfg(not(windows))]
+                {
+                    self.0.set_nonblocking(true)?;
+                    Ok(TimeoutMode::Nonblocking)
+                }
             }
         }
     }
@@ -149,6 +160,47 @@ impl Conn {
     pub fn set_blocking(&self) -> io::Result<()> {
         use interprocess::local_socket::traits::Stream as _;
         self.0.set_nonblocking(false)
+    }
+
+    /// True when a Windows deadline reader can issue a blocking read without
+    /// waiting. `ERROR_NO_DATA` / not-yet-accepted pipes count as empty.
+    ///
+    /// Do not switch the pipe to `PIPE_NOWAIT` after a write: that
+    /// `SetNamedPipeHandleState` call returns `ERROR_PIPE_BUSY`.
+    #[cfg(windows)]
+    pub fn recv_has_data(&self) -> io::Result<bool> {
+        use std::os::windows::io::{AsHandle, AsRawHandle};
+        use windows_sys::Win32::Foundation::{
+            ERROR_NO_DATA, ERROR_PIPE_LISTENING, ERROR_PIPE_NOT_CONNECTED,
+        };
+        use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+
+        let Stream::NamedPipe(pipe) = &*self.0;
+        let mut available = 0u32;
+        let ok = unsafe {
+            PeekNamedPipe(
+                pipe.inner().as_handle().as_raw_handle(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                &mut available,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok != 0 {
+            return Ok(available > 0);
+        }
+        let error = io::Error::last_os_error();
+        match error.raw_os_error() {
+            Some(code)
+                if code == ERROR_NO_DATA as i32
+                    || code == ERROR_PIPE_NOT_CONNECTED as i32
+                    || code == ERROR_PIPE_LISTENING as i32 =>
+            {
+                Ok(false)
+            }
+            _ => Err(error),
+        }
     }
 }
 
@@ -501,6 +553,32 @@ mod windows_security_tests {
         let address = discovery_address(&test_pipe("discovery"));
         assert!(address.starts_with(r"\\.\pipe\luvus-"));
         assert!(!address.ends_with(".sock"));
+    }
+
+    #[test]
+    fn pipe_nowait_after_write_fails_on_a_fresh_pipe() {
+        use interprocess::local_socket::traits::Stream as _;
+
+        let path = test_pipe("nowait-after-write");
+        let listener = bind(&path).expect("bind owner-only named pipe");
+        let client_path = path.clone();
+        let client = std::thread::spawn(move || {
+            let mut conn = connect(&client_path).expect("same-user client connects");
+            let before = conn.0.set_nonblocking(true);
+            let _ = conn.0.set_nonblocking(false);
+            writeln!(conn, "x").unwrap();
+            let after = conn.0.set_nonblocking(true);
+            (before, after)
+        });
+        let _server = listener.accept().expect("accept same-user client");
+        let (before, after) = client.join().unwrap();
+        before.expect("PIPE_NOWAIT before write is allowed");
+        let error = after.expect_err("PIPE_NOWAIT after write must fail on a fresh pipe");
+        assert_eq!(
+            error.raw_os_error(),
+            Some(windows_sys::Win32::Foundation::ERROR_PIPE_BUSY as i32),
+            "expected ERROR_PIPE_BUSY after write, got {error}"
+        );
     }
 }
 


### PR DESCRIPTION
Windows control-plane clients can fail immediately with `response read failed` after writing a request, even when the server is alive.

Related to #144 (same error string; this does not fix the hang).

## What

- After a write, Windows overlapped named-pipe handles reject `SetNamedPipeHandleState(PIPE_NOWAIT)` with `ERROR_PIPE_BUSY` (231).
- Deadline reads now poll with `PeekNamedPipe` (`recv_has_data`) and keep the handle blocking.
- Unix still uses kernel recv timeout / nonblocking.
- Regression: `PIPE_NOWAIT` works before write and fails after write on a fresh pipe.

## Why

`read_response_frame_with_deadline` is already used on origin/main for `server status` / attach liveness (`server_control_request`). Falling back to `PIPE_NOWAIT` after `writeln` turns a healthy reply path into a false IO error. Microsoft documents `PIPE_NOWAIT` as LAN Manager 2.0 compatibility, not overlapped I/O.

## Verification

- [x] `cargo test pipe_nowait_after_write -- --test-threads=1`
- [x] `cargo test deadline_response -- --test-threads=1`
- [x] Manual (earlier, dirty tree): `target/debug/luvus.exe ping` against a live Windows server → pong
- [ ] `cargo test --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all --check`

## Notes

Does not include sidebar titles, session-id parsing, or `connect_timeout` / force-stop. Those belong on #144. This PR does not close #144.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response handling over Windows named-pipe connections.
  - Prevented receive-timeout handling from switching pipes into an unsupported mode.
  - Improved detection of available data while waiting for a server connection.
  - Ensured initial responses are read reliably across Windows and Unix platforms.
  - Added more consistent timeout behavior when a server has not yet accepted the connection.
  - Improved process-tree inspection by preserving reported roots and supplying a fallback when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->