### PR TITLE
feat(github): automate issue and pull request labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,14 @@ your workflow.
 2.
 3.
 
+**Area**
+<!--
+Replace this comment with one or more affected areas: agents, server, terminal,
+panes and tabs, workspaces, input, files, git and diff, mission control,
+settings, automation, modules, orchestration, bars, themes, localization,
+website, packaging.
+-->
+
 **Environment**
 - OS + version (for macOS, run `sw_vers`):
 - Terminal app + version (for example Ghostty, iTerm2, Windows Terminal, or kitty):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,6 +11,17 @@ What are you trying to do that luvus makes hard or impossible today?
 **What would you like to happen?**
 Describe the feature — a keybinding, a CLI command, a UI change, …
 
+**Area**
+<!--
+Replace this comment with one or more affected areas: agents, server, terminal,
+panes and tabs, workspaces, input, files, git and diff, mission control,
+settings, automation, modules, orchestration, bars, themes, localization,
+website, packaging.
+-->
+
+**Platform**
+<!-- Replace this comment with all, windows, macos, or linux. -->
+
 **Alternatives**
 Could this live as a [module](https://github.com/RizRiyz/luvus/blob/main/MODULE-GUIDE.md)
 instead of core? Anything you use today as a workaround?

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -156,9 +156,3 @@
           - "flake.lock"
           - "install.sh"
           - ".github/workflows/release.yml"
-
-"platform: windows":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "src/platform/windows.rs"
-          - "**/*.ps1"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,164 @@
+# Pull request area labels derived from changed files. Keep these rules focused:
+# broad files such as src/app/mod.rs intentionally do not label every subsystem.
+
+"area: agents":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/agent.rs"
+          - "src/agent/**"
+          - "src/detect.rs"
+          - "src/integration.rs"
+          - "src/skill.rs"
+          - "skills/luvus/**"
+          - "plugins/luvus/skills/luvus/**"
+          - "website/public/agent-readme.md"
+          - "website/src/content/docs/docs/guides/agents.mdx"
+          - "website/src/content/docs/docs/guides/agent-messaging.mdx"
+          - "website/src/content/docs/docs/reference/agents.mdx"
+
+"area: server":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/ipc/**"
+          - "src/logging/**"
+          - "src/persist.rs"
+          - "src/session.rs"
+
+"area: terminal":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/terminal/**"
+          - "vendor/alacritty_terminal/**"
+          - "vendor/vte/**"
+          - "website/src/content/docs/docs/guides/scrollback.mdx"
+          - "website/src/content/docs/docs/reference/terminal-backend.mdx"
+
+"area: panes and tabs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/layout.rs"
+          - "src/ui/panes.rs"
+          - "src/ui/tabbar.rs"
+          - "website/src/content/docs/docs/guides/layout.mdx"
+
+"area: workspaces":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/ui/sidebar.rs"
+          - "src/app/switcher.rs"
+          - "src/ui/switcher.rs"
+
+"area: input":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/app/input.rs"
+          - "src/app/keys.rs"
+          - "website/src/content/docs/docs/reference/keybindings.mdx"
+
+"area: files":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/files/**"
+          - "src/app/files.rs"
+          - "src/ui/files.rs"
+          - "website/src/content/docs/docs/guides/files.mdx"
+
+"area: git and diff":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/git/**"
+          - "src/diff/**"
+          - "src/app/git.rs"
+          - "src/app/diff.rs"
+          - "src/ui/git.rs"
+          - "src/ui/diff.rs"
+          - "website/src/content/docs/docs/guides/git.mdx"
+          - "website/src/content/docs/docs/guides/diff.mdx"
+
+"area: mission control":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/mission/**"
+          - "src/app/mission.rs"
+          - "src/ui/mission.rs"
+
+"area: settings":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/config.rs"
+          - "src/app/settings.rs"
+          - "src/ui/settings.rs"
+          - "website/src/content/docs/docs/guides/settings.mdx"
+          - "website/src/content/docs/docs/reference/configuration.mdx"
+
+"area: automation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/cli.rs"
+          - "src/api/**"
+          - "src/app/dispatch.rs"
+          - "protocol/uhp/**"
+          - "examples/uhp/**"
+          - "plugins/luvus/**"
+          - "website/src/content/docs/docs/guides/codex-plugin.mdx"
+          - "website/src/content/docs/docs/guides/scripting.mdx"
+          - "website/src/content/docs/docs/guides/uhp.mdx"
+          - "website/src/content/docs/docs/reference/api.mdx"
+          - "website/src/content/docs/docs/reference/cli.mdx"
+          - "website/src/content/docs/docs/reference/uhp.mdx"
+
+"area: modules":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/module/**"
+          - "MODULE-GUIDE.md"
+          - "website/src/content/docs/docs/extend/**"
+
+"area: orchestration":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/orch/**"
+          - "src/app/board.rs"
+          - "src/ui/board.rs"
+          - "website/src/content/docs/docs/guides/orchestration.mdx"
+          - "website/src/content/docs/docs/guides/worktrees.mdx"
+
+"area: bars":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/bar/**"
+          - "website/src/content/docs/docs/guides/bar.mdx"
+
+"area: themes":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/theme/**"
+          - "src/ui/theme.rs"
+          - "community/themes/**"
+          - "website/src/content/docs/docs/guides/themes.mdx"
+
+"area: localization":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/i18n/**"
+
+"area: website":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "website/**"
+
+"area: packaging":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Cargo.toml"
+          - "Cargo.lock"
+          - "flake.nix"
+          - "flake.lock"
+          - "install.sh"
+          - ".github/workflows/release.yml"
+
+"platform: windows":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/platform/windows.rs"
+          - "**/*.ps1"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
-          sync-labels: false
+          sync-labels: true
 
       - name: Label pull request type and platform
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -32,6 +32,19 @@ jobs:
           script: |
             const title = context.payload.pull_request.title.trim();
             const labels = new Set();
+            const managedLabels = new Set([
+              "bug",
+              "enhancement",
+              "documentation",
+              "performance",
+              "maintenance",
+              "tests",
+              "ci",
+              "dependencies",
+              "platform: windows",
+              "platform: macos",
+              "platform: linux",
+            ]);
 
             const types = [
               [/^fix(?:\([^)]*\))?!?:/i, "bug"],
@@ -66,6 +79,39 @@ jobs:
               labels.add("dependencies");
             }
 
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            if (
+              files.some(
+                ({ filename }) =>
+                  filename === "src/platform/windows.rs" || filename.endsWith(".ps1"),
+              )
+            ) {
+              labels.add("platform: windows");
+            }
+
+            const currentLabels = new Set(
+              context.payload.pull_request.labels.map(({ name }) => name),
+            );
+            for (const label of managedLabels) {
+              if (!labels.has(label) && currentLabels.has(label)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: label,
+                  });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+            }
+
             if (labels.size > 0) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
@@ -90,7 +136,10 @@ jobs:
             const title = issue.title.toLowerCase();
             const body = issue.body || "";
             const cleanBody = body.replace(/<!--[\s\S]*?-->/g, "");
-            const labels = new Set(["status: needs triage"]);
+            const labels = new Set();
+            if (context.payload.action !== "edited") {
+              labels.add("status: needs triage");
+            }
 
             function section(name) {
               const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -140,9 +189,33 @@ jobs:
               labels.add("platform: linux");
             }
 
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              labels: [...labels],
-            });
+            const managedLabels = new Set([
+              ...areaRules.map(([, label]) => label),
+              "platform: windows",
+              "platform: macos",
+              "platform: linux",
+            ]);
+            const currentLabels = new Set(issue.labels.map(({ name }) => name));
+            for (const label of managedLabels) {
+              if (!labels.has(label) && currentLabels.has(label)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label,
+                  });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+            }
+
+            if (labels.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [...labels],
+              });
+            }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,148 @@
+name: Label issues and pull requests
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  pull-request:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      # This workflow never checks out or executes pull request code.
+      - name: Label changed areas
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false
+
+      - name: Label pull request type and platform
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const title = context.payload.pull_request.title.trim();
+            const labels = new Set();
+
+            const types = [
+              [/^fix(?:\([^)]*\))?!?:/i, "bug"],
+              [/^feat(?:\([^)]*\))?!?:/i, "enhancement"],
+              [/^docs(?:\([^)]*\))?!?:/i, "documentation"],
+              [/^perf(?:\([^)]*\))?!?:/i, "performance"],
+              [/^(?:refactor|chore)(?:\([^)]*\))?!?:/i, "maintenance"],
+              [/^test(?:\([^)]*\))?!?:/i, "tests"],
+              [/^(?:ci|build)(?:\([^)]*\))?!?:/i, "ci"],
+            ];
+
+            for (const [pattern, label] of types) {
+              if (pattern.test(title)) {
+                labels.add(label);
+                break;
+              }
+            }
+
+            const platformScopes = [
+              [/\bwindows\b|\(windows\)/i, "platform: windows"],
+              [/\bmacos\b|\(macos\)/i, "platform: macos"],
+              [/\blinux\b|\(linux\)/i, "platform: linux"],
+            ];
+            for (const [pattern, label] of platformScopes) {
+              if (pattern.test(title)) labels.add(label);
+            }
+
+            if (
+              context.actor === "dependabot[bot]" ||
+              /^(?:build|chore)\(deps(?:-[^)]+)?\)!?:/i.test(title)
+            ) {
+              labels.add("dependencies");
+            }
+
+            if (labels.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [...labels],
+              });
+            }
+
+  issue:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Label issue area and platform
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const title = issue.title.toLowerCase();
+            const body = issue.body || "";
+            const cleanBody = body.replace(/<!--[\s\S]*?-->/g, "");
+            const labels = new Set(["status: needs triage"]);
+
+            function section(name) {
+              const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+              const match = cleanBody.match(
+                new RegExp(
+                  `\\*\\*${escaped}\\*\\*[ \\t]*\\r?\\n([\\s\\S]*?)(?=\\r?\\n\\*\\*|$)`,
+                  "i",
+                ),
+              );
+              return match ? match[1].trim().toLowerCase() : "";
+            }
+
+            const explicitArea = section("Area");
+            const areaRules = [
+              ["agents", "area: agents", /\b(agent|agents|claude|codex|copilot|opencode|resume|fork)\b/i],
+              ["server", "area: server", /\b(server|socket|session|persistence)\b/i],
+              ["terminal", "area: terminal", /\b(terminal|pty|scrollback|vt engine)\b/i],
+              ["panes and tabs", "area: panes and tabs", /\b(pane|panes|tab|tabs|split|layout)\b/i],
+              ["workspaces", "area: workspaces", /\b(workspace|workspaces)\b/i],
+              ["input", "area: input", /\b(keyboard|keybinding|shortcut|mouse|clipboard|copy|paste|selection)\b/i],
+              ["files", "area: files", /\b(file browser|file preview|open file|files?)\b/i],
+              ["git and diff", "area: git and diff", /\b(git|diff|github)\b/i],
+              ["mission control", "area: mission control", /\b(mission control|usage|pricing)\b/i],
+              ["settings", "area: settings", /\b(settings?|configuration)\b/i],
+              ["automation", "area: automation", /\b(cli|api|uhp|skill|plugin|command)\b/i],
+              ["modules", "area: modules", /\b(module|modules)\b/i],
+              ["orchestration", "area: orchestration", /\b(orchestration|worktree|lease|task board)\b/i],
+              ["bars", "area: bars", /\b(top bar|bottom bar|luvus bar)\b/i],
+              ["themes", "area: themes", /\b(theme|themes)\b/i],
+              ["localization", "area: localization", /\b(i18n|localization|translation|language)\b/i],
+              ["website", "area: website", /\b(website|documentation|docs)\b/i],
+              ["packaging", "area: packaging", /\b(install|installer|homebrew|cargo install|nix|package|release)\b/i],
+            ];
+
+            for (const [value, label, titlePattern] of areaRules) {
+              if (explicitArea.includes(value) || (!explicitArea && titlePattern.test(title))) {
+                labels.add(label);
+              }
+            }
+
+            const explicitPlatform = section("Platform");
+            const osLine = cleanBody.match(/^- OS[^\n]*:[ \t]*(.+)$/im)?.[1] || "";
+            const platformText = `${explicitPlatform} ${osLine}`;
+            if (/\bwindows\b/i.test(platformText)) labels.add("platform: windows");
+            if (/\bmacos\b|\bmac os\b|\bos x\b/i.test(platformText)) labels.add("platform: macos");
+            if (/\blinux\b|\bubuntu\b|\bdebian\b|\bfedora\b|\barch\b/i.test(platformText)) {
+              labels.add("platform: linux");
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: [...labels],
+            });


### PR DESCRIPTION
Adds deterministic issue and pull request labeling for the Luvus repository.

## What

- labels pull requests by changed subsystem paths
- derives pull request type from Conventional Commit titles
- detects platform-specific pull requests from titles and Windows paths
- marks new and reopened issues as `status: needs triage`
- labels issues from the explicit Area and Platform template fields
- falls back to conservative title matching when an issue has no selected area
- adds the repository labels required by the workflow
- pins official GitHub Actions to full commit SHAs

## Why

Maintainers currently classify issues and pull requests manually. This keeps classification consistent while leaving priority, approval, reproduction status, and merge readiness under maintainer control.

## Safety

The pull request workflow reads metadata and changed paths through the GitHub API. It never checks out or executes contributor code, and it does not call an external labeling service. Labels outside the automated type, area, platform, and dependency sets are preserved.

## Verification

- YAML parsing passed
- embedded JavaScript syntax checking passed
- pull request type, dependency, and platform classification passed
- untouched issue template regression test passed
- explicit issue area and platform classification passed
- all referenced labels were confirmed on GitHub
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved bug report forms with fields for affected product areas.
  - Enhanced feature request forms to capture affected areas and supported platforms.

- **Chores**
  - Added automated labeling for pull requests and issues based on affected areas, platforms, and request details.
  - Added default triage labeling to organize newly submitted issues more consistently.
  - Added rules to keep labels synchronized and remove outdated classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->