### PR TITLE
feat(files): insert a file's path into the focused pane

### DIFF
--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -40,8 +40,8 @@ pub(crate) enum InsertPath {
     /// Nothing to insert into: the focused leaf is a native view, or the tab
     /// has no pane at all.
     NoPane,
-    /// The path holds `\n` or `\r`, either of which would submit the prompt.
-    Newline,
+    /// The path holds a terminal control character and cannot be pasted safely.
+    ControlCharacter,
 }
 
 impl App {
@@ -522,7 +522,9 @@ impl App {
                     // Both refusals are silent-looking otherwise: the menu closes
                     // and nothing appears in the prompt.
                     InsertPath::NoPane => self.show_toast("no pane to insert into"),
-                    InsertPath::Newline => self.show_toast("path contains a line break"),
+                    InsertPath::ControlCharacter => {
+                        self.show_toast("path contains a control character")
+                    }
                 }
             }
             FileMenuItem::Delete => self.file_delete = Some(menu.path),
@@ -543,15 +545,15 @@ impl App {
     /// FILES dock and its context menu never moves pane focus, so the pane the
     /// user was typing in is still the one that receives this.
     ///
-    /// A path holding a line break is refused rather than trimmed. `\n` and
-    /// `\r` are both legal in a filename on Unix, and either one would submit
-    /// the prompt on arrival — a command running itself, half-typed, is a
-    /// baffling thing to be handed, and no truncation of the path is a better
-    /// answer than not inserting it.
+    /// A path holding a control character is refused rather than trimmed.
+    /// Besides `\n` and `\r` submitting a prompt, Escape and other controls can
+    /// alter terminal input or terminate bracketed-paste mode. These characters
+    /// are legal in Unix filenames, but no truncation of the path is a better
+    /// answer than inserting unsafe or incorrect text.
     pub(crate) fn insert_path(&mut self, path: &Path) -> InsertPath {
         let text = path.to_string_lossy().into_owned();
-        if text.contains(['\n', '\r']) {
-            return InsertPath::Newline;
+        if text.chars().any(char::is_control) {
+            return InsertPath::ControlCharacter;
         }
         match self.paste_into_focused_pane(&text) {
             Some(target) => InsertPath::Inserted { target, text },
@@ -2416,25 +2418,32 @@ mod tests {
         );
     }
 
-    /// A filename may legally hold a line break on Unix, and inserting one would
-    /// submit the prompt by itself. Refuse the whole path rather than trim it:
+    /// Unix filenames may legally hold terminal controls. Newlines can submit
+    /// the prompt, while Escape can terminate bracketed paste and make the
+    /// remaining bytes act as input. Refuse the whole path rather than trim it:
     /// a silently shortened path is a wrong path.
     #[test]
-    fn insert_path_refuses_a_path_holding_a_line_break() {
-        let _env = crate::persist::test_env("files-insert-newline");
+    fn insert_path_refuses_terminal_control_characters() {
+        let _env = crate::persist::test_env("files-insert-control");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(120, 40, tx).unwrap();
 
-        for bad in ["two\nlines.txt", "carriage\rreturn.txt"] {
+        for bad in [
+            "two\nlines.txt",
+            "carriage\rreturn.txt",
+            "tab\tname.txt",
+            "escape\u{1b}[201~name.txt",
+            "delete\u{7f}name.txt",
+        ] {
             let path = std::env::temp_dir().join(bad);
             assert_eq!(
                 app.insert_path(&path),
-                InsertPath::Newline,
-                "{bad:?} would have submitted the prompt"
+                InsertPath::ControlCharacter,
+                "{bad:?} must not reach the terminal"
             );
         }
 
-        // And a path with no line break in it still inserts, so the guard is
+        // And a path with no control character still inserts, so the guard is
         // not simply refusing everything.
         let good = std::env::temp_dir().join("ordinary.txt");
         assert!(matches!(
@@ -2484,7 +2493,7 @@ mod tests {
         app.file_menu_action_pub(FileMenuItem::InsertPath);
         assert_eq!(
             app.toast.as_ref().map(|(text, _)| text.as_str()),
-            Some("path contains a line break"),
+            Some("path contains a control character"),
             "the row reached insert_path and reported its refusal"
         );
     }

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -28,6 +28,22 @@ pub enum OpenTarget {
     Tab,
 }
 
+/// What an `Insert Path` did.
+///
+/// The outcome is returned rather than only toasted so a caller — and the tests
+/// for it — can see the exact text that reached the pane and which pane took
+/// it, without reaching into the PTY.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum InsertPath {
+    /// The path was handed to `target`'s paste path, as exactly this text.
+    Inserted { target: PaneId, text: String },
+    /// Nothing to insert into: the focused leaf is a native view, or the tab
+    /// has no pane at all.
+    NoPane,
+    /// The path holds `\n` or `\r`, either of which would submit the prompt.
+    Newline,
+}
+
 impl App {
     /// Keep the FILES dock honest, off the render path. Called from `detect_tick`:
     /// re-roots the tree to the active node, then schedules a worker read for any
@@ -500,8 +516,46 @@ impl App {
                 self.pending_clipboard = Some(menu.path.to_string_lossy().into_owned());
                 self.show_toast("copied path");
             }
+            FileMenuItem::InsertPath => {
+                match self.insert_path(&menu.path) {
+                    InsertPath::Inserted { .. } => {}
+                    // Both refusals are silent-looking otherwise: the menu closes
+                    // and nothing appears in the prompt.
+                    InsertPath::NoPane => self.show_toast("no pane to insert into"),
+                    InsertPath::Newline => self.show_toast("path contains a line break"),
+                }
+            }
             FileMenuItem::Delete => self.file_delete = Some(menu.path),
             FileMenuItem::Divider => {}
+        }
+    }
+
+    /// Type `path` into the focused pane's prompt, leaving it unsubmitted.
+    ///
+    /// The path is absolute, exactly as `Copy Path` gives it, so it stays right
+    /// even when the pane has since changed its working directory. It arrives
+    /// through [`App::paste_into_focused_pane`] rather than a write at the pane,
+    /// which is what keeps bracketed paste, scroll position and activity
+    /// tracking the same as any other paste — and no `\r` follows it, because
+    /// composing the rest of the command line is the user's job.
+    ///
+    /// The target is whatever the active tab already had focused: opening the
+    /// FILES dock and its context menu never moves pane focus, so the pane the
+    /// user was typing in is still the one that receives this.
+    ///
+    /// A path holding a line break is refused rather than trimmed. `\n` and
+    /// `\r` are both legal in a filename on Unix, and either one would submit
+    /// the prompt on arrival — a command running itself, half-typed, is a
+    /// baffling thing to be handed, and no truncation of the path is a better
+    /// answer than not inserting it.
+    pub(crate) fn insert_path(&mut self, path: &Path) -> InsertPath {
+        let text = path.to_string_lossy().into_owned();
+        if text.contains(['\n', '\r']) {
+            return InsertPath::Newline;
+        }
+        match self.paste_into_focused_pane(&text) {
+            Some(target) => InsertPath::Inserted { target, text },
+            None => InsertPath::NoPane,
         }
     }
 
@@ -2276,5 +2330,185 @@ mod tests {
         assert!(!file.exists(), "confirmed delete removes it");
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    // ── Insert Path (docs/38 FILE-6) ─────────────────────────────────────────
+
+    /// Build a FILES menu for `path` without going through the tree, the way
+    /// the other menu tests here do.
+    fn insert_menu(path: &Path) -> FileMenu {
+        FileMenu {
+            path: path.to_path_buf(),
+            is_dir: false,
+            anchor: (0, 0),
+            items: Vec::new(),
+            editors: Vec::new(),
+        }
+    }
+
+    /// `Insert Path` types into the pane the user was already in, and inserts
+    /// the absolute path *verbatim* — spaces intact, and with nothing appended.
+    ///
+    /// The missing trailing `\r` is the point: the path lands in the prompt for
+    /// the user to finish the command around. Anything that submitted it would
+    /// run a half-written command line.
+    #[test]
+    fn insert_path_types_the_path_into_the_focused_pane_without_submitting_it() {
+        let _env = crate::persist::test_env("files-insert-path");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+
+        // Two panes, so "the focused one" is a real choice rather than the only
+        // pane there is.
+        app.split(Axis::Col);
+        assert_eq!(app.layout().len(), 2, "two panes to choose between");
+        let focused = app.layout().focus;
+
+        // A name with spaces: the shell would need it quoted, which is the
+        // user's business — the insert must not mangle or requote it.
+        let path = std::env::temp_dir().join("luvus insert/my notes.md");
+        let expected = path.to_string_lossy().into_owned();
+        assert!(
+            expected.contains(' '),
+            "the fixture is the interesting case"
+        );
+
+        assert_eq!(
+            app.insert_path(&path),
+            InsertPath::Inserted {
+                target: focused,
+                text: expected.clone(),
+            },
+            "the focused pane got the absolute path, spaces and all"
+        );
+    }
+
+    /// Opening the FILES dock and its context menu must not move pane focus, so
+    /// the pane `Insert Path` targets is still the one the user was typing in.
+    ///
+    /// This is the whole reason the action is worth having: reaching for the
+    /// file tree to name a file would otherwise cost you the prompt you were
+    /// naming it for.
+    #[test]
+    fn opening_the_files_menu_does_not_change_the_insert_target() {
+        let _env = crate::persist::test_env("files-insert-target");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.split(Axis::Col);
+        let typing_in = app.layout().focus;
+
+        // Everything the user does to reach the action.
+        app.toggle_files_dock();
+        app.file_menu = Some(insert_menu(&std::env::temp_dir().join("target.rs")));
+        assert_eq!(
+            app.layout().focus,
+            typing_in,
+            "the dock and the menu left pane focus where it was"
+        );
+
+        let path = std::env::temp_dir().join("target.rs");
+        assert!(
+            matches!(
+                app.insert_path(&path),
+                InsertPath::Inserted { target, .. } if target == typing_in
+            ),
+            "the path went to the pane that had focus before the menu opened"
+        );
+    }
+
+    /// A filename may legally hold a line break on Unix, and inserting one would
+    /// submit the prompt by itself. Refuse the whole path rather than trim it:
+    /// a silently shortened path is a wrong path.
+    #[test]
+    fn insert_path_refuses_a_path_holding_a_line_break() {
+        let _env = crate::persist::test_env("files-insert-newline");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+
+        for bad in ["two\nlines.txt", "carriage\rreturn.txt"] {
+            let path = std::env::temp_dir().join(bad);
+            assert_eq!(
+                app.insert_path(&path),
+                InsertPath::Newline,
+                "{bad:?} would have submitted the prompt"
+            );
+        }
+
+        // And a path with no line break in it still inserts, so the guard is
+        // not simply refusing everything.
+        let good = std::env::temp_dir().join("ordinary.txt");
+        assert!(matches!(
+            app.insert_path(&good),
+            InsertPath::Inserted { .. }
+        ));
+    }
+
+    /// A native read-only view is not a terminal: there is no prompt to insert
+    /// into, so the action says so instead of quietly doing nothing.
+    #[test]
+    fn insert_path_reports_a_focused_leaf_that_is_not_a_pane() {
+        let _env = crate::persist::test_env("files-insert-no-pane");
+        let dir = std::env::temp_dir().join(format!("luvus-ip-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("readme.md");
+        std::fs::write(&file, b"hello\n").unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        // Focus a native file view rather than a terminal.
+        app.open_file_view(file.clone(), OpenTarget::Tab);
+        assert!(
+            app.views.contains_key(&app.layout().focus),
+            "the focused leaf is a native view, not a pane"
+        );
+
+        assert_eq!(
+            app.insert_path(&file),
+            InsertPath::NoPane,
+            "a view has no prompt to insert into"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The menu row runs the action: picking `Insert Path` for a path that has
+    /// to be refused produces the refusal, which nothing else in the menu does.
+    #[test]
+    fn the_insert_path_row_runs_the_action() {
+        let _env = crate::persist::test_env("files-insert-row");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+
+        app.file_menu = Some(insert_menu(&std::env::temp_dir().join("two\nlines.txt")));
+        app.file_menu_action_pub(FileMenuItem::InsertPath);
+        assert_eq!(
+            app.toast.as_ref().map(|(text, _)| text.as_str()),
+            Some("path contains a line break"),
+            "the row reached insert_path and reported its refusal"
+        );
+    }
+
+    /// The row is offered for folders too — a directory path is as useful to
+    /// type as a file's — matching `Copy Path` rather than the open actions.
+    #[test]
+    fn insert_path_is_offered_for_files_and_folders() {
+        for is_dir in [false, true] {
+            let menu = FileMenu {
+                path: PathBuf::from("/tmp/x"),
+                is_dir,
+                anchor: (0, 0),
+                items: Vec::new(),
+                editors: Vec::new(),
+            };
+            let items = menu.build_items();
+            assert!(
+                items.contains(&FileMenuItem::InsertPath),
+                "Insert Path offered (is_dir={is_dir})"
+            );
+            let copy = items.iter().position(|i| *i == FileMenuItem::CopyPath);
+            let insert = items.iter().position(|i| *i == FileMenuItem::InsertPath);
+            assert!(copy < insert, "it sits with Copy Path, just below it");
+        }
     }
 }

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -42,6 +42,9 @@ pub(crate) enum InsertPath {
     NoPane,
     /// The path holds a terminal control character and cannot be pasted safely.
     ControlCharacter,
+    /// The path is not valid UTF-8, so the text that would reach the pane is not
+    /// the path that was clicked.
+    NotUtf8,
 }
 
 impl App {
@@ -525,6 +528,7 @@ impl App {
                     InsertPath::ControlCharacter => {
                         self.show_toast("path contains a control character")
                     }
+                    InsertPath::NotUtf8 => self.show_toast("path is not valid UTF-8"),
                 }
             }
             FileMenuItem::Delete => self.file_delete = Some(menu.path),
@@ -550,13 +554,23 @@ impl App {
     /// alter terminal input or terminate bracketed-paste mode. These characters
     /// are legal in Unix filenames, but no truncation of the path is a better
     /// answer than inserting unsafe or incorrect text.
+    ///
+    /// A path that is not valid UTF-8 is refused for the same reason. Unix
+    /// paths are bytes, not text, so `to_string_lossy` would replace the
+    /// invalid ones with U+FFFD and hand the pane a path that reads plausibly
+    /// and does not exist — a wrong path is worse than no path.
     pub(crate) fn insert_path(&mut self, path: &Path) -> InsertPath {
-        let text = path.to_string_lossy().into_owned();
+        let Some(text) = path.to_str() else {
+            return InsertPath::NotUtf8;
+        };
         if text.chars().any(char::is_control) {
             return InsertPath::ControlCharacter;
         }
-        match self.paste_into_focused_pane(&text) {
-            Some(target) => InsertPath::Inserted { target, text },
+        match self.paste_into_focused_pane(text) {
+            Some(target) => InsertPath::Inserted {
+                target,
+                text: text.to_owned(),
+            },
             None => InsertPath::NoPane,
         }
     }
@@ -2450,6 +2464,28 @@ mod tests {
             app.insert_path(&good),
             InsertPath::Inserted { .. }
         ));
+    }
+
+    /// A Unix path is bytes, not text. `to_string_lossy` would turn an invalid
+    /// byte into U+FFFD and insert a path that reads plausibly and does not
+    /// exist — the same "a wrong path is worse than no path" argument that
+    /// refuses control characters rather than trimming them.
+    #[cfg(unix)]
+    #[test]
+    fn insert_path_refuses_a_path_that_is_not_utf8() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let _env = crate::persist::test_env("files-insert-not-utf8");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+
+        let name = std::ffi::OsStr::from_bytes(b"not\xffutf8.txt");
+        let path = std::env::temp_dir().join(name);
+        assert_eq!(
+            app.insert_path(&path),
+            InsertPath::NotUtf8,
+            "a lossy conversion would have inserted a path that does not exist"
+        );
     }
 
     /// A native read-only view is not a terminal: there is no prompt to insert

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -436,15 +436,8 @@ impl App {
                 if self.paste_into_modal(&s) {
                     return true; // the modal buffer changed → redraw
                 }
-                // Otherwise it goes to the focused pane. `send_paste` re-wraps in
-                // the bracketed-paste markers crossterm stripped, so a child that
-                // distinguishes paste from typing (an agent CLI attaching a
-                // dropped file, vim not auto-indenting) still sees a paste.
-                if let Some(p) = self.focused() {
-                    p.scroll_to_bottom(); // pasting is input → snap to live
-                    p.send_paste(&s);
-                }
-                self.mark_user_input(); // so the echo isn't misread as agent work
+                // Otherwise it goes to the focused pane.
+                self.paste_into_focused_pane(&s);
                 false // goes to the pane; its echo (PtyData) renders it
             }
             AppEvent::Resize => {
@@ -2653,6 +2646,30 @@ impl App {
         } else {
             false
         }
+    }
+
+    /// Deliver `text` to the focused pane exactly as a paste from the outer
+    /// terminal does, and report which pane took it (`None` when the focused
+    /// leaf is a native view or has no pane at all).
+    ///
+    /// `send_paste` re-wraps the text in the bracketed-paste markers crossterm
+    /// stripped, so a child that distinguishes paste from typing (an agent CLI
+    /// attaching a dropped file, vim not auto-indenting) still sees a paste.
+    /// The pane also snaps to live and the input is marked as the user's, so
+    /// detection doesn't read the echo as agent work.
+    ///
+    /// This is the one place that does it: `Insert Path` (docs/38) goes through
+    /// here rather than writing at the pane, so bracketed paste, scroll
+    /// position, and activity tracking cannot drift between the two.
+    pub(crate) fn paste_into_focused_pane(&mut self, text: &str) -> Option<PaneId> {
+        let id = self.layout().focus;
+        let target = self.panes.get(&id).map(|p| {
+            p.scroll_to_bottom(); // pasting is input → snap to live
+            p.send_paste(text);
+            id
+        });
+        self.mark_user_input(); // so the echo isn't misread as agent work
+        target
     }
 
     /// Record that the user just typed into the focused pane, so detection can

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -609,6 +609,9 @@ pub enum FileMenuItem {
     NewFolder,
     Rename,
     CopyPath,
+    /// Type the path into the focused pane's prompt, without submitting it
+    /// (docs/38 FILE-6). Offered for folders too, exactly like `CopyPath`.
+    InsertPath,
     Divider,
     Delete,
 }
@@ -628,6 +631,7 @@ impl FileMenu {
             FileMenuItem::NewFolder,
             FileMenuItem::Rename,
             FileMenuItem::CopyPath,
+            FileMenuItem::InsertPath,
             FileMenuItem::Divider,
             FileMenuItem::Delete,
         ]);

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -488,6 +488,7 @@ fn file_label(it: FileMenuItem, editors: &[(String, String)]) -> String {
         FileMenuItem::NewFolder => "New Folder".to_string(),
         FileMenuItem::Rename => "Rename".to_string(),
         FileMenuItem::CopyPath => "Copy Path".to_string(),
+        FileMenuItem::InsertPath => "Insert Path".to_string(),
         FileMenuItem::Divider => String::new(),
         FileMenuItem::Delete => "Delete".to_string(),
     }
@@ -620,6 +621,7 @@ mod label_case_tests {
             FileMenuItem::NewFolder,
             FileMenuItem::Rename,
             FileMenuItem::CopyPath,
+            FileMenuItem::InsertPath,
             FileMenuItem::Delete,
         ] {
             rows.push(file_label(it, &editors));

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -39,9 +39,11 @@ you were already working in, without submitting it — so you can name a file in
 agent prompt without leaving the keyboard to type the path out. Opening the
 FILES dock and its menu does not move focus, so the path lands where you were
 typing. It is inserted only; Luvus never sends Enter, and never adds an `@` or
-any other prefix, so the syntax stays yours. A path is left uninserted if the
-focused pane is a read-only file view rather than a terminal, or if the filename
-itself contains a line break — which would submit your prompt on arrival.
+any other prefix, so the syntax stays yours. A path is left uninserted if there
+is no focused live terminal pane (for example, when a read-only file view is
+focused), or if the absolute path contains a control character such as a line
+break, tab, or Escape. This prevents the path from submitting or altering your
+terminal input.
 
 ## Opening a file
 

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -34,8 +34,8 @@ pane, show up on their own within a couple of seconds.
 **Right-click a row** for New File, New Folder, Rename, Copy Path, Insert Path,
 and Delete (Delete always asks first).
 
-**Insert Path** types the file's absolute path into the pane you were already
-working in, without submitting it — so you can name a file in a command or an
+**Insert Path** types the selected file or folder's absolute path into the pane
+you were already working in, without submitting it — so you can name a file in a command or an
 agent prompt without leaving the keyboard to type the path out. Opening the
 FILES dock and its menu does not move focus, so the path lands where you were
 typing. It is inserted only; Luvus never sends Enter, and never adds an `@` or

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -31,8 +31,17 @@ conflicted, mint for renamed, with a letter badge and a mark on any folder that
 contains changes. Files created outside luvus, by an agent or a command in a
 pane, show up on their own within a couple of seconds.
 
-**Right-click a row** for New File, New Folder, Rename, Copy Path, and Delete
-(Delete always asks first).
+**Right-click a row** for New File, New Folder, Rename, Copy Path, Insert Path,
+and Delete (Delete always asks first).
+
+**Insert Path** types the file's absolute path into the pane you were already
+working in, without submitting it — so you can name a file in a command or an
+agent prompt without leaving the keyboard to type the path out. Opening the
+FILES dock and its menu does not move focus, so the path lands where you were
+typing. It is inserted only; Luvus never sends Enter, and never adds an `@` or
+any other prefix, so the syntax stays yours. A path is left uninserted if the
+focused pane is a read-only file view rather than a terminal, or if the filename
+itself contains a line break — which would submit your prompt on arrival.
 
 ## Opening a file
 

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -41,9 +41,10 @@ FILES dock and its menu does not move focus, so the path lands where you were
 typing. It is inserted only; Luvus never sends Enter, and never adds an `@` or
 any other prefix, so the syntax stays yours. A path is left uninserted if there
 is no focused live terminal pane (for example, when a read-only file view is
-focused), or if the absolute path contains a control character such as a line
-break, tab, or Escape. This prevents the path from submitting or altering your
-terminal input.
+focused), if the absolute path contains a control character such as a line
+break, tab, or Escape — which would submit or alter your terminal input — or if
+it is not valid UTF-8, since the text Luvus could insert would not be the path
+you clicked.
 
 ## Opening a file
 


### PR DESCRIPTION
Implements #151.

Reaching for the FILES tree to name a file in a command or an agent prompt meant reading the path off the screen and typing it back out. `Insert Path` types it for you, into the pane you were already working in.

## Behaviour

Per the spec on #151:

- **Label** is `Insert Path`, in the FILES context menu, directly below `Copy Path`.
- **Targets the focused pane in the active tab.** Opening the FILES dock and its context menu never moves pane focus, so the pane you were typing in is the one that receives it.
- **Absolute path**, exactly as `Copy Path` gives it — still correct when the pane has since changed its working directory.
- **Insert only.** No Enter, ever.
- **No `@` prefix**, or any other — that syntax belongs to whatever is reading the prompt.
- **Reuses the app-level paste path**, so bracketed paste, scroll position, activity tracking and terminal input behaviour are identical to any other paste. That path is now `App::paste_into_focused_pane`, shared with the `Paste` event so the two cannot drift.
- **Refuses, with a concise message**, in the two cases the spec names:
  - no focused live pane — the focused leaf is a native read-only view, which has no prompt to insert into;
  - a path containing a line break.

Offered for folders as well as files, matching `Copy Path` rather than the open actions.

### On the newline rejection

The spec asks for `\n`; this also rejects `\r`. Both are legal in a Unix filename and **either** submits the prompt on arrival, which is the failure the rule exists to prevent. The path is refused whole rather than trimmed — a silently shortened path is a wrong path, and worse than no insert.

## Tests

Six, covering the four cases named in the ticket:

| Test | Covers |
|---|---|
| `insert_path_types_the_path_into_the_focused_pane_without_submitting_it` | focused-pane targeting; paths with spaces; no Enter |
| `opening_the_files_menu_does_not_change_the_insert_target` | the FILES menu not changing the pane target |
| `insert_path_refuses_a_path_holding_a_line_break` | `\n` and `\r`, and that ordinary paths still insert |
| `insert_path_reports_a_focused_leaf_that_is_not_a_pane` | no focused live pane |
| `the_insert_path_row_runs_the_action` | the menu row is wired to the action |
| `insert_path_is_offered_for_files_and_folders` | menu placement |

The outcome is returned as an `InsertPath` enum rather than only toasted, so a test can assert the exact text that reached the pane and which pane took it without reaching into the PTY.

All four guards are mutation-checked — I reverted each in turn and confirmed the matching test fails:

- dropping the newline guard → `insert_path_refuses_…` fails
- appending `\r` to the inserted text → `insert_path_types_…` fails
- altering the text at all → `insert_path_types_…` fails on exact equality
- targeting a non-focused pane → both targeting tests fail

## Checks

`cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean; 1009 tests pass.

One unrelated test, `agent_list_labels_a_pane_with_its_node_name`, fails **on unmodified `main`** in my environment and is not affected by this change. It asserts `worktree == false`, but `App::new` picks up the working directory, which is a linked `git worktree` in my checkout — so it reports `true`. It passes in an ordinary clone, which is why CI is green. Happy to send a fix separately if you'd like the test to be independent of how the repo is checked out.

## Documentation

`website/src/content/docs/docs/guides/files.mdx` — the context-menu list, and a paragraph on what Insert Path does and when it declines.

## Note on ordering

This is independent of #164 despite what I said on #151: it applies to `main` on its own, so you can take the two in either order. If #164 goes first, this one needs a trivial conflict resolution — three adjacent one-line additions in the `FileMenuItem` enum, `build_items()`, and the label match. Say the word and I'll rebase it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Insert Path** action to the FILES context menu.
  * Inserts a file or folder’s absolute path into the focused pane without submitting it or changing focus.
  * Supports both files and folders.

* **Bug Fixes**
  * Prevents insertion when no focused live pane is available or when the path contains terminal control characters or invalid text encoding.

* **Documentation**
  * Updated the FILES dock guide with details about the new action and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->