### PR TITLE
perf(binary): reduce SQLite footprint on macOS

### DIFF
--- a/.github/binary-size-baseline.json
+++ b/.github/binary-size-baseline.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "thresholds": {
+    "warn_percent": 5,
+    "block_percent": 10
+  },
+  "targets": {
+    "aarch64-apple-darwin": {
+      "executable_bytes": 7433008,
+      "archive_bytes": 3221261
+    },
+    "x86_64-apple-darwin": {
+      "executable_bytes": 8043516,
+      "archive_bytes": 3431185
+    },
+    "aarch64-unknown-linux-musl": {
+      "executable_bytes": 9075944,
+      "archive_bytes": 4233398
+    },
+    "x86_64-unknown-linux-musl": {
+      "executable_bytes": 10571024,
+      "archive_bytes": 4561370
+    },
+    "x86_64-pc-windows-msvc": {
+      "executable_bytes": 11894272,
+      "archive_bytes": 4376756
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
   binary-size:
     name: macos binary size
     runs-on: macos-14
+    permissions:
+      contents: read
     env:
       SQLITE3_LIB_DIR: /usr/lib
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Harden dependency downloads: retry transient failures and disable HTTP/2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
   macos:
     name: macos test
     runs-on: macos-14
+    env:
+      SQLITE3_LIB_DIR: /usr/lib
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -70,6 +72,25 @@ jobs:
           cargo build --locked
           python3 examples/uhp/terminal/live_conformance.py --luvus target/debug/luvus
           python3 examples/uhp/terminal/failure_conformance.py --luvus target/debug/luvus
+
+  binary-size:
+    name: macos binary size
+    runs-on: macos-14
+    env:
+      SQLITE3_LIB_DIR: /usr/lib
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --locked
+      - name: Package measured binary
+        run: COPYFILE_DISABLE=1 tar -C target/release -czf target/luvus-size.tar.gz luvus
+      - name: Check reviewed baseline
+        run: |
+          python3 scripts/check-binary-size.py \
+            --target aarch64-apple-darwin \
+            --binary target/release/luvus \
+            --archive target/luvus-size.tar.gz
 
   windows:
     name: windows protocol · ConPTY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,9 @@ jobs:
           archive: luvus-$tag-$target
           checksum: sha256
           locked: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Build and package first; publish only after the size gate passes.
+          dry-run: true
+          dry-run-intended: true
       - name: Report binary size
         shell: bash
         run: |
@@ -89,6 +91,25 @@ jobs:
             --target "${{ matrix.target }}" \
             --binary "$binary" \
             --archive "$archive"
+      - name: Upload validated archive
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE_TAR: ${{ steps.package.outputs.tar }}
+          ARCHIVE_ZIP: ${{ steps.package.outputs.zip }}
+          CHECKSUM_SHA256: ${{ steps.package.outputs.sha256 }}
+        run: |
+          archive="$ARCHIVE_TAR"
+          if [[ -z "$archive" ]]; then
+            archive="$ARCHIVE_ZIP"
+          fi
+          if [[ -z "$archive" || -z "$CHECKSUM_SHA256" ]]; then
+            echo "release package outputs are missing" >&2
+            exit 1
+          fi
+          gh release upload "$GITHUB_REF_NAME" \
+            "$archive" "$CHECKSUM_SHA256" \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
   # Build native Linux packages (.deb + .rpm) for both arches and attach them to
   # the Release. luvus is a static musl binary, so each package just drops the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,13 +61,34 @@ jobs:
       # Builds (cross-compiling musl/aarch64 via `cross` automatically), packages
       # `luvus-<tag>-<target>.{tar.gz,zip}` + a .sha256, and uploads them to the
       # Release created above.
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - id: package
+        uses: taiki-e/upload-rust-binary-action@v1
+        env:
+          # Keep official macOS archives tied to the SDK library even when a
+          # runner also has a Homebrew SQLite pkg-config entry.
+          SQLITE3_LIB_DIR: ${{ contains(matrix.target, 'apple-darwin') && '/usr/lib' || '' }}
         with:
           bin: luvus
           target: ${{ matrix.target }}
           archive: luvus-$tag-$target
           checksum: sha256
+          locked: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Report binary size
+        shell: bash
+        run: |
+          binary="target/${{ matrix.target }}/release/luvus"
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            binary="${binary}.exe"
+          fi
+          archive="${{ steps.package.outputs.tar }}"
+          if [[ -z "$archive" ]]; then
+            archive="${{ steps.package.outputs.zip }}"
+          fi
+          python3 scripts/check-binary-size.py \
+            --target "${{ matrix.target }}" \
+            --binary "$binary" \
+            --archive "$archive"
 
   # Build native Linux packages (.deb + .rpm) for both arches and attach them to
   # the Release. luvus is a static musl binary, so each package just drops the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,15 +587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
-dependencies = [
- "hashbrown 0.17.1",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,16 +1388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
-dependencies = [
- "hashbrown 0.16.1",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,10 +1396,8 @@ dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -1632,18 +1611,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
-dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,6 @@ unicode-width = "0.2"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# OpenCode 1.18+ stores per-session token and cost aggregates in SQLite.  Read
-# it in-process and read-only: spawning the OpenCode/Bun runtime every Mission
-# Control refresh is both slower and substantially heavier.
-rusqlite = { version = "0.40", features = ["bundled"] }
 # SHA-256 tracks managed skill files and verifies release, theme, and diff
 # artifacts. The canonical Luvus skill itself is bundled with this release.
 semver = "1"
@@ -87,6 +83,18 @@ getrandom = "0.3"
 # `libc` (setsid + macOS proc_pidinfo) is only needed on Unix.
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# OpenCode 1.18+ stores per-session token and cost aggregates in SQLite. Read it
+# in-process and read-only: spawning the OpenCode/Bun runtime every Mission
+# Control refresh is both slower and substantially heavier. The one-shot query
+# does not use rusqlite's optional statement cache. macOS ships a stable SQLite
+# system library; other platforms retain the bundled engine so Cargo installs
+# and static release artifacts stay self-contained.
+[target.'cfg(target_os = "macos")'.dependencies]
+rusqlite = { version = "0.40", default-features = false }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+rusqlite = { version = "0.40", default-features = false, features = ["bundled"] }
 
 # Native Windows terminal-backend safety: owner verification for named-pipe
 # peers, PID-reuse-safe process creation timestamps, and one bounded ToolHelp

--- a/scripts/check-binary-size.py
+++ b/scripts/check-binary-size.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Report release artifact sizes and guard reviewed per-target baselines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--archive", required=True, type=Path)
+    parser.add_argument(
+        "--baseline",
+        default=Path(".github/binary-size-baseline.json"),
+        type=Path,
+    )
+    parser.add_argument(
+        "--informational",
+        action="store_true",
+        help="report growth without failing, for reviewed security updates",
+    )
+    return parser.parse_args()
+
+
+def percent_change(actual: int, baseline: int) -> float:
+    return (actual - baseline) * 100.0 / baseline
+
+
+def main() -> int:
+    args = parse_args()
+    for label, path in (("binary", args.binary), ("archive", args.archive)):
+        if not path.is_file():
+            print(f"missing {label} artifact: {path}", file=sys.stderr)
+            return 2
+    config = json.loads(args.baseline.read_text(encoding="utf-8"))
+    try:
+        expected = config["targets"][args.target]
+    except KeyError:
+        print(f"missing binary-size baseline for {args.target}", file=sys.stderr)
+        return 2
+
+    warn_at = float(config["thresholds"]["warn_percent"])
+    block_at = float(config["thresholds"]["block_percent"])
+    measurements = (
+        ("Executable", args.binary.stat().st_size, int(expected["executable_bytes"])),
+        ("Archive", args.archive.stat().st_size, int(expected["archive_bytes"])),
+    )
+    rows = [
+        f"### Binary size for `{args.target}`",
+        "",
+        "| Artifact | Current | Baseline | Change |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    blocked = False
+    for label, actual, baseline in measurements:
+        change = percent_change(actual, baseline)
+        rows.append(f"| {label} | {actual:,} B | {baseline:,} B | {change:+.2f}% |")
+        message = (
+            f"{args.target} {label.lower()} is {change:+.2f}% versus its "
+            f"reviewed baseline ({actual} versus {baseline} bytes)"
+        )
+        if change > block_at and not args.informational:
+            print(f"::error title=Binary size exceeded {block_at:g}%::{message}")
+            blocked = True
+        elif change > warn_at:
+            print(f"::warning title=Binary size exceeded {warn_at:g}%::{message}")
+
+    report = "\n".join(rows) + "\n"
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with Path(summary).open("a", encoding="utf-8") as output:
+            output.write(report)
+    else:
+        print(report, end="")
+    return 1 if blocked else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/usage.rs
+++ b/src/agent/usage.rs
@@ -735,13 +735,49 @@ fn fx_usage(dir: &Path) -> Option<AgentUsage> {
 mod tests {
     use super::*;
     use std::fs;
+    use std::time::Instant;
 
     fn tmp(tag: &str) -> PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("luvus-agent-usage-{tag}-{}", std::process::id()));
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target/test-state/agent-usage")
+            .join(format!("{tag}-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    fn create_opencode_schema(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                model TEXT,
+                cost REAL NOT NULL,
+                tokens_input INTEGER NOT NULL,
+                tokens_output INTEGER NOT NULL,
+                tokens_reasoning INTEGER NOT NULL,
+                tokens_cache_read INTEGER NOT NULL,
+                tokens_cache_write INTEGER NOT NULL
+            );",
+        )
+        .unwrap();
+    }
+
+    fn insert_opencode_session(
+        conn: &Connection,
+        id: &str,
+        directory: &str,
+        model: &str,
+        cost: f64,
+        tokens: [i64; 4],
+    ) {
+        conn.execute(
+            "INSERT INTO session VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, ?8)",
+            rusqlite::params![
+                id, directory, model, cost, tokens[0], tokens[1], tokens[2], tokens[3]
+            ],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -851,37 +887,18 @@ mod tests {
         let dir = tmp("opencode");
         let db = dir.join("opencode.db");
         let conn = Connection::open(&db).unwrap();
-        conn.execute_batch(
-            "CREATE TABLE session (
-                id TEXT PRIMARY KEY,
-                directory TEXT NOT NULL,
-                model TEXT,
-                cost REAL NOT NULL,
-                tokens_input INTEGER NOT NULL,
-                tokens_output INTEGER NOT NULL,
-                tokens_reasoning INTEGER NOT NULL,
-                tokens_cache_read INTEGER NOT NULL,
-                tokens_cache_write INTEGER NOT NULL
-            );",
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO session VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            rusqlite::params![
-                "ses-1",
-                "/work/app",
-                r#"{"id":"anthropic/claude-sonnet-4"}"#,
-                0.42,
-                300i64,
-                40i64,
-                5i64,
-                600i64,
-                10i64
-            ],
-        )
-        .unwrap();
+        create_opencode_schema(&conn);
+        insert_opencode_session(
+            &conn,
+            "ses-1",
+            "/work/app",
+            r#"{"id":"anthropic/claude-sonnet-4"}"#,
+            0.42,
+            [300, 40, 600, 10],
+        );
         drop(conn);
 
+        let before = fs::read(&db).unwrap();
         let usage = opencode_usage(&db, "ses-1", Path::new("/work/app")).unwrap();
         assert_eq!(
             (usage.tokens_in, usage.tokens_out, usage.cache),
@@ -890,6 +907,203 @@ mod tests {
         assert_eq!(usage.model, "anthropic/claude-sonnet-4");
         assert_eq!(usage.cost, Some(0.42));
         assert!(opencode_usage(&db, "ses-1", Path::new("/work/other")).is_none());
+        assert!(opencode_usage(&db, "missing", Path::new("/work/app")).is_none());
+        assert_eq!(
+            fs::read(&db).unwrap(),
+            before,
+            "read-only query changed the database"
+        );
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn opencode_accepts_plain_models_estimates_zero_cost_and_clamps_tokens() {
+        let dir = tmp("opencode-values");
+        let db = dir.join("opencode.db");
+        let conn = Connection::open(&db).unwrap();
+        create_opencode_schema(&conn);
+        insert_opencode_session(
+            &conn,
+            "plain",
+            "/work/plain",
+            "claude-sonnet-4",
+            0.0,
+            [300, 40, 600, 10],
+        );
+        insert_opencode_session(
+            &conn,
+            "negative",
+            "/work/negative",
+            "unknown-model",
+            0.0,
+            [-1, -2, -3, -4],
+        );
+        drop(conn);
+
+        let usage = opencode_usage(&db, "plain", Path::new("/work/plain")).unwrap();
+        assert_eq!(usage.model, "claude-sonnet-4");
+        assert_eq!(
+            (usage.tokens_in, usage.tokens_out, usage.cache),
+            (300, 40, 610)
+        );
+        let expected = estimate_cost("claude-sonnet-4", 300, 40, 610).unwrap();
+        assert_eq!(usage.cost, Some(expected));
+
+        let usage = opencode_usage(&db, "negative", Path::new("/work/negative")).unwrap();
+        assert_eq!((usage.tokens_in, usage.tokens_out, usage.cache), (0, 0, 0));
+        assert_eq!(usage.cost, None);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn opencode_missing_incompatible_and_corrupt_databases_are_non_fatal() {
+        let dir = tmp("opencode-invalid");
+        let missing = dir.join("missing.db");
+        assert!(opencode_usage(&missing, "ses-1", Path::new("/work/app")).is_none());
+        assert!(
+            !missing.exists(),
+            "read-only open created a missing database"
+        );
+
+        let incompatible = dir.join("incompatible.db");
+        drop(Connection::open(&incompatible).unwrap());
+        assert!(opencode_usage(&incompatible, "ses-1", Path::new("/work/app")).is_none());
+
+        let corrupt = dir.join("corrupt.db");
+        fs::write(&corrupt, b"not a sqlite database").unwrap();
+        assert!(opencode_usage(&corrupt, "ses-1", Path::new("/work/app")).is_none());
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn opencode_reads_committed_wal_data_without_mutating_rows_or_schema() {
+        let dir = tmp("opencode-wal");
+        let db = dir.join("opencode.db");
+        let writer = Connection::open(&db).unwrap();
+        assert_eq!(
+            writer
+                .query_row("PRAGMA journal_mode=WAL", [], |row| row.get::<_, String>(0))
+                .unwrap(),
+            "wal"
+        );
+        create_opencode_schema(&writer);
+        insert_opencode_session(
+            &writer,
+            "ses-wal",
+            "/work/wal",
+            "gpt-5",
+            0.25,
+            [100, 20, 30, 4],
+        );
+        writer
+            .execute(
+                "UPDATE session SET tokens_input = 250, tokens_output = 45 WHERE id = 'ses-wal'",
+                [],
+            )
+            .unwrap();
+        let wal = db.with_extension("db-wal");
+        let shared_memory = db.with_extension("db-shm");
+        let db_before = fs::read(&db).unwrap();
+        let wal_before = fs::read(&wal).unwrap();
+        let shared_memory_len = fs::metadata(&shared_memory).unwrap().len();
+
+        let usage = opencode_usage(&db, "ses-wal", Path::new("/work/wal")).unwrap();
+        assert_eq!(
+            (usage.tokens_in, usage.tokens_out, usage.cache),
+            (250, 45, 34)
+        );
+        assert_eq!(usage.cost, Some(0.25));
+        let stored: (i64, i64) = writer
+            .query_row(
+                "SELECT tokens_input, tokens_output FROM session WHERE id = 'ses-wal'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(stored, (250, 45));
+        let schema_rows: i64 = writer
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE name = 'session' AND type = 'table'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(schema_rows, 1);
+        assert_eq!(fs::read(&db).unwrap(), db_before);
+        assert_eq!(fs::read(&wal).unwrap(), wal_before);
+        assert_eq!(
+            fs::metadata(&shared_memory).unwrap().len(),
+            shared_memory_len
+        );
+        drop(writer);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn opencode_locked_database_wait_is_bounded_and_recovers() {
+        let dir = tmp("opencode-locked");
+        let db = dir.join("opencode.db");
+        let writer = Connection::open(&db).unwrap();
+        create_opencode_schema(&writer);
+        insert_opencode_session(
+            &writer,
+            "ses-locked",
+            "/work/locked",
+            "gpt-5",
+            0.5,
+            [100, 20, 30, 4],
+        );
+        writer
+            .execute_batch("BEGIN EXCLUSIVE; UPDATE session SET tokens_input = 200;")
+            .unwrap();
+
+        let started = Instant::now();
+        assert!(opencode_usage(&db, "ses-locked", Path::new("/work/locked")).is_none());
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "locked read exceeded its bounded wait: {:?}",
+            started.elapsed()
+        );
+
+        writer.execute_batch("ROLLBACK").unwrap();
+        let usage = opencode_usage(&db, "ses-locked", Path::new("/work/locked")).unwrap();
+        assert_eq!(usage.tokens_in, 100);
+        drop(writer);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn opencode_thousand_warm_reads_keep_values_stable() {
+        let dir = tmp("opencode-warm-reads");
+        let db = dir.join("opencode.db");
+        let conn = Connection::open(&db).unwrap();
+        create_opencode_schema(&conn);
+        insert_opencode_session(
+            &conn,
+            "ses-bench",
+            "/work/bench",
+            "gpt-5",
+            0.5,
+            [100, 20, 30, 4],
+        );
+        drop(conn);
+
+        let mut elapsed = Vec::with_capacity(1_000);
+        for _ in 0..1_000 {
+            let started = Instant::now();
+            let usage = opencode_usage(&db, "ses-bench", Path::new("/work/bench")).unwrap();
+            elapsed.push(started.elapsed());
+            assert_eq!(
+                (usage.tokens_in, usage.tokens_out, usage.cache),
+                (100, 20, 34)
+            );
+        }
+        elapsed.sort_unstable();
+        eprintln!(
+            "OpenCode 1,000 warm reads: median {:?}, total {:?}",
+            elapsed[elapsed.len() / 2],
+            elapsed.iter().sum::<Duration>()
+        );
         fs::remove_dir_all(dir).unwrap();
     }
 


### PR DESCRIPTION
## Summary

This reduces the macOS Luvus release size while preserving the existing in-process, read-only OpenCode usage reader.

macOS now links against the SQLite library supplied by the operating system. Windows and Linux continue using the bundled SQLite engine, so static release artifacts and source installation on those platforms remain self-contained.

The change also disables unused `rusqlite` default features and removes the statement-cache and WASM dependencies that Luvus does not use.

## Measured impact

The comparison used the same source, Rust 1.97.1, release profile, and lockfile on macOS arm64.

| Artifact | Bundled SQLite | System SQLite | Reduction |
| --- | ---: | ---: | ---: |
| Stripped executable | 9,177,712 bytes | 7,433,008 bytes | 19.0% |
| Compressed archive | 4,114,329 bytes | 3,221,261 bytes | 21.7% |
| Mach-O `__text` | 7,101,480 bytes | 5,506,648 bytes | 22.5% |

The x86_64 macOS release also builds successfully and links `/usr/lib/libsqlite3.dylib`.

A lean bundled SQLite experiment was measured separately. It reduced the compressed artifact by only 6.3%, below the planned 10% acceptance gate, so this PR does not vendor or maintain a SQLite fork.

## Compatibility and safety

The OpenCode query and runtime behavior are unchanged. New focused tests cover:

- JSON and plain-string model values
- positive provider costs and estimated zero-cost fallback
- negative token clamping
- missing sessions and different working directories
- missing, incompatible, and corrupt databases
- committed WAL data while a writer remains connected
- database, WAL, row, and schema preservation during read-only access
- bounded lock waits and recovery after the lock is released
- 1,000 repeated warm reads with stable results

The isolated debug runtime test detected OpenCode correctly and reached its idle state. It used a project-local development home with all inherited production socket and session selectors removed. No production Luvus server or user database was touched.

## Size regression protection

This adds a small dependency-free size checker and reviewed per-target baselines.

- CI reports the macOS executable and archive sizes before merge
- release jobs report executable and archive sizes for every official target
- growth above 5% produces a warning
- growth above 10% requires a reviewed baseline update
- reviewed dependency security updates can use informational reporting
- official macOS artifacts explicitly select the SDK SQLite library even when a runner also has a Homebrew pkg-config entry

## Verification

- `cargo fmt --all --check`
- `cargo test --locked`
- focused OpenCode SQLite tests with 6 passing
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release --locked`
- macOS arm64 and x86_64 release builds
- `otool -L` linkage inspection
- `cargo package --allow-dirty` with the published terminal crate graph
- workflow YAML parsing
- binary-size checker validation

Windows and musl retain upstream bundled SQLite in their Cargo feature graphs. Their official builds remain covered by the existing release and CI runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Improvements**
  - Added binary and archive size validation for release artifacts across supported platforms.
  - Release builds now report artifact sizes and warn or fail when configured limits are exceeded.
  - Added macOS release validation for more consistent packages.

- **Compatibility**
  - Improved macOS support by using the system SQLite library.

- **Bug Fixes**
  - Expanded usage tracking reliability for database recovery, cost estimates, token handling, and reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->