### PR TITLE
fix(diff): improve sidebar and viewer scrolling

### DIFF
--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::Rect;
 
 use crate::app::{App, DiffMenu, DiffMenuItem, Tab, ViewKind};
 use crate::diff::{DiffKey, DiffListRow, DiffLoad, DiffView, FilesMode};
@@ -210,7 +211,6 @@ impl App {
         self.diff.status_root = Some(visible_root.clone());
         match result {
             Ok(mut snapshot) => {
-                let old_selected = self.diff.selected_key.clone();
                 let old_fingerprints = self
                     .diff
                     .snapshot
@@ -255,25 +255,6 @@ impl App {
                 self.diff.snapshot = Some(snapshot);
                 self.apply_diff_progress();
                 self.diff.rebuild_rows();
-                let mut cursor_restored = false;
-                if let Some(key) = old_selected {
-                    if let Some(position) = self.diff.rows.iter().position(|row| {
-                        let DiffListRow::File(index) = row else {
-                            return false;
-                        };
-                        self.diff
-                            .snapshot
-                            .as_ref()
-                            .and_then(|snapshot| snapshot.files.get(*index))
-                            .is_some_and(|file| file.key == key)
-                    }) {
-                        self.diff.cursor = position;
-                        cursor_restored = true;
-                    }
-                }
-                if cursor_restored {
-                    self.diff.ensure_cursor_visible();
-                }
                 let live_refresh = self.config.layout.diff_live_refresh;
                 let visible: std::collections::HashSet<PaneId> =
                     self.layout().leaves().into_iter().collect();
@@ -325,6 +306,7 @@ impl App {
     }
 
     pub fn diff_scroll_by(&mut self, delta: isize) {
+        self.diff.scroll_detached = true;
         if delta < 0 {
             self.diff.scroll = self.diff.scroll.saturating_sub(delta.unsigned_abs());
         } else {
@@ -392,6 +374,7 @@ impl App {
             return;
         }
         self.diff.cursor = row.min(self.diff.rows.len().saturating_sub(1));
+        self.diff.scroll_detached = false;
         self.diff.ensure_cursor_visible();
         let Some(file) = self.diff.selected_file().cloned() else {
             return;
@@ -619,20 +602,7 @@ impl App {
                 reconciled = loaded.reconciled_notes;
                 view.stack_rows = crate::diff::rows::stack_rows(&diff);
                 view.split_rows = crate::diff::rows::split_rows(&diff);
-                view.stack_indices = view
-                    .stack_rows
-                    .iter()
-                    .enumerate()
-                    .flat_map(|(index, line)| {
-                        let old = line
-                            .old_line
-                            .map(|n| ((crate::diff::DiffSide::Old, n), index));
-                        let new = line
-                            .new_line
-                            .map(|n| ((crate::diff::DiffSide::New, n), index));
-                        old.into_iter().chain(new)
-                    })
-                    .collect();
+                view.rebuild_row_indices();
                 cache = Some(diff.clone());
                 DiffLoad::Ready(Box::new(diff))
             }
@@ -1037,18 +1007,22 @@ impl App {
         let Some(pane) = self.diff_note_drag.take() else {
             return;
         };
-        let viewport = self
+        let content = self
             .pane_content_rects
             .iter()
             .find(|(p, _)| *p == pane)
-            .map(|(_, rect)| rect.height.saturating_sub(2) as usize)
-            .unwrap_or(20);
+            .map(|(_, rect)| *rect)
+            .unwrap_or(Rect::new(0, 0, 80, 22));
+        let viewport = content.height.saturating_sub(2) as usize;
+        let marker_style = self.config.layout.diff_marker_style;
         let Some(ViewKind::Diff(view)) = self.views.get_mut(&pane) else {
             return;
         };
         view.note_selecting = false;
         view.note_draft = Some(String::new());
         view.scroll = view.selected.saturating_sub(viewport.saturating_sub(9));
+        let split = view.effective_split(content.width);
+        view.ensure_horizontal_visible(content.width, marker_style, split);
     }
 
     fn commit_diff_note(&mut self, id: PaneId, body: String) {
@@ -1476,17 +1450,7 @@ impl App {
             .map(|(_, rect)| rect.width)
             .unwrap_or(80);
         let marker_style = self.config.layout.diff_marker_style;
-        let is_split = {
-            if view.wrap {
-                false
-            } else {
-                matches!(
-                    view.preference,
-                    crate::diff::DiffLayoutPreference::Split
-                        | crate::diff::DiffLayoutPreference::Auto
-                ) && pane_width >= 96
-            }
-        };
+        let is_split = view.effective_split(pane_width);
         let next = if delta > 0 {
             rows.into_iter().find(|row| *row > view.selected)
         } else {
@@ -1523,15 +1487,7 @@ impl App {
             let Some(ViewKind::Diff(view)) = self.views.get(&id) else {
                 return false;
             };
-            if view.wrap {
-                false
-            } else {
-                matches!(
-                    view.preference,
-                    crate::diff::DiffLayoutPreference::Split
-                        | crate::diff::DiffLayoutPreference::Auto
-                ) && pane_width >= 96
-            }
+            view.effective_split(pane_width)
         };
 
         enum Deferred {
@@ -1774,16 +1730,11 @@ impl App {
                 }
                 // Recompute effective split after s/w may have changed
                 // preference or wrap.
-                let now_split = if view.wrap {
-                    false
-                } else {
-                    matches!(
-                        view.preference,
-                        crate::diff::DiffLayoutPreference::Split
-                            | crate::diff::DiffLayoutPreference::Auto
-                    ) && pane_width >= 96
-                };
-                if view.selected != old_selected || now_split != is_split {
+                let now_split = view.effective_split(pane_width);
+                if view.selected != old_selected
+                    || now_split != is_split
+                    || matches!(key.code, KeyCode::Char('h' | 'l'))
+                {
                     view.ensure_horizontal_visible(pane_width, marker_style, now_split);
                 }
             }
@@ -2356,20 +2307,8 @@ mod tests {
         view.preference = crate::diff::DiffLayoutPreference::Split;
         view.stack_rows = stack_rows;
         view.split_rows = split_rows;
-        view.stack_indices = view
-            .stack_rows
-            .iter()
-            .enumerate()
-            .flat_map(|(index, line)| {
-                let old = line
-                    .old_line
-                    .map(|n| ((crate::diff::DiffSide::Old, n), index));
-                let new = line
-                    .new_line
-                    .map(|n| ((crate::diff::DiffSide::New, n), index));
-                old.into_iter().chain(new)
-            })
-            .collect();
+        view.rebuild_row_indices();
+        view.horizontal = usize::MAX;
         view.load = DiffLoad::Ready(Box::new(file_diff));
 
         let mut terminal = Terminal::new(TestBackend::new(180, 40)).unwrap();
@@ -2431,7 +2370,9 @@ mod tests {
         assert!(matches!(
             app.views.get(&id),
             Some(ViewKind::Diff(view))
-                if view.selected == last_row && view.note_draft.as_deref() == Some("")
+                if view.selected == last_row
+                    && view.note_draft.as_deref() == Some("")
+                    && view.horizontal < view.stack_rows[last_row].text.chars().count()
         ));
 
         // A press and release on the same row is the one-line form of the same
@@ -2454,6 +2395,110 @@ mod tests {
             Some(ViewKind::Diff(view))
                 if view.note_draft.as_deref() == Some("")
                     && view.range_anchor == Some((crate::diff::DiffSide::New, 9))
+        ));
+    }
+
+    #[test]
+    fn repeated_horizontal_navigation_stays_inside_the_selected_line() {
+        let _env = crate::persist::test_env("diff-horizontal-keys");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(40, 20, tx).unwrap();
+        let key = install_snapshot(&mut app);
+        app.open_diff_view(key, OpenTarget::Tab);
+        let id = app.layout().focus;
+        app.pane_content_rects = vec![(id, Rect::new(0, 0, 20, 12))];
+        let Some(ViewKind::Diff(view)) = app.views.get_mut(&id) else {
+            panic!("native DIFF view");
+        };
+        view.preference = crate::diff::DiffLayoutPreference::Stack;
+        view.stack_rows = vec![DiffLine {
+            kind: DiffLineKind::Context,
+            old_line: Some(1),
+            new_line: Some(1),
+            text: "abcdefghijklmnopqrstuvwxyz".into(),
+        }];
+
+        for _ in 0..20 {
+            assert!(app.handle_diff_key(id, KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE)));
+        }
+        let max = match app.views.get(&id) {
+            Some(ViewKind::Diff(view)) => view.horizontal,
+            _ => unreachable!(),
+        };
+        assert!(max < 26, "selected line retains visible text");
+
+        for _ in 0..20 {
+            assert!(app.handle_diff_key(id, KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE)));
+        }
+        assert!(matches!(
+            app.views.get(&id),
+            Some(ViewKind::Diff(view)) if view.horizontal == 0
+        ));
+    }
+
+    #[test]
+    fn split_wheel_scroll_maps_visible_rows_back_to_stack_selection() {
+        let _env = crate::persist::test_env("diff-split-wheel");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 20, tx).unwrap();
+        let key = install_snapshot(&mut app);
+        app.open_diff_view(key.clone(), OpenTarget::Tab);
+        let id = app.layout().focus;
+        let file_diff = FileDiff {
+            key,
+            status: DiffFileStatus::Modified,
+            additions: 1,
+            deletions: 2,
+            binary: false,
+            truncated: false,
+            omitted_lines: 0,
+            hunks: vec![DiffHunk {
+                id: "hunk".into(),
+                old_start: 1,
+                new_start: 1,
+                header: "@@ -1,2 +1 @@".into(),
+                lines: vec![
+                    DiffLine {
+                        kind: DiffLineKind::Deletion,
+                        old_line: Some(1),
+                        new_line: None,
+                        text: "old one".into(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Deletion,
+                        old_line: Some(2),
+                        new_line: None,
+                        text: "old two".into(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Addition,
+                        old_line: None,
+                        new_line: Some(1),
+                        text: "new".into(),
+                    },
+                ],
+            }],
+        };
+        let Some(ViewKind::Diff(view)) = app.views.get_mut(&id) else {
+            panic!("native DIFF view");
+        };
+        view.preference = crate::diff::DiffLayoutPreference::Split;
+        view.stack_rows = crate::diff::rows::stack_rows(&file_diff);
+        view.split_rows = crate::diff::rows::split_rows(&file_diff);
+        view.selected_side = crate::diff::DiffSide::New;
+        view.rebuild_row_indices();
+        view.load = DiffLoad::Ready(Box::new(file_diff));
+        app.pane_content_rects = vec![(id, Rect::new(0, 0, 120, 4))];
+
+        assert!(app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 1,
+            row: 1,
+            modifiers: KeyModifiers::NONE,
+        })));
+        assert!(matches!(
+            app.views.get(&id),
+            Some(ViewKind::Diff(view)) if view.selected == 3 && view.scroll == 3
         ));
     }
 

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -255,6 +255,7 @@ impl App {
                 self.diff.snapshot = Some(snapshot);
                 self.apply_diff_progress();
                 self.diff.rebuild_rows();
+                let mut cursor_restored = false;
                 if let Some(key) = old_selected {
                     if let Some(position) = self.diff.rows.iter().position(|row| {
                         let DiffListRow::File(index) = row else {
@@ -267,7 +268,11 @@ impl App {
                             .is_some_and(|file| file.key == key)
                     }) {
                         self.diff.cursor = position;
+                        cursor_restored = true;
                     }
+                }
+                if cursor_restored {
+                    self.diff.ensure_cursor_visible();
                 }
                 let live_refresh = self.config.layout.diff_live_refresh;
                 let visible: std::collections::HashSet<PaneId> =
@@ -387,6 +392,7 @@ impl App {
             return;
         }
         self.diff.cursor = row.min(self.diff.rows.len().saturating_sub(1));
+        self.diff.ensure_cursor_visible();
         let Some(file) = self.diff.selected_file().cloned() else {
             return;
         };
@@ -613,6 +619,20 @@ impl App {
                 reconciled = loaded.reconciled_notes;
                 view.stack_rows = crate::diff::rows::stack_rows(&diff);
                 view.split_rows = crate::diff::rows::split_rows(&diff);
+                view.stack_indices = view
+                    .stack_rows
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(index, line)| {
+                        let old = line
+                            .old_line
+                            .map(|n| ((crate::diff::DiffSide::Old, n), index));
+                        let new = line
+                            .new_line
+                            .map(|n| ((crate::diff::DiffSide::New, n), index));
+                        old.into_iter().chain(new)
+                    })
+                    .collect();
                 cache = Some(diff.clone());
                 DiffLoad::Ready(Box::new(diff))
             }
@@ -1020,7 +1040,7 @@ impl App {
         let viewport = self
             .pane_content_rects
             .iter()
-            .find(|(id, _)| *id == pane)
+            .find(|(p, _)| *p == pane)
             .map(|(_, rect)| rect.height.saturating_sub(2) as usize)
             .unwrap_or(20);
         let Some(ViewKind::Diff(view)) = self.views.get_mut(&pane) else {
@@ -1449,6 +1469,24 @@ impl App {
             .collect();
         rows.sort_unstable();
         rows.dedup();
+        let pane_width = self
+            .pane_content_rects
+            .iter()
+            .find(|(pane, _)| *pane == id)
+            .map(|(_, rect)| rect.width)
+            .unwrap_or(80);
+        let marker_style = self.config.layout.diff_marker_style;
+        let is_split = {
+            if view.wrap {
+                false
+            } else {
+                matches!(
+                    view.preference,
+                    crate::diff::DiffLayoutPreference::Split
+                        | crate::diff::DiffLayoutPreference::Auto
+                ) && pane_width >= 96
+            }
+        };
         let next = if delta > 0 {
             rows.into_iter().find(|row| *row > view.selected)
         } else {
@@ -1457,6 +1495,7 @@ impl App {
         if let (Some(row), Some(ViewKind::Diff(view))) = (next, self.views.get_mut(&id)) {
             view.selected = row;
             view.scroll = row.saturating_sub(2);
+            view.ensure_horizontal_visible(pane_width, marker_style, is_split);
         }
     }
 
@@ -1473,6 +1512,27 @@ impl App {
             .find(|(pane, _)| *pane == id)
             .map(|(_, rect)| rect.height.saturating_sub(2) as usize)
             .unwrap_or(20);
+        let pane_width = self
+            .pane_content_rects
+            .iter()
+            .find(|(pane, _)| *pane == id)
+            .map(|(_, rect)| rect.width)
+            .unwrap_or(80);
+        let marker_style = self.config.layout.diff_marker_style;
+        let is_split = {
+            let Some(ViewKind::Diff(view)) = self.views.get(&id) else {
+                return false;
+            };
+            if view.wrap {
+                false
+            } else {
+                matches!(
+                    view.preference,
+                    crate::diff::DiffLayoutPreference::Split
+                        | crate::diff::DiffLayoutPreference::Auto
+                ) && pane_width >= 96
+            }
+        };
 
         enum Deferred {
             None,
@@ -1569,6 +1629,7 @@ impl App {
                 } else if view.selected >= view.scroll.saturating_add(viewport) {
                     view.scroll = view.selected.saturating_sub(viewport.saturating_sub(1));
                 }
+                view.ensure_horizontal_visible(pane_width, marker_style, is_split);
             } else if view.search_editing {
                 match key.code {
                     KeyCode::Char(c) => view.search.get_or_insert_with(String::new).push(c),
@@ -1587,6 +1648,7 @@ impl App {
                             {
                                 view.selected = index;
                                 view.scroll = index.saturating_sub(viewport / 2);
+                                view.ensure_horizontal_visible(pane_width, marker_style, is_split);
                             }
                         }
                     }
@@ -1599,6 +1661,7 @@ impl App {
             } else {
                 let row_count = view.stack_rows.len();
                 let max = row_count.saturating_sub(1);
+                let old_selected = view.selected;
                 match key.code {
                     KeyCode::Char('j') | KeyCode::Down => {
                         view.selected = (view.selected + 1).min(max)
@@ -1618,7 +1681,25 @@ impl App {
                     KeyCode::Right => view.selected_side = crate::diff::DiffSide::New,
                     KeyCode::Char('h') => view.horizontal = view.horizontal.saturating_sub(8),
                     KeyCode::Char('l') => view.horizontal = view.horizontal.saturating_add(8),
-                    KeyCode::Char('s') => view.preference = view.preference.cycle(),
+                    KeyCode::Char('s') => {
+                        // When Auto resolves to Split (wide enough, no wrap),
+                        // skip directly to Stack so the user doesn't need to
+                        // press 's' twice to see a visual change.
+                        let was_effectively_split = !view.wrap
+                            && matches!(
+                                view.preference,
+                                crate::diff::DiffLayoutPreference::Split
+                                    | crate::diff::DiffLayoutPreference::Auto
+                            )
+                            && pane_width >= 96;
+                        if was_effectively_split
+                            && view.preference == crate::diff::DiffLayoutPreference::Auto
+                        {
+                            view.preference = crate::diff::DiffLayoutPreference::Stack;
+                        } else {
+                            view.preference = view.preference.cycle();
+                        }
+                    }
                     KeyCode::Char('w') => view.wrap = !view.wrap,
                     KeyCode::Char('+') | KeyCode::Char('=') => deferred = Deferred::Context(1),
                     KeyCode::Char('-') => deferred = Deferred::Context(-1),
@@ -1637,6 +1718,7 @@ impl App {
                             })
                         {
                             view.selected = next;
+                            view.ensure_horizontal_visible(pane_width, marker_style, is_split);
                         }
                     }
                     KeyCode::Char('{') => {
@@ -1651,6 +1733,7 @@ impl App {
                             })
                         {
                             view.selected = previous;
+                            view.ensure_horizontal_visible(pane_width, marker_style, is_split);
                         }
                     }
                     KeyCode::Char('/') => {
@@ -1688,6 +1771,20 @@ impl App {
                     view.scroll = view.selected;
                 } else if view.selected >= view.scroll.saturating_add(viewport) {
                     view.scroll = view.selected.saturating_sub(viewport.saturating_sub(1));
+                }
+                // Recompute effective split after s/w may have changed
+                // preference or wrap.
+                let now_split = if view.wrap {
+                    false
+                } else {
+                    matches!(
+                        view.preference,
+                        crate::diff::DiffLayoutPreference::Split
+                            | crate::diff::DiffLayoutPreference::Auto
+                    ) && pane_width >= 96
+                };
+                if view.selected != old_selected || now_split != is_split {
+                    view.ensure_horizontal_visible(pane_width, marker_style, now_split);
                 }
             }
         }
@@ -2259,6 +2356,20 @@ mod tests {
         view.preference = crate::diff::DiffLayoutPreference::Split;
         view.stack_rows = stack_rows;
         view.split_rows = split_rows;
+        view.stack_indices = view
+            .stack_rows
+            .iter()
+            .enumerate()
+            .flat_map(|(index, line)| {
+                let old = line
+                    .old_line
+                    .map(|n| ((crate::diff::DiffSide::Old, n), index));
+                let new = line
+                    .new_line
+                    .map(|n| ((crate::diff::DiffSide::New, n), index));
+                old.into_iter().chain(new)
+            })
+            .collect();
         view.load = DiffLoad::Ready(Box::new(file_diff));
 
         let mut terminal = Terminal::new(TestBackend::new(180, 40)).unwrap();

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1528,15 +1528,7 @@ impl App {
                         v.scroll_by(scroll, viewport, text_w);
                     }
                     Some(crate::app::ViewKind::Diff(v)) => {
-                        let is_split = if v.wrap {
-                            false
-                        } else {
-                            matches!(
-                                v.preference,
-                                crate::diff::DiffLayoutPreference::Split
-                                    | crate::diff::DiffLayoutPreference::Auto
-                            ) && rect.width >= 96
-                        };
+                        let is_split = v.effective_split(rect.width);
                         if hscroll != 0 {
                             if hscroll < 0 {
                                 v.horizontal = v.horizontal.saturating_sub(8);
@@ -1551,15 +1543,27 @@ impl App {
                             } else {
                                 v.stack_rows.len()
                             };
-                            if scroll < 0 {
+                            if is_split {
+                                let current = v.split_row_for_stack(v.scroll);
+                                let split = if scroll < 0 {
+                                    current.saturating_sub(3)
+                                } else {
+                                    current.saturating_add(3).min(rows.saturating_sub(viewport))
+                                };
+                                if let Some(stack) = v.stack_row_for_split(split) {
+                                    v.scroll = stack;
+                                    v.selected = stack;
+                                }
+                            } else if scroll < 0 {
                                 v.scroll = v.scroll.saturating_sub(3);
+                                v.selected = v.scroll;
                             } else {
                                 v.scroll = v
                                     .scroll
                                     .saturating_add(3)
                                     .min(rows.saturating_sub(viewport));
+                                v.selected = v.scroll;
                             }
-                            v.selected = v.scroll;
                         }
                     }
                     None => {}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1452,15 +1452,23 @@ impl App {
             _ => {}
         }
         let scroll: i32 = match m.kind {
-            MouseEventKind::Down(MouseButton::Left) => 0,
             MouseEventKind::ScrollUp => -3,
             MouseEventKind::ScrollDown => 3,
-            _ => return, // motion / release: hover updated, nothing else to do
+            _ => 0,
         };
+        let hscroll: i32 = match m.kind {
+            MouseEventKind::ScrollLeft => -3,
+            MouseEventKind::ScrollRight => 3,
+            _ => 0,
+        };
+        if scroll == 0 && hscroll == 0 && !matches!(m.kind, MouseEventKind::Down(MouseButton::Left))
+        {
+            return; // motion / release: hover updated, nothing else to do
+        }
         let (c, r) = (m.column, m.row);
         let hit = |rect: Rect| c >= rect.x && c < rect.right() && r >= rect.y && r < rect.bottom();
 
-        if scroll != 0 {
+        if scroll != 0 || hscroll != 0 {
             // Wheel over a sidebar list scrolls it one item per notch (the next
             // render clamps the offset to the list length).
             let step = |off: usize| {
@@ -1470,15 +1478,15 @@ impl App {
                     off + 1
                 }
             };
-            if hit(self.workspaces_area) {
+            if scroll != 0 && hit(self.workspaces_area) {
                 self.workspaces_scroll = step(self.workspaces_scroll);
                 return;
             }
-            if hit(self.agents_area) {
+            if scroll != 0 && hit(self.agents_area) {
                 self.agents_scroll = step(self.agents_scroll);
                 return;
             }
-            if hit(self.files_area) {
+            if scroll != 0 && hit(self.files_area) {
                 if self.files_mode == crate::diff::FilesMode::Diff {
                     self.diff_scroll_by(if scroll < 0 { -1 } else { 1 });
                 } else {
@@ -1487,17 +1495,17 @@ impl App {
                 return;
             }
             // Wheel over a git tab scrolls its active view (docs/17).
-            if self.active_is_git() && hit(self.last_pane_area) {
+            if scroll != 0 && self.active_is_git() && hit(self.last_pane_area) {
                 self.git_scroll(scroll);
                 return;
             }
             // Wheel over the orchestration board scrolls its list (docs/22).
-            if self.active_is_orch() && hit(self.orch_area) {
+            if scroll != 0 && self.active_is_orch() && hit(self.orch_area) {
                 self.orch_scroll_by(scroll);
                 return;
             }
             // Wheel over Mission Control scrolls its agent list (docs/54).
-            if self.active_is_mission() && hit(self.mission_area) {
+            if scroll != 0 && self.active_is_mission() && hit(self.mission_area) {
                 let n = self.mission_rows.len();
                 self.mission_cursor = match scroll {
                     s if s < 0 => self.mission_cursor.saturating_sub(1),
@@ -1513,108 +1521,135 @@ impl App {
                 .find(|(id, rect)| self.views.contains_key(id) && hit(*rect))
                 .map(|(id, rect)| (*id, *rect))
             {
-                let viewport = rect.height.saturating_sub(1) as usize;
+                let viewport = rect.height.saturating_sub(2) as usize;
                 match self.views.get_mut(&id) {
                     Some(crate::app::ViewKind::File(v)) => {
                         let text_w = view_text_w(v, rect.width);
                         v.scroll_by(scroll, viewport, text_w);
                     }
                     Some(crate::app::ViewKind::Diff(v)) => {
-                        let rows = v.stack_rows.len().max(v.split_rows.len());
-                        if scroll < 0 {
-                            v.scroll = v.scroll.saturating_sub(3);
+                        let is_split = if v.wrap {
+                            false
                         } else {
-                            v.scroll = v
-                                .scroll
-                                .saturating_add(3)
-                                .min(rows.saturating_sub(viewport));
+                            matches!(
+                                v.preference,
+                                crate::diff::DiffLayoutPreference::Split
+                                    | crate::diff::DiffLayoutPreference::Auto
+                            ) && rect.width >= 96
+                        };
+                        if hscroll != 0 {
+                            if hscroll < 0 {
+                                v.horizontal = v.horizontal.saturating_sub(8);
+                            } else {
+                                v.horizontal = v.horizontal.saturating_add(8);
+                            }
+                            let marker_style = self.config.layout.diff_marker_style;
+                            v.ensure_horizontal_visible(rect.width, marker_style, is_split);
+                        } else {
+                            let rows = if is_split {
+                                v.split_rows.len()
+                            } else {
+                                v.stack_rows.len()
+                            };
+                            if scroll < 0 {
+                                v.scroll = v.scroll.saturating_sub(3);
+                            } else {
+                                v.scroll = v
+                                    .scroll
+                                    .saturating_add(3)
+                                    .min(rows.saturating_sub(viewport));
+                            }
+                            v.selected = v.scroll;
                         }
-                        v.selected = v.scroll;
                     }
                     None => {}
                 }
                 return;
             }
             // Otherwise the wheel scrolls the pane under the cursor.
-            if let Some(id) = self
-                .pane_rects
-                .iter()
-                .find(|(_, rect)| hit(*rect))
-                .map(|(id, _)| *id)
-            {
-                let up = scroll < 0;
-                // Pane-local, 1-based coordinates for a forwarded mouse event.
-                let content = self
-                    .pane_content_rects
+            // Skip when only horizontal scroll is active — there is no
+            // meaningful terminal horizontal-wheel protocol to forward.
+            if scroll != 0 {
+                if let Some(id) = self
+                    .pane_rects
                     .iter()
-                    .find(|(pid, _)| *pid == id)
-                    .map(|(_, r)| *r);
-                // Set after the pane borrow ends: `Some(v)` writes `scroll_pane = v`.
-                let mut set_scroll: Option<Option<PaneId>> = None;
-                // Forwarding the wheel makes the app repaint; that output is the
-                // user scrolling, not the agent working (docs/07).
-                let mut scrolled_the_app = false;
-                let extending_selection = self.selection.is_some_and(|selection| {
-                    selection.pane == id && selection.dragging && selection.retained.is_some()
-                });
-                let mut scrolled_selection = false;
-                if let Some(pane) = self.panes.get(&id) {
-                    let mm = pane.mouse_mode();
-                    if extending_selection && !pane.alt_screen() {
-                        // The selection gesture owns primary-screen scrolling,
-                        // even when the child reports mouse input. Its endpoints
-                        // are retained-history rows, so the original anchor stays
-                        // attached to the same text while the cursor extends.
-                        pane.scroll(-scroll);
-                        set_scroll = Some((pane.scroll_state().0 > 0).then_some(id));
-                        scrolled_selection = true;
-                    } else if mm.report {
-                        // The app tracks the mouse (e.g. a TUI agent like Claude
-                        // Code on the alternate screen) — forward the wheel so it
-                        // scrolls its own transcript, exactly like a real terminal.
-                        let base = content.unwrap_or(Rect::new(0, 0, 1, 1));
-                        let col = m.column.saturating_sub(base.x) + 1;
-                        let row = m.row.saturating_sub(base.y) + 1;
-                        // Preserve the terminal protocol's one-event/one-report
-                        // boundary. In particular, Windows ConPTY may coalesce
-                        // rapid writes; sending duplicates here can make a TUI
-                        // receive several concatenated SGR reports as one input
-                        // record and reject the entire wheel action.
-                        pane.send(&mouse_wheel_seq(up, col, row, mm.sgr));
-                        scrolled_the_app = true;
-                    } else if !pane.alt_screen() {
-                        // Primary screen with real history: scroll luvus's
-                        // scrollback viewport (`scroll` is -3 up / +3 down, and a
-                        // positive delta scrolls up into history — so negate it).
-                        pane.scroll(-scroll);
-                        // Engage keyboard scroll mode while scrolled up (so the
-                        // number/j/k keys work); disengage once back at live.
-                        set_scroll = Some((pane.scroll_state().0 > 0).then_some(id));
-                    } else if mm.alternate_scroll {
-                        // The application explicitly requested alternate
-                        // scrolling, so translate wheel movement into its
-                        // cursor-key scroll input. Without that mode there is
-                        // no host history on an alternate screen to move.
-                        let seq: &[u8] = if up { b"\x1b[A" } else { b"\x1b[B" };
-                        for _ in 0..scroll.abs() {
-                            pane.send(seq);
+                    .find(|(_, rect)| hit(*rect))
+                    .map(|(id, _)| *id)
+                {
+                    let up = scroll < 0;
+                    // Pane-local, 1-based coordinates for a forwarded mouse event.
+                    let content = self
+                        .pane_content_rects
+                        .iter()
+                        .find(|(pid, _)| *pid == id)
+                        .map(|(_, r)| *r);
+                    // Set after the pane borrow ends: `Some(v)` writes `scroll_pane = v`.
+                    let mut set_scroll: Option<Option<PaneId>> = None;
+                    // Forwarding the wheel makes the app repaint; that output is the
+                    // user scrolling, not the agent working (docs/07).
+                    let mut scrolled_the_app = false;
+                    let extending_selection = self.selection.is_some_and(|selection| {
+                        selection.pane == id && selection.dragging && selection.retained.is_some()
+                    });
+                    let mut scrolled_selection = false;
+                    if let Some(pane) = self.panes.get(&id) {
+                        let mm = pane.mouse_mode();
+                        if extending_selection && !pane.alt_screen() {
+                            // The selection gesture owns primary-screen scrolling,
+                            // even when the child reports mouse input. Its endpoints
+                            // are retained-history rows, so the original anchor stays
+                            // attached to the same text while the cursor extends.
+                            pane.scroll(-scroll);
+                            set_scroll = Some((pane.scroll_state().0 > 0).then_some(id));
+                            scrolled_selection = true;
+                        } else if mm.report {
+                            // The app tracks the mouse (e.g. a TUI agent like Claude
+                            // Code on the alternate screen) — forward the wheel so it
+                            // scrolls its own transcript, exactly like a real terminal.
+                            let base = content.unwrap_or(Rect::new(0, 0, 1, 1));
+                            let col = m.column.saturating_sub(base.x) + 1;
+                            let row = m.row.saturating_sub(base.y) + 1;
+                            // Preserve the terminal protocol's one-event/one-report
+                            // boundary. In particular, Windows ConPTY may coalesce
+                            // rapid writes; sending duplicates here can make a TUI
+                            // receive several concatenated SGR reports as one input
+                            // record and reject the entire wheel action.
+                            pane.send(&mouse_wheel_seq(up, col, row, mm.sgr));
+                            scrolled_the_app = true;
+                        } else if !pane.alt_screen() {
+                            // Primary screen with real history: scroll luvus's
+                            // scrollback viewport (`scroll` is -3 up / +3 down, and a
+                            // positive delta scrolls up into history — so negate it).
+                            pane.scroll(-scroll);
+                            // Engage keyboard scroll mode while scrolled up (so the
+                            // number/j/k keys work); disengage once back at live.
+                            set_scroll = Some((pane.scroll_state().0 > 0).then_some(id));
+                        } else if mm.alternate_scroll {
+                            // The application explicitly requested alternate
+                            // scrolling, so translate wheel movement into its
+                            // cursor-key scroll input. Without that mode there is
+                            // no host history on an alternate screen to move.
+                            let seq: &[u8] = if up { b"\x1b[A" } else { b"\x1b[B" };
+                            for _ in 0..scroll.abs() {
+                                pane.send(seq);
+                            }
+                            scrolled_the_app = true;
                         }
-                        scrolled_the_app = true;
+                    }
+                    if scrolled_the_app {
+                        self.mark_input_for(id);
+                    }
+                    if let Some(v) = set_scroll {
+                        self.scroll_pane = v;
+                    }
+                    if scrolled_selection {
+                        if let Some(selection) = self.selection.as_mut() {
+                            selection.scrolled = true;
+                        }
+                        self.update_mouse_selection_cursor(m.column, m.row);
                     }
                 }
-                if scrolled_the_app {
-                    self.mark_input_for(id);
-                }
-                if let Some(v) = set_scroll {
-                    self.scroll_pane = v;
-                }
-                if scrolled_selection {
-                    if let Some(selection) = self.selection.as_mut() {
-                        selection.scrolled = true;
-                    }
-                    self.update_mouse_selection_cursor(m.column, m.row);
-                }
-            }
+            } // scroll != 0
             return;
         }
 

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -363,6 +363,7 @@ pub struct DiffState {
     pub progress: crate::diff::notes::ReviewProgress,
     pub selected_notes: std::collections::HashSet<String>,
     pub viewport: usize,
+    pub scroll_detached: bool,
     cache: DiffCache,
 }
 
@@ -384,6 +385,7 @@ impl Default for DiffState {
             progress: crate::diff::notes::ReviewProgress::default(),
             selected_notes: std::collections::HashSet::new(),
             viewport: 0,
+            scroll_detached: false,
             cache: DiffCache::default(),
         }
     }
@@ -434,8 +436,22 @@ pub struct DiffAgentPicker {
 
 impl DiffState {
     pub fn rebuild_rows(&mut self) {
+        let old_cursor = self.cursor;
+        let old_selected = self.selected_key.clone().or_else(|| {
+            let index = match self.rows.get(self.cursor)? {
+                DiffListRow::File(index) => *index,
+                DiffListRow::Group(_) => return None,
+            };
+            self.snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.files.get(index))
+                .map(|file| file.key.clone())
+        });
         self.rows.clear();
         let Some(snapshot) = &self.snapshot else {
+            self.cursor = 0;
+            self.scroll = 0;
+            self.scroll_detached = false;
             return;
         };
         for layer in [
@@ -464,10 +480,29 @@ impl DiffState {
                 self.rows.extend(group.into_iter().map(DiffListRow::File));
             }
         }
-        self.cursor = self.cursor.min(self.rows.len().saturating_sub(1));
-        if matches!(self.rows.get(self.cursor), Some(DiffListRow::Group(_))) {
-            self.move_cursor(1);
+        let restored = old_selected.as_ref().and_then(|selected| {
+            self.rows.iter().position(|row| {
+                let DiffListRow::File(index) = row else {
+                    return false;
+                };
+                snapshot
+                    .files
+                    .get(*index)
+                    .is_some_and(|file| &file.key == selected)
+            })
+        });
+        if let Some(position) = restored {
+            self.cursor = position;
+        } else {
+            self.cursor = self.cursor.min(self.rows.len().saturating_sub(1));
+            if matches!(self.rows.get(self.cursor), Some(DiffListRow::Group(_))) {
+                self.move_cursor(1);
+            }
         }
+        if self.cursor != old_cursor || old_selected.is_some() && restored.is_none() {
+            self.scroll_detached = false;
+        }
+        self.ensure_cursor_visible();
     }
 
     pub fn move_cursor(&mut self, delta: isize) {
@@ -495,6 +530,9 @@ impl DiffState {
         }
         let max_scroll = self.rows.len().saturating_sub(cap);
         self.scroll = self.scroll.min(max_scroll);
+        if self.scroll_detached {
+            return;
+        }
         if self.cursor < self.scroll {
             self.scroll = self.cursor;
         } else if self.cursor >= self.scroll.saturating_add(cap) {
@@ -651,6 +689,7 @@ pub struct DiffView {
     pub stack_rows: Vec<DiffLine>,
     pub split_rows: Vec<crate::diff::rows::SplitRow>,
     pub stack_indices: HashMap<(DiffSide, u32), usize>,
+    pub split_indices: Vec<(Option<usize>, Option<usize>)>,
     pub request_token: u64,
     pub preference: DiffLayoutPreference,
     pub scroll: usize,
@@ -686,6 +725,7 @@ impl DiffView {
             stack_rows: Vec::new(),
             split_rows: Vec::new(),
             stack_indices: HashMap::new(),
+            split_indices: Vec::new(),
             request_token: 0,
             preference,
             scroll: 0,
@@ -730,10 +770,81 @@ impl DiffView {
         }
         if text_len <= text_w {
             self.horizontal = 0;
-        } else if self.horizontal + text_w > text_len
+        } else if self.horizontal.saturating_add(text_w) > text_len
             || self.horizontal > text_len.saturating_sub(text_w)
         {
             self.horizontal = text_len.saturating_sub(text_w);
+        }
+    }
+
+    pub fn effective_split(&self, pane_width: u16) -> bool {
+        !self.wrap
+            && matches!(
+                self.preference,
+                DiffLayoutPreference::Split | DiffLayoutPreference::Auto
+            )
+            && pane_width >= 96
+    }
+
+    pub fn rebuild_row_indices(&mut self) {
+        self.stack_indices.clear();
+        let mut headers = Vec::new();
+        for (index, line) in self.stack_rows.iter().enumerate() {
+            if line.kind == DiffLineKind::Header {
+                headers.push(index);
+            }
+            if let Some(number) = line.old_line {
+                self.stack_indices.insert((DiffSide::Old, number), index);
+            }
+            if let Some(number) = line.new_line {
+                self.stack_indices.insert((DiffSide::New, number), index);
+            }
+        }
+
+        let mut header = 0;
+        self.split_indices = self
+            .split_rows
+            .iter()
+            .map(|row| {
+                if row
+                    .old
+                    .as_ref()
+                    .or(row.new.as_ref())
+                    .is_some_and(|line| line.kind == DiffLineKind::Header)
+                {
+                    let index = headers.get(header).copied();
+                    header += 1;
+                    return (index, index);
+                }
+                let old = row
+                    .old
+                    .as_ref()
+                    .and_then(|line| line.old_line)
+                    .and_then(|number| self.stack_indices.get(&(DiffSide::Old, number)))
+                    .copied();
+                let new = row
+                    .new
+                    .as_ref()
+                    .and_then(|line| line.new_line)
+                    .and_then(|number| self.stack_indices.get(&(DiffSide::New, number)))
+                    .copied();
+                (old, new)
+            })
+            .collect();
+    }
+
+    pub fn split_row_for_stack(&self, stack: usize) -> usize {
+        self.split_indices
+            .iter()
+            .position(|(old, new)| *old == Some(stack) || *new == Some(stack))
+            .unwrap_or(0)
+    }
+
+    pub fn stack_row_for_split(&self, split: usize) -> Option<usize> {
+        let (old, new) = *self.split_indices.get(split)?;
+        match self.selected_side {
+            DiffSide::Old => old.or(new),
+            DiffSide::New => new.or(old),
         }
     }
 }
@@ -779,6 +890,153 @@ mod tests {
         assert!(state.cache_get(&key, 3, "before").is_some());
         assert!(state.cache_get(&key, 3, "after").is_none());
         assert!(state.cache_get(&key, 4, "before").is_none());
+    }
+
+    #[test]
+    fn horizontal_visibility_clamps_without_hiding_the_selected_line() {
+        let mut view = DiffView::new(
+            PathBuf::from("/repo"),
+            test_key(),
+            DiffLayoutPreference::Stack,
+            3,
+            false,
+            false,
+        );
+        view.stack_rows.push(DiffLine {
+            kind: DiffLineKind::Context,
+            old_line: Some(1),
+            new_line: Some(1),
+            text: "abcdefghijklmnopqrstuvwxyz".into(),
+        });
+        view.horizontal = usize::MAX;
+        view.ensure_horizontal_visible(10, DiffMarkerStyle::Symbols, false);
+        assert_eq!(view.horizontal, 18);
+        assert!(view.horizontal < view.stack_rows[0].text.chars().count());
+
+        view.stack_rows[0].text = "short".into();
+        view.ensure_horizontal_visible(10, DiffMarkerStyle::Symbols, false);
+        assert_eq!(view.horizontal, 0);
+    }
+
+    #[test]
+    fn split_rows_map_to_stack_rows_on_the_selected_side() {
+        let mut view = DiffView::new(
+            PathBuf::from("/repo"),
+            test_key(),
+            DiffLayoutPreference::Split,
+            3,
+            false,
+            false,
+        );
+        view.stack_rows = vec![
+            DiffLine {
+                kind: DiffLineKind::Header,
+                old_line: None,
+                new_line: None,
+                text: "@@ -1,2 +1 @@".into(),
+            },
+            DiffLine {
+                kind: DiffLineKind::Deletion,
+                old_line: Some(1),
+                new_line: None,
+                text: "old one".into(),
+            },
+            DiffLine {
+                kind: DiffLineKind::Deletion,
+                old_line: Some(2),
+                new_line: None,
+                text: "old two".into(),
+            },
+            DiffLine {
+                kind: DiffLineKind::Addition,
+                old_line: None,
+                new_line: Some(1),
+                text: "new".into(),
+            },
+        ];
+        view.split_rows = vec![
+            crate::diff::rows::SplitRow {
+                old: Some(view.stack_rows[0].clone()),
+                new: Some(view.stack_rows[0].clone()),
+            },
+            crate::diff::rows::SplitRow {
+                old: Some(view.stack_rows[1].clone()),
+                new: Some(view.stack_rows[3].clone()),
+            },
+            crate::diff::rows::SplitRow {
+                old: Some(view.stack_rows[2].clone()),
+                new: None,
+            },
+        ];
+        view.rebuild_row_indices();
+
+        view.selected_side = DiffSide::New;
+        assert_eq!(view.stack_row_for_split(1), Some(3));
+        view.selected_side = DiffSide::Old;
+        assert_eq!(view.stack_row_for_split(1), Some(1));
+        assert_eq!(view.stack_row_for_split(2), Some(2));
+        assert_eq!(view.split_row_for_stack(3), 1);
+    }
+
+    #[test]
+    fn row_rebuild_preserves_detached_scroll_until_selection_moves() {
+        let key = test_key();
+        let second_path = RepoPath::from_path(Path::new("src/second.rs")).unwrap();
+        let second_key = DiffKey {
+            new_path: Some(second_path.clone()),
+            old_path: Some(second_path),
+            ..key.clone()
+        };
+        let mut state = DiffState {
+            viewport: 1,
+            snapshot: Some(DiffSnapshot {
+                generation: 1,
+                fingerprint: "snapshot".into(),
+                repo_id: "repo".into(),
+                worktree_id: "tree".into(),
+                visible_root: PathBuf::from("/repo"),
+                repo_root: PathBuf::from("/repo"),
+                branch: "main".into(),
+                files: vec![
+                    DiffFile {
+                        key: key.clone(),
+                        status: DiffFileStatus::Modified,
+                        additions: Some(1),
+                        deletions: Some(0),
+                        binary: false,
+                        unresolved_notes: 0,
+                        viewed_fingerprint: None,
+                        fingerprint: "one".into(),
+                    },
+                    DiffFile {
+                        key: second_key,
+                        status: DiffFileStatus::Modified,
+                        additions: Some(1),
+                        deletions: Some(0),
+                        binary: false,
+                        unresolved_notes: 0,
+                        viewed_fingerprint: None,
+                        fingerprint: "two".into(),
+                    },
+                ],
+                omitted_files: 0,
+            }),
+            ..DiffState::default()
+        };
+        state.rebuild_rows();
+        state.selected_key = Some(key);
+        state.cursor = 1;
+        state.scroll = 2;
+        state.scroll_detached = true;
+
+        state.rebuild_rows();
+        assert_eq!(state.cursor, 1);
+        assert_eq!(state.scroll, 2, "manual viewport remains detached");
+
+        state.filter = DiffFilter::HasNotes;
+        state.rebuild_rows();
+        assert_eq!(state.scroll, 0, "shrinking rows clamps the viewport");
+        assert!(!state.scroll_detached, "invalid selection reattaches");
     }
 
     #[cfg(unix)]

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -362,6 +362,7 @@ pub struct DiffState {
     pub notes: Vec<crate::diff::notes::ReviewNote>,
     pub progress: crate::diff::notes::ReviewProgress,
     pub selected_notes: std::collections::HashSet<String>,
+    pub viewport: usize,
     cache: DiffCache,
 }
 
@@ -382,6 +383,7 @@ impl Default for DiffState {
             notes: Vec::new(),
             progress: crate::diff::notes::ReviewProgress::default(),
             selected_notes: std::collections::HashSet::new(),
+            viewport: 0,
             cache: DiffCache::default(),
         }
     }
@@ -483,6 +485,20 @@ impl DiffState {
             if cursor == 0 || cursor == self.rows.len().saturating_sub(1) as isize {
                 break;
             }
+        }
+    }
+
+    pub fn ensure_cursor_visible(&mut self) {
+        let cap = self.viewport;
+        if cap == 0 {
+            return;
+        }
+        let max_scroll = self.rows.len().saturating_sub(cap);
+        self.scroll = self.scroll.min(max_scroll);
+        if self.cursor < self.scroll {
+            self.scroll = self.cursor;
+        } else if self.cursor >= self.scroll.saturating_add(cap) {
+            self.scroll = self.cursor.saturating_sub(cap.saturating_sub(1));
         }
     }
 
@@ -634,6 +650,7 @@ pub struct DiffView {
     pub load: DiffLoad,
     pub stack_rows: Vec<DiffLine>,
     pub split_rows: Vec<crate::diff::rows::SplitRow>,
+    pub stack_indices: HashMap<(DiffSide, u32), usize>,
     pub request_token: u64,
     pub preference: DiffLayoutPreference,
     pub scroll: usize,
@@ -668,6 +685,7 @@ impl DiffView {
             load: DiffLoad::Loading,
             stack_rows: Vec::new(),
             split_rows: Vec::new(),
+            stack_indices: HashMap::new(),
             request_token: 0,
             preference,
             scroll: 0,
@@ -684,6 +702,38 @@ impl DiffView {
             note_edit_id: None,
             range_anchor: None,
             dirty: false,
+        }
+    }
+
+    pub fn ensure_horizontal_visible(
+        &mut self,
+        pane_width: u16,
+        marker_style: DiffMarkerStyle,
+        split: bool,
+    ) {
+        let Some(line) = self.stack_rows.get(self.selected) else {
+            return;
+        };
+        let text_len = line.text.chars().count();
+        let bar_w = if marker_style.shows_bars() { 1 } else { 0 };
+        let symbol_w = if marker_style.shows_symbols() { 2 } else { 0 };
+        let numbers_w = if self.show_line_numbers { 12 } else { 0 };
+        let gutter_w = bar_w + symbol_w + numbers_w;
+        let side_width = if split {
+            (pane_width.saturating_sub(1)) / 2
+        } else {
+            pane_width
+        };
+        let text_w = side_width.saturating_sub(gutter_w as u16) as usize;
+        if text_w == 0 {
+            return;
+        }
+        if text_len <= text_w {
+            self.horizontal = 0;
+        } else if self.horizontal + text_w > text_len
+            || self.horizontal > text_len.saturating_sub(text_w)
+        {
+            self.horizontal = text_len.saturating_sub(text_w);
         }
     }
 }

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -1,7 +1,5 @@
 //! Native DIFF renderer (docs/88). It draws only the visible cached row slice.
 
-use std::collections::HashMap;
-
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
@@ -352,15 +350,6 @@ fn draw_split(
     t: &Theme,
 ) {
     let notes = DiffNotes { view, state };
-    let mut stack_indices = HashMap::new();
-    for (index, line) in view.stack_rows.iter().enumerate() {
-        if let Some(number) = line.old_line {
-            stack_indices.insert((DiffSide::Old, number), index);
-        }
-        if let Some(number) = line.new_line {
-            stack_indices.insert((DiffSide::New, number), index);
-        }
-    }
     let selected_anchor = view.stack_rows.get(view.selected).and_then(line_anchor);
     let scroll_anchor = view.stack_rows.get(view.scroll).and_then(line_anchor);
     let start = scroll_anchor
@@ -424,13 +413,13 @@ fn draw_split(
         );
         if hits.interactive {
             if let Some(number) = row.old.as_ref().and_then(|line| line.old_line) {
-                if let Some(index) = stack_indices.get(&(DiffSide::Old, number)) {
+                if let Some(index) = view.stack_indices.get(&(DiffSide::Old, number)) {
                     hits.source
                         .push((hits.pane, *index, DiffSide::Old, old_rect));
                 }
             }
             if let Some(number) = row.new.as_ref().and_then(|line| line.new_line) {
-                if let Some(index) = stack_indices.get(&(DiffSide::New, number)) {
+                if let Some(index) = view.stack_indices.get(&(DiffSide::New, number)) {
                     hits.source
                         .push((hits.pane, *index, DiffSide::New, new_rect));
                 }
@@ -463,13 +452,13 @@ fn draw_split(
             .old
             .as_ref()
             .and_then(|line| line.old_line)
-            .and_then(|number| stack_indices.get(&(DiffSide::Old, number)))
+            .and_then(|number| view.stack_indices.get(&(DiffSide::Old, number)))
             .is_some_and(|index| *index == view.selected)
             || row
                 .new
                 .as_ref()
                 .and_then(|line| line.new_line)
-                .and_then(|number| stack_indices.get(&(DiffSide::New, number)))
+                .and_then(|number| view.stack_indices.get(&(DiffSide::New, number)))
                 .is_some_and(|index| *index == view.selected);
         if selected_here && view.note_draft.is_some() {
             y = draw_note_composer(f, area, y, view, t);
@@ -996,6 +985,19 @@ mod tests {
             false,
             false,
         );
+        view.stack_indices = rows
+            .iter()
+            .enumerate()
+            .flat_map(|(index, line)| {
+                let old = line
+                    .old_line
+                    .map(|n| ((crate::diff::DiffSide::Old, n), index));
+                let new = line
+                    .new_line
+                    .map(|n| ((crate::diff::DiffSide::New, n), index));
+                old.into_iter().chain(new)
+            })
+            .collect();
         view.stack_rows = rows;
         view
     }

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -210,11 +210,7 @@ fn draw_diff_list(
     }
     let max_scroll = app.diff.rows.len().saturating_sub(cap);
     app.diff.scroll = app.diff.scroll.min(max_scroll);
-    if app.diff.cursor < app.diff.scroll {
-        app.diff.scroll = app.diff.cursor;
-    } else if app.diff.cursor >= app.diff.scroll.saturating_add(cap) {
-        app.diff.scroll = app.diff.cursor.saturating_sub(cap.saturating_sub(1));
-    }
+    app.diff.viewport = cap;
     let snapshot = app.diff.snapshot.as_ref().expect("rows require snapshot");
     let rows = &app.diff.rows;
     for row_index in app.diff.scroll..rows.len().min(app.diff.scroll.saturating_add(cap)) {

--- a/src/ui/tabbar.rs
+++ b/src/ui/tabbar.rs
@@ -497,8 +497,17 @@ mod width_tests {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(180, 40, tx).unwrap();
         for _ in 0..27 {
-            app.run_cmd(crate::app::Cmd::NewTab);
+            app.workspaces[0].tabs.push(crate::app::Tab {
+                id: crate::ids::public_id("tab"),
+                layout: crate::layout::TileLayout::new(crate::ids::PaneId::alloc()),
+                git: None,
+                orch: false,
+                mission: false,
+                name: None,
+            });
         }
+        app.workspaces[0].active_tab = 27;
+        assert_eq!(app.workspaces[0].tabs.len(), 28, "test has 28 tabs");
         let widget = crate::bar::BarWidget::new(
             crate::bar::BarWidgetKey::new("example", "wide"),
             crate::bar::BarRegion::TopRight,


### PR DESCRIPTION
## Summary

- Decouple the Diff sidebar scroll position from the selected file, preventing periodic refreshes from snapping the list back
- Keep explicitly activated or restored file selections visible
- Add keyboard and horizontal mouse-wheel scrolling to the Diff Viewer
- Clamp horizontal and vertical scrolling to the active Stack or Split layout
- Make layout toggling respond immediately when Auto currently resolves to Split
- Cache split-view row indices to avoid repeated per-frame work and reduce layout-switching delay
- Stabilize the tabbar overflow navigation test by using synthetic tabs instead of spawning multiple PTYs

## Testing

- `cargo fmt --all --check`
- `cargo test --locked`
- Repeated the focused tabbar overflow test 10 times successfully

## Notes

`cargo clippy --all-targets -- -D warnings` reports pre-existing warnings in unrelated files under the locally available Rust toolchains.

<img width="417" height="645" alt="image" src="https://github.com/user-attachments/assets/f689f254-241a-4c66-a2b6-848ee8b296c9" />

<img width="413" height="648" alt="image" src="https://github.com/user-attachments/assets/4c71d131-ea7c-4d68-aa2c-7f54f6611c3f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added horizontal scrolling for native diff views using mouse wheel gestures.
  - Improved keyboard navigation so selected content remains visible horizontally and vertically.
  - Added viewport-aware cursor scrolling.
  - Updated the `s` shortcut to switch wide, unwrapped Auto layouts directly to stacked layout.

- **Bug Fixes**
  - Improved scrolling and selection synchronization across navigation, search, note selection, and hunk jumps.
  - Corrected diff hit detection and split-view scrolling.
  - Prevented horizontal-only wheel gestures from affecting terminal panes.
  - Improved file list and diff selection visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->