### PR TITLE
fix(menu): scroll a context menu that does not fit

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -983,6 +983,9 @@ impl App {
         use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
         // Track the cursor for hover affordances (e.g. the session delete ✕).
         self.hover = Some((m.column, m.row));
+        if let MouseEventKind::Down(_) = m.kind {
+            self.menu_scroll.press(m.column, m.row);
+        }
         // Any click dismisses the help overlay.
         if self.help_open {
             if let MouseEventKind::Down(MouseButton::Left) = m.kind {
@@ -1150,6 +1153,20 @@ impl App {
                 _ => {}
             }
             return;
+        }
+        // A context menu taller than the space it has scrolls under the wheel:
+        // menus are mouse-only, so this is the only way to reach a row that does
+        // not fit. Only a popup actually under the cursor takes the event, so the
+        // wheel goes on doing what it did before everywhere else.
+        if let MouseEventKind::ScrollUp | MouseEventKind::ScrollDown = m.kind {
+            let delta = if matches!(m.kind, MouseEventKind::ScrollUp) {
+                -1
+            } else {
+                1
+            };
+            if self.menu_scroll.wheel(m.column, m.row, delta) {
+                return;
+            }
         }
         // The tab context menu owns the mouse while open.
         if self.tab_menu.is_some() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1282,6 +1282,101 @@ impl CopyMode {
     }
 }
 
+/// Which popup a menu scroll offset belongs to. A submenu scrolls independently
+/// of the menu that opened it, so the two have separate ids.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum PopupId {
+    Ws,
+    Tab,
+    TabSwap,
+    Pane,
+    PaneMove,
+    Agent,
+    Diff,
+    File,
+    Dock,
+}
+
+/// Scroll state for context menus taller than the space they are drawn in.
+///
+/// `render_popup` used to stop laying rows out once it ran out of height, and a
+/// row with no rect is unclickable rather than merely unpainted — so the actions
+/// a menu puts last went silently missing in a short or compact session. The
+/// rows scroll now instead.
+///
+/// Context menus are mouse-only — there is no keyboard route into one — so the
+/// wheel over the popup is the whole gesture, and this is the state it needs.
+#[derive(Default)]
+pub struct MenuScroll {
+    /// Rows scrolled off the top, per popup.
+    offsets: std::collections::HashMap<PopupId, usize>,
+    /// Where each popup was drawn this frame and how far it can scroll. A wheel
+    /// event hit-tests against these, so it moves the popup under the cursor
+    /// rather than whichever menu happens to be open.
+    frames: Vec<(PopupId, Rect, usize)>,
+}
+
+impl MenuScroll {
+    /// Start a frame. Last frame's geometry is stale, and a popup that is no
+    /// longer drawn forgets its offset — so reopening a menu starts at the top
+    /// rather than wherever the last one was left.
+    pub fn begin_frame(&mut self) {
+        let drawn = std::mem::take(&mut self.frames);
+        self.offsets
+            .retain(|id, _| drawn.iter().any(|(drawn_id, _, _)| drawn_id == id));
+    }
+
+    /// Record where a popup was drawn and how far it can scroll, returning the
+    /// offset to draw it at. Clamped, so a menu that grew shorter — or a window
+    /// that grew taller — cannot leave it scrolled past its last row.
+    pub fn record(&mut self, id: PopupId, popup: Rect, max: usize) -> usize {
+        let offset = self.offsets.get(&id).copied().unwrap_or(0).min(max);
+        self.offsets.insert(id, offset);
+        self.frames.push((id, popup, max));
+        offset
+    }
+
+    /// Scroll the popup under `(column, row)`, if there is one. Returns whether
+    /// a popup took the event, so the wheel goes on doing what it did before
+    /// everywhere else.
+    pub fn wheel(&mut self, column: u16, row: u16, delta: i32) -> bool {
+        let Some((id, _, max)) = self.frames.iter().copied().find(|(_, rect, _)| {
+            column >= rect.x && column < rect.right() && row >= rect.y && row < rect.bottom()
+        }) else {
+            return false;
+        };
+        // A menu that fits still owns the wheel: scrolling the pane behind an
+        // open popup is not what the gesture means.
+        if max > 0 {
+            let now = self.offsets.get(&id).copied().unwrap_or(0) as i32;
+            let next = (now + delta).clamp(0, max as i32) as usize;
+            self.offsets.insert(id, next);
+        }
+        true
+    }
+
+    /// A press that is not on an open popup: whatever menu it opens (or
+    /// dismisses) starts at the top next time. Menus have no other identity to
+    /// key an offset on — the same popup id is reused for every file you
+    /// right-click — and a press outside is what opens and closes them, so it is
+    /// the honest moment to forget where the last one was scrolled to.
+    pub fn press(&mut self, column: u16, row: u16) {
+        let on_popup = self.frames.iter().any(|(_, rect, _)| {
+            column >= rect.x && column < rect.right() && row >= rect.y && row < rect.bottom()
+        });
+        if !on_popup {
+            self.offsets.clear();
+        }
+    }
+
+    /// The offset a popup is drawn at. Tests read this; the renderer gets it
+    /// back from [`MenuScroll::record`].
+    #[cfg(test)]
+    pub fn offset_of(&self, id: PopupId) -> usize {
+        self.offsets.get(&id).copied().unwrap_or(0)
+    }
+}
+
 pub struct App {
     pub panes: HashMap<PaneId, Pane>,
     /// One random value for this server lifetime. Harness runtimes from an old
@@ -1681,6 +1776,9 @@ pub struct App {
     pub last_active_ws_shown: usize,
     /// Last mouse position, for hover affordances (the session delete ✕).
     pub hover: Option<(u16, u16)>,
+    /// Scroll offsets for context-menu popups that do not fit (see
+    /// [`MenuScroll`]), and the geometry a wheel event hit-tests against.
+    pub menu_scroll: MenuScroll,
     app_tx: Sender<AppEvent>,
     pub last_pane_area: Rect,
     // Hit-test geometry from the last render, for mouse clicks.
@@ -2033,6 +2131,7 @@ impl App {
             switcher_close_rect: None,
             last_active_ws_shown: 0,
             hover: None,
+            menu_scroll: MenuScroll::default(),
             app_tx,
             last_pane_area: Rect::ZERO,
             pane_rects: Vec::new(),
@@ -2573,6 +2672,7 @@ impl App {
             switcher_close_rect: None,
             last_active_ws_shown: 0,
             hover: None,
+            menu_scroll: MenuScroll::default(),
             app_tx,
             last_pane_area: Rect::ZERO,
             pane_rects: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1340,7 +1340,11 @@ impl MenuScroll {
     /// a popup took the event, so the wheel goes on doing what it did before
     /// everywhere else.
     pub fn wheel(&mut self, column: u16, row: u16, delta: i32) -> bool {
-        let Some((id, _, max)) = self.frames.iter().copied().find(|(_, rect, _)| {
+        // Last drawn wins, the way the paint does: a submenu is anchored beside
+        // its parent but clamped back on screen at the right edge, where it
+        // lands on top of it. Searching forward would hand the wheel to the
+        // parent the submenu is covering.
+        let Some((id, _, max)) = self.frames.iter().rev().copied().find(|(_, rect, _)| {
             column >= rect.x && column < rect.right() && row >= rect.y && row < rect.bottom()
         }) else {
             return false;

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -943,6 +943,26 @@ mod tests {
         );
     }
 
+    /// A submenu is anchored beside its parent, but clamped back on screen at
+    /// the right edge — where it covers the parent it belongs to. The wheel goes
+    /// to what is on top, which is the one drawn last.
+    #[test]
+    fn an_overlapping_submenu_takes_the_wheel_from_the_menu_it_covers() {
+        let mut scroll = crate::app::MenuScroll::default();
+        let parent = Rect::new(40, 0, 20, 10);
+        let submenu = Rect::new(45, 0, 20, 10); // clamped left, over the parent
+        scroll.record(PopupId::Pane, parent, 5);
+        scroll.record(PopupId::PaneMove, submenu, 5);
+
+        assert!(scroll.wheel(50, 3, 1), "the overlap belongs to a popup");
+        assert_eq!(scroll.offset_of(PopupId::PaneMove), 1, "the visible one");
+        assert_eq!(scroll.offset_of(PopupId::Pane), 0, "not the covered one");
+
+        // And the parent still takes the wheel where it is not covered.
+        assert!(scroll.wheel(41, 3, 1));
+        assert_eq!(scroll.offset_of(PopupId::Pane), 1);
+    }
+
     #[test]
     fn reopening_a_menu_starts_it_at_the_top() {
         let _env = crate::persist::test_env("menu-scroll-reopen");

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -859,9 +859,18 @@ mod tests {
             "Delete does not fit yet, so it has no rect to click"
         );
 
+        // One notch moves the list by one row.
         let over = (top.x + 1, top.y);
         mouse(&mut app, MouseEventKind::ScrollDown, over);
-        mouse(&mut app, MouseEventKind::ScrollDown, over);
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert_eq!(app.menu_scroll.offset_of(PopupId::File), 1);
+
+        // Then to the bottom. Deliberately more notches than this menu has rows:
+        // the offset clamps, and the test should not have to be edited every time
+        // the FILES menu grows a row.
+        for _ in 0..20 {
+            mouse(&mut app, MouseEventKind::ScrollDown, over);
+        }
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
 
         let delete = rect_of(&app, FileMenuItem::Delete);

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -3,8 +3,8 @@
 
 use super::*;
 use crate::app::{
-    AgentMenuItem, DiffMenuItem, FileMenuItem, ModuleMenuAction, PaneMenuItem, TabMenuItem,
-    WsMenuItem,
+    AgentMenuItem, DiffMenuItem, FileMenuItem, MenuScroll, ModuleMenuAction, PaneMenuItem, PopupId,
+    TabMenuItem, WsMenuItem,
 };
 use crate::i18n::Catalog;
 use ratatui::widgets::{Borders, Clear};
@@ -25,18 +25,39 @@ fn row_is_hovered(row: Rect, hover: Option<(u16, u16)>) -> bool {
     })
 }
 
+/// What a popup needs from the app to draw itself: where the cursor is, whether
+/// this is the compact layout, and which popup it is — the last so its scroll
+/// offset survives between frames without every caller tracking one.
+struct PopupCtx<'a> {
+    hover: Option<(u16, u16)>,
+    mobile: bool,
+    id: PopupId,
+    scroll: &'a mut MenuScroll,
+}
+
 /// Render a context-menu popup anchored near `anchor` (clamped so it stays on
 /// screen) and return one clickable rect per row — dividers included — in order,
 /// for the input layer to hit-test.
+///
+/// A popup taller than the space it has scrolls, and a row that is out of view
+/// gets an empty rect: it can never be hit, and callers keep zipping their items
+/// against the full-length result. Dropping the overflow instead — which is what
+/// this did before — made the rows a menu puts last unreachable rather than
+/// merely unpainted.
 fn render_popup(
     f: &mut RenderTarget,
     area: Rect,
     anchor: (u16, u16),
     rows: &[MenuRow],
-    hover: Option<(u16, u16)>,
-    mobile: bool,
     t: &Theme,
+    ctx: PopupCtx<'_>,
 ) -> Vec<Rect> {
+    let PopupCtx {
+        hover,
+        mobile,
+        id,
+        scroll,
+    } = ctx;
     let (ax, ay) = anchor;
     // Size the box to the widest label (+ a leading pad + the border).
     let label_w = rows
@@ -71,17 +92,20 @@ fn render_popup(
     let inner = block.inner(popup);
     f.render_widget(block, popup);
 
-    let mut rects = Vec::with_capacity(rows.len());
-    for (i, r) in rows.iter().enumerate() {
+    // How many rows fit, and how far the list can therefore be scrolled.
+    let per_screen = (inner.height / row_height) as usize;
+    let max_offset = rows.len().saturating_sub(per_screen);
+    let offset = scroll.record(id, popup, max_offset);
+
+    let mut rects = vec![Rect::default(); rows.len()];
+    for (slot, i) in (offset..rows.len()).take(per_screen).enumerate() {
+        let r = &rows[i];
+        let slot = slot as u16;
         let row = Rect::new(
             inner.x,
-            inner.y + i as u16 * row_height,
+            inner.y + slot * row_height,
             inner.width,
-            row_height.min(
-                inner
-                    .bottom()
-                    .saturating_sub(inner.y + i as u16 * row_height),
-            ),
+            row_height.min(inner.bottom().saturating_sub(inner.y + slot * row_height)),
         );
         if row.height == 0 {
             break;
@@ -102,7 +126,7 @@ fn render_popup(
                 )),
                 text_row,
             );
-            rects.push(row);
+            rects[i] = row;
             continue;
         }
         let hot = row_is_hovered(row, hover);
@@ -121,7 +145,26 @@ fn render_popup(
             )),
             text_row,
         );
-        rects.push(row);
+        rects[i] = row;
+    }
+
+    // Say when rows are out of view, so a clipped menu does not read as a whole
+    // one. The marker sits in the border, which costs no row.
+    if popup.width >= 3 {
+        let marker_x = popup.right().saturating_sub(2);
+        let style = Style::new().fg(t.accent).bg(t.surface0);
+        if offset > 0 {
+            f.render_widget(
+                Paragraph::new(Span::styled("\u{25b2}", style)),
+                Rect::new(marker_x, popup.y, 1, 1),
+            );
+        }
+        if offset < max_offset {
+            f.render_widget(
+                Paragraph::new(Span::styled("\u{25bc}", style)),
+                Rect::new(marker_x, popup.bottom().saturating_sub(1), 1, 1),
+            );
+        }
     }
     rects
 }
@@ -151,7 +194,19 @@ pub(super) fn draw_ws_menu(
             destructive: matches!(it, WsMenuItem::Close | WsMenuItem::DeleteWorktree),
         })
         .collect();
-    let rects = render_popup(f, area, anchor, &rows, app.hover, app.compact, t);
+    let rects = render_popup(
+        f,
+        area,
+        anchor,
+        &rows,
+        t,
+        PopupCtx {
+            hover: app.hover,
+            mobile: app.compact,
+            id: PopupId::Ws,
+            scroll: &mut app.menu_scroll,
+        },
+    );
     if let Some(menu) = app.ws_menu.as_mut() {
         menu.items = items.into_iter().zip(rects).collect();
     }
@@ -181,12 +236,27 @@ pub(super) fn draw_tab_menu(
             destructive: false,
         })
         .collect();
-    let rects = render_popup(f, area, anchor, &rows, app.hover, app.compact, t);
+    let rects = render_popup(
+        f,
+        area,
+        anchor,
+        &rows,
+        t,
+        PopupCtx {
+            hover: app.hover,
+            mobile: app.compact,
+            id: PopupId::Tab,
+            scroll: &mut app.menu_scroll,
+        },
+    );
     let swap_rect = items
         .iter()
         .zip(&rects)
         .find(|(item, _)| **item == TabMenuItem::SwapWith)
-        .map(|(_, rect)| *rect);
+        .map(|(_, rect)| *rect)
+        // A parent row that scrolled out of view has no rect to hang a submenu
+        // off, and an empty one would anchor it at the origin.
+        .filter(|rect: &Rect| rect.height > 0);
     if let Some(menu) = app.tab_menu.as_mut() {
         menu.items = items.iter().copied().zip(rects.iter().copied()).collect();
     }
@@ -224,7 +294,19 @@ pub(super) fn draw_tab_menu(
             })
             .collect();
         let sub_anchor = (parent.right() + 1, parent.y.saturating_sub(1));
-        let sub_rects = render_popup(f, area, sub_anchor, &sub_rows, app.hover, app.compact, t);
+        let sub_rects = render_popup(
+            f,
+            area,
+            sub_anchor,
+            &sub_rows,
+            t,
+            PopupCtx {
+                hover: app.hover,
+                mobile: app.compact,
+                id: PopupId::TabSwap,
+                scroll: &mut app.menu_scroll,
+            },
+        );
         if let Some(menu) = app.tab_menu.as_mut() {
             menu.swap_rects = swap_targets
                 .iter()
@@ -263,12 +345,27 @@ pub(super) fn draw_pane_menu(
             destructive: matches!(it, PaneMenuItem::Close),
         })
         .collect();
-    let rects = render_popup(f, area, anchor, &rows, app.hover, app.compact, t);
+    let rects = render_popup(
+        f,
+        area,
+        anchor,
+        &rows,
+        t,
+        PopupCtx {
+            hover: app.hover,
+            mobile: app.compact,
+            id: PopupId::Pane,
+            scroll: &mut app.menu_scroll,
+        },
+    );
     let move_rect = items
         .iter()
         .zip(&rects)
         .find(|(it, _)| **it == PaneMenuItem::MoveToTab)
-        .map(|(_, r)| *r);
+        .map(|(_, r)| *r)
+        // A parent row that scrolled out of view has no rect to hang a submenu
+        // off, and an empty one would anchor it at the origin.
+        .filter(|rect: &Rect| rect.height > 0);
     if let Some(menu) = app.pane_menu.as_mut() {
         menu.items = items.iter().copied().zip(rects.iter().copied()).collect();
     }
@@ -306,7 +403,19 @@ pub(super) fn draw_pane_menu(
                 .collect();
             // Beside the main popup, first row aligned with the "Move to tab" row.
             let sub_anchor = (mrect.right() + 1, mrect.y.saturating_sub(1));
-            let sub_rects = render_popup(f, area, sub_anchor, &sub_rows, app.hover, app.compact, t);
+            let sub_rects = render_popup(
+                f,
+                area,
+                sub_anchor,
+                &sub_rows,
+                t,
+                PopupCtx {
+                    hover: app.hover,
+                    mobile: app.compact,
+                    id: PopupId::PaneMove,
+                    scroll: &mut app.menu_scroll,
+                },
+            );
             if let Some(menu) = app.pane_menu.as_mut() {
                 menu.tab_rects = move_targets
                     .iter()
@@ -344,7 +453,19 @@ pub(super) fn draw_agent_menu(
             destructive: matches!(it, AgentMenuItem::Close),
         })
         .collect();
-    let rects = render_popup(f, area, anchor, &rows, app.hover, app.compact, t);
+    let rects = render_popup(
+        f,
+        area,
+        anchor,
+        &rows,
+        t,
+        PopupCtx {
+            hover: app.hover,
+            mobile: app.compact,
+            id: PopupId::Agent,
+            scroll: &mut app.menu_scroll,
+        },
+    );
     if let Some(menu) = app.agent_menu.as_mut() {
         menu.items = items.into_iter().zip(rects).collect();
     }
@@ -439,7 +560,19 @@ pub(super) fn draw_file_menu(f: &mut RenderTarget, area: Rect, app: &mut App, t:
             destructive: matches!(it, FileMenuItem::Delete),
         })
         .collect();
-    let rects = render_popup(f, area, anchor, &rows, app.hover, app.compact, t);
+    let rects = render_popup(
+        f,
+        area,
+        anchor,
+        &rows,
+        t,
+        PopupCtx {
+            hover: app.hover,
+            mobile: app.compact,
+            id: PopupId::File,
+            scroll: &mut app.menu_scroll,
+        },
+    );
     if let Some(menu) = app.file_menu.as_mut() {
         menu.items = items.into_iter().zip(rects).collect();
     }
@@ -469,7 +602,19 @@ pub(super) fn draw_diff_menu(f: &mut RenderTarget, area: Rect, app: &mut App, t:
             destructive: false,
         })
         .collect();
-    let rects = render_popup(f, area, menu.anchor, &rows, app.hover, app.compact, t);
+    let rects = render_popup(
+        f,
+        area,
+        menu.anchor,
+        &rows,
+        t,
+        PopupCtx {
+            hover: app.hover,
+            mobile: app.compact,
+            id: PopupId::Diff,
+            scroll: &mut app.menu_scroll,
+        },
+    );
     if let Some(menu) = app.diff_menu.as_mut() {
         menu.items = items.into_iter().zip(rects).collect();
     }
@@ -511,7 +656,19 @@ pub(super) fn draw_dock_menu(f: &mut RenderTarget, area: Rect, app: &mut App, t:
         })
         .collect();
     let anchor = menu.anchor;
-    let rects = render_popup(f, area, anchor, &rows, app.hover, app.compact, t);
+    let rects = render_popup(
+        f,
+        area,
+        anchor,
+        &rows,
+        t,
+        PopupCtx {
+            hover: app.hover,
+            mobile: app.compact,
+            id: PopupId::Dock,
+            scroll: &mut app.menu_scroll,
+        },
+    );
     if let Some(menu) = app.dock_menu.as_mut() {
         menu.rects = rects;
     }
@@ -631,5 +788,172 @@ mod label_case_tests {
             .filter_map(|r| offending_word(r).map(|w| format!("{r:?} (word {w:?})")))
             .collect();
         assert!(bad.is_empty(), "menu rows are not Title Case: {bad:#?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, FileMenu, FileMenuItem, PopupId};
+    use crate::event::AppEvent;
+    use ratatui::backend::TestBackend;
+    use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::Terminal;
+
+    /// A FILES menu with two editors is ten rows, which does not fit a ten-row
+    /// terminal — the shape that used to lose its last rows outright.
+    fn app_with_file_menu(height: u16) -> App {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, height, tx).unwrap();
+        app.file_menu = Some(file_menu());
+        app
+    }
+
+    fn file_menu() -> FileMenu {
+        FileMenu {
+            path: std::env::temp_dir().join("scroll.txt"),
+            is_dir: false,
+            anchor: (10, 0),
+            items: Vec::new(),
+            editors: vec![
+                ("vim".to_string(), "Vim".to_string()),
+                ("hx".to_string(), "Helix".to_string()),
+            ],
+        }
+    }
+
+    /// The rect the input layer would hit-test for `item`. An empty one means the
+    /// row is out of view, and so unreachable.
+    fn rect_of(app: &App, item: FileMenuItem) -> Rect {
+        app.file_menu
+            .as_ref()
+            .expect("menu open")
+            .items
+            .iter()
+            .find(|(it, _)| *it == item)
+            .map(|(_, rect)| *rect)
+            .expect("row is in the menu")
+    }
+
+    fn mouse(app: &mut App, kind: MouseEventKind, at: (u16, u16)) {
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind,
+            column: at.0,
+            row: at.1,
+            modifiers: KeyModifiers::NONE,
+        }));
+    }
+
+    #[test]
+    fn a_menu_taller_than_its_space_scrolls_instead_of_dropping_its_last_rows() {
+        let _env = crate::persist::test_env("menu-scroll-reach");
+        let mut app = app_with_file_menu(10);
+        let mut term = Terminal::new(TestBackend::new(80, 10)).unwrap();
+
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let top = rect_of(&app, FileMenuItem::OpenReadonly);
+        assert!(top.height > 0, "the first row is on screen");
+        assert_eq!(
+            rect_of(&app, FileMenuItem::Delete).height,
+            0,
+            "Delete does not fit yet, so it has no rect to click"
+        );
+
+        let over = (top.x + 1, top.y);
+        mouse(&mut app, MouseEventKind::ScrollDown, over);
+        mouse(&mut app, MouseEventKind::ScrollDown, over);
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+
+        let delete = rect_of(&app, FileMenuItem::Delete);
+        assert!(
+            delete.height > 0,
+            "the wheel brought the last row into view — this is the bug"
+        );
+
+        // And it is genuinely clickable, not merely painted: the rect the render
+        // handed back is the one the input layer acts on.
+        mouse(
+            &mut app,
+            MouseEventKind::Down(MouseButton::Left),
+            (delete.x + 1, delete.y),
+        );
+        assert!(
+            app.file_delete.is_some(),
+            "clicking the scrolled-in row ran its action"
+        );
+    }
+
+    #[test]
+    fn menu_scroll_stops_at_both_ends() {
+        let _env = crate::persist::test_env("menu-scroll-clamp");
+        let mut app = app_with_file_menu(10);
+        let mut term = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let over = {
+            let top = rect_of(&app, FileMenuItem::OpenReadonly);
+            (top.x + 1, top.y)
+        };
+
+        for _ in 0..20 {
+            mouse(&mut app, MouseEventKind::ScrollDown, over);
+        }
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let bottom = app.menu_scroll.offset_of(PopupId::File);
+        assert!(bottom > 0, "it scrolled");
+        assert!(
+            rect_of(&app, FileMenuItem::Delete).height > 0,
+            "the last row is in view and the list cannot run past it"
+        );
+
+        for _ in 0..20 {
+            mouse(&mut app, MouseEventKind::ScrollUp, over);
+        }
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert_eq!(
+            app.menu_scroll.offset_of(PopupId::File),
+            0,
+            "and back to the first row, not past it"
+        );
+        assert!(rect_of(&app, FileMenuItem::OpenReadonly).height > 0);
+    }
+
+    #[test]
+    fn the_wheel_away_from_a_popup_leaves_it_alone() {
+        let _env = crate::persist::test_env("menu-scroll-elsewhere");
+        let mut app = app_with_file_menu(10);
+        let mut term = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+
+        // Far from the popup, which is anchored at column 10.
+        mouse(&mut app, MouseEventKind::ScrollDown, (70, 8));
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert_eq!(
+            app.menu_scroll.offset_of(PopupId::File),
+            0,
+            "the wheel belongs to whatever is under it, not to the open menu"
+        );
+    }
+
+    #[test]
+    fn reopening_a_menu_starts_it_at_the_top() {
+        let _env = crate::persist::test_env("menu-scroll-reopen");
+        let mut app = app_with_file_menu(10);
+        let mut term = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let over = {
+            let top = rect_of(&app, FileMenuItem::OpenReadonly);
+            (top.x + 1, top.y)
+        };
+        mouse(&mut app, MouseEventKind::ScrollDown, over);
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert!(app.menu_scroll.offset_of(PopupId::File) > 0, "scrolled");
+
+        // A press away from the popup is what dismisses one menu and opens the
+        // next, so the next one starts where a menu should.
+        mouse(&mut app, MouseEventKind::Down(MouseButton::Right), (70, 8));
+        app.file_menu = Some(file_menu());
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert_eq!(app.menu_scroll.offset_of(PopupId::File), 0);
+        assert!(rect_of(&app, FileMenuItem::OpenReadonly).height > 0);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -166,6 +166,9 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     let mission_refresh_rect = app.mission_refresh_rect;
     let changelog_scroll = app.changelog_scroll;
     let file_tree_scroll = app.file_tree.scroll;
+    // Popup scroll offsets and geometry are recorded by an ordinary draw, and a
+    // projection renders at its own size — so keep them out of its way.
+    let menu_scroll = std::mem::take(&mut app.menu_scroll);
 
     // Geometry collections are write-only outputs of a render. Move the active
     // client's values aside instead of cloning them on every secondary frame.
@@ -292,6 +295,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     app.mission_refresh_rect = mission_refresh_rect;
     app.changelog_scroll = changelog_scroll;
     app.file_tree.scroll = file_tree_scroll;
+    app.menu_scroll = menu_scroll;
     app.pane_rects = pane_rects;
     app.pane_content_rects = pane_content_rects;
     app.pane_title_rects = pane_title_rects;
@@ -395,6 +399,7 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
     f.render_widget(Block::new().style(Style::new().bg(t.mantle)), area);
     app.bar.hits.clear();
     app.bar.overflow_hits.clear();
+    app.menu_scroll.begin_frame();
     app.mobile_pane_prev_rect = None;
     app.mobile_pane_next_rect = None;
 


### PR DESCRIPTION
Closes #169.

## What was wrong

`render_popup` sized the popup to the space available and then stopped laying rows out as soon as one computed to zero height:

```rust
if row.height == 0 {
    break;
}
```

A clipped row got neither a glyph nor a rect, and the returned `Vec<Rect>` is what the input layer hit-tests — so the row was unreachable, not merely off-screen. No scrolling, no keyboard route, and nothing on screen to say the menu was incomplete. All nine call sites share the function, so every context menu did this: workspace, pane, tab, agent, diff, FILES, dock, and both submenus.

## What it does now

The rows scroll. A row out of view gets an empty rect, which can never be hit and keeps every caller zipping its items against a full-length result — so no call site changed. A `▲` / `▼` in the border says when there is more; it costs no row.

Context menus are mouse-only — there is no keyboard route into one — so the wheel over the popup is the whole gesture. Only a popup actually under the cursor takes the event, so the wheel goes on doing what it did before everywhere else. A menu that fits still swallows it, because scrolling the pane behind an open popup is not what the gesture means.

## The state, and where it resets

`MenuScroll` on `App`, keyed by `PopupId`, so a submenu scrolls independently of the menu that opened it. Two things clear it:

- **A press away from any popup.** That is what opens and dismisses menus, and the same `PopupId` is reused for every file you right-click, so there is no other identity to key an offset on. A press *inside* a popup leaves it alone.
- **A popup that stops being drawn** forgets its offset on the next frame, which covers the closes a press does not (Esc, programmatic).

Two smaller things fell out of it:

- **`render_projection` takes the scroll state aside** along with the other interactive state it protects. A secondary client renders at its own size, and clamping is size-dependent, so without this a passive projection could move the active client's menu.
- **A submenu whose parent row scrolled out of view no longer opens.** Its anchor comes from the parent's rect, and an empty one would have anchored it at the origin.

`PopupCtx` bundles what a popup needs from the app (`hover`, compact, id, scroll). That is partly clippy's argument limit and partly that nine positional arguments had stopped being readable.

## Answering the two questions from the issue

**Compact mode needs nothing extra.** Rows are two cells high there, so fewer fit and the offset simply matters more — the same mechanism covers it. I did not add the single-height fallback: it trades a row's legibility for a screenful and stops helping the moment the menu is one row longer again, which is how this bug arrived in the first place.

**The marker is in the border**, not a row of its own. A menu that is short of space should not spend a row saying so.

## Tests

Four, through the real render and `handle_event(Mouse)` path rather than against `render_popup` directly:

- the last row has no rect at ten rows, gains one after the wheel, **and its click runs the action** — the rect the render hands back is the one the input layer acts on, which is the whole bug
- scrolling stops at both ends
- the wheel away from the popup leaves it alone
- reopening a menu starts it at the top

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` are clean — 1031 passed.

## An unrelated flake, if you run the suite in a worktree

`app::dispatch::tests::agent_list_labels_a_pane_with_its_node_name` asserts `row["worktree"] == false`, but `App::new` reads the ambient cwd, so it fails whenever the suite runs from a linked git worktree and passes in a normal clone. Same class as #163, nothing to do with this change — flagging it so a red local run is not mistaken for one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context menus now support scrolling when they contain more items than fit on screen.
  * Mouse-wheel scrolling applies only when the pointer is over the open menu.
  * Menus display indicators when additional items are available above or below the visible area.
  * Reopened menus start at the top for easier navigation.

* **Bug Fixes**
  * Prevented menu scrolling from unintentionally affecting panes, tabs, or other interface areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->