### PR TITLE
fix(workspace): document cwd rehome across platforms

### DIFF
--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -74,10 +74,13 @@ there.
 
 ## Windows: what's different?
 
-Use Windows Terminal. Live per-pane cwd tracking and the shell hook aren't
-available, and luvus cannot inspect a pane's processes, so it identifies agents
-from the command, window title, and screen text instead. Zero-config agent
-resume still works. Named pipes replace Unix sockets transparently.
+Use Windows Terminal. Pane working directories are read from the process, so
+[cwd rehome](/docs/guides/layout/#following-a-panes-working-directory) works
+the same as on macOS and Linux. The shell integration hook is not available.
+PowerShell `Set-Location` may not update the process current directory luvus
+reads; `cd` in `cmd.exe` typically does. Agent identity still comes from the
+command, window title, and screen text. Zero-config agent resume still works.
+Named pipes replace Unix sockets transparently.
 
 ## The terminal shows "◱ enlarge terminal"
 

--- a/website/src/content/docs/docs/getting-started/concepts.mdx
+++ b/website/src/content/docs/docs/getting-started/concepts.mdx
@@ -51,14 +51,17 @@ known sessions without starting any server or background manager.
 
 ```
 Session
-└── Workspace   one per project folder (fixed cwd, shows its git branch)
+└── Workspace   one per project folder (shows its git branch)
     └── Tab     a layout of panes (or a special tab: git, orchestration)
         └── Pane   a real terminal running a shell or an agent
 ```
 
 - **Workspaces** are the sidebar's top list. `Ctrl+Space N` opens the folder
-  picker. Running `luvus` inside a folder adds it automatically. A workspace's
-  cwd is fixed at creation, so `cd`-ing inside a pane never moves it.
+  picker. Running `luvus` inside a folder adds it automatically. The workspace
+  folder itself stays where it was created. After `cd` into another git
+  project, luvus can move the whole tab there (and open a workspace if none
+  matches). See
+  [Following a pane's working directory](/docs/guides/layout/#following-a-panes-working-directory).
 - **Tabs** hold split layouts. Two special tabs exist: the
   [git tab](/docs/guides/git/) and the
   [orchestration board](/docs/guides/orchestration/).

--- a/website/src/content/docs/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/docs/getting-started/installation.mdx
@@ -114,9 +114,12 @@ Pick whichever channel you prefer:
     ```
     Or download the `…-x86_64-pc-windows-msvc.zip` from the
     [releases page](https://github.com/RizRiyz/luvus/releases) and put
-    `luvus.exe` on your `PATH`. Run luvus inside **Windows Terminal**. Live
-    cwd tracking and the shell integration hook aren't available on Windows,
-    but agent session resume still works.
+    `luvus.exe` on your `PATH`. Run luvus inside **Windows Terminal**. Pane cwd
+    tracking uses the process current directory, so tabs can rehome after `cd`
+    the same way they do on macOS and Linux (see
+    [Following a pane's working directory](/docs/guides/layout/#following-a-panes-working-directory)).
+    The shell integration hook is not available. Agent session resume still
+    works.
   </TabItem>
 </Tabs>
 

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -74,9 +74,10 @@ final position and preserves whichever tab was active.
 
 ## Workspaces
 
-A **workspace** is one project folder, fixed at its `cwd` (see
+A **workspace** is one project folder (see
 [Core Concepts](/docs/getting-started/concepts/#2-workspace--tab--pane)). They
-live in the sidebar's top list.
+live in the sidebar's top list. The folder on a workspace row does not change;
+tabs can move when their panes `cd` into another git project.
 
 - **Open one:** the `+` button above the list, or `Ctrl+Space N`, opens a
   **folder picker**. Browse with the arrows / wheel, use the **Home** row to jump
@@ -121,6 +122,36 @@ it from the desktop switcher with `Ctrl+Space M`, or open it through automation:
 luvus mission open
 luvus mission open 2
 ```
+
+### Following a pane's working directory
+
+This is the same on macOS, Linux, and Windows. About once a second, luvus
+reads each pane's process working directory. The workspace folder stays put;
+the **tab** is what moves.
+
+- **Git project, already open.** If every pane in a tab's layout is inside the
+  same other workspace, the whole tab moves there. Splits stay together.
+- **Git project, not open.** luvus opens a workspace at that git root (no extra
+  shell) and moves the tab. Nested worktrees with their own `.git` become
+  their own workspace instead of staying under the parent checkout.
+- **Mixed-cwd splits.** If only some panes in a split have `cd`'d into another
+  project, the tab stays. luvus will not tear a layout apart.
+- **Two-scan stability.** A *child* process that `chdir`s into a different git
+  repo must appear on two consecutive scans before it can change the pane cwd
+  or move the tab. A short-lived helper in another repo does not rehome
+  anything. The pane's own PTY child cwd is used as soon as it is seen.
+- **Source workspace closure.** If that was the last ordinary tab in the source
+  workspace, luvus closes the empty workspace (same helper as sidebar Close:
+  FILES/DIFF waiters fail and `workspace.closed` fires). Focus follows the
+  moved tab only when you were looking at it; an unfocused last-tab rehome
+  keeps the workspace you are viewing.
+- **Non-git paths.** `cd /tmp` (or any folder that is not a git project and not
+  inside an open workspace) does not create or move a workspace.
+
+Dashboard tabs (git, orchestration, and similar) never rehome. On Windows,
+PowerShell `Set-Location` may not update the process current directory luvus
+reads; `cd` in `cmd.exe` typically does. The shell integration hook is still
+Unix-only.
 
 ## The sidebar
 

--- a/website/src/content/docs/docs/guides/worktrees.mdx
+++ b/website/src/content/docs/docs/guides/worktrees.mdx
@@ -22,3 +22,8 @@ can work the same repo without any chance of stepping on each other's edits.
 The sidebar **nests worktrees under their repo**, so the grouping is always
 visible. This is also the foundation the
 [orchestration board](/docs/guides/orchestration/) builds on.
+
+If a pane `cd`s into a nested worktree folder (for example
+`.worktrees/<name>`), luvus treats that worktree as its own workspace instead
+of leaving the tab under the parent checkout. See
+[Following a pane's working directory](/docs/guides/layout/#following-a-panes-working-directory).


### PR DESCRIPTION
## What

Document pane cwd rehome as a **cross-platform** feature (macOS, Linux, and Windows), not a Windows-only quirk.

Public docs now describe:

- **Workspace creation** at an unmatched git root, including nested worktrees
- **Whole-tab movement** so split layouts stay together
- **Two-scan stability** for a descendant git cwd
- **Mixed-CWD splits stay** (luvus will not tear a layout apart)
- **Source-workspace closure** when the last ordinary tab leaves

This is the user-facing description for the rehome behavior already implemented on #158. It does not rewrite #158's title.

## Why

RizRiyz review on #158 item 3: after `cd`, luvus can automatically create a workspace, move an entire tab, and close the source workspace on macOS and Linux as well as Windows. That is broader than the current `fix(windows)` title and the old static-workspace copy ("cwd is fixed, `cd` never moves it").

GitHub cannot open a stacked PR against `RizRiyz/luvus:fix/workspace-mapping` because that branch exists only on the fork (same as #158's head). This PR is therefore docs-only against `main`.

## Verification

- Diff vs `main` is five files under `website/src/content/docs/` only. No git-off-loop, descendant-test, or PEB `cfg` changes.
- Copy checked against the rehome rules on #158: `rehome_panes_by_cwd`, `choose_pane_cwd` (`CWD_REHOME_STABLE_SCANS = 2`), `open_missing_git_workspaces`, `move_tab_across_workspaces`.
- No Rust edit, so `cargo fmt` / `cargo test` were not rerun.

Addresses RizRiyz review on https://github.com/RizRiyz/luvus/pull/158 item 3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that tabs can automatically move between workspaces as panes enter different Git projects or worktrees.
  * Documented working-directory tracking, workspace creation and closure, stability checks, non-Git behavior, and dashboard exclusions.
  * Expanded Windows guidance, including process current-directory tracking, shell integration limitations, and command-specific behavior.
  * Clarified that agent session resume remains supported on Windows.
  * Added guidance for treating nested worktrees as separate workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->