### PR TITLE
fix(detect): grok reads Working while a subagent runs

### DIFF
--- a/src/detect.rs
+++ b/src/detect.rs
@@ -589,6 +589,19 @@ fn builtin_rules() -> Vec<Rule> {
             Region::Screen,
             vec![any(&["ctrl+c:cancel"])],
         ),
+        // While a subagent is running, Grok replaces that footer entirely with
+        // "1 subagent still running - send a message to interrupt", so the rule
+        // above stops matching and the pane reads Idle for however long the
+        // subagent takes - minutes, in practice. Same reasoning as WORKING_HINTS:
+        // an invitation to interrupt only exists while there is something to
+        // interrupt.
+        per(
+            "grok",
+            State::Working,
+            105,
+            Region::Screen,
+            vec![any(&["send a message to interrupt"])],
+        ),
     ]
 }
 
@@ -1704,6 +1717,23 @@ mod tests {
             &Manifests::builtin(),
         );
         assert_eq!(d.state, State::Blocked);
+    }
+
+    #[test]
+    fn grok_running_a_subagent_is_working() {
+        // Grok swaps its `Ctrl+c:cancel` footer for a subagent line while a
+        // subagent runs; without a rule for it the pane read Idle throughout.
+        let d = classify(
+            Some("grok"),
+            "  * Run File issue to lift config live into configlist\n  * Running 1 subagent\n\n  o 1 subagent still running - send a message to interrupt",
+            true,
+            false,
+            "grok",
+            "grok",
+            &[],
+            &Manifests::builtin(),
+        );
+        assert_eq!(d.state, State::Working);
     }
 
     #[test]


### PR DESCRIPTION
## What

Grok already has a per-agent working hint for its `Ctrl+c:cancel` footer. While a subagent is running, Grok replaces that footer entirely with:

```
◎ 1 subagent still running · send a message to interrupt
```

so the existing hint stops matching, and the pane reads `Idle` for however long the subagent takes — minutes, in practice.

## How it showed up

On 0.13.1, a Grok pane nine minutes into a subagent reported `Idle`. `luvus agent explain` was unambiguous that nothing had matched:

```json
"state_evidence": {
  "source": "no_positive_state_evidence",
  "confidence": "none",
  "rule_priority": null,
  "rule_region": null
}
```

So `Idle` was the fallback rather than a finding. With the rule, the same pane gives `source: manifest_rule`, `confidence: high`, `rule_priority: 105`.

I found this while building a bar widget that renders `agent list`, where "idle" and "we could not tell" are indistinguishable to the reader — but the gap is in detection, not in anything downstream.

## Why per-agent rather than `WORKING_HINTS`

Following the comment on the rule directly above it: Grok's punctuation is its own, which is why `ctrl+c:cancel` is a per-agent hint instead of a generic one. Same applies here, and it keeps the string away from the other fourteen agents. The underlying reasoning is the one `WORKING_HINTS` is built on though — an invitation to interrupt only exists while there is something to interrupt.

## Checks

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --locked` — 955 passed, 0 failed

Adds `detect::tests::grok_running_a_subagent_is_working`, built from the real pane text.

## Caveat

This covers the subagent footer specifically. I have not observed what Grok prints during an ordinary turn that shows neither footer, so there may be a further gap I could not test for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Grok activity detection when a subagent is running.
  * Grok panes now correctly show as working when displaying the “send a message to interrupt” footer.
  * Existing cancellation prompts continue to be recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->