### PR TITLE
fix(files): preserve dock side when toggling

### DIFF
--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -214,15 +214,17 @@ impl App {
         }
     }
 
-    /// `Ctrl+Space e`: mount the FILES dock on the left sidebar, or unmount it if
-    /// it is already shown. Mounting also makes sure the sidebar is visible.
+    /// `Ctrl+Space e`: unmount the FILES dock, or restore it to the side where
+    /// the user last placed it. Mounting also makes sure that side is visible.
     pub fn toggle_files_dock(&mut self) {
         if self.sidebars.side_of(&DockKind::Files).is_some() {
             self.unmount_dock(&DockKind::Files);
         } else {
-            self.sidebars.left.docks.push(DockKind::Files);
-            self.sidebars.left.visible = true;
-            self.save_sidebars();
+            let target = self.sidebars.files_side;
+            if self.sidebars.has_room(target) {
+                self.sidebars.get_mut(target).visible = true;
+            }
+            self.move_dock(&DockKind::Files, target);
         }
     }
 
@@ -794,8 +796,42 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{DockKind, FileMenu, FileMenuItem};
+    use crate::app::{DockKind, FileMenu, FileMenuItem, Side};
     use ratatui::{backend::TestBackend, Terminal};
+
+    #[test]
+    fn files_toggle_restores_last_side_across_restart() {
+        let _env = crate::persist::test_env("files-toggle-side");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+
+        assert!(app.move_dock(&DockKind::Files, Side::Right));
+        assert_eq!(app.sidebars.side_of(&DockKind::Files), Some(Side::Right));
+        app.toggle_files_dock();
+        assert_eq!(app.sidebars.side_of(&DockKind::Files), None);
+        assert_eq!(
+            app.config
+                .sidebars
+                .as_ref()
+                .and_then(|sidebars| sidebars.files_side),
+            Some(Side::Right),
+            "hiding FILES keeps its last placement in config"
+        );
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut reopened = App::new(80, 24, tx).unwrap();
+        assert_eq!(reopened.sidebars.side_of(&DockKind::Files), None);
+        reopened.toggle_files_dock();
+        assert_eq!(
+            reopened.sidebars.side_of(&DockKind::Files),
+            Some(Side::Right),
+            "showing FILES restores the persisted side"
+        );
+        assert!(
+            reopened.sidebars.right.visible,
+            "showing FILES also reveals its sidebar"
+        );
+    }
 
     #[test]
     fn recent_files_are_deduplicated_newest_first_and_bounded() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -125,7 +125,8 @@ pub enum ViewKind {
 }
 
 /// Which sidebar a dock lives in (docs/29).
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Side {
     Left,
     Right,
@@ -251,6 +252,9 @@ impl SideState {
 pub struct Sidebars {
     pub left: SideState,
     pub right: SideState,
+    /// Last explicit FILES placement. Unlike the mounted dock vectors, this
+    /// survives turning FILES off so the toggle can restore the user's side.
+    pub files_side: Side,
 }
 
 impl Sidebars {
@@ -267,15 +271,26 @@ impl Sidebars {
         }
     }
     fn from_config(cfg: &crate::config::SidebarsConfig) -> Sidebars {
+        let left = SideState::from_config(&cfg.left);
+        let right = SideState::from_config(&cfg.right);
+        let files_side = if left.has(&DockKind::Files) {
+            Side::Left
+        } else if right.has(&DockKind::Files) {
+            Side::Right
+        } else {
+            cfg.files_side.unwrap_or(Side::Left)
+        };
         Sidebars {
-            left: SideState::from_config(&cfg.left),
-            right: SideState::from_config(&cfg.right),
+            left,
+            right,
+            files_side,
         }
     }
     fn to_config(&self) -> crate::config::SidebarsConfig {
         crate::config::SidebarsConfig {
             left: self.left.to_config(),
             right: self.right.to_config(),
+            files_side: Some(self.files_side),
         }
     }
     /// Whether `side` has a free dock slot (below `MAX_DOCKS_PER_SIDE`, docs/29).
@@ -2650,6 +2665,9 @@ impl App {
         let dst = self.sidebars.get_mut(target);
         if !dst.docks.contains(kind) {
             dst.docks.push(kind.clone());
+        }
+        if kind == &DockKind::Files {
+            self.sidebars.files_side = target;
         }
         // Placing a module dock on a side is the user opting it back in, so clear
         // any explicit "off" flag (the inverse of `unmount_dock`).
@@ -9983,6 +10001,7 @@ mod tests {
                 width: 26,
                 docks: Vec::new(),
             },
+            files_side: None,
         };
         let sidebars = Sidebars::from_config(&cfg);
         assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -292,6 +292,10 @@ pub struct SidebarsConfig {
     pub left: SideConfig,
     #[serde(default = "SideConfig::right_default")]
     pub right: SideConfig,
+    /// Last explicit FILES placement, retained while the dock is off so the
+    /// show/hide shortcut restores it to the same side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub files_side: Option<crate::app::Side>,
 }
 
 /// One sidebar's persisted state: shown/hidden, width, and its ordered dock ids.
@@ -330,6 +334,7 @@ impl SidebarsConfig {
         SidebarsConfig {
             left: SideConfig::left_default(),
             right: SideConfig::right_default(),
+            files_side: None,
         }
     }
     /// Migrate a pre-DOCK config: the default layout at the stored width.

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -12,7 +12,8 @@ in a real editor.
 
 Press **`Ctrl+Space e`** to show or hide it, or place it from
 **Settings → Layout** like any other dock. It follows the active workspace, so
-switching projects re-roots the tree.
+switching projects re-roots the tree. Showing it again restores the last side
+you placed it on.
 
 The global fuzzy finder can search every eligible file name and relative path
 in the workspace even when its folder has never been expanded here. Press

--- a/website/src/content/docs/docs/reference/configuration.mdx
+++ b/website/src/content/docs/docs/reference/configuration.mdx
@@ -39,6 +39,7 @@ cleanly across versions because unknown fields get defaults.
 | `layout.diff_marker_style` | changed-line indicator: `symbols` (default), `bars`, or `both` |
 | `layout.diff_color_mode` | changed-line palette: `theme` (default) follows the active theme, while `standard` uses fixed red and green review colors |
 | `layout.diff_live_refresh` | refresh visible diff views when the shared FILES status scan changes |
+| `sidebars.files_side` | last side used by the FILES dock (`left` or `right`), retained while the dock is hidden |
 | `prefix` | the command-mode prefix (default `ctrl+space`). Accepts `f1`–`f12` as safe single keys, or a character/Space chord containing `Ctrl` or `Alt`, such as `ctrl+b`, `alt+\`, or `shift+f12` (see [Keybindings](/docs/reference/keybindings/)) |
 | `keybindings` | command id → key, overriding the defaults |
 | `bars.top_right` / `bars.bottom_right` / `bars.off` | canonical widget ids (`module:id`) in each Luvus Bar placement. `core:runtime-status` defaults to Bottom. Live content and notifications are never persisted. |


### PR DESCRIPTION
Restore the FILES/DIFF dock to its last configured sidebar when it is shown again.

## What

- Remember the last explicit FILES dock side in the persisted sidebar configuration.
- Make the FILES toggle remount the dock on that side instead of hardcoding the left sidebar.
- Reveal the remembered sidebar when remounting the dock.
- Add a regression test covering hide, restart, and restore on the right sidebar.
- Document the restored placement behavior and `sidebars.files_side` setting.

## Why

Moving FILES to the right sidebar worked until the user toggled it off and on. `toggle_files_dock()` always pushed the dock into `sidebars.left`, overwriting the user's layout when it saved the new state.

I searched the open PR list and historical PR/issue results for FILES dock/sidebar placement changes and did not find an existing fix for this behavior.

## Verification

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test --locked files_toggle_restores_last_side_across_restart`
- [x] `npm run build` in `website/`
- [x] `cargo test --locked`
- [x] Manual testing, if applicable

## Notes

The full locked test suite is not currently clean on this macOS checkout. `ui::sidebar::tests::agent_row_shows_the_pane_delegation_token` fails reproducibly on an unmodified `upstream/main` worktree as well. During the parallel full run, `focused_agent_meta_line_is_readable` also failed once but passes when run alone. The focused regression test and all Clippy/format checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The FILES dock now remembers whether it was positioned on the left or right.
  * Reopening the dock restores its previously selected side when space is available.
  * The placement preference persists across application restarts.

* **Documentation**
  * Updated FILES dock guidance and configuration reference to describe the saved sidebar placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->