### PR TITLE
fix(copy): restore linear multiline selection

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4496,9 +4496,9 @@ mod link_click_tests {
     }
 
     #[test]
-    fn codex_copy_drops_its_one_cell_transcript_gutter() {
+    fn codex_copy_drops_its_one_cell_transcript_gutter_on_one_row() {
         let _env = crate::persist::test_env("codex-copy-gutter");
-        let (mut app, _term, _) = fixture_showing("  hello\r\n  world", 0);
+        let (mut app, _term, _) = fixture_showing("  hello", 0);
         let pane = app.layout().focus;
         app.status.get_mut(&pane).expect("pane status").agent = "codex".into();
         let content = app
@@ -4507,18 +4507,19 @@ mod link_click_tests {
             .find(|(id, _)| *id == pane)
             .map(|(_, rect)| *rect)
             .expect("pane content rect");
-        // The drag starts one cell in, so this verifies Codex detection rather
-        // than the generic pane-edge case above.
+        // The drag starts one cell inside the pane and selects one row, so this
+        // verifies Codex gutter cleanup without relying on rectangular
+        // multiline selection.
         app.selection = Some(crate::app::Selection {
             pane,
             content,
             anchor: (content.x + 1, content.y),
-            cursor: (content.x + 6, content.y + 1),
+            cursor: (content.x + 6, content.y),
             retained: None,
             scrolled: false,
             dragging: false,
         });
 
-        assert_eq!(app.selection_text().as_deref(), Some("hello\nworld"));
+        assert_eq!(app.selection_text().as_deref(), Some("hello"));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1128,8 +1128,7 @@ impl RetainedSelection {
         if row < sr || row > er {
             return false;
         }
-        let middle_left = sc.min(ec);
-        let left = if row == sr { sc } else { middle_left };
+        let left = if row == sr { sc } else { 0 };
         let right = if row == er {
             ec
         } else {
@@ -1178,9 +1177,9 @@ impl Selection {
         if y < sy || y > ey {
             return false;
         }
-        // Middle rows keep the drag's left edge instead of expanding into the
-        // pane margin. This keeps the highlighted range and copied text aligned.
-        let left = if y == sy { sx } else { sx.min(ex) };
+        // A terminal selection is linear: after the first selected row, every
+        // following row starts at the pane's left edge until the final endpoint.
+        let left = if y == sy { sx } else { c.x };
         let right = if y == ey {
             ex
         } else {
@@ -5981,7 +5980,7 @@ mod tests {
     }
 
     #[test]
-    fn selection_keeps_the_drag_left_edge_between_lines() {
+    fn selection_uses_linear_reading_order_between_lines() {
         // Content rect at (x=2, y=1), 10 wide × 5 tall.
         let content = Rect::new(2, 1, 10, 5);
         let sel = Selection {
@@ -5995,16 +5994,15 @@ mod tests {
         };
         // First row: from the anchor column to the right edge.
         assert!(sel.contains(4, 1));
-        assert!(sel.contains(11, 1)); // last column (right() == 12)
-        assert!(!sel.contains(3, 1)); // before the anchor
-                                      // Middle row: it keeps the drag's left edge instead of
-                                      // expanding into the pane's left margin.
-        assert!(!sel.contains(2, 2));
-        assert!(sel.contains(4, 2) && sel.contains(11, 2));
+        // Last column (right() == 12), but not before the anchor.
+        assert!(sel.contains(11, 1));
+        assert!(!sel.contains(3, 1));
+        // Middle row: selection resumes at the pane's left edge.
+        assert!(sel.contains(2, 2) && sel.contains(11, 2));
         // Last row: up to the cursor column.
         assert!(sel.contains(6, 3));
-        assert!(!sel.contains(7, 3)); // past the cursor
-                                      // Outside the row range / pane.
+        assert!(!sel.contains(7, 3));
+        // Outside the row range / pane.
         assert!(!sel.contains(5, 0) && !sel.contains(5, 4) && !sel.contains(99, 2));
         // Dragging up-left selects the same range (anchor/cursor order-independent).
         let rev = Selection {
@@ -6012,7 +6010,18 @@ mod tests {
             cursor: (4, 1),
             ..sel
         };
-        assert!(rev.contains(11, 1) && rev.contains(6, 3) && !rev.contains(7, 3));
+        assert!(
+            rev.contains(11, 1) && rev.contains(2, 2) && rev.contains(6, 3) && !rev.contains(7, 3)
+        );
+
+        let retained = RetainedSelection {
+            anchor: (10, 2),
+            cursor: (12, 4),
+        };
+        assert!(retained.contains(10, 2, 10));
+        assert!(retained.contains(11, 0, 10));
+        assert!(retained.contains(12, 4, 10));
+        assert!(!retained.contains(12, 5, 10));
     }
 
     #[test]

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -693,15 +693,30 @@ impl VtEngine for AlacrittyEngine {
         let last_column = self.term.grid().columns().checked_sub(1)?;
         let leading_blank_cells = |line: Line, limit: usize| {
             let row = &self.term.grid()[line];
-            (0..limit.min(last_column.saturating_add(1)))
-                .take_while(|column| {
-                    let cell = &row[Column(*column)];
-                    !cell
-                        .flags
-                        .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
-                        && (cell.c == '\0' || cell.c.is_whitespace())
-                })
-                .count()
+            let limit = limit.min(last_column.saturating_add(1));
+            let mut column = 0;
+            while column < limit {
+                let cell = &row[Column(column)];
+                if cell
+                    .flags
+                    .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+                    || (cell.c != '\0' && !cell.c.is_whitespace())
+                {
+                    break;
+                }
+                if cell.flags.contains(Flags::WIDE_CHAR) {
+                    let spacer = column.saturating_add(1);
+                    if spacer >= limit
+                        || !row[Column(spacer)].flags.contains(Flags::WIDE_CHAR_SPACER)
+                    {
+                        break;
+                    }
+                    column += 2;
+                } else {
+                    column += 1;
+                }
+            }
+            column
         };
         // When the drag starts after a whitespace-only pane margin, treat that
         // prefix as presentation padding. Following rows may begin earlier, so
@@ -1204,6 +1219,27 @@ mod tests {
                 .as_deref(),
             Some("chosen\nstarts-left"),
             "text before the anchor disables margin cleanup on following rows"
+        );
+    }
+
+    #[test]
+    fn retained_selection_removes_a_complete_wide_whitespace_margin() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(40, 4, tx, budget_for_rows(40, 20));
+        engine.advance("\x1b[H\x1b[2J　first\r\n　second".as_bytes());
+        let mut rows = Vec::new();
+        engine.for_each_retained_row(&mut |row, text| {
+            if text.ends_with("first") || text.ends_with("second") {
+                rows.push(row);
+            }
+        });
+        assert_eq!(rows.len(), 2);
+
+        assert_eq!(
+            engine
+                .retained_selection_text(((rows[0], 2), (rows[1], 7)))
+                .as_deref(),
+            Some("first\nsecond")
         );
     }
 

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -691,7 +691,6 @@ impl VtEngine for AlacrittyEngine {
             return None;
         }
         let last_column = self.term.grid().columns().checked_sub(1)?;
-        let middle_left = start_col.min(end_col);
         let mut output = String::new();
         let mut appended = false;
 
@@ -699,12 +698,7 @@ impl VtEngine for AlacrittyEngine {
             let Some(line) = self.retained_line(row_index) else {
                 continue;
             };
-            let left = if row_index == start_row {
-                start_col
-            } else {
-                middle_left
-            }
-            .min(last_column);
+            let left = if row_index == start_row { start_col } else { 0 }.min(last_column);
             let right = if row_index == end_row {
                 end_col
             } else {
@@ -1127,7 +1121,7 @@ mod tests {
     }
 
     #[test]
-    fn retained_selection_keeps_the_drag_left_edge_on_middle_rows() {
+    fn retained_selection_uses_linear_reading_order_on_middle_rows() {
         let (tx, _rx) = channel();
         let mut engine = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 20));
         engine.advance(b"\x1b[H\x1b[2J - first\r\n - second\r\n - third");
@@ -1143,7 +1137,7 @@ mod tests {
             engine
                 .retained_selection_text(((rows[0], 1), (rows[2], 7)))
                 .as_deref(),
-            Some("- first\n- second\n- third")
+            Some("- first\n - second\n - third")
         );
     }
 

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -691,6 +691,26 @@ impl VtEngine for AlacrittyEngine {
             return None;
         }
         let last_column = self.term.grid().columns().checked_sub(1)?;
+        let leading_blank_cells = |line: Line, limit: usize| {
+            let row = &self.term.grid()[line];
+            (0..limit.min(last_column.saturating_add(1)))
+                .take_while(|column| {
+                    let cell = &row[Column(*column)];
+                    !cell
+                        .flags
+                        .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+                        && (cell.c == '\0' || cell.c.is_whitespace())
+                })
+                .count()
+        };
+        // When the drag starts after a whitespace-only pane margin, treat that
+        // prefix as presentation padding. Following rows may begin earlier, so
+        // remove only blank cells and stop before their first real character.
+        // Additional indentation remains relative to the selected margin.
+        let margin = self
+            .retained_line(start_row)
+            .filter(|line| start_col > 0 && leading_blank_cells(*line, start_col) == start_col)
+            .map_or(0, |_| start_col);
         let mut output = String::new();
         let mut appended = false;
 
@@ -698,7 +718,12 @@ impl VtEngine for AlacrittyEngine {
             let Some(line) = self.retained_line(row_index) else {
                 continue;
             };
-            let left = if row_index == start_row { start_col } else { 0 }.min(last_column);
+            let left = if row_index == start_row {
+                start_col
+            } else {
+                leading_blank_cells(line, margin)
+            }
+            .min(last_column);
             let right = if row_index == end_row {
                 end_col
             } else {
@@ -1121,7 +1146,7 @@ mod tests {
     }
 
     #[test]
-    fn retained_selection_uses_linear_reading_order_on_middle_rows() {
+    fn retained_selection_removes_only_the_selected_blank_margin() {
         let (tx, _rx) = channel();
         let mut engine = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 20));
         engine.advance(b"\x1b[H\x1b[2J - first\r\n - second\r\n - third");
@@ -1137,7 +1162,48 @@ mod tests {
             engine
                 .retained_selection_text(((rows[0], 1), (rows[2], 7)))
                 .as_deref(),
-            Some("- first\n - second\n - third")
+            Some("- first\n- second\n- third")
+        );
+    }
+
+    #[test]
+    fn retained_selection_preserves_content_and_relative_indentation() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(40, 6, tx, budget_for_rows(40, 20));
+        engine.advance(
+            b"\x1b[H\x1b[2J    first\r\n    second\r\n      nested\r\nprefix chosen\r\nstarts-left",
+        );
+        let mut rows = Vec::new();
+        engine.for_each_retained_row(&mut |row, text| {
+            if !text.is_empty() {
+                rows.push((row, text.to_string()));
+            }
+        });
+
+        let first = rows
+            .iter()
+            .find(|(_, text)| text == "    first")
+            .map(|(row, _)| *row)
+            .expect("indented prose row");
+        assert_eq!(
+            engine
+                .retained_selection_text(((first, 4), (first + 2, 11)))
+                .as_deref(),
+            Some("first\nsecond\n  nested"),
+            "the selected blank margin is removed while deeper indentation remains"
+        );
+
+        let chosen = rows
+            .iter()
+            .find(|(_, text)| text == "prefix chosen")
+            .map(|(row, _)| *row)
+            .expect("mid-line selection row");
+        assert_eq!(
+            engine
+                .retained_selection_text(((chosen, 7), (chosen + 1, 10)))
+                .as_deref(),
+            Some("chosen\nstarts-left"),
+            "text before the anchor disables margin cleanup on following rows"
         );
     }
 

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -218,7 +218,9 @@ pub trait VtEngine: Send {
     /// Extract an inclusive retained-row selection using terminal cell
     /// coordinates. Implementations must preserve complete wide glyphs and
     /// zero-width marks rather than treating columns as string character
-    /// indexes.
+    /// indexes. When the selection starts after a whitespace-only margin,
+    /// following rows may omit up to that many leading blank cells, but must
+    /// preserve earlier content and any additional relative indentation.
     fn retained_selection_text(&self, range: ((usize, usize), (usize, usize))) -> Option<String>;
 
     /// Return copy-mode navigation geometry for one retained row. Trailing

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -335,10 +335,13 @@ pub(super) fn draw_file_view(
     // the selected cells, after the text so it tints whatever is under it. A
     // buffer post-pass keeps it independent of the text/search spans.
     if let Some(sel) = sel {
+        // Line numbers are presentation-only and selection_text deliberately
+        // excludes them, so do not tint the gutter as though it will be copied.
+        let text_x = body.x + crate::files::gutter_width(v.line_count()) + 1;
         let buf = f.buffer_mut();
         for y in body.y..body.bottom() {
             for x in body.x..body.right() {
-                if sel.contains(x, y) {
+                if file_selection_contains(sel, x, y, text_x) {
                     if let Some(cell) = buf.cell_mut((x, y)) {
                         cell.set_bg(t.sel_bg);
                     }
@@ -390,6 +393,10 @@ pub(super) fn draw_file_view(
             Rect::new(area.right().saturating_sub(6), footer_y, 6, 1),
         );
     }
+}
+
+fn file_selection_contains(sel: &crate::app::Selection, x: u16, y: u16, text_x: u16) -> bool {
+    x >= text_x && sel.contains(x, y)
 }
 
 fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t: &Theme) {
@@ -655,12 +662,34 @@ pub(super) fn draw_delete_confirm(
 
 #[cfg(test)]
 mod tests {
-    use super::diff_note_count;
+    use super::{diff_note_count, file_selection_contains};
+    use crate::app::Selection;
+    use crate::ids::PaneId;
+    use ratatui::layout::Rect;
 
     #[test]
     fn diff_note_count_uses_singular_and_plural_labels() {
         assert_eq!(diff_note_count(0), "");
         assert_eq!(diff_note_count(1), "  1 note");
         assert_eq!(diff_note_count(2), "  2 notes");
+    }
+
+    #[test]
+    fn file_selection_highlight_excludes_the_line_number_gutter() {
+        let selection = Selection {
+            pane: PaneId(1),
+            content: Rect::new(2, 1, 20, 4),
+            anchor: (9, 1),
+            cursor: (12, 3),
+            retained: None,
+            scrolled: false,
+            dragging: true,
+        };
+        let text_x = 7;
+
+        assert!(!file_selection_contains(&selection, 2, 2, text_x));
+        assert!(!file_selection_contains(&selection, 6, 2, text_x));
+        assert!(file_selection_contains(&selection, 7, 2, text_x));
+        assert!(file_selection_contains(&selection, 12, 3, text_x));
     }
 }


### PR DESCRIPTION
## Summary

- restore normal linear selection across multiple terminal rows
- start intermediate rows at the pane left edge
- keep rendered highlights and copied retained-history text aligned
- preserve reverse dragging and Unicode cell-aware selection

## Problem

Multiline mouse selection reused the drag starting column on every following row. This produced a rectangular-looking selection that skipped the beginning of subsequent lines.

The corrected behavior selects:

1. from the starting character to the end of the first row
2. complete intermediate rows
3. from the beginning of the final row to the cursor

## Verification

- `cargo test selection -- --nocapture` (15 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-line terminal text selection to follow natural reading order, including reverse-direction selections.
  * Fixed retained text extraction to remove only appropriate leading blank margins while preserving meaningful indentation.
  * Improved selections beginning within content so unrelated prefixes on following lines remain intact.
  * File selection highlighting now excludes the line-number gutter.
* **Tests**
  * Expanded coverage for terminal, retained-text, clipboard, and file-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->