### PR TITLE
fix(terminal): backport Alacritty terminal stability fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,9 @@ name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "atomic"
@@ -809,8 +812,9 @@ dependencies = [
 
 [[package]]
 name = "luvus-alacritty-terminal"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
+ "arrayvec",
  "base64",
  "bitflags 2.13.0",
  "home",

--- a/vendor/alacritty_terminal/CHANGELOG.md
+++ b/vendor/alacritty_terminal/CHANGELOG.md
@@ -8,6 +8,14 @@ sections should follow the order `Added`, `Changed`, `Deprecated`, `Fixed` and
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.26.1
+
+### Fixed
+
+- Panic when the PTY could not be set to non-blocking
+- Off-by-one in `ViMotion::ParagraphUp`
+- Unbounded per-cell memory usage for zero-width characters
+
 ## 0.26.0
 
 ### Added

--- a/vendor/alacritty_terminal/Cargo.toml
+++ b/vendor/alacritty_terminal/Cargo.toml
@@ -13,7 +13,7 @@
 edition = "2024"
 rust-version = "1.85.0"
 name = "luvus-alacritty-terminal"
-version = "0.26.0"
+version = "0.26.1"
 authors = [
     "Christian Duerr <contact@christianduerr.com>",
     "Joe Wilm <joe@jwilm.com>",
@@ -47,6 +47,10 @@ path = "src/lib.rs"
 [[test]]
 name = "ref"
 path = "tests/ref.rs"
+
+[dependencies.arrayvec]
+version = "0.7.2"
+features = ["serde"]
 
 [dependencies.base64]
 version = "0.22.0"

--- a/vendor/alacritty_terminal/Cargo.toml.orig
+++ b/vendor/alacritty_terminal/Cargo.toml.orig
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty_terminal"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "Library for writing terminal emulators"
@@ -15,6 +15,7 @@ default = ["serde"]
 serde = ["dep:serde", "bitflags/serde", "vte/serde"]
 
 [dependencies]
+arrayvec = { version = "0.7.2", features = ["serde"] }
 base64 = "0.22.0"
 bitflags = "2.4.1"
 home = "0.5.5"

--- a/vendor/alacritty_terminal/src/term/cell.rs
+++ b/vendor/alacritty_terminal/src/term/cell.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use arrayvec::ArrayVec;
 use bitflags::bitflags;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -8,6 +9,12 @@ use serde::{Deserialize, Serialize};
 use crate::grid::{self, GridCell};
 use crate::index::Column;
 use crate::vte::ansi::{Color, Hyperlink as VteHyperlink, NamedColor};
+
+/// Maximum number of zerowidth characters to retain per grid cell.
+///
+/// This enforces an upper bound on memory usage per cell, to ensure malicious
+/// applications cannot use this as a denial-of-service vector.
+const MAX_ZEROWIDTH_CHARS: usize = 9;
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -123,7 +130,7 @@ impl ResetDiscriminant<Color> for Cell {
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CellExtra {
-    zerowidth: Vec<char>,
+    zerowidth: ArrayVec<char, MAX_ZEROWIDTH_CHARS>,
     underline_color: Option<Color>,
     hyperlink: Option<Hyperlink>,
 }
@@ -163,7 +170,7 @@ impl Cell {
     #[inline]
     pub fn push_zerowidth(&mut self, character: char) {
         let extra = self.extra.get_or_insert(Default::default());
-        Arc::make_mut(extra).zerowidth.push(character);
+        let _ = Arc::make_mut(extra).zerowidth.try_push(character);
     }
 
     /// Remove all wide char data from a cell.
@@ -171,7 +178,7 @@ impl Cell {
     pub fn clear_wide(&mut self) {
         self.flags.remove(Flags::WIDE_CHAR);
         if let Some(extra) = self.extra.as_mut() {
-            Arc::make_mut(extra).zerowidth = Vec::new();
+            Arc::make_mut(extra).zerowidth = ArrayVec::new();
         }
         self.c = ' ';
     }
@@ -304,6 +311,20 @@ mod tests {
 
         // Ensure that cell size isn't growing by accident.
         assert!(mem::size_of::<Cell>() <= EXPECTED_CELL_SIZE);
+    }
+
+    #[test]
+    fn zerowidth_characters_are_bounded() {
+        let mut cell = Cell::default();
+        for index in 0..MAX_ZEROWIDTH_CHARS + 5 {
+            let character = char::from_u32(0x300 + index as u32).unwrap();
+            cell.push_zerowidth(character);
+        }
+
+        let zerowidth = cell.zerowidth().unwrap();
+        assert_eq!(zerowidth.len(), MAX_ZEROWIDTH_CHARS);
+        assert_eq!(zerowidth[0], '\u{300}');
+        assert_eq!(zerowidth[MAX_ZEROWIDTH_CHARS - 1], '\u{308}');
     }
 
     #[test]

--- a/vendor/alacritty_terminal/src/tty/unix.rs
+++ b/vendor/alacritty_terminal/src/tty/unix.rs
@@ -278,31 +278,36 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
     // Prepare signal handling before spawning child.
     let (signals, sig_id) = {
         let (sender, recv) = UnixStream::pair()?;
+        recv.set_nonblocking(true)?;
 
         // Register the recv end of the pipe for SIGCHLD.
         let sig_id = signal_pipe::register(sigconsts::SIGCHLD, sender)?;
-        recv.set_nonblocking(true)?;
         (recv, sig_id)
     };
 
     match builder.spawn() {
         Ok(child) => {
+            let pty = Pty { child, file: File::from(master), signals, sig_id };
+
             unsafe {
                 // Maybe this should be done outside of this function so nonblocking
                 // isn't forced upon consumers. Although maybe it should be?
-                set_nonblocking(master_fd)?;
+                set_nonblocking(pty.file.as_raw_fd())?;
             }
 
-            Ok(Pty { child, file: File::from(master), signals, sig_id })
+            Ok(pty)
         },
-        Err(err) => Err(Error::new(
-            err.kind(),
-            format!(
-                "Failed to spawn command '{}': {}",
-                builder.get_program().to_string_lossy(),
-                err
-            ),
-        )),
+        Err(err) => {
+            unregister_signal(sig_id);
+            Err(Error::new(
+                err.kind(),
+                format!(
+                    "Failed to spawn command '{}': {}",
+                    builder.get_program().to_string_lossy(),
+                    err
+                ),
+            ))
+        },
     }
 }
 

--- a/vendor/alacritty_terminal/src/tty/unix.rs
+++ b/vendor/alacritty_terminal/src/tty/unix.rs
@@ -290,7 +290,7 @@ pub fn from_fd(config: &Options, window_id: u64, master: OwnedFd, slave: OwnedFd
             unsafe {
                 // Maybe this should be done outside of this function so nonblocking
                 // isn't forced upon consumers. Although maybe it should be?
-                set_nonblocking(master_fd);
+                set_nonblocking(master_fd)?;
             }
 
             Ok(Pty { child, file: File::from(master), signals, sig_id })
@@ -436,9 +436,14 @@ impl ToWinsize for WindowSize {
     }
 }
 
-unsafe fn set_nonblocking(fd: c_int) {
+unsafe fn set_nonblocking(fd: c_int) -> Result<()> {
     let res = unsafe { fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK) };
-    assert_eq!(res, 0);
+    if res == 0 { Ok(()) } else { Err(Error::last_os_error()) }
+}
+
+#[test]
+fn invalid_fd_cannot_be_set_nonblocking() {
+    assert!(unsafe { set_nonblocking(-1) }.is_err());
 }
 
 #[test]

--- a/vendor/alacritty_terminal/src/vi_mode.rs
+++ b/vendor/alacritty_terminal/src/vi_mode.rs
@@ -161,7 +161,7 @@ impl ViModeCursor {
                 // Skip empty lines until we find the next paragraph,
                 // then skip over the paragraph until we reach the next empty line.
                 let topmost_line = term.topmost_line();
-                self.point.line = (*topmost_line..*self.point.line)
+                self.point.line = (*topmost_line..=*self.point.line)
                     .rev()
                     .skip_while(|line| term.grid()[Line(*line)].is_clear())
                     .find(|line| term.grid()[Line(*line)].is_clear())
@@ -441,6 +441,18 @@ mod tests {
 
         cursor = cursor.motion(&mut term, ViMotion::Up);
         assert_eq!(cursor.point, Point::new(Line(0), Column(0)));
+    }
+
+    #[test]
+    fn paragraph_up_stops_at_adjacent_empty_line() {
+        let mut term = term();
+        term.grid_mut()[Line(3)][Column(0)].c = 'a';
+        term.grid_mut()[Line(5)][Column(0)].c = 'b';
+
+        let cursor = ViModeCursor::new(Point::new(Line(5), Column(0)));
+        let cursor = cursor.motion(&mut term, ViMotion::ParagraphUp);
+
+        assert_eq!(cursor.point, Point::new(Line(4), Column(0)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Backport three focused fixes from upstream Alacritty into Luvus's vendored `alacritty_terminal` fork without replacing the compact scrollback and memory work maintained in this repository.

The vendored package is advanced from `luvus-alacritty-terminal` 0.26.0 to 0.26.1 so the support-crate version records the new behavior.

## What changed

### Return PTY setup errors instead of panicking

Backports [alacritty/alacritty@985394d](https://github.com/alacritty/alacritty/commit/985394dd42ca1408868ccee8070c8c75cccd762f).

Unix PTY initialization previously asserted that `fcntl` succeeded while enabling nonblocking mode. An invalid descriptor or operating-system failure could therefore panic the process. `set_nonblocking` now returns `io::Result`, and the error is propagated through PTY construction while preserving the successful path.

A regression test verifies that an invalid descriptor returns an error instead of panicking.

### Correct Vi paragraph-up navigation

Backports [alacritty/alacritty@7dd7b5b](https://github.com/alacritty/alacritty/commit/7dd7b5b09e06ca58daadfb12bd45a9aa8fa716f2).

`ViMotion::ParagraphUp` used an exclusive range that omitted the current line. This could skip an adjacent empty separator and move to the wrong paragraph boundary. The search now includes the current line, with a regression test for adjacent paragraphs.

### Bound zero-width characters per cell

Backports [alacritty/alacritty@ede2ac1](https://github.com/alacritty/alacritty/commit/ede2ac144da4dec4c075bfa803aacf3b3739bce6).

Zero-width Unicode characters were stored in an unbounded `Vec` inside each terminal cell. Repeated combining marks could grow one cell indefinitely. The vendored `alacritty_terminal` now uses `ArrayVec<char, 9>`, retaining normal grapheme behavior while placing a fixed upper bound on per-cell storage. Characters beyond the upstream limit are safely discarded.

`arrayvec` was already present in the dependency graph through the vendored VTE crate. This change enables its Serde support for terminal cell serialization.

## Scope and compatibility

- Keeps Luvus's compact cold-history and scrollback memory patches intact.
- Does not replace the vendored crate with upstream master.
- Does not change the `VtEngine` interface or Luvus rendering code.
- The PTY change is Unix-only. Windows PTY behavior is unchanged.
- Normal PTY startup and Unicode rendering retain their existing behavior.

## Verification

- `cargo test --manifest-path vendor/alacritty_terminal/Cargo.toml --lib`
  - 142 passed
- `cargo test --manifest-path vendor/alacritty_terminal/Cargo.toml --test ref`
  - 45 passed
- `cargo test --locked terminal::vt`
  - 26 passed
- `cargo fmt --all --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo build --locked`
- `cargo package --allow-dirty --manifest-path vendor/alacritty_terminal/Cargo.toml --config 'patch.crates-io.luvus-vte.path="vendor/vte"'`
- Isolated debug lifecycle using `~/.luvus-dev` and session `alacritty-backport-test`
  - server started
  - a live zsh PTY was created and listed
  - server stopped cleanly

A real Windows runtime was not available for this validation. The platform-independent parser and cell changes are covered by the vendored test suites, while the PTY change is compiled only on Unix.

## Performance comparison

Compared the unchanged `origin/main` baseline at `bca9261d` using `luvus-alacritty-terminal` 0.26.0 with this PR at `f4abda97` using 0.26.1. Both were clean locked release builds produced in the same checkout on the same Darwin 24.6.0 arm64 host with 11 logical CPUs. All servers used isolated state below `target/`.

### Normal pane workload

The complete 1, 10, and 50-pane release matrix used 50 request samples and a 5-second idle window. The 10 and 50-pane cases were repeated with 100 samples and a 10-second idle window because the first pass showed normal short-run memory and scheduler variation. The table uses the confirmation pass for 10 and 50 panes.

| Panes | Build | Inventory p50/p95 | Visible capture p50/p95 | Input ack p50/p95 | RSS | Idle CPU |
|---:|---|---:|---:|---:|---:|---:|
| 1 | 0.26.0 baseline | 0.139 / 0.158 ms | 0.140 / 0.154 ms | 0.144 / 0.158 ms | 9.78 MiB | 0.60% |
| 1 | 0.26.1 updated | 0.140 / 0.156 ms | 0.144 / 0.171 ms | 0.146 / 0.169 ms | 9.58 MiB | 0.60% |
| 10 | 0.26.0 baseline | 0.200 / 0.216 ms | 0.152 / 0.166 ms | 0.139 / 0.154 ms | 12.38 MiB | 0.80% |
| 10 | 0.26.1 updated | 0.198 / 0.215 ms | 0.144 / 0.155 ms | 0.138 / 0.159 ms | 12.34 MiB | 0.80% |
| 50 | 0.26.0 baseline | 0.481 / 0.501 ms | 0.147 / 0.158 ms | 0.142 / 0.150 ms | 17.88 MiB | 0.90% |
| 50 | 0.26.1 updated | 0.481 / 0.491 ms | 0.142 / 0.155 ms | 0.139 / 0.148 ms | 17.84 MiB | 0.80% |

Thread and descriptor counts were identical in the confirmation run: 26 threads and 35 descriptors at 10 panes, then 106 threads and 155 descriptors at 50 panes. The 0.1 percentage-point idle CPU difference at 50 panes is one process-time timer tick and is not treated as a performance claim. Normal latency and memory are effectively unchanged.

### Render hot path

The existing release `bench_render_hotpath` test was run five times from each compiled test executable. These are medians:

| Operation | 0.26.0 baseline | 0.26.1 updated | Delta |
|---|---:|---:|---:|
| Typing frame | 130.794 us | 130.994 us | +0.15% |
| Scrolling frame | 131.202 us | 131.295 us | +0.07% |
| Pane grid walk | 12.018 us | 11.987 us | -0.26% |
| Server frame | 95.164 us | 95.549 us | +0.40% |

All render differences stay below 0.5%, so this test found no measurable hot-path regression.

### Zero-width stress case

A dedicated release workload sent either 9 combining marks or 1,000,000 combining marks into one terminal cell, waited for a final output marker, and measured only the Luvus server process. Each case used three fresh isolated servers and the table reports medians.

| One-cell workload | Build | Completion | Server RSS delta | Physical footprint delta | Server CPU |
|---:|---|---:|---:|---:|---:|
| 9 marks | 0.26.0 baseline | 27.452 ms | +0.688 MiB | +0.469 MiB | below timer resolution |
| 9 marks | 0.26.1 updated | 26.443 ms | +0.750 MiB | +0.469 MiB | below timer resolution |
| 1,000,000 marks | 0.26.0 baseline | 56.909 ms | +10.875 MiB | +4.531 MiB | 0.03 s |
| 1,000,000 marks | 0.26.1 updated | 51.663 ms | +0.609 MiB | +0.312 MiB | 0.03 s |

For the pathological input, bounded `ArrayVec` storage reduced observed RSS growth by 94.4%, physical-footprint growth by 93.1%, and completion time by 9.2%. The updated million-mark result stayed within the ordinary pane-allocation noise established by the nine-mark control.

### Artifact cost and conclusion

The optimized binary changed from 7,548,752 bytes to 7,548,800 bytes, an increase of 48 bytes. The matched release tests show no meaningful regression for ordinary panes or rendering, while the adversarial zero-width case now has bounded memory behavior and substantially lower observed resource growth.

These measurements are host-specific engineering evidence rather than portable guarantees. Short CPU windows, shell startup, allocator state, filesystem activity, and host scheduling can move individual readings, which is why the normal 10 and 50-pane cases and the render microbenchmark were repeated.
