### PR TITLE
style(sidebar): use thinner scrollbars

### DIFF
--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -55,10 +55,9 @@ fn list_capacity(rows: u16) -> usize {
 }
 
 /// A scrollbar on the sidebar's right edge, shown only when the list overflows
-/// its area. Drawn as a **background fill** (blank cell + coloured `bg`), so it
-/// renders as a solid line in every terminal (no box-drawing glyph to dash on
-/// macOS Terminal.app). A faint full-height track carries a small brighter
-/// thumb sized to the visible fraction of the list.
+/// its area. Thin block glyphs keep the indicator lighter than a full-cell
+/// background strip while remaining terminal-native: a faint quarter-cell
+/// track carries a brighter half-cell thumb sized to the visible fraction.
 fn draw_scrollbar(
     f: &mut RenderTarget,
     track: Rect,
@@ -80,8 +79,8 @@ fn draw_scrollbar(
     for i in 0..len {
         let on = i >= pos && i < pos + thumb;
         let cell = &mut buf[(track.x, track.y + i as u16)];
-        cell.set_symbol(" ");
-        cell.set_bg(if on { t.overlay1 } else { t.surface1 });
+        cell.set_symbol(if on { "▐" } else { "▕" });
+        cell.set_fg(if on { t.overlay1 } else { t.surface1 });
     }
 }
 
@@ -729,7 +728,33 @@ fn header(text: &str, t: &Theme) -> Line<'static> {
 #[cfg(test)]
 mod tests {
     use crate::app::App;
-    use ratatui::{backend::TestBackend, Terminal};
+    use ratatui::{backend::TestBackend, buffer::Buffer, layout::Rect, Terminal};
+
+    #[test]
+    fn sidebar_scrollbar_is_thin_and_proportional() {
+        let area = Rect::new(0, 0, 1, 6);
+        let mut buffer = Buffer::empty(area);
+        let theme = crate::ui::theme::by_name("quattro-rally");
+        {
+            let mut target = crate::ui::RenderTarget::new(&mut buffer, area);
+            super::draw_scrollbar(&mut target, area, 6, 2, 0, &theme);
+        }
+
+        let symbols: Vec<&str> = (0..area.height)
+            .map(|row| buffer.cell((0, row)).expect("scrollbar cell").symbol())
+            .collect();
+        assert_eq!(
+            symbols,
+            vec!["▐", "▐", "▕", "▕", "▕", "▕"],
+            "the two-row proportional thumb sits on a thin full-height track"
+        );
+        assert!(
+            (0..area.height).all(|row| buffer
+                .cell((0, row))
+                .is_some_and(|cell| cell.style().bg == Some(ratatui::style::Color::Reset))),
+            "the scrollbar must not paint a full-cell background strip"
+        );
+    }
 
     fn buffer_contains(term: &Terminal<TestBackend>, needle: &str) -> bool {
         let buf = term.backend().buffer();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -56,8 +56,9 @@ fn list_capacity(rows: u16) -> usize {
 
 /// A scrollbar on the sidebar's right edge, shown only when the list overflows
 /// its area. Thin block glyphs keep the indicator lighter than a full-cell
-/// background strip while remaining terminal-native: a faint quarter-cell
-/// track carries a brighter half-cell thumb sized to the visible fraction.
+/// background strip while remaining terminal-native: a faint one-eighth-cell
+/// track carries a brighter thumb of the same narrow width, sized to the
+/// visible fraction.
 fn draw_scrollbar(
     f: &mut RenderTarget,
     track: Rect,
@@ -79,7 +80,7 @@ fn draw_scrollbar(
     for i in 0..len {
         let on = i >= pos && i < pos + thumb;
         let cell = &mut buf[(track.x, track.y + i as u16)];
-        cell.set_symbol(if on { "▐" } else { "▕" });
+        cell.set_symbol("▕");
         cell.set_fg(if on { t.overlay1 } else { t.surface1 });
     }
 }
@@ -745,9 +746,11 @@ mod tests {
             .collect();
         assert_eq!(
             symbols,
-            vec!["▐", "▐", "▕", "▕", "▕", "▕"],
-            "the two-row proportional thumb sits on a thin full-height track"
+            vec!["▕", "▕", "▕", "▕", "▕", "▕"],
+            "the proportional thumb and track stay one-eighth of a cell wide"
         );
+        assert_eq!(buffer.cell((0, 0)).expect("thumb cell").fg, theme.overlay1);
+        assert_eq!(buffer.cell((0, 2)).expect("track cell").fg, theme.surface1);
         assert!(
             (0..area.height).all(|row| buffer
                 .cell((0, row))


### PR DESCRIPTION
## Summary

- replace the full-cell Workspace and Agent scrollbar strip with a one-eighth-cell terminal-native track
- distinguish the proportional thumb through color without increasing its width
- preserve the existing scroll range, position calculation, and overflow-only visibility
- add a focused rendering regression test

## Why

The previous scrollbar filled an entire terminal-cell column with background color. In compact sidebars that made the indicator visually heavier than the surrounding workspace and agent rows.

The new scrollbar uses the narrow ▕ glyph for both the track and thumb. The thumb remains easy to locate through its brighter theme color while the whole indicator stays one-eighth of a cell wide.

## Behavior

This changes presentation only. Wheel scrolling, active-item reveal, list capacity, thumb position, and thumb length calculations are unchanged. The scrollbar also stops painting over the cell background, so row and theme backgrounds remain intact.

## Verification

- cargo test ui::sidebar:: -- --nocapture
- rustfmt --edition 2021 --check src/ui/sidebar.rs
- git diff --check

All seven focused sidebar tests pass.