### PR TITLE
feat(agent): add native Muse detection and resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,9 @@ boundaries are:
   Git/files/diff, Mission Control, overlays, and hit-test geometry.
 - `src/detect.rs`: agent identity and state evidence. Detection is native Luvus
   behavior and must not depend on an installed agent skill.
-- `src/agent.rs`: native session discovery, resume, fork, and command building.
+- `src/agent.rs`: native session registry, resume/fork orchestration, and shared
+  command building. Put non-trivial agent-specific discovery or integration code
+  in `src/agent/<agent>/` (for example `src/agent/muse/`), not in the registry.
 - `src/integration.rs`: optional agent-native hooks for precise session and
   lifecycle reports. Hooks augment detection; they do not replace it.
 - `src/cli.rs`, `src/api/`, and `src/app/dispatch.rs`: parsing/help, public UHP

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
   working, done, or idle state with session titles, tokens, cost, context use,
   and optional sound alerts.
 - **Agent workflows:** Start, name, message, inspect, wait for, resume, and send
-  keys to agents. Fork Claude, Grok, Codex, and Pi sessions with their context intact.
+  keys to agents. Fork Claude, Grok, Codex, Pi, and OMP sessions with their
+  context intact.
 - **Files and code:** Browse a Git-aware file tree, inspect files and changes,
   reveal paths, and open files in a pane, tab, preview, or external editor.
 - **Git and GitHub:** View status, branches, commits, contributors, pull
@@ -94,6 +95,7 @@ Keyboard → Keyboard Shortcuts → Input Sources** to free `Ctrl+Space`.
 | Grok | ✓ | ✓ | ✓ |
 | Pi | ✓ | ✓ | No |
 | Oh My Pi (omp) | ✓ | ✓ | ✓ |
+| Muse Code | ✓ | ✓ | No |
 | Fx | ✓ | No | No |
 | Cursor | ✓ | resume command | No |
 | Gemini · Aider · Amp · Droid · Qwen · Kiro | ✓ | No | No |

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -295,7 +295,7 @@ luvus agent get <target>
 luvus agent fork <target> [--name <alias>] [--no-focus]
 ```
 
-Native forks currently support Claude, Grok, Codex, and Pi. Report
+Native forks currently support Claude, Grok, Codex, Pi, and OMP. Report
 `unsupported_agent`, `session_unknown`, or `spawn_failed` exactly when returned.
 Do not approximate a failed fork with `pane split`, `agent start`, or `resume`,
 because those paths do not guarantee an independent copy of the conversation.

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -295,7 +295,7 @@ luvus agent get <target>
 luvus agent fork <target> [--name <alias>] [--no-focus]
 ```
 
-Native forks currently support Claude, Grok, Codex, and Pi. Report
+Native forks currently support Claude, Grok, Codex, Pi, and OMP. Report
 `unsupported_agent`, `session_unknown`, or `spawn_failed` exactly when returned.
 Do not approximate a failed fork with `pane split`, `agent start`, or `resume`,
 because those paths do not guarantee an independent copy of the conversation.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -9,6 +9,7 @@
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+pub(crate) mod muse;
 pub(crate) mod omp;
 mod usage;
 pub use usage::{session_mtime, session_usage};
@@ -98,6 +99,21 @@ static SOURCES: &[SessionSource] = &[
         // `fork` creates a new conversation from the selected rollout while
         // leaving the source session untouched.
         fork: Some(|q| format!("codex fork {q}\r")),
+    },
+    SessionSource {
+        name: muse::NAME,
+        discover: Some(Discovery {
+            base: muse::sessions_base,
+            recent: muse::recent,
+            latest: muse::latest,
+            list: Some(muse::list),
+        }),
+        resume: |q| format!("muse resume {q}\r"),
+        // Muse's `/fork` is available only inside the already-running TUI, and
+        // Muse refuses to resume that live UUID in a sibling. Luvus cannot keep
+        // the original pane running while creating a branch until Muse exposes
+        // an external fork command or flag.
+        fork: None,
     },
     SessionSource {
         name: "kimi",
@@ -268,13 +284,15 @@ fn filter_launch_flags(agent: &str, launch: &[String]) -> Vec<String> {
     const STANDALONE: &[&str] = &["--continue", "--fork-session", "--print", "-p"];
 
     let mut i = 0;
-    // Codex selects a session with positional `resume <id>` / `fork <id>`
-    // subcommands rather than flags, so drop either when it leads the captured
-    // argv. A restored fork must resume its new id, not fork the parent again.
-    if agent == "codex"
+    // Codex and Muse select sessions with positional subcommands rather than
+    // flags. Drop them when they lead captured argv so a restored pane gets
+    // exactly one fresh session selector. A restored Codex fork must resume its
+    // new id, not fork the parent again.
+    if (agent == "codex"
         && launch
             .first()
-            .is_some_and(|s| matches!(s.as_str(), "resume" | "fork"))
+            .is_some_and(|s| matches!(s.as_str(), "resume" | "fork")))
+        || (agent == muse::NAME && launch.first().is_some_and(|s| s == "resume"))
     {
         i = 1;
         if launch.get(1).is_some_and(|v| !v.starts_with('-')) {
@@ -1473,6 +1491,11 @@ mod tests {
         assert!(resume_command("codex", "c1")
             .unwrap()
             .contains("codex resume"));
+        assert_eq!(
+            resume_command("muse", "7de3d84e-31f9-4437-b2f8-0b56db788042").as_deref(),
+            Some("muse resume '7de3d84e-31f9-4437-b2f8-0b56db788042'\r")
+        );
+        assert!(is_resumable("muse"));
         assert!(resume_command("kimi", "k1")
             .unwrap()
             .contains("kimi --resume"));
@@ -1785,6 +1808,10 @@ mod tests {
             f("codex", &["fork", "sess_9", "--model", "o3"]),
             vec!["--model", "o3"]
         );
+        assert_eq!(
+            f("muse", &["resume", "muse-id", "--reasoning-effort", "high"]),
+            vec!["--reasoning-effort", "high"]
+        );
         // A kept flag keeps its value.
         assert_eq!(
             f("claude", &["--permission-mode", "bypassPermissions"]),
@@ -1884,6 +1911,10 @@ mod tests {
         let grok = fork_command("grok", "g1").unwrap();
         assert!(grok.contains("grok --resume") && grok.contains("--fork-session"));
         assert!(can_fork("claude") && can_fork("codex") && can_fork("pi") && can_fork("grok"));
+        assert!(
+            !can_fork("muse"),
+            "Muse has no external native fork entrypoint"
+        );
         // Resume-capable, but no native fork (the copy-then-resume tier is future).
         assert!(!can_fork("copilot"));
         assert!(!can_fork("cursor"));

--- a/src/agent/muse/mod.rs
+++ b/src/agent/muse/mod.rs
@@ -1,0 +1,212 @@
+//! Native Meta Muse Code session support.
+//!
+//! Muse stores durable sessions under
+//! `$XDG_DATA_HOME/muse/sessions/YYYY/MM/DD/<uuid>/session.jsonl` (falling back
+//! to `~/.local/share`). Metadata records near the start of each log carry the
+//! exact session UUID and workspace root, so discovery never derives identity
+//! from a directory name or transcript text.
+
+use std::io::{BufRead, Read};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use super::SessionInfo;
+
+pub const NAME: &str = "muse";
+pub const DISTINCT_IDENTITIES: &[&str] = &["muse-code", "muse-cli", "muse code"];
+pub const AMBIGUOUS_IDENTITIES: &[&str] = &["muse"];
+
+/// Muse's launcher execs a release-specific binary such as
+/// `muse-bin-0.2.1-R1215.1`. Require a digit immediately after the prefix so
+/// unrelated programs such as `muse-bin-helper` are not accepted.
+pub fn is_versioned_binary(binary: &str) -> bool {
+    binary
+        .strip_prefix("muse-bin-")
+        .and_then(|version| version.as_bytes().first())
+        .is_some_and(u8::is_ascii_digit)
+}
+
+pub fn sessions_base() -> PathBuf {
+    std::env::var_os("XDG_DATA_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| super::home().join(".local").join("share"))
+        .join("muse")
+        .join("sessions")
+}
+
+/// `(mtime, path)` for the native date-sharded session logs. Directory walks
+/// are depth-bounded and do not follow symlinks.
+fn session_files(base: &Path) -> Vec<(SystemTime, PathBuf)> {
+    fn walk(dir: &Path, depth: u8, out: &mut Vec<(SystemTime, PathBuf)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(kind) = entry.file_type() else {
+                continue;
+            };
+            if kind.is_dir() && depth < 4 {
+                walk(&path, depth + 1, out);
+            } else if kind.is_file()
+                && path.file_name().and_then(|name| name.to_str()) == Some("session.jsonl")
+            {
+                if let Ok(updated) = entry.metadata().and_then(|meta| meta.modified()) {
+                    out.push((updated, path));
+                }
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    walk(base, 0, &mut files);
+    files
+}
+
+/// Read only Muse's early metadata envelope, never message or tool payloads.
+/// Both fields are required and may arrive in separate records.
+fn read_session(path: &Path) -> Option<(String, PathBuf)> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut session_id = None;
+    let mut workspace = None;
+    for line in std::io::BufReader::new(file)
+        .take(256 * 1024)
+        .lines()
+        .take(64)
+        .map_while(Result::ok)
+    {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let payload_type = value
+            .get("payload_type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let Some(record) = value.pointer("/payload/record") else {
+            continue;
+        };
+        if payload_type == "session.opened.observed" {
+            session_id = record
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| super::safe_id(id))
+                .map(str::to_owned);
+        } else if payload_type == "runtime.session.metadata" {
+            workspace = record
+                .get("workspace_root")
+                .and_then(serde_json::Value::as_str)
+                .filter(|cwd| !cwd.is_empty())
+                .map(PathBuf::from);
+        } else if payload_type == "runtime.session.route_facts" && workspace.is_none() {
+            workspace = record
+                .get("cwd")
+                .and_then(serde_json::Value::as_str)
+                .filter(|cwd| !cwd.is_empty())
+                .map(PathBuf::from);
+        }
+        if session_id.is_some() && workspace.is_some() {
+            break;
+        }
+    }
+    Some((session_id?, workspace?))
+}
+
+pub fn list(base: &Path, cwd: &Path) -> Vec<String> {
+    let mut files = session_files(base);
+    files.sort_by_key(|(updated, _)| std::cmp::Reverse(*updated));
+    files
+        .into_iter()
+        .filter_map(|(_, path)| read_session(&path))
+        .filter(|(_, workspace)| crate::platform::same_path(workspace, cwd))
+        .map(|(id, _)| id)
+        .collect()
+}
+
+pub fn latest(base: &Path, cwd: &Path) -> Option<String> {
+    list(base, cwd).into_iter().next()
+}
+
+pub fn recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    let mut files = session_files(base);
+    files.sort_by_key(|(updated, _)| std::cmp::Reverse(*updated));
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for (updated, path) in files {
+        if out.len() >= limit {
+            break;
+        }
+        let Some((session_id, cwd)) = read_session(&path) else {
+            continue;
+        };
+        if seen.insert(cwd.clone()) {
+            out.push(SessionInfo {
+                agent: NAME.to_string(),
+                session_id,
+                cwd,
+                updated,
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_session(base: &Path, day: &str, id: &str, cwd: &str) -> PathBuf {
+        let dir = base.join(day).join(id);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("session.jsonl");
+        fs::write(
+            &path,
+            format!(
+                "{{\"payload_type\":\"session.opened.observed\",\"payload\":{{\"record\":{{\"session_id\":\"{id}\"}}}}}}\n\
+                 {{\"payload_type\":\"runtime.session.metadata\",\"payload\":{{\"record\":{{\"workspace_root\":\"{cwd}\"}}}}}}\n"
+            ),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn versioned_binary_requires_a_numeric_release() {
+        assert!(is_versioned_binary("muse-bin-0.2.1-r1215.1"));
+        assert!(!is_versioned_binary("muse-bin"));
+        assert!(!is_versioned_binary("muse-bin-helper"));
+        assert!(!is_versioned_binary("museum"));
+    }
+
+    #[test]
+    fn discovers_native_sessions_by_metadata_not_directory_name() {
+        let base = std::env::temp_dir().join(format!("luvus-muse-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        let first = write_session(
+            &base,
+            "2026/08/27",
+            "7de3d84e-31f9-4437-b2f8-0b56db788042",
+            "/work/app",
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        write_session(
+            &base,
+            "2026/08/28",
+            "8ef4e95f-42fa-5548-c309-1c67ec899153",
+            "/work/app",
+        );
+        fs::write(first.with_file_name("unrelated.jsonl"), "{not json}\n").unwrap();
+
+        assert_eq!(
+            latest(&base, Path::new("/work/app")).as_deref(),
+            Some("8ef4e95f-42fa-5548-c309-1c67ec899153")
+        );
+        assert_eq!(list(&base, Path::new("/work/app")).len(), 2);
+        let recent = recent(&base, 5);
+        assert_eq!(recent.len(), 1, "recent sessions deduplicate by workspace");
+        assert_eq!(recent[0].agent, NAME);
+        assert!(latest(&base, Path::new("/work/other")).is_none());
+        let _ = fs::remove_dir_all(base);
+    }
+}

--- a/src/agent/muse/mod.rs
+++ b/src/agent/muse/mod.rs
@@ -26,6 +26,14 @@ pub fn is_versioned_binary(binary: &str) -> bool {
         .is_some_and(u8::is_ascii_digit)
 }
 
+fn is_session_uuid(id: &str) -> bool {
+    id.len() == 36
+        && id.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            _ => byte.is_ascii_hexdigit(),
+        })
+}
+
 pub fn sessions_base() -> PathBuf {
     std::env::var_os("XDG_DATA_HOME")
         .filter(|value| !value.is_empty())
@@ -90,19 +98,19 @@ fn read_session(path: &Path) -> Option<(String, PathBuf)> {
             session_id = record
                 .get("session_id")
                 .and_then(serde_json::Value::as_str)
-                .filter(|id| super::safe_id(id))
+                .filter(|id| is_session_uuid(id))
                 .map(str::to_owned);
         } else if payload_type == "runtime.session.metadata" {
             workspace = record
                 .get("workspace_root")
                 .and_then(serde_json::Value::as_str)
-                .filter(|cwd| !cwd.is_empty())
+                .filter(|cwd| Path::new(cwd).is_absolute())
                 .map(PathBuf::from);
         } else if payload_type == "runtime.session.route_facts" && workspace.is_none() {
             workspace = record
                 .get("cwd")
                 .and_then(serde_json::Value::as_str)
-                .filter(|cwd| !cwd.is_empty())
+                .filter(|cwd| Path::new(cwd).is_absolute())
                 .map(PathBuf::from);
         }
         if session_id.is_some() && workspace.is_some() {
@@ -131,7 +139,7 @@ pub fn recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
     let mut files = session_files(base);
     files.sort_by_key(|(updated, _)| std::cmp::Reverse(*updated));
     let mut out = Vec::new();
-    let mut seen = std::collections::HashSet::new();
+    let mut seen: Vec<PathBuf> = Vec::new();
     for (updated, path) in files {
         if out.len() >= limit {
             break;
@@ -139,14 +147,19 @@ pub fn recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
         let Some((session_id, cwd)) = read_session(&path) else {
             continue;
         };
-        if seen.insert(cwd.clone()) {
-            out.push(SessionInfo {
-                agent: NAME.to_string(),
-                session_id,
-                cwd,
-                updated,
-            });
+        if seen
+            .iter()
+            .any(|workspace| crate::platform::same_path(workspace, &cwd))
+        {
+            continue;
         }
+        seen.push(cwd.clone());
+        out.push(SessionInfo {
+            agent: NAME.to_string(),
+            session_id,
+            cwd,
+            updated,
+        });
     }
     out
 }
@@ -155,6 +168,14 @@ pub fn recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn workspace_path() -> PathBuf {
+        if cfg!(windows) {
+            PathBuf::from(r"C:\work\app")
+        } else {
+            PathBuf::from("/work/app")
+        }
+    }
 
     fn write_session(base: &Path, day: &str, id: &str, cwd: &str) -> PathBuf {
         let dir = base.join(day).join(id);
@@ -183,30 +204,92 @@ mod tests {
     fn discovers_native_sessions_by_metadata_not_directory_name() {
         let base = std::env::temp_dir().join(format!("luvus-muse-{}", std::process::id()));
         let _ = fs::remove_dir_all(&base);
+        let workspace = workspace_path();
+        let workspace_text = workspace.to_string_lossy();
         let first = write_session(
             &base,
             "2026/08/27",
             "7de3d84e-31f9-4437-b2f8-0b56db788042",
-            "/work/app",
+            &workspace_text,
         );
         std::thread::sleep(std::time::Duration::from_millis(20));
         write_session(
             &base,
             "2026/08/28",
             "8ef4e95f-42fa-5548-c309-1c67ec899153",
-            "/work/app",
+            &workspace_text,
         );
         fs::write(first.with_file_name("unrelated.jsonl"), "{not json}\n").unwrap();
 
         assert_eq!(
-            latest(&base, Path::new("/work/app")).as_deref(),
+            latest(&base, &workspace).as_deref(),
             Some("8ef4e95f-42fa-5548-c309-1c67ec899153")
         );
-        assert_eq!(list(&base, Path::new("/work/app")).len(), 2);
+        assert_eq!(list(&base, &workspace).len(), 2);
         let recent = recent(&base, 5);
         assert_eq!(recent.len(), 1, "recent sessions deduplicate by workspace");
         assert_eq!(recent[0].agent, NAME);
-        assert!(latest(&base, Path::new("/work/other")).is_none());
+        assert!(latest(&base, &workspace.with_file_name("other")).is_none());
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn rejects_malformed_session_metadata() {
+        let base = std::env::temp_dir().join(format!("luvus-muse-invalid-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        let workspace = workspace_path();
+        write_session(
+            &base,
+            "2026/08/27",
+            "not-a-muse-session",
+            &workspace.to_string_lossy(),
+        );
+        write_session(
+            &base,
+            "2026/08/28",
+            "7de3d84e-31f9-4437-b2f8-0b56db788042",
+            "relative/workspace",
+        );
+        let route_dir = base
+            .join("2026/08/29")
+            .join("8ef4e95f-42fa-5548-c309-1c67ec899153");
+        fs::create_dir_all(&route_dir).unwrap();
+        fs::write(
+            route_dir.join("session.jsonl"),
+            "{\"payload_type\":\"session.opened.observed\",\"payload\":{\"record\":{\"session_id\":\"8ef4e95f-42fa-5548-c309-1c67ec899153\"}}}\n\
+             {\"payload_type\":\"runtime.session.route_facts\",\"payload\":{\"record\":{\"cwd\":\"relative/fallback\"}}}\n",
+        )
+        .unwrap();
+
+        assert!(recent(&base, 5).is_empty());
+        assert!(list(&base, &workspace).is_empty());
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn recent_uses_platform_path_identity() {
+        let base = std::env::temp_dir().join(format!("luvus-muse-paths-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        let workspace = workspace_path();
+        let variant = if cfg!(windows) {
+            r"c:/WORK/app/".to_string()
+        } else {
+            "/work/app/".to_string()
+        };
+        write_session(
+            &base,
+            "2026/08/27",
+            "7de3d84e-31f9-4437-b2f8-0b56db788042",
+            &workspace.to_string_lossy(),
+        );
+        write_session(
+            &base,
+            "2026/08/28",
+            "8ef4e95f-42fa-5548-c309-1c67ec899153",
+            &variant,
+        );
+
+        assert_eq!(recent(&base, 5).len(), 1);
         let _ = fs::remove_dir_all(base);
     }
 }

--- a/src/agent/muse/mod.rs
+++ b/src/agent/muse/mod.rs
@@ -78,6 +78,7 @@ fn read_session(path: &Path) -> Option<(String, PathBuf)> {
     let file = std::fs::File::open(path).ok()?;
     let mut session_id = None;
     let mut workspace = None;
+    let mut route_workspace = None;
     for line in std::io::BufReader::new(file)
         .take(256 * 1024)
         .lines()
@@ -106,8 +107,8 @@ fn read_session(path: &Path) -> Option<(String, PathBuf)> {
                 .and_then(serde_json::Value::as_str)
                 .filter(|cwd| Path::new(cwd).is_absolute())
                 .map(PathBuf::from);
-        } else if payload_type == "runtime.session.route_facts" && workspace.is_none() {
-            workspace = record
+        } else if payload_type == "runtime.session.route_facts" && route_workspace.is_none() {
+            route_workspace = record
                 .get("cwd")
                 .and_then(serde_json::Value::as_str)
                 .filter(|cwd| Path::new(cwd).is_absolute())
@@ -117,7 +118,7 @@ fn read_session(path: &Path) -> Option<(String, PathBuf)> {
             break;
         }
     }
-    Some((session_id?, workspace?))
+    Some((session_id?, workspace.or(route_workspace)?))
 }
 
 pub fn list(base: &Path, cwd: &Path) -> Vec<String> {
@@ -181,14 +182,15 @@ mod tests {
         let dir = base.join(day).join(id);
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("session.jsonl");
-        fs::write(
-            &path,
-            format!(
-                "{{\"payload_type\":\"session.opened.observed\",\"payload\":{{\"record\":{{\"session_id\":\"{id}\"}}}}}}\n\
-                 {{\"payload_type\":\"runtime.session.metadata\",\"payload\":{{\"record\":{{\"workspace_root\":\"{cwd}\"}}}}}}\n"
-            ),
-        )
-        .unwrap();
+        let opened = serde_json::json!({
+            "payload_type": "session.opened.observed",
+            "payload": {"record": {"session_id": id}},
+        });
+        let metadata = serde_json::json!({
+            "payload_type": "runtime.session.metadata",
+            "payload": {"record": {"workspace_root": cwd}},
+        });
+        fs::write(&path, format!("{opened}\n{metadata}\n")).unwrap();
         path
     }
 
@@ -290,6 +292,41 @@ mod tests {
         );
 
         assert_eq!(recent(&base, 5).len(), 1);
+        let _ = fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn metadata_workspace_outranks_earlier_route_facts() {
+        let base = std::env::temp_dir().join(format!("luvus-muse-order-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        let workspace = workspace_path();
+        let fallback = workspace.with_file_name("fallback");
+        let id = "7de3d84e-31f9-4437-b2f8-0b56db788042";
+        let dir = base.join("2026/08/28").join(id);
+        fs::create_dir_all(&dir).unwrap();
+        let records = [
+            serde_json::json!({
+                "payload_type": "session.opened.observed",
+                "payload": {"record": {"session_id": id}},
+            }),
+            serde_json::json!({
+                "payload_type": "runtime.session.route_facts",
+                "payload": {"record": {"cwd": fallback}},
+            }),
+            serde_json::json!({
+                "payload_type": "runtime.session.metadata",
+                "payload": {"record": {"workspace_root": workspace}},
+            }),
+        ];
+        let body = records
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(dir.join("session.jsonl"), format!("{body}\n")).unwrap();
+
+        assert_eq!(latest(&base, &workspace).as_deref(), Some(id));
+        assert!(latest(&base, &fallback).is_none());
         let _ = fs::remove_dir_all(base);
     }
 }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -115,6 +115,14 @@ const KNOWN_AGENTS: &[KnownAgent] = &[
         distinct: &[],
         ambiguous: &["grok"],
     },
+    // Muse's launcher execs a versioned `muse-bin-*` binary, handled by
+    // `match_binary`. The brand itself is an ordinary English word, so only
+    // trust bare `muse` in deliberate command/title evidence.
+    KnownAgent {
+        name: crate::agent::muse::NAME,
+        distinct: crate::agent::muse::DISTINCT_IDENTITIES,
+        ambiguous: crate::agent::muse::AMBIGUOUS_IDENTITIES,
+    },
     // Oh My Pi (omp) precedes pi in this registry ON PURPOSE: the brand
     // "oh-my-pi" word-contains pi's ambiguous token, and the first match wins.
     // omp's brand + npm binary are distinctive, so trust them from pane
@@ -611,6 +619,54 @@ fn builtin_rules() -> Vec<Rule> {
             Region::Screen,
             vec![any(&["send a message to interrupt"])],
         ),
+        // Muse question, trust, and approval overlays. These paired controls
+        // outrank its generic `esc to interrupt` working hint, including the
+        // multi-select question UI that deliberately retains that phrase.
+        per(
+            "muse",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&["enter to select", "tab for an optional note"])],
+        ),
+        per(
+            "muse",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&["enter to toggle", "esc to interrupt"])],
+        ),
+        per(
+            "muse",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&["do you trust this workspace?", "trust and continue"])],
+        ),
+        per(
+            "muse",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&[
+                "allow this stage once",
+                "always allow in this workspace",
+            ])],
+        ),
+        per(
+            "muse",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&["allow once", "allow for this session"])],
+        ),
+        per(
+            "muse",
+            State::Blocked,
+            325,
+            Region::Screen,
+            vec![all(&["yes, proceed", "yes, don't ask again this session"])],
+        ),
     ]
 }
 
@@ -1092,6 +1148,11 @@ impl Manifests {
 
     /// The agent whose patterns name exactly this binary.
     fn match_binary(&self, base: &str) -> Option<String> {
+        if crate::agent::muse::is_versioned_binary(base)
+            && self.agents.iter().any(|agent| agent.name == "muse")
+        {
+            return Some("muse".to_string());
+        }
         self.agents
             .iter()
             .find(|a| a.all().any(|p| p == base))
@@ -1319,6 +1380,70 @@ mod tests {
             &m,
         );
         assert_eq!(incidental.agent, "zsh", "screen prose must not name fx");
+    }
+
+    #[test]
+    fn muse_identity_accepts_native_binaries_without_trusting_prose() {
+        let m = Manifests::builtin();
+        assert_eq!(
+            m.agent_in_processes(&[
+                "/Users/me/.local/bin/muse-bin-0.2.1-R1215.1 --provider meta".into()
+            ]),
+            Some("muse".into())
+        );
+        assert_eq!(
+            m.agent_in_processes(&["/Users/me/.local/bin/muse --provider echo".into()]),
+            Some("muse".into())
+        );
+        assert_eq!(
+            m.agent_in_processes(&["/usr/local/bin/muse-bin-helper".into()]),
+            None,
+            "a similarly named helper is not Muse Code"
+        );
+
+        let incidental = classify(
+            Some("zsh"),
+            "the museum uses a muse as its example",
+            true,
+            false,
+            "zsh",
+            "",
+            &[],
+            &m,
+        );
+        assert_eq!(
+            incidental.agent, "zsh",
+            "bare muse is never trusted from pane output"
+        );
+    }
+
+    #[test]
+    fn muse_native_interactions_override_the_working_hint() {
+        let classify_muse = |bottom: &str| {
+            classify(
+                Some("Muse Code"),
+                bottom,
+                true,
+                false,
+                "zsh",
+                "muse",
+                &["muse-bin-0.2.1-R1215.1".into()],
+                &Manifests::builtin(),
+            )
+            .state
+        };
+        assert_eq!(
+            classify_muse("Which files?\nEnter to toggle · Esc to interrupt"),
+            State::Blocked
+        );
+        assert_eq!(
+            classify_muse("Do you trust this workspace?\nTrust and continue"),
+            State::Blocked
+        );
+        assert_eq!(
+            classify_muse("◆ Working (2s · esc to interrupt)"),
+            State::Working
+        );
     }
 
     #[test]

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -157,6 +157,7 @@ struct AgentIdent {
     name: String,
     distinct: Vec<String>,
     ambiguous: Vec<String>,
+    binary_matcher: Option<fn(&str) -> bool>,
 }
 
 impl AgentIdent {
@@ -174,6 +175,8 @@ fn builtin_agents() -> Vec<AgentIdent> {
             name: a.name.to_string(),
             distinct: a.distinct.iter().map(|s| s.to_string()).collect(),
             ambiguous: a.ambiguous.iter().map(|s| s.to_string()).collect(),
+            binary_matcher: (a.name == crate::agent::muse::NAME)
+                .then_some(crate::agent::muse::is_versioned_binary as fn(&str) -> bool),
         })
         .collect()
 }
@@ -787,6 +790,7 @@ impl ManifestFile {
                     name: name.clone(),
                     distinct: Vec::new(),
                     ambiguous: Vec::new(),
+                    binary_matcher: None,
                 });
                 agents.last_mut().expect("just pushed")
             }
@@ -794,6 +798,7 @@ impl ManifestFile {
         if id.replace {
             entry.distinct.clear();
             entry.ambiguous.clear();
+            entry.binary_matcher = None;
         }
         entry.distinct.extend(lc(&id.distinct));
         entry.ambiguous.extend(lc(&id.ambiguous));
@@ -1148,10 +1153,12 @@ impl Manifests {
 
     /// The agent whose patterns name exactly this binary.
     fn match_binary(&self, base: &str) -> Option<String> {
-        if crate::agent::muse::is_versioned_binary(base)
-            && self.agents.iter().any(|agent| agent.name == "muse")
+        if let Some(agent) = self
+            .agents
+            .iter()
+            .find(|agent| agent.binary_matcher.is_some_and(|matcher| matcher(base)))
         {
-            return Some("muse".to_string());
+            return Some(agent.name.clone());
         }
         self.agents
             .iter()
@@ -1414,6 +1421,30 @@ mod tests {
         assert_eq!(
             incidental.agent, "zsh",
             "bare muse is never trusted from pane output"
+        );
+    }
+
+    #[test]
+    fn muse_identity_replace_disables_the_versioned_binary_matcher() {
+        let mut m = Manifests::builtin();
+        toml::from_str::<ManifestFile>(
+            r#"
+            agent = "muse"
+            [identity]
+            distinct = ["custom-muse"]
+            replace = true
+        "#,
+        )
+        .unwrap()
+        .apply_identity(&mut m.agents);
+
+        assert_eq!(
+            m.agent_in_processes(&["muse-bin-0.2.1-R1215.1".into()]),
+            None
+        );
+        assert_eq!(
+            m.agent_in_processes(&["custom-muse".into()]),
+            Some("muse".into())
         );
     }
 

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -29,7 +29,7 @@ Run `luvus doctor`. Local views need `git`. PRs/issues need an authenticated
 
 luvus identifies an agent by the program running in the pane, matched against a
 list of names it knows (Claude Code, Copilot, Codex, opencode, Kimi, Cursor,
-Gemini, Aider, Amp, Droid, Grok, Qwen, Kiro). If your agent runs under a name
+Gemini, Aider, Amp, Droid, Grok, Muse, Qwen, Kiro). If your agent runs under a name
 luvus does not know, teach it one in `~/.luvus/manifests/<agent>.toml`:
 
 ```toml

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -10,8 +10,8 @@ back after a restart, all without wrapping or modifying the agents themselves.
 ## The AGENTS sidebar
 
 Every pane running a recognized agent (Claude Code, Copilot, Codex, opencode,
-Kimi, Grok, Pi, Oh My Pi (OMP), Cursor, Gemini, Qwen, Kiro, Aider, Amp, Droid,
-or fx) appears in the sidebar with a live state:
+Kimi, Grok, Muse Code, Pi, Oh My Pi (OMP), Cursor, Gemini, Qwen, Kiro, Aider,
+Amp, Droid, or fx) appears in the sidebar with a live state:
 
 | State | Meaning | How it's detected |
 |---|---|---|
@@ -64,7 +64,7 @@ one or Luvus has pricing for the model.
 | Gemini and Qwen | project chat records |
 | fx | session usage snapshot |
 
-Aider, Kiro, Cursor, Amp, Droid, and manifest-defined agents still receive live
+Aider, Kiro, Cursor, Amp, Droid, Muse, and manifest-defined agents still receive live
 identity and state detection, but show `—` for usage until they expose a stable
 per-session counter or report one through an integration. Luvus never estimates
 tokens from transcript text.
@@ -83,7 +83,7 @@ each pane and matches the program name. A pane running `claude` is Claude Code;
 a pane that merely prints the word "claude" is a shell.
 
 That distinction matters more than it sounds. Names like `amp`, `cursor`,
-`droid`, `grok` and `pi` are ordinary English words, so reading them off the
+`droid`, `grok`, `muse`, and `pi` are ordinary English words, so reading them off the
 screen turns "for example" into Amp and "cursor is out of bounds" into Cursor.
 Your sidebar fills with agents that were never running.
 
@@ -123,6 +123,7 @@ command for you:
 | Grok | its session directory (`~/.grok/sessions`) |
 | Pi | its session store (`~/.pi/agent/sessions`) |
 | Oh My Pi (OMP) | its profile-, XDG-, and override-aware native session store |
+| Muse Code | its XDG data store (`$XDG_DATA_HOME/muse/sessions`) |
 | Gemini | its project chat store (`~/.gemini/tmp`) |
 | Qwen | its project chat store (`~/.qwen/tmp`) |
 | fx | its session store (`~/.fx/sessions`) |
@@ -171,9 +172,13 @@ unsupported or unresolved fork for success.
 Codex forks require the exact session identity reported by its integration or
 recorded when Luvus resumes a session. Luvus never guesses the newest Codex
 rollout in a shared folder, because that could fork another pane's active
-conversation. Install or refresh the hook with
+conversation. Install or refresh the Codex hook with
 `luvus integration install codex`; its SessionStart and prompt hooks bind new
 and resumed Codex panes to their exact rollout.
+
+Muse Code supports native detection and resume, but not **Fork to New Pane**.
+Its `/fork` command exists only inside the active TUI, and its CLI refuses to
+resume the same live session in a sibling pane.
 
 ## Precise events: the integration hook
 

--- a/website/src/content/docs/docs/guides/codex-plugin.mdx
+++ b/website/src/content/docs/docs/guides/codex-plugin.mdx
@@ -175,7 +175,7 @@ luvus agent fork reviewer --name experiment --no-focus
 ```
 
 The fork inherits the source conversation and receives its own new session.
-Native forks currently support Claude, Grok, Codex, and Pi. If the target is
+Native forks currently support Claude, Grok, Codex, Pi, and OMP. If the target is
 unsupported, its session cannot be resolved, or its pane cannot start, the
 skill reports Luvus's structured error instead of substituting a split, new
 agent, or resume operation that could lose or reuse the wrong context.

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -13,6 +13,7 @@ description: What luvus supports per agent, covering live status, session resume
 | Grok Build | ✓ | ✓ | ✓ | ✓ |
 | Pi | ✓ | ✓ | ✓ | no |
 | Oh My Pi (omp) | ✓ | ✓ | ✓ | ✓ |
+| Muse Code | ✓ | ✓ | no | no |
 | Cursor | ✓ | resume command | no | no |
 | Gemini | ✓ | no | no | no |
 | Aider | ✓ | no | no | no |
@@ -32,9 +33,9 @@ description: What luvus supports per agent, covering live status, session resume
   original keeps running. It needs an agent with a native fork command, so today
   that is **Claude** (`claude --resume <id> --fork-session`), **Grok**
   (`grok --resume <id> --fork-session`), **Codex** (`codex fork <id>`),
-  **Pi** (`pi --fork <id>`), and **Oh My Pi (omp)** (`omp --fork <id>`). Right-click the pane and
-  choose **Fork to New Pane**, or press `Ctrl+Space f`. The action only appears
-  for agents that can fork.
+  **Pi** (`pi --fork <id>`), and **Oh My Pi (omp)** (`omp --fork <id>`).
+  Right-click the pane and choose **Fork to New Pane**, or press `Ctrl+Space f`.
+  The action only appears when Luvus can resolve the source session safely.
 - **Hook**, via `luvus integration install <agent>`, makes the agent report its
   exact session id and lifecycle events. OMP additionally reports authoritative
   idle/working/blocked/done state through Luvus's bounded agent authority API.


### PR DESCRIPTION
## Summary

- add native Muse Code identity detection for the launcher, aliases, and versioned `muse-bin-*` process
- classify Muse working, trust, question, multi-select, approval, and network-confirmation states
- discover Muse sessions from its XDG-aware date-sharded session store and resume them with `muse resume <session-id>`
- keep Muse-specific discovery in `src/agent/muse/` and document that convention for future integrations
- update the README, bundled Luvus skills, FAQ, agent guide, and capability reference

## Safety and compatibility

- reads only the early metadata envelope from each Muse session log, bounded to 64 lines and 256 KiB
- requires both a validated session UUID and workspace path; prompt and tool payloads are not consumed
- bounds directory traversal and does not follow symlinks
- treats bare `muse` as ambiguous screen text while accepting deliberate process/title evidence
- keeps Muse fork unsupported because its `/fork` is TUI-only and the CLI cannot safely resume the same live session in a sibling pane
- leaves existing Claude, Grok, Codex, Pi, and OMP fork commands unchanged

## Validation

- `cargo fmt --all --check`
- `cargo test agent::tests:: -- --nocapture`
- `cargo test agent::muse::tests:: -- --nocapture`
- `cargo test detect::tests::muse -- --nocapture`
- `cargo test app::tests::fork_pane_splits -- --nocapture`
- `cargo test app::tests::codex_pane_menu -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `npm --prefix website run build`
- isolated runtime validation of Muse session discovery and `muse resume` behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Muse Code detection, live status reporting, and session resume support.
  * Muse sessions can now be discovered and resumed from the current workspace.
  * Added support for OMP as a native fork target.
* **Limitations**
  * Muse Code does not support opening forks in new panes or hook-based event reporting.
* **Documentation**
  * Updated guides, FAQs, and support references for Muse Code and OMP capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->