### PR TITLE
fix(server): force-stop when the named pipe no longer answers

### DIFF
--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -257,7 +257,9 @@ pub fn run() -> Result<()> {
     let client_sock = persist::client_socket_path();
     // A responsive listener means another server owns this state directory.
     // Do not reclaim either socket or start a competing process.
-    if transport::connect(&sock).is_ok() || transport::connect(&client_sock).is_ok() {
+    if transport::connect_timeout(&sock, Duration::from_millis(50)).is_ok()
+        || transport::connect_timeout(&client_sock, Duration::from_millis(50)).is_ok()
+    {
         return Ok(());
     }
     let _logging = crate::logging::init(crate::logging::Role::Server);
@@ -368,6 +370,7 @@ pub fn run() -> Result<()> {
             crate::logging::Field::RestoreSkipped(0),
         ],
     );
+    let _pid_file = persist::ServerPidFile::claim();
     // The session is restored and the API socket is listening, so a module's
     // `[[startup]]` hooks can now call back in — this is where a module
     // repaints the docks it owns (docs/13 §3.7).

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -257,8 +257,8 @@ pub fn run() -> Result<()> {
     let client_sock = persist::client_socket_path();
     // A responsive listener means another server owns this state directory.
     // Do not reclaim either socket or start a competing process.
-    if transport::connect_timeout(&sock, Duration::from_millis(50)).is_ok()
-        || transport::connect_timeout(&client_sock, Duration::from_millis(50)).is_ok()
+    if transport::endpoint_exists(&sock, Duration::from_millis(50))
+        || transport::endpoint_exists(&client_sock, Duration::from_millis(50))
     {
         return Ok(());
     }

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -151,16 +151,8 @@ impl Conn {
         match self.0.set_send_timeout(Some(timeout)) {
             Ok(()) => Ok(TimeoutMode::Kernel),
             Err(error) if error.kind() == io::ErrorKind::Unsupported => {
-                #[cfg(windows)]
-                {
-                    let _ = timeout;
-                    Ok(TimeoutMode::Nonblocking)
-                }
-                #[cfg(not(windows))]
-                {
-                    self.0.set_nonblocking(true)?;
-                    Ok(TimeoutMode::Nonblocking)
-                }
+                self.0.set_nonblocking(true)?;
+                Ok(TimeoutMode::Nonblocking)
             }
             Err(error) => Err(error),
         }

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -202,6 +202,47 @@ impl Conn {
             _ => Err(error),
         }
     }
+
+    /// PID of the process that owns the listening endpoint.
+    ///
+    /// Used by `server stop` when the app loop no longer answers: the pipe or
+    /// socket can still accept connections while requests hang forever.
+    pub fn server_pid(&self) -> io::Result<u32> {
+        #[cfg(windows)]
+        {
+            let Stream::NamedPipe(pipe) = &*self.0;
+            pipe.inner().server_process_id()
+        }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            use std::mem::{size_of, zeroed};
+            use std::os::fd::AsRawFd;
+
+            let Stream::UdSocket(socket) = &*self.0;
+            let mut credentials: libc::ucred = unsafe { zeroed() };
+            let mut len = size_of::<libc::ucred>() as libc::socklen_t;
+            let result = unsafe {
+                libc::getsockopt(
+                    socket.inner().as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_PEERCRED,
+                    (&raw mut credentials).cast(),
+                    &raw mut len,
+                )
+            };
+            if result != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(credentials.pid as u32)
+        }
+        #[cfg(not(any(windows, target_os = "linux", target_os = "android")))]
+        {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "server pid is not available on this transport",
+            ))
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -431,6 +472,47 @@ pub(crate) fn discovery_address(path: &Path) -> String {
     }
 }
 
+/// Connect, but do not block the caller forever.
+///
+/// Windows named-pipe `connect` waits indefinitely when every instance is busy.
+/// A helper thread cannot fix that: `main` still waits for the blocked
+/// `connect` thread, so `ping` / `server stop` appear hung after the timeout.
+/// Wait on the pipe with a kernel timeout, then connect.
+pub fn connect_timeout(path: &Path, timeout: Duration) -> io::Result<Conn> {
+    #[cfg(windows)]
+    {
+        wait_for_named_pipe(path, timeout)?;
+        connect(path)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = timeout;
+        connect(path)
+    }
+}
+
+#[cfg(windows)]
+fn wait_for_named_pipe(path: &Path, timeout: Duration) -> io::Result<()> {
+    use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
+
+    let name = format!(r"\\.\pipe\{}", pipe_id(path));
+    let wide: Vec<u16> = name.encode_utf16().chain(Some(0)).collect();
+    let ms = u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX);
+    let ok = unsafe { WaitNamedPipeW(wide.as_ptr(), ms) };
+    if ok != 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    // ERROR_SEM_TIMEOUT (121): the wait elapsed with no free instance.
+    if error.raw_os_error() == Some(121) {
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "connection timed out",
+        ));
+    }
+    Err(error)
+}
+
 /// Connect to a server socket identified by a per-session filesystem path.
 pub fn connect(path: &Path) -> io::Result<Conn> {
     #[cfg(windows)]
@@ -578,6 +660,40 @@ mod windows_security_tests {
             error.raw_os_error(),
             Some(windows_sys::Win32::Foundation::ERROR_PIPE_BUSY as i32),
             "expected ERROR_PIPE_BUSY after write, got {error}"
+        );
+    }
+
+    #[test]
+    fn client_sees_the_named_pipe_server_pid() {
+        let path = test_pipe("server-pid");
+        let listener = bind(&path).expect("bind owner-only named pipe");
+        let client_path = path.clone();
+        let expected = std::process::id();
+        let client = std::thread::spawn(move || {
+            let conn = connect(&client_path).expect("same-user client connects");
+            conn.server_pid().expect("named-pipe server pid")
+        });
+        let _server = listener.accept().expect("accept same-user client");
+        assert_eq!(client.join().unwrap(), expected);
+    }
+
+    #[test]
+    fn connect_timeout_fails_fast_when_the_pipe_is_absent() {
+        match connect_timeout(&test_pipe("missing"), Duration::from_secs(1)) {
+            Ok(_) => panic!("absent pipe must not connect"),
+            Err(err) => assert_ne!(err.kind(), io::ErrorKind::TimedOut),
+        }
+    }
+
+    #[test]
+    fn connect_timeout_returns_quickly_when_the_pipe_is_listening() {
+        let path = test_pipe("listening-no-accept");
+        let _listener = bind(&path).expect("bind owner-only named pipe");
+        let started = std::time::Instant::now();
+        let _ = connect_timeout(&path, Duration::from_millis(200));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "connect_timeout must not pin the process on a listening pipe"
         );
     }
 }

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -773,14 +773,9 @@ mod windows_security_tests {
     #[test]
     fn connect_timeout_times_out_when_every_instance_is_busy() {
         let path = test_pipe("busy-timeout");
-        let listener = bind(&path).expect("bind owner-only named pipe");
-        let occupied_path = path.clone();
-        let occupied = std::thread::spawn(move || connect(&occupied_path));
-        let _peer = listener.accept().expect("accept occupying client");
-        let first = occupied
-            .join()
-            .expect("occupying connect")
-            .expect("occupying client");
+        let _listener = bind(&path).expect("bind owner-only named pipe");
+        let first = connect_timeout(&path, Duration::from_millis(200))
+            .expect("first client occupies the free instance");
         let started = std::time::Instant::now();
         let result = connect_timeout(&path, Duration::from_millis(200));
         assert!(
@@ -789,10 +784,8 @@ mod windows_security_tests {
         );
         match result {
             Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
-            Ok(_) => {
-                // Listener may have created another instance; still must be fast.
-            }
-            Err(error) => panic!("unexpected connect_timeout error: {error}"),
+            Ok(_) => panic!("busy pipe must time out, got a connection"),
+            Err(error) => panic!("busy pipe must time out, got {error}"),
         }
         drop(first);
     }

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -9,6 +9,8 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(windows)]
+use std::time::Instant;
 
 use fs2::FileExt;
 use interprocess::local_socket::prelude::*;
@@ -478,15 +480,13 @@ pub(crate) fn discovery_address(path: &Path) -> String {
 
 /// Connect, but do not block the caller forever.
 ///
-/// Windows named-pipe `connect` waits indefinitely when every instance is busy.
-/// A helper thread cannot fix that: `main` still waits for the blocked
-/// `connect` thread, so `ping` / `server stop` appear hung after the timeout.
-/// Wait on the pipe with a kernel timeout, then connect.
+/// Windows named-pipe `CreateFile` waits indefinitely when every instance is
+/// busy. Loop `CreateFile` / `WaitNamedPipe` against the remaining deadline
+/// instead of calling unbounded `connect()` after one successful wait.
 pub fn connect_timeout(path: &Path, timeout: Duration) -> io::Result<Conn> {
     #[cfg(windows)]
     {
-        wait_for_named_pipe(path, timeout)?;
-        connect(path)
+        connect_named_pipe_timeout(path, timeout)
     }
     #[cfg(not(windows))]
     {
@@ -521,25 +521,64 @@ pub fn endpoint_exists(path: &Path, timeout: Duration) -> bool {
 }
 
 #[cfg(windows)]
-fn wait_for_named_pipe(path: &Path, timeout: Duration) -> io::Result<()> {
+fn connect_named_pipe_timeout(path: &Path, timeout: Duration) -> io::Result<Conn> {
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+    use windows_sys::Win32::Foundation::{
+        ERROR_PIPE_BUSY, ERROR_SEM_TIMEOUT, GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_OVERLAPPED, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
     use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
 
     let name = format!(r"\\.\pipe\{}", pipe_id(path));
     let wide: Vec<u16> = name.encode_utf16().chain(Some(0)).collect();
-    let ms = u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX);
-    let ok = unsafe { WaitNamedPipeW(wide.as_ptr(), ms) };
-    if ok != 0 {
-        return Ok(());
+    let deadline = Instant::now() + timeout;
+    loop {
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                std::ptr::null_mut(),
+                OPEN_EXISTING,
+                FILE_FLAG_OVERLAPPED,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle != INVALID_HANDLE_VALUE {
+            let owned = unsafe { OwnedHandle::from_raw_handle(handle) };
+            let np = interprocess::os::windows::named_pipe::local_socket::Stream::try_from(owned)
+                .map_err(|error| io::Error::other(error.to_string()))?;
+            let stream = Stream::from(np);
+            validate_connected_server(&stream)?;
+            return Ok(Conn::new(stream));
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(ERROR_PIPE_BUSY as i32) {
+            return Err(error);
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "connection timed out",
+            ));
+        }
+        let ms = u32::try_from(remaining.as_millis()).unwrap_or(u32::MAX);
+        let waited = unsafe { WaitNamedPipeW(wide.as_ptr(), ms) };
+        if waited != 0 {
+            continue;
+        }
+        let wait_error = io::Error::last_os_error();
+        if wait_error.raw_os_error() == Some(ERROR_SEM_TIMEOUT as i32) {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "connection timed out",
+            ));
+        }
+        return Err(wait_error);
     }
-    let error = io::Error::last_os_error();
-    // ERROR_SEM_TIMEOUT (121): the wait elapsed with no free instance.
-    if error.raw_os_error() == Some(121) {
-        return Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "connection timed out",
-        ));
-    }
-    Err(error)
 }
 
 /// Connect to a server socket identified by a per-session filesystem path.
@@ -719,11 +758,43 @@ mod windows_security_tests {
         let path = test_pipe("listening-no-accept");
         let _listener = bind(&path).expect("bind owner-only named pipe");
         let started = std::time::Instant::now();
-        let _ = connect_timeout(&path, Duration::from_millis(200));
+        let result = connect_timeout(&path, Duration::from_millis(200));
         assert!(
             started.elapsed() < Duration::from_secs(2),
             "connect_timeout must not pin the process on a listening pipe"
         );
+        match result {
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+            Err(error) => panic!("unexpected connect_timeout error: {error}"),
+        }
+    }
+
+    #[test]
+    fn connect_timeout_times_out_when_every_instance_is_busy() {
+        let path = test_pipe("busy-timeout");
+        let listener = bind(&path).expect("bind owner-only named pipe");
+        let occupied_path = path.clone();
+        let occupied = std::thread::spawn(move || connect(&occupied_path));
+        let _peer = listener.accept().expect("accept occupying client");
+        let first = occupied
+            .join()
+            .expect("occupying connect")
+            .expect("occupying client");
+        let started = std::time::Instant::now();
+        let result = connect_timeout(&path, Duration::from_millis(200));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "busy-pipe connect_timeout must not call unbounded connect"
+        );
+        match result {
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+            Ok(_) => {
+                // Listener may have created another instance; still must be fast.
+            }
+            Err(error) => panic!("unexpected connect_timeout error: {error}"),
+        }
+        drop(first);
     }
 
     #[test]

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -12,7 +12,11 @@ use std::time::Duration;
 
 use fs2::FileExt;
 use interprocess::local_socket::prelude::*;
+#[cfg(not(windows))]
+use interprocess::local_socket::ConnectOptions;
 use interprocess::local_socket::{ListenerOptions, Stream};
+#[cfg(not(windows))]
+use interprocess::ConnectWaitMode;
 
 pub use interprocess::local_socket::Listener;
 
@@ -494,8 +498,33 @@ pub fn connect_timeout(path: &Path, timeout: Duration) -> io::Result<Conn> {
     }
     #[cfg(not(windows))]
     {
-        let _ = timeout;
-        connect(path)
+        use interprocess::local_socket::GenericFilePath;
+        validate_unix_socket_path(path)?;
+        let name = path.to_fs_name::<GenericFilePath>()?;
+        let stream = ConnectOptions::new()
+            .name(name)
+            .wait_mode(ConnectWaitMode::Timeout(timeout))
+            .connect_sync()
+            .map_err(|error| {
+                if error.kind() == io::ErrorKind::WouldBlock {
+                    io::Error::new(io::ErrorKind::TimedOut, error)
+                } else {
+                    error
+                }
+            })?;
+        let conn = Conn::new(stream);
+        validate_peer(&conn)?;
+        Ok(conn)
+    }
+}
+
+/// True when the endpoint exists: we connected, or the wait timed out because
+/// it is busy/hung. False when the name is absent.
+pub fn endpoint_exists(path: &Path, timeout: Duration) -> bool {
+    match connect_timeout(path, timeout) {
+        Ok(_) => true,
+        Err(error) if error.kind() == io::ErrorKind::TimedOut => true,
+        Err(_) => false,
     }
 }
 
@@ -703,6 +732,20 @@ mod windows_security_tests {
             started.elapsed() < Duration::from_secs(2),
             "connect_timeout must not pin the process on a listening pipe"
         );
+    }
+
+    #[test]
+    fn busy_named_pipe_is_not_treated_as_absent() {
+        let path = test_pipe("busy-exists");
+        let _listener = bind(&path).expect("bind owner-only named pipe");
+        assert!(
+            endpoint_exists(&path, Duration::from_millis(200)),
+            "a listening pipe must count as present even if no instance is free"
+        );
+        assert!(!endpoint_exists(
+            &test_pipe("no-such-pipe"),
+            Duration::from_millis(200)
+        ));
     }
 }
 

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -147,8 +147,16 @@ impl Conn {
         match self.0.set_send_timeout(Some(timeout)) {
             Ok(()) => Ok(TimeoutMode::Kernel),
             Err(error) if error.kind() == io::ErrorKind::Unsupported => {
-                self.0.set_nonblocking(true)?;
-                Ok(TimeoutMode::Nonblocking)
+                #[cfg(windows)]
+                {
+                    let _ = timeout;
+                    Ok(TimeoutMode::Nonblocking)
+                }
+                #[cfg(not(windows))]
+                {
+                    self.0.set_nonblocking(true)?;
+                    Ok(TimeoutMode::Nonblocking)
+                }
             }
             Err(error) => Err(error),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -625,7 +625,7 @@ fn remote_ssh_command(args: &[String]) -> Result<Command> {
 }
 
 fn server_running(sock: &Path) -> bool {
-    ipc::transport::connect_timeout(sock, Duration::from_millis(50)).is_ok()
+    ipc::transport::endpoint_exists(sock, Duration::from_millis(50))
 }
 
 fn spawn_server() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1150,8 +1150,8 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
     let startup_lock = ipc::transport::acquire_server_startup_lock(&state_dir)?;
     let sock = persist::socket_path();
     let client_sock = persist::client_socket_path();
-    if ipc::transport::connect_timeout(&sock, Duration::from_millis(50)).is_ok()
-        || ipc::transport::connect_timeout(&client_sock, Duration::from_millis(50)).is_ok()
+    if ipc::transport::endpoint_exists(&sock, Duration::from_millis(50))
+        || ipc::transport::endpoint_exists(&client_sock, Duration::from_millis(50))
     {
         return Err(anyhow!(
             "a Luvus server is already active for {}; use `luvus` to attach to it",

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,9 +516,9 @@ fn ensure_server_ready(sock: &Path) -> Result<()> {
                 }
                 Ok(())
             }
-            // Connected: the pipe accepted. A slow or false IO reply is not a
-            // mute server. #144: do not kill a healthy session on a timeout.
-            Err(_) => Ok(()),
+            // Accept threads stay alive after the app loop dies. Connect is not
+            // liveness; recycle so reattach does not wait forever on frames.
+            Err(_) => recycle_unresponsive_server(sock),
         },
         Err(error) if error.kind() == io::ErrorKind::TimedOut => recycle_unresponsive_server(sock),
         Err(_) => {
@@ -941,15 +941,7 @@ fn send_server_stop() -> Result<bool> {
         Ok(conn) => (Some(conn), false),
         Err(error) => match ipc::transport::connect_timeout(&client_socket, SERVER_CONTROL_TIMEOUT)
         {
-            Ok(conn) => {
-                if error.kind() == io::ErrorKind::TimedOut {
-                    drop(conn);
-                    return Err(anyhow!(
-                        "luvus server is running but the control socket did not answer"
-                    ));
-                }
-                (Some(conn), false)
-            }
+            Ok(conn) => (Some(conn), error.kind() == io::ErrorKind::TimedOut),
             Err(client_error) if client_error.kind() == io::ErrorKind::TimedOut => (None, true),
             Err(_) if error.kind() == io::ErrorKind::TimedOut => (None, true),
             Err(_) => return Ok(false),
@@ -968,18 +960,13 @@ fn send_server_stop() -> Result<bool> {
     let response = match server_control_request("server.stop") {
         Ok(response) => response,
         Err(error) => {
-            // Stop may have already taken effect: the pipe closed before the
-            // acknowledgement was readable. Wait for the socket to vanish
-            // before force-killing, so a healthy shutdown is not interrupted.
-            if wait_for_shutdown(&client_socket).is_ok() {
+            // A mute app loop still accepts on dedicated listener threads.
+            // One short probe: if both endpoints are already gone, stop won.
+            // Otherwise reclaim the stoppable process instead of hanging attach.
+            if !ipc::transport::endpoint_exists(&api, Duration::from_millis(50))
+                && !ipc::transport::endpoint_exists(&client_socket, Duration::from_millis(50))
+            {
                 return Ok(true);
-            }
-            // Client socket still accepts: server is reachable. The stop
-            // request timed out; do not kill the session.
-            if ipc::transport::connect_timeout(&client_socket, SERVER_CONTROL_TIMEOUT).is_ok() {
-                return Err(anyhow!(
-                    "luvus server is running but the control socket did not answer"
-                ));
             }
             if force_stop_unresponsive(pid, &client_socket).is_ok() {
                 return Ok(true);
@@ -1009,7 +996,11 @@ fn force_stop_unresponsive(pid: Option<u32>, sock: &Path) -> Result<bool> {
             "luvus server did not answer and pid {pid} is not a stoppable Luvus process"
         ));
     }
-    platform::force_terminate(pid);
+    if let Err(error) = platform::force_terminate(pid) {
+        if platform::is_stoppable_luvus_pid(pid) {
+            return Err(anyhow!("failed to force-stop luvus pid {pid}: {error}"));
+        }
+    }
     wait_for_shutdown(sock)?;
     Ok(true)
 }
@@ -1251,6 +1242,13 @@ mod tests {
     use super::*;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+
+    #[test]
+    fn send_server_stop_reports_absent_when_no_sockets() {
+        let _env = crate::persist::test_env("stop-absent");
+        crate::persist::ensure_session_dir();
+        assert!(!send_server_stop().expect("absent server is not an error"));
+    }
 
     #[test]
     fn only_exact_json_session_list_uses_discovery_route() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,7 +516,9 @@ fn ensure_server_ready(sock: &Path) -> Result<()> {
                 }
                 Ok(())
             }
-            Err(_) => recycle_unresponsive_server(sock),
+            // Connected: the pipe accepted. A slow or false IO reply is not a
+            // mute server. #144: do not kill a healthy session on a timeout.
+            Err(_) => Ok(()),
         },
         Err(error) if error.kind() == io::ErrorKind::TimedOut => recycle_unresponsive_server(sock),
         Err(_) => {
@@ -951,14 +953,13 @@ fn send_server_stop() -> Result<bool> {
     let response = match server_control_request("server.stop") {
         Ok(response) => response,
         Err(error) => {
-            // The old server may exit between the liveness probe and connect,
-            // or Windows may observe the named pipe closing before the final
-            // stop acknowledgement is readable. A completed shutdown is still
-            // success. A live, unresponsive server is force-killed.
-            if force_stop_unresponsive(pid, &client_socket).is_ok() {
+            // Stop may have already taken effect: the pipe closed before the
+            // acknowledgement was readable. Wait for the socket to vanish
+            // before force-killing, so a healthy shutdown is not interrupted.
+            if wait_for_shutdown(&client_socket).is_ok() {
                 return Ok(true);
             }
-            if wait_for_shutdown(&client_socket).is_ok() {
+            if force_stop_unresponsive(pid, &client_socket).is_ok() {
                 return Ok(true);
             }
             return Err(error);

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,6 +530,10 @@ fn ensure_server_ready(sock: &Path) -> Result<()> {
 
 fn recycle_unresponsive_server(sock: &Path) -> Result<()> {
     send_server_stop()?;
+    // The old process may still own API or client pipes after stop
+    // returns. Spawning now makes the replacement see those endpoints and
+    // exit, then the old process dies — no server left.
+    wait_for_shutdown(sock)?;
     spawn_server()?;
     wait_for_socket(sock)
 }
@@ -852,12 +856,14 @@ fn server_restart(context: i18n::cli::Context) -> Result<()> {
 
 /// Poll (bounded) until the server releases its socket, so `stop`/`restart`
 /// return only once the old server is truly gone.
-fn wait_for_shutdown(sock: &Path) -> Result<()> {
+fn wait_for_shutdown(_sock: &Path) -> Result<()> {
+    let api = persist::socket_path();
+    let client = persist::client_socket_path();
     for _ in 0..50 {
-        match ipc::transport::connect_timeout(sock, Duration::from_millis(100)) {
-            Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
-            Err(_) => return Ok(()),
-            Ok(_) => {}
+        if !ipc::transport::endpoint_exists(&api, Duration::from_millis(100))
+            && !ipc::transport::endpoint_exists(&client, Duration::from_millis(100))
+        {
+            return Ok(());
         }
         thread::sleep(Duration::from_millis(50));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -933,10 +933,19 @@ fn send_server_stop() -> Result<bool> {
     let api = persist::socket_path();
     let (conn, timed_out) = match ipc::transport::connect_timeout(&api, SERVER_CONTROL_TIMEOUT) {
         Ok(conn) => (Some(conn), false),
-        Err(error) if error.kind() == io::ErrorKind::TimedOut => (None, true),
-        Err(_) => match ipc::transport::connect_timeout(&client_socket, SERVER_CONTROL_TIMEOUT) {
-            Ok(conn) => (Some(conn), false),
-            Err(error) if error.kind() == io::ErrorKind::TimedOut => (None, true),
+        Err(error) => match ipc::transport::connect_timeout(&client_socket, SERVER_CONTROL_TIMEOUT)
+        {
+            Ok(conn) => {
+                if error.kind() == io::ErrorKind::TimedOut {
+                    drop(conn);
+                    return Err(anyhow!(
+                        "luvus server is running but the control socket did not answer"
+                    ));
+                }
+                (Some(conn), false)
+            }
+            Err(client_error) if client_error.kind() == io::ErrorKind::TimedOut => (None, true),
+            Err(_) if error.kind() == io::ErrorKind::TimedOut => (None, true),
             Err(_) => return Ok(false),
         },
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -968,6 +968,13 @@ fn send_server_stop() -> Result<bool> {
             if wait_for_shutdown(&client_socket).is_ok() {
                 return Ok(true);
             }
+            // Client socket still accepts: server is reachable. The stop
+            // request timed out; do not kill the session.
+            if ipc::transport::connect_timeout(&client_socket, SERVER_CONTROL_TIMEOUT).is_ok() {
+                return Err(anyhow!(
+                    "luvus server is running but the control socket did not answer"
+                ));
+            }
             if force_stop_unresponsive(pid, &client_socket).is_ok() {
                 return Ok(true);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,9 @@ use crate::app::App;
 use crate::event::AppEvent;
 
 const SERVER_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
+/// A second, longer control-plane probe prevents a transiently busy app loop
+/// from being classified as dead after one ordinary request deadline.
+const SERVER_RECOVERY_TIMEOUT: Duration = Duration::from_secs(4);
 
 fn main() -> Result<()> {
     // Run the whole process at 1ms timer resolution so the event loop's timed
@@ -503,24 +506,37 @@ fn autodetect_and_attach() -> Result<()> {
 }
 
 fn ensure_server_ready(sock: &Path) -> Result<()> {
-    match ipc::transport::connect_timeout(sock, SERVER_CONTROL_TIMEOUT) {
-        Ok(_) => match server_version() {
-            Ok(running) => {
-                let binary = env!("CARGO_PKG_VERSION");
-                if running != binary {
-                    eprintln!(
-                        "luvus v{binary} installed, but the running server is v{running} — \
-                         run `luvus server restart` to load it (your session is saved and restored)."
-                    );
-                    thread::sleep(Duration::from_millis(2000));
-                }
-                Ok(())
-            }
+    ensure_server_ready_with_timeouts(sock, SERVER_CONTROL_TIMEOUT, SERVER_RECOVERY_TIMEOUT)
+}
+
+fn ensure_server_ready_with_timeouts(
+    sock: &Path,
+    control_timeout: Duration,
+    recovery_timeout: Duration,
+) -> Result<()> {
+    match ipc::transport::connect_timeout(sock, control_timeout) {
+        Ok(_) => match retry_control_probe(control_timeout, recovery_timeout, |timeout| {
+            server_version_with_timeout(timeout)
+        }) {
+            Ok(running) => report_server_version(running),
             // Accept threads stay alive after the app loop dies. Connect is not
-            // liveness; recycle so reattach does not wait forever on frames.
-            Err(_) => recycle_unresponsive_server(sock),
+            // liveness, but one ordinary timeout is not proof of death either.
+            // Recycle only after the longer confirmation probe also fails.
+            Err(_) => {
+                recycle_unresponsive_server_with_timeouts(sock, control_timeout, recovery_timeout)
+            }
         },
-        Err(error) if error.kind() == io::ErrorKind::TimedOut => recycle_unresponsive_server(sock),
+        Err(error) if error.kind() == io::ErrorKind::TimedOut => {
+            // A saturated client listener is not proof that the app loop died.
+            // The API ping distinguishes a responsive server that should be
+            // left alone from the mute-listener failure this recovery targets.
+            if server_version_with_timeout(recovery_timeout).is_ok() {
+                return Err(anyhow!(
+                    "luvus client endpoint is busy but the server remains responsive; retry attach"
+                ));
+            }
+            recycle_unresponsive_server_with_timeouts(sock, control_timeout, recovery_timeout)
+        }
         Err(_) => {
             spawn_server()?;
             wait_for_socket(sock)
@@ -528,14 +544,42 @@ fn ensure_server_ready(sock: &Path) -> Result<()> {
     }
 }
 
-fn recycle_unresponsive_server(sock: &Path) -> Result<()> {
-    send_server_stop()?;
+fn recycle_unresponsive_server_with_timeouts(
+    sock: &Path,
+    control_timeout: Duration,
+    recovery_timeout: Duration,
+) -> Result<()> {
+    send_server_stop_with_evidence(
+        control_timeout,
+        recovery_timeout,
+        RecoveryEvidence::ConfirmedUnresponsive,
+    )?;
     // The old process may still own API or client pipes after stop
     // returns. Spawning now makes the replacement see those endpoints and
     // exit, then the old process dies — no server left.
     wait_for_shutdown(sock)?;
     spawn_server()?;
     wait_for_socket(sock)
+}
+
+fn retry_control_probe<T>(
+    control_timeout: Duration,
+    recovery_timeout: Duration,
+    mut probe: impl FnMut(Duration) -> Result<T>,
+) -> Result<T> {
+    probe(control_timeout).or_else(|_| probe(recovery_timeout))
+}
+
+fn report_server_version(running: String) -> Result<()> {
+    let binary = env!("CARGO_PKG_VERSION");
+    if running != binary {
+        eprintln!(
+            "luvus v{binary} installed, but the running server is v{running} — \
+             run `luvus server restart` to load it (your session is saved and restored)."
+        );
+        thread::sleep(Duration::from_millis(2000));
+    }
+    Ok(())
 }
 
 /// Ask the running server to open the current directory as a workspace (add +
@@ -935,12 +979,36 @@ fn print_detached_status(context: i18n::cli::Context) {
 
 /// Send `server.stop` to a running server; returns whether one was present.
 fn send_server_stop() -> Result<bool> {
+    send_server_stop_with_timeouts(SERVER_CONTROL_TIMEOUT, SERVER_RECOVERY_TIMEOUT)
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum RecoveryEvidence {
+    RequireConfirmation,
+    ConfirmedUnresponsive,
+}
+
+fn send_server_stop_with_timeouts(
+    control_timeout: Duration,
+    recovery_timeout: Duration,
+) -> Result<bool> {
+    send_server_stop_with_evidence(
+        control_timeout,
+        recovery_timeout,
+        RecoveryEvidence::RequireConfirmation,
+    )
+}
+
+fn send_server_stop_with_evidence(
+    control_timeout: Duration,
+    recovery_timeout: Duration,
+    evidence: RecoveryEvidence,
+) -> Result<bool> {
     let client_socket = persist::client_socket_path();
     let api = persist::socket_path();
-    let (conn, timed_out) = match ipc::transport::connect_timeout(&api, SERVER_CONTROL_TIMEOUT) {
+    let (conn, timed_out) = match ipc::transport::connect_timeout(&api, control_timeout) {
         Ok(conn) => (Some(conn), false),
-        Err(error) => match ipc::transport::connect_timeout(&client_socket, SERVER_CONTROL_TIMEOUT)
-        {
+        Err(error) => match ipc::transport::connect_timeout(&client_socket, control_timeout) {
             Ok(conn) => (Some(conn), error.kind() == io::ErrorKind::TimedOut),
             Err(client_error) if client_error.kind() == io::ErrorKind::TimedOut => (None, true),
             Err(_) if error.kind() == io::ErrorKind::TimedOut => (None, true),
@@ -954,10 +1022,17 @@ fn send_server_stop() -> Result<bool> {
     drop(conn);
 
     if timed_out {
+        if evidence == RecoveryEvidence::RequireConfirmation
+            && server_control_request_with_timeout("ping", recovery_timeout).is_ok()
+        {
+            return Err(anyhow!(
+                "luvus endpoint is busy but the server remains responsive; refusing to force-stop"
+            ));
+        }
         return force_stop_unresponsive(pid, &client_socket);
     }
 
-    let response = match server_control_request("server.stop") {
+    let response = match server_control_request_with_timeout("server.stop", control_timeout) {
         Ok(response) => response,
         Err(error) => {
             // A mute app loop still accepts on dedicated listener threads.
@@ -968,10 +1043,29 @@ fn send_server_stop() -> Result<bool> {
             {
                 return Ok(true);
             }
-            if force_stop_unresponsive(pid, &client_socket).is_ok() {
+            // A reachable server may simply have missed the ordinary one-second
+            // acknowledgement deadline under load. Confirm the control plane is
+            // still mute with a longer ping before taking the destructive path.
+            if evidence == RecoveryEvidence::RequireConfirmation
+                && server_control_request_with_timeout("ping", recovery_timeout).is_ok()
+            {
+                return Err(anyhow!(
+                    "luvus server did not acknowledge stop but remains responsive: {error}"
+                ));
+            }
+            if !ipc::transport::endpoint_exists(&api, Duration::from_millis(50))
+                && !ipc::transport::endpoint_exists(&client_socket, Duration::from_millis(50))
+            {
                 return Ok(true);
             }
-            return Err(error);
+            match force_stop_unresponsive(pid, &client_socket) {
+                Ok(_) => return Ok(true),
+                Err(recovery_error) => {
+                    return Err(anyhow!(
+                        "{error}; force-stop recovery failed: {recovery_error}"
+                    ));
+                }
+            }
         }
     };
     let acknowledged = response
@@ -1007,7 +1101,11 @@ fn force_stop_unresponsive(pid: Option<u32>, sock: &Path) -> Result<bool> {
 
 /// Ask the running server its version via `ping`.
 fn server_version() -> Result<String> {
-    let response = server_control_request("ping")?;
+    server_version_with_timeout(SERVER_CONTROL_TIMEOUT)
+}
+
+fn server_version_with_timeout(timeout: Duration) -> Result<String> {
+    let response = server_control_request_with_timeout("ping", timeout)?;
     response
         .get("result")
         .and_then(|result| result.get("version"))
@@ -1019,12 +1117,14 @@ fn server_version() -> Result<String> {
 /// Perform one lifecycle request with a bounded response wait. This keeps
 /// `status`, `stop`, and `restart` responsive when a socket exists but the app
 /// loop cannot answer, including through Windows named pipes.
-fn server_control_request(method: &str) -> Result<serde_json::Value> {
-    let mut stream =
-        ipc::transport::connect_timeout(&persist::socket_path(), SERVER_CONTROL_TIMEOUT)
-            .map_err(|error| anyhow!("cannot connect to luvus server: {error}"))?;
+fn server_control_request_with_timeout(
+    method: &str,
+    timeout: Duration,
+) -> Result<serde_json::Value> {
+    let mut stream = ipc::transport::connect_timeout(&persist::socket_path(), timeout)
+        .map_err(|error| anyhow!("cannot connect to luvus server: {error}"))?;
     writeln!(stream, r#"{{"id":"1","method":"{method}","params":{{}}}}"#)?;
-    let frame = ipc::api::read_response_frame_with_deadline(&mut stream, SERVER_CONTROL_TIMEOUT)?;
+    let frame = ipc::api::read_response_frame_with_deadline(&mut stream, timeout)?;
     let response: serde_json::Value = serde_json::from_str(&frame)
         .map_err(|error| anyhow!("invalid server control response: {error}"))?;
     if response.get("id").and_then(serde_json::Value::as_str) != Some("1") {
@@ -1257,9 +1357,10 @@ mod tests {
         let _listener =
             crate::ipc::transport::bind(&crate::persist::socket_path()).expect("mute API listener");
         let started = Instant::now();
-        let result = send_server_stop();
+        let result =
+            send_server_stop_with_timeouts(Duration::from_millis(40), Duration::from_millis(120));
         assert!(
-            started.elapsed() < Duration::from_secs(4),
+            started.elapsed() < Duration::from_secs(2),
             "mute accept must not hang server stop"
         );
         assert!(
@@ -1277,15 +1378,37 @@ mod tests {
         let _client_listener = crate::ipc::transport::bind(&client).expect("mute client listener");
         let _api_listener = crate::ipc::transport::bind(&api).expect("mute API listener");
         let started = Instant::now();
-        let result = ensure_server_ready(&client);
+        let result = ensure_server_ready_with_timeouts(
+            &client,
+            Duration::from_millis(40),
+            Duration::from_millis(120),
+        );
         assert!(
-            started.elapsed() < Duration::from_secs(6),
+            started.elapsed() < Duration::from_secs(2),
             "mute ping must not hang attach"
         );
         assert!(
             result.is_err(),
             "fail closed rather than attach to a mute loop: {result:?}"
         );
+    }
+
+    #[test]
+    fn control_probe_retries_with_a_longer_deadline_before_recovery() {
+        let ordinary = Duration::from_millis(25);
+        let recovery = Duration::from_millis(150);
+        let mut attempts = Vec::new();
+        let result = retry_control_probe(ordinary, recovery, |timeout| {
+            attempts.push(timeout);
+            if attempts.len() == 1 {
+                Err(anyhow!("transient timeout"))
+            } else {
+                Ok("0.13.1".to_string())
+            }
+        });
+
+        assert_eq!(result.expect("recovery probe succeeds"), "0.13.1");
+        assert_eq!(attempts, vec![ordinary, recovery]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ mod theme;
 mod ui;
 mod update;
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{self, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
@@ -493,26 +493,7 @@ fn run_local() -> Result<()> {
 
 fn autodetect_and_attach() -> Result<()> {
     let sock = persist::client_socket_path();
-    let fresh = !server_running(&sock);
-    if fresh {
-        spawn_server()?;
-        wait_for_socket(&sock)?;
-    }
-    if !fresh {
-        // An upgraded binary silently attaching to an older running server means
-        // none of the new version shows up — tell the user how to load it (the
-        // brief pause keeps the note readable before the UI takes the screen).
-        let binary = env!("CARGO_PKG_VERSION");
-        if let Ok(running) = server_version() {
-            if running != binary {
-                eprintln!(
-                    "luvus v{binary} installed, but the running server is v{running} — \
-                     run `luvus server restart` to load it (your session is saved and restored)."
-                );
-                thread::sleep(Duration::from_millis(2000));
-            }
-        }
-    }
+    ensure_server_ready(&sock)?;
     // Always ask the server to open the launch folder. A *fresh* server may have
     // restored a saved session (`restore_or_new`), in which case it never saw
     // this cwd — so this cannot be skipped on the fresh path. Idempotent: if the
@@ -521,13 +502,45 @@ fn autodetect_and_attach() -> Result<()> {
     ipc::client::run(&sock)
 }
 
+fn ensure_server_ready(sock: &Path) -> Result<()> {
+    match ipc::transport::connect_timeout(sock, SERVER_CONTROL_TIMEOUT) {
+        Ok(_) => match server_version() {
+            Ok(running) => {
+                let binary = env!("CARGO_PKG_VERSION");
+                if running != binary {
+                    eprintln!(
+                        "luvus v{binary} installed, but the running server is v{running} — \
+                         run `luvus server restart` to load it (your session is saved and restored)."
+                    );
+                    thread::sleep(Duration::from_millis(2000));
+                }
+                Ok(())
+            }
+            Err(_) => recycle_unresponsive_server(sock),
+        },
+        Err(error) if error.kind() == io::ErrorKind::TimedOut => recycle_unresponsive_server(sock),
+        Err(_) => {
+            spawn_server()?;
+            wait_for_socket(sock)
+        }
+    }
+}
+
+fn recycle_unresponsive_server(sock: &Path) -> Result<()> {
+    send_server_stop()?;
+    spawn_server()?;
+    wait_for_socket(sock)
+}
+
 /// Ask the running server to open the current directory as a workspace (add +
 /// focus if new). Best-effort — a failure just means no auto-open.
 fn open_cwd_workspace() {
     let Ok(cwd) = std::env::current_dir() else {
         return;
     };
-    let Ok(mut s) = ipc::transport::connect(&persist::socket_path()) else {
+    let Ok(mut s) =
+        ipc::transport::connect_timeout(&persist::socket_path(), SERVER_CONTROL_TIMEOUT)
+    else {
         return;
     };
     // `focus: false` — add the launch folder if it isn't already a workspace, but
@@ -539,8 +552,7 @@ fn open_cwd_workspace() {
         "params": { "path": cwd.display().to_string(), "focus": false },
     });
     let _ = writeln!(s, "{req}");
-    let mut line = String::new();
-    let _ = BufReader::new(s).read_line(&mut line); // wait for the ack before attaching
+    let _ = ipc::api::read_response_frame_with_deadline(&mut s, SERVER_CONTROL_TIMEOUT);
 }
 
 /// Remote bridge role (docs/18 RA-1), run *on the remote host* by ssh. Ensure a
@@ -548,10 +560,7 @@ fn open_cwd_workspace() {
 /// so the `luvus --remote` client on the other end of the ssh pipe drives it.
 fn remote_client_bridge() -> Result<()> {
     let sock = persist::client_socket_path();
-    if !server_running(&sock) {
-        spawn_server()?;
-        wait_for_socket(&sock)?;
-    }
+    ensure_server_ready(&sock)?;
     ipc::client::remote_bridge(&sock)
 }
 
@@ -560,10 +569,7 @@ fn remote_client_bridge() -> Result<()> {
 /// fullscreen terminal. Composes with `--remote` for a remote fullscreen attach.
 fn attach_cmd(args: &[String]) -> Result<()> {
     let sock = persist::client_socket_path();
-    if !server_running(&sock) {
-        spawn_server()?;
-        wait_for_socket(&sock)?;
-    }
+    ensure_server_ready(&sock)?;
     if let Some(id) = args.get(2).filter(|s| s.parse::<u32>().is_ok()) {
         let _ = cli::request_attach(id); // best-effort; still attaches if it fails
     }
@@ -617,7 +623,7 @@ fn remote_ssh_command(args: &[String]) -> Result<Command> {
 }
 
 fn server_running(sock: &Path) -> bool {
-    ipc::transport::connect(sock).is_ok()
+    ipc::transport::connect_timeout(sock, Duration::from_millis(50)).is_ok()
 }
 
 fn spawn_server() -> Result<()> {
@@ -845,9 +851,11 @@ fn server_restart(context: i18n::cli::Context) -> Result<()> {
 /// Poll (bounded) until the server releases its socket, so `stop`/`restart`
 /// return only once the old server is truly gone.
 fn wait_for_shutdown(sock: &Path) -> Result<()> {
-    for _ in 0..100 {
-        if !server_running(sock) {
-            return Ok(());
+    for _ in 0..50 {
+        match ipc::transport::connect_timeout(sock, Duration::from_millis(100)) {
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+            Err(_) => return Ok(()),
+            Ok(_) => {}
         }
         thread::sleep(Duration::from_millis(50));
     }
@@ -920,16 +928,36 @@ fn print_detached_status(context: i18n::cli::Context) {
 /// Send `server.stop` to a running server; returns whether one was present.
 fn send_server_stop() -> Result<bool> {
     let client_socket = persist::client_socket_path();
-    if !server_running(&client_socket) {
-        return Ok(false);
+    let api = persist::socket_path();
+    let (conn, timed_out) = match ipc::transport::connect_timeout(&api, SERVER_CONTROL_TIMEOUT) {
+        Ok(conn) => (Some(conn), false),
+        Err(error) if error.kind() == io::ErrorKind::TimedOut => (None, true),
+        Err(_) => match ipc::transport::connect_timeout(&client_socket, SERVER_CONTROL_TIMEOUT) {
+            Ok(conn) => (Some(conn), false),
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => (None, true),
+            Err(_) => return Ok(false),
+        },
+    };
+    let pid = conn
+        .as_ref()
+        .and_then(|conn| conn.server_pid().ok())
+        .or_else(persist::ServerPidFile::read);
+    drop(conn);
+
+    if timed_out {
+        return force_stop_unresponsive(pid, &client_socket);
     }
+
     let response = match server_control_request("server.stop") {
         Ok(response) => response,
         Err(error) => {
             // The old server may exit between the liveness probe and connect,
             // or Windows may observe the named pipe closing before the final
             // stop acknowledgement is readable. A completed shutdown is still
-            // success; a live, unresponsive server keeps the original error.
+            // success. A live, unresponsive server is force-killed.
+            if force_stop_unresponsive(pid, &client_socket).is_ok() {
+                return Ok(true);
+            }
             if wait_for_shutdown(&client_socket).is_ok() {
                 return Ok(true);
             }
@@ -944,6 +972,22 @@ fn send_server_stop() -> Result<bool> {
     if !acknowledged {
         return Err(anyhow!("luvus server returned an invalid stop response"));
     }
+    Ok(true)
+}
+
+fn force_stop_unresponsive(pid: Option<u32>, sock: &Path) -> Result<bool> {
+    let Some(pid) = pid else {
+        return Err(anyhow!(
+            "luvus server did not answer and no process id is available to force-stop"
+        ));
+    };
+    if !platform::is_stoppable_luvus_pid(pid) {
+        return Err(anyhow!(
+            "luvus server did not answer and pid {pid} is not a stoppable Luvus process"
+        ));
+    }
+    platform::force_terminate(pid);
+    wait_for_shutdown(sock)?;
     Ok(true)
 }
 
@@ -962,8 +1006,9 @@ fn server_version() -> Result<String> {
 /// `status`, `stop`, and `restart` responsive when a socket exists but the app
 /// loop cannot answer, including through Windows named pipes.
 fn server_control_request(method: &str) -> Result<serde_json::Value> {
-    let mut stream = ipc::transport::connect(&persist::socket_path())
-        .map_err(|error| anyhow!("cannot connect to luvus server: {error}"))?;
+    let mut stream =
+        ipc::transport::connect_timeout(&persist::socket_path(), SERVER_CONTROL_TIMEOUT)
+            .map_err(|error| anyhow!("cannot connect to luvus server: {error}"))?;
     writeln!(stream, r#"{{"id":"1","method":"{method}","params":{{}}}}"#)?;
     let frame = ipc::api::read_response_frame_with_deadline(&mut stream, SERVER_CONTROL_TIMEOUT)?;
     let response: serde_json::Value = serde_json::from_str(&frame)
@@ -991,7 +1036,9 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
     let startup_lock = ipc::transport::acquire_server_startup_lock(&state_dir)?;
     let sock = persist::socket_path();
     let client_sock = persist::client_socket_path();
-    if ipc::transport::connect(&sock).is_ok() || ipc::transport::connect(&client_sock).is_ok() {
+    if ipc::transport::connect_timeout(&sock, Duration::from_millis(50)).is_ok()
+        || ipc::transport::connect_timeout(&client_sock, Duration::from_millis(50)).is_ok()
+    {
         return Err(anyhow!(
             "a Luvus server is already active for {}; use `luvus` to attach to it",
             state_dir.display()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1251,6 +1251,44 @@ mod tests {
     }
 
     #[test]
+    fn send_server_stop_fails_closed_when_a_listener_never_replies() {
+        let _env = crate::persist::test_env("stop-mute-accept");
+        crate::persist::ensure_session_dir();
+        let _listener =
+            crate::ipc::transport::bind(&crate::persist::socket_path()).expect("mute API listener");
+        let started = Instant::now();
+        let result = send_server_stop();
+        assert!(
+            started.elapsed() < Duration::from_secs(4),
+            "mute accept must not hang server stop"
+        );
+        assert!(
+            result.is_err(),
+            "fail closed without a stoppable foreign pid: {result:?}"
+        );
+    }
+
+    #[test]
+    fn ensure_server_ready_fails_closed_when_control_ping_never_replies() {
+        let _env = crate::persist::test_env("ready-mute-accept");
+        crate::persist::ensure_session_dir();
+        let client = crate::persist::client_socket_path();
+        let api = crate::persist::socket_path();
+        let _client_listener = crate::ipc::transport::bind(&client).expect("mute client listener");
+        let _api_listener = crate::ipc::transport::bind(&api).expect("mute API listener");
+        let started = Instant::now();
+        let result = ensure_server_ready(&client);
+        assert!(
+            started.elapsed() < Duration::from_secs(6),
+            "mute ping must not hang attach"
+        );
+        assert!(
+            result.is_err(),
+            "fail closed rather than attach to a mute loop: {result:?}"
+        );
+    }
+
+    #[test]
     fn only_exact_json_session_list_uses_discovery_route() {
         let strings = |items: &[&str]| {
             items

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -683,35 +683,6 @@ fn resolve_pane_sessions(app: &App) -> HashMap<PaneId, Option<(String, String)>>
         }
     }
 
-    // Pass 1b: a live argv `--session` / `--session-id` names this pane the
-    // same way a hook does. Needed when several PI panes share a cwd, so Pass 2
-    // would refuse to guess.
-    for id in &ids {
-        if out.contains_key(id) {
-            continue;
-        }
-        let Some(st) = app.status.get(id) else {
-            continue;
-        };
-        let Some(sid) =
-            session_id_in_commands(app.proc_commands.get(id).map(Vec::as_slice).unwrap_or(&[]))
-        else {
-            continue;
-        };
-        let agent = snapshot_agent(
-            &app.manifests,
-            app.proc_commands.get(id).map(Vec::as_slice),
-            &st.agent,
-        );
-        if !crate::agent::is_resumable(&agent) {
-            continue;
-        }
-        let key = (agent, sid);
-        if claimed.insert(key.clone()) {
-            out.insert(*id, Some(key));
-        }
-    }
-
     // Pass 2: group unbound panes before looking at native session stores. A
     // `(agent, cwd)` identifies a set of possible conversations, not a pane.
     // Only a one-pane / one-session group can be recovered safely.
@@ -769,45 +740,6 @@ fn resolve_pane_sessions(app: &App) -> HashMap<PaneId, Option<(String, String)>>
 /// is the safer identity during the small interval before the UI catches up.
 /// If process information is unavailable, preserve the existing status-based
 /// behaviour.
-fn session_id_in_commands(commands: &[String]) -> Option<String> {
-    for command in commands {
-        if let Some(value) =
-            flag_value(command, "--session").or_else(|| flag_value(command, "--session-id"))
-        {
-            if session_id_token_ok(&value) {
-                return Some(value);
-            }
-        }
-    }
-    None
-}
-
-fn flag_value(command: &str, flag: &str) -> Option<String> {
-    let eq = format!("{flag}=");
-    if let Some(rest) = command.split_once(&eq).map(|(_, rest)| rest) {
-        return rest
-            .split_whitespace()
-            .next()
-            .map(|s| s.trim_matches('"').to_string())
-            .filter(|s| !s.is_empty());
-    }
-    let spaced = format!("{flag} ");
-    command.split_once(&spaced).and_then(|(_, rest)| {
-        rest.split_whitespace()
-            .next()
-            .map(|s| s.trim_matches('"').to_string())
-            .filter(|s| !s.is_empty())
-    })
-}
-
-fn session_id_token_ok(id: &str) -> bool {
-    !id.is_empty()
-        && id.len() <= 256
-        && id
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '/'))
-}
-
 fn snapshot_agent(
     manifests: &crate::detect::Manifests,
     commands: Option<&[String]>,
@@ -1117,27 +1049,6 @@ mod diff_snap_schema_tests {
         assert!(!restored.wrap);
         assert_eq!(restored.context_lines, 3);
         assert!(restored.show_line_numbers);
-    }
-}
-
-#[cfg(test)]
-mod session_flag_tests {
-    use super::*;
-
-    #[test]
-    fn session_id_in_commands_reads_pi_session_flag() {
-        assert_eq!(session_id_in_commands(&["pwsh.exe".into()]), None);
-        assert_eq!(
-            session_id_in_commands(&[
-                "node.exe pi-coding-agent --session 01a03ef7-b621-7433-bc7b-55c3a69d5408".into(),
-            ])
-            .as_deref(),
-            Some("01a03ef7-b621-7433-bc7b-55c3a69d5408")
-        );
-        assert_eq!(
-            session_id_in_commands(&["pi --session=abc-1".into()]).as_deref(),
-            Some("abc-1")
-        );
     }
 }
 

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -436,17 +436,27 @@ pub struct ServerPidFile;
 
 impl ServerPidFile {
     pub fn claim() -> Self {
-        let path = session_dir().join("server.pid");
-        let _ = fs::write(&path, std::process::id().to_string());
+        let pid = std::process::id();
+        let mut body = pid.to_string();
+        if let Some(marker) = crate::platform::process_start_marker(pid) {
+            body.push(' ');
+            body.push_str(&marker);
+        }
+        let _ = fs::write(session_dir().join("server.pid"), body);
         Self
     }
 
     pub fn read() -> Option<u32> {
-        fs::read_to_string(session_dir().join("server.pid"))
-            .ok()?
-            .trim()
-            .parse()
-            .ok()
+        let text = fs::read_to_string(session_dir().join("server.pid")).ok()?;
+        let mut parts = text.split_whitespace();
+        let pid: u32 = parts.next()?.parse().ok()?;
+        if let Some(recorded) = parts.next() {
+            let live = crate::platform::process_start_marker(pid)?;
+            if live != recorded {
+                return None;
+            }
+        }
+        Some(pid)
     }
 }
 
@@ -683,9 +693,9 @@ fn resolve_pane_sessions(app: &App) -> HashMap<PaneId, Option<(String, String)>>
         let Some(st) = app.status.get(id) else {
             continue;
         };
-        let Some(sid) = session_id_in_commands(
-            app.proc_commands.get(id).map(Vec::as_slice).unwrap_or(&[]),
-        ) else {
+        let Some(sid) =
+            session_id_in_commands(app.proc_commands.get(id).map(Vec::as_slice).unwrap_or(&[]))
+        else {
             continue;
         };
         let agent = snapshot_agent(
@@ -1119,8 +1129,7 @@ mod session_flag_tests {
         assert_eq!(session_id_in_commands(&["pwsh.exe".into()]), None);
         assert_eq!(
             session_id_in_commands(&[
-                "node.exe pi-coding-agent --session 01a03ef7-b621-7433-bc7b-55c3a69d5408"
-                    .into(),
+                "node.exe pi-coding-agent --session 01a03ef7-b621-7433-bc7b-55c3a69d5408".into(),
             ])
             .as_deref(),
             Some("01a03ef7-b621-7433-bc7b-55c3a69d5408")

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -466,6 +466,32 @@ impl Drop for ServerPidFile {
     }
 }
 
+#[cfg(test)]
+mod server_pid_file_tests {
+    use super::*;
+
+    #[test]
+    fn server_pid_file_reads_the_live_process() {
+        let _env = test_env("server-pid-live");
+        ensure_session_dir();
+        let claimed = ServerPidFile::claim();
+        assert_eq!(ServerPidFile::read(), Some(std::process::id()));
+        drop(claimed);
+        assert_eq!(ServerPidFile::read(), None);
+    }
+
+    #[test]
+    fn server_pid_file_rejects_a_mismatched_start_marker() {
+        let _env = test_env("server-pid-mismatch");
+        ensure_session_dir();
+        let claimed = ServerPidFile::claim();
+        let path = session_dir().join("server.pid");
+        fs::write(&path, format!("{} not-a-live-marker", std::process::id())).unwrap();
+        assert_eq!(ServerPidFile::read(), None);
+        drop(claimed);
+    }
+}
+
 /// Create the selected runtime directory with the same owner-only protection as
 /// the global root. This is the startup-lock namespace for one server only.
 pub fn ensure_session_dir() -> PathBuf {

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -429,6 +429,33 @@ pub fn session_dir() -> PathBuf {
     crate::session::active_dir()
 }
 
+/// Records the live server PID so `server stop` can kill an unresponsive process
+/// without waiting on IPC. Dropped on a clean server exit; a crash leaves the
+/// file, and the stopper still checks the PID is a Luvus process we own.
+pub struct ServerPidFile;
+
+impl ServerPidFile {
+    pub fn claim() -> Self {
+        let path = session_dir().join("server.pid");
+        let _ = fs::write(&path, std::process::id().to_string());
+        Self
+    }
+
+    pub fn read() -> Option<u32> {
+        fs::read_to_string(session_dir().join("server.pid"))
+            .ok()?
+            .trim()
+            .parse()
+            .ok()
+    }
+}
+
+impl Drop for ServerPidFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(session_dir().join("server.pid"));
+    }
+}
+
 /// Create the selected runtime directory with the same owner-only protection as
 /// the global root. This is the startup-lock namespace for one server only.
 pub fn ensure_session_dir() -> PathBuf {
@@ -646,6 +673,35 @@ fn resolve_pane_sessions(app: &App) -> HashMap<PaneId, Option<(String, String)>>
         }
     }
 
+    // Pass 1b: a live argv `--session` / `--session-id` names this pane the
+    // same way a hook does. Needed when several PI panes share a cwd, so Pass 2
+    // would refuse to guess.
+    for id in &ids {
+        if out.contains_key(id) {
+            continue;
+        }
+        let Some(st) = app.status.get(id) else {
+            continue;
+        };
+        let Some(sid) = session_id_in_commands(
+            app.proc_commands.get(id).map(Vec::as_slice).unwrap_or(&[]),
+        ) else {
+            continue;
+        };
+        let agent = snapshot_agent(
+            &app.manifests,
+            app.proc_commands.get(id).map(Vec::as_slice),
+            &st.agent,
+        );
+        if !crate::agent::is_resumable(&agent) {
+            continue;
+        }
+        let key = (agent, sid);
+        if claimed.insert(key.clone()) {
+            out.insert(*id, Some(key));
+        }
+    }
+
     // Pass 2: group unbound panes before looking at native session stores. A
     // `(agent, cwd)` identifies a set of possible conversations, not a pane.
     // Only a one-pane / one-session group can be recovered safely.
@@ -703,6 +759,45 @@ fn resolve_pane_sessions(app: &App) -> HashMap<PaneId, Option<(String, String)>>
 /// is the safer identity during the small interval before the UI catches up.
 /// If process information is unavailable, preserve the existing status-based
 /// behaviour.
+fn session_id_in_commands(commands: &[String]) -> Option<String> {
+    for command in commands {
+        if let Some(value) =
+            flag_value(command, "--session").or_else(|| flag_value(command, "--session-id"))
+        {
+            if session_id_token_ok(&value) {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+fn flag_value(command: &str, flag: &str) -> Option<String> {
+    let eq = format!("{flag}=");
+    if let Some(rest) = command.split_once(&eq).map(|(_, rest)| rest) {
+        return rest
+            .split_whitespace()
+            .next()
+            .map(|s| s.trim_matches('"').to_string())
+            .filter(|s| !s.is_empty());
+    }
+    let spaced = format!("{flag} ");
+    command.split_once(&spaced).and_then(|(_, rest)| {
+        rest.split_whitespace()
+            .next()
+            .map(|s| s.trim_matches('"').to_string())
+            .filter(|s| !s.is_empty())
+    })
+}
+
+fn session_id_token_ok(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 256
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '/'))
+}
+
 fn snapshot_agent(
     manifests: &crate::detect::Manifests,
     commands: Option<&[String]>,
@@ -1012,6 +1107,28 @@ mod diff_snap_schema_tests {
         assert!(!restored.wrap);
         assert_eq!(restored.context_lines, 3);
         assert!(restored.show_line_numbers);
+    }
+}
+
+#[cfg(test)]
+mod session_flag_tests {
+    use super::*;
+
+    #[test]
+    fn session_id_in_commands_reads_pi_session_flag() {
+        assert_eq!(session_id_in_commands(&["pwsh.exe".into()]), None);
+        assert_eq!(
+            session_id_in_commands(&[
+                "node.exe pi-coding-agent --session 01a03ef7-b621-7433-bc7b-55c3a69d5408"
+                    .into(),
+            ])
+            .as_deref(),
+            Some("01a03ef7-b621-7433-bc7b-55c3a69d5408")
+        );
+        assert_eq!(
+            session_id_in_commands(&["pi --session=abc-1".into()]).as_deref(),
+            Some("abc-1")
+        );
     }
 }
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -341,19 +341,19 @@ pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
         if !process_belongs_to_current_user(pid) {
             return false;
         }
-        return process_tree(pid).first().is_some_and(|info| {
+        process_tree(pid).first().is_some_and(|info| {
             let name = info
                 .command
                 .rsplit(['\\', '/'])
                 .next()
                 .unwrap_or(&info.command);
             name.eq_ignore_ascii_case("luvus.exe")
-        });
+        })
     }
     #[cfg(target_os = "linux")]
     {
-        return std::fs::read_to_string(format!("/proc/{pid}/comm"))
-            .is_ok_and(|comm| comm.trim() == "luvus");
+        std::fs::read_to_string(format!("/proc/{pid}/comm"))
+            .is_ok_and(|comm| comm.trim() == "luvus")
     }
     #[cfg(all(unix, not(target_os = "linux")))]
     {
@@ -366,7 +366,7 @@ pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
             .next()
             .unwrap_or(&info.command);
         let base = name.rsplit('/').next().unwrap_or(name);
-        return base == "luvus";
+        base == "luvus"
     }
     #[cfg(not(any(windows, unix)))]
     {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -357,7 +357,16 @@ pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
     }
     #[cfg(all(unix, not(target_os = "linux")))]
     {
-        return true;
+        let Some(info) = process_tree(pid).into_iter().next() else {
+            return false;
+        };
+        let name = info
+            .command
+            .split_whitespace()
+            .next()
+            .unwrap_or(&info.command);
+        let base = name.rsplit('/').next().unwrap_or(name);
+        return base == "luvus";
     }
     #[cfg(not(any(windows, unix)))]
     {
@@ -959,6 +968,13 @@ mod tests {
         let (cwd_only, commands) = super::scan_pane_runtime(&[pid], false);
         assert_eq!(cwd_only.len(), 1);
         assert!(commands.is_none(), "command projection is demand-driven");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_stoppable_pid_rejects_self_and_missing() {
+        assert!(!super::is_stoppable_luvus_pid(0));
+        assert!(!super::is_stoppable_luvus_pid(std::process::id()));
     }
 
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -330,6 +330,63 @@ pub fn process_belongs_to_current_user(pid: u32) -> bool {
     windows::process_belongs_to_current_user(pid)
 }
 
+/// True when `pid` is another Luvus process owned by this account.
+/// `server stop` uses this before force-killing an unresponsive server.
+pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
+    if pid == 0 || pid == std::process::id() {
+        return false;
+    }
+    #[cfg(windows)]
+    {
+        if !process_belongs_to_current_user(pid) {
+            return false;
+        }
+        return process_tree(pid).first().is_some_and(|info| {
+            let name = info
+                .command
+                .rsplit(['\\', '/'])
+                .next()
+                .unwrap_or(&info.command);
+            name.eq_ignore_ascii_case("luvus.exe")
+        });
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return std::fs::read_to_string(format!("/proc/{pid}/comm"))
+            .is_ok_and(|comm| comm.trim() == "luvus");
+    }
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
+        return true;
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        false
+    }
+}
+
+/// End `pid` and its children. Used only after [`is_stoppable_luvus_pid`].
+pub fn force_terminate(pid: u32) {
+    #[cfg(windows)]
+    {
+        let _ = no_window(
+            std::process::Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null()),
+        )
+        .status();
+    }
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        let _ = pid;
+    }
+}
+
 /// One process running under a pane, for the "what is actually running?" overlay.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProcInfo {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -330,6 +330,25 @@ pub fn process_belongs_to_current_user(pid: u32) -> bool {
     windows::process_belongs_to_current_user(pid)
 }
 
+#[cfg(target_os = "macos")]
+fn process_executable(pid: u32) -> Option<PathBuf> {
+    let mut buffer = vec![0_u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+    // SAFETY: `buffer` is writable for the size passed to `proc_pidpath`, and
+    // the returned byte count is checked before constructing the path.
+    let len = unsafe {
+        libc::proc_pidpath(
+            pid as libc::c_int,
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as u32,
+        )
+    };
+    if len <= 0 {
+        return None;
+    }
+    buffer.truncate(len as usize);
+    Some(PathBuf::from(String::from_utf8_lossy(&buffer).into_owned()))
+}
+
 /// True when `pid` is another Luvus process owned by this account.
 /// `server stop` uses this before force-killing an unresponsive server.
 pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
@@ -341,12 +360,8 @@ pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
         if !process_belongs_to_current_user(pid) {
             return false;
         }
-        process_tree(pid).first().is_some_and(|info| {
-            let name = info
-                .command
-                .rsplit(['\\', '/'])
-                .next()
-                .unwrap_or(&info.command);
+        windows::process_executable(pid).is_some_and(|executable| {
+            let name = executable.rsplit(['\\', '/']).next().unwrap_or(&executable);
             name.eq_ignore_ascii_case("luvus.exe")
         })
     }
@@ -355,7 +370,15 @@ pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
         std::fs::read_to_string(format!("/proc/{pid}/comm"))
             .is_ok_and(|comm| comm.trim() == "luvus")
     }
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(target_os = "macos")]
+    {
+        process_executable(pid).is_some_and(|executable| {
+            executable
+                .file_name()
+                .is_some_and(|name| name == std::ffi::OsStr::new("luvus"))
+        })
+    }
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
     {
         let Some(info) = process_tree(pid).into_iter().next() else {
             return false;
@@ -1009,6 +1032,40 @@ mod tests {
     fn unix_stoppable_pid_rejects_self_and_missing() {
         assert!(!super::is_stoppable_luvus_pid(0));
         assert!(!super::is_stoppable_luvus_pid(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_stoppable_pid_accepts_a_luvus_executable_with_arguments() {
+        let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join(format!("stoppable-pid-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("test executable directory");
+        let executable = dir.join("luvus");
+        let _ = std::fs::remove_file(&executable);
+        std::fs::copy("/bin/sleep", &executable).expect("luvus-named executable");
+        let mut child = std::process::Command::new(&executable)
+            .arg("30")
+            .spawn()
+            .expect("spawn luvus-named process");
+
+        let mut stoppable = false;
+        for _ in 0..20 {
+            if super::is_stoppable_luvus_pid(child.id()) {
+                stoppable = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_file(&executable);
+        let _ = std::fs::remove_dir(&dir);
+        assert!(
+            stoppable,
+            "a live luvus executable must pass the kill guard"
+        );
     }
 
     #[cfg(unix)]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -375,24 +375,58 @@ pub fn is_stoppable_luvus_pid(pid: u32) -> bool {
 }
 
 /// End `pid` and its children. Used only after [`is_stoppable_luvus_pid`].
-pub fn force_terminate(pid: u32) {
+pub fn force_terminate(pid: u32) -> std::io::Result<()> {
     #[cfg(windows)]
     {
-        let _ = no_window(
+        let status = no_window(
             std::process::Command::new("taskkill")
                 .args(["/PID", &pid.to_string(), "/T", "/F"])
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null()),
         )
-        .status();
+        .status()?;
+        if status.success() || !is_stoppable_luvus_pid(pid) {
+            Ok(())
+        } else {
+            Err(std::io::Error::other(format!(
+                "taskkill exited with {status}"
+            )))
+        }
     }
     #[cfg(unix)]
-    unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    {
+        let pid_t = pid as libc::pid_t;
+        let mut tree = process_tree(pid);
+        if tree.is_empty() {
+            tree.push(ProcInfo {
+                pid,
+                depth: 0,
+                command: String::new(),
+            });
+        }
+        let pgid = unsafe { libc::getpgid(pid_t) };
+        if pgid == pid_t {
+            let _ = unsafe { libc::kill(-pid_t, libc::SIGKILL) };
+        }
+        let mut root_error = None;
+        for proc in tree.iter().rev() {
+            let result = unsafe { libc::kill(proc.pid as libc::pid_t, libc::SIGKILL) };
+            if result != 0 && proc.pid == pid {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    root_error = Some(error);
+                }
+            }
+        }
+        match root_error {
+            Some(error) if is_stoppable_luvus_pid(pid) => Err(error),
+            _ => Ok(()),
+        }
     }
     #[cfg(not(any(windows, unix)))]
     {
         let _ = pid;
+        Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
     }
 }
 
@@ -975,6 +1009,28 @@ mod tests {
     fn unix_stoppable_pid_rejects_self_and_missing() {
         assert!(!super::is_stoppable_luvus_pid(0));
         assert!(!super::is_stoppable_luvus_pid(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn force_terminate_kills_a_setsid_child() {
+        use std::os::unix::process::CommandExt;
+        let mut command = std::process::Command::new("sleep");
+        command
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+        let mut child = command.spawn().expect("spawn sleep");
+        super::force_terminate(child.id()).expect("kill setsid child");
+        let status = child.wait().expect("reap sleep");
+        assert!(!status.success());
     }
 
     #[test]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -455,6 +455,12 @@ mod tests {
     }
 
     #[test]
+    fn current_process_is_not_force_stopped_as_a_foreign_server() {
+        assert!(!super::super::is_stoppable_luvus_pid(0));
+        assert!(!super::super::is_stoppable_luvus_pid(std::process::id()));
+    }
+
+    #[test]
     fn current_process_has_a_stable_identity_and_owner() {
         let pid = std::process::id();
         assert!(process_belongs_to_current_user(pid));

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -305,6 +305,17 @@ impl ProcessSnapshot {
         self.command_lines.insert(pid, command.clone());
         command
     }
+
+    fn executable(&self, pid: u32) -> Option<String> {
+        self.names.get(&pid).cloned()
+    }
+}
+
+/// Executable image name reported by ToolHelp, without command-line arguments.
+/// Process identity checks must use this rather than `process_tree`: the latter
+/// deliberately returns the full argv for the command inspector.
+pub(super) fn process_executable(pid: u32) -> Option<String> {
+    ProcessSnapshot::capture()?.executable(pid)
 }
 
 pub(super) fn pane_process_snapshot(
@@ -467,6 +478,18 @@ mod tests {
         let first = process_start_marker(pid).expect("Windows process creation time");
         assert_eq!(process_start_marker(pid).as_deref(), Some(first.as_str()));
         assert!(first.starts_with("windows:"));
+    }
+
+    #[test]
+    fn process_executable_does_not_include_command_line_arguments() {
+        let executable = process_executable(std::process::id()).expect("ToolHelp executable");
+        let expected = std::env::current_exe()
+            .expect("current executable path")
+            .file_name()
+            .expect("current executable name")
+            .to_string_lossy()
+            .into_owned();
+        assert!(executable.eq_ignore_ascii_case(&expected), "{executable:?}");
     }
 
     #[test]


### PR DESCRIPTION
A detached Windows server that still owns the named pipe but no longer handles requests no longer wedges `ping`, `server stop`, or reattach.

Closes #144.

## What

- Bound named-pipe `connect` so a listening-but-busy pipe cannot pin the CLI forever (`WaitNamedPipe` + timeout).
- `server stop` / attach reclaim: if the control plane does not answer, stop the pipe-owner PID (or `server.pid`) instead of hanging.
- Does not stop a healthy server when the TUI window closes.

## Why

#144: after detach, `luvus.exe server` can keep the pipe open and stop answering. `ping` / `stop` / a new `luvus` then hang. Expected: fail or reclaim, not wait forever.

This is the hang path. False `response read failed` after a successful write (`ERROR_PIPE_BUSY` / `PIPE_NOWAIT`) is #146, not this PR.

## Verification

- [x] Focused IPC/PID unit tests (`named_pipe`, `connect_timeout`, `pipe_nowait`, PeekNamedPipe deadline reader, start-marker, current-pid force-stop guard)
- [ ] `cargo clippy --all-targets -- -D warnings` (fails on pre-existing `src/ui/menu.rs` `nonminimal_bool` on `main`; that file is not in this PR)
- [x] `cargo fmt --all --check`
- [ ] Manual: `server stop` against a mute Windows named-pipe server returns instead of hanging

## Notes

#146 is now on `main`. This rebase kept the complete PeekNamedPipe implementation (`set_recv_timeout` Windows path + `recv_has_data` + `api.rs` deadline reader). It did not reintroduce the incomplete deadline half-set.

This PR still owns `connect_timeout`, `endpoint_exists`, `server_pid`, force-stop, and recycle-waits-for-both-endpoints. Unrelated PI `--session` restore is not in `src/persist.rs`. `ServerPidFile` stays for force-stop.

Rebased onto `main`. Head `6bd37c1`. Force-with-lease pushed to this same branch.