### PR TITLE
perf(runtime): share process snapshots

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -483,6 +483,15 @@ impl App {
         {
             self.last_cwd_at = now;
             self.cwd_scan_inflight = true;
+            // Agent identity keeps its independent two-second cadence, but
+            // when its deadline lands on this CWD scan both projections share
+            // one OS process-table snapshot.
+            let include_processes = now.duration_since(self.last_proc_at) >= Duration::from_secs(2)
+                && !self.proc_scan_inflight;
+            if include_processes {
+                self.last_proc_at = now;
+                self.proc_scan_inflight = true;
+            }
             let panes: Vec<(PaneId, u32)> = self
                 .panes
                 .iter()
@@ -501,7 +510,8 @@ impl App {
             let tx = self.app_tx.clone();
             std::thread::spawn(move || {
                 let pids: Vec<u32> = panes.iter().map(|(_, pid)| *pid).collect();
-                let evidence = crate::platform::scan_pane_cwds(&pids);
+                let (evidence, processes) =
+                    crate::platform::scan_pane_runtime(&pids, include_processes);
                 let pane_results: Vec<(PaneId, crate::platform::PaneCwdEvidence)> = panes
                     .into_iter()
                     .zip(evidence)
@@ -518,6 +528,9 @@ impl App {
                     branches,
                     workspace_candidates,
                 });
+                if include_processes {
+                    let _ = tx.send(AppEvent::ProcScanned(processes));
+                }
             });
             // Keep the FILES dock rooted at the active node and its open dirs
             // read (docs/38). Off-loop: this only schedules reads, never blocks.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -464,45 +464,101 @@ fn ps_command_table() -> Option<PsTable> {
     Some((cmd, children))
 }
 
+type ProcessTrees = std::collections::HashMap<u32, Vec<(u32, u16)>>;
+type ProcessCommands = std::collections::HashMap<u32, Vec<String>>;
+
+/// Capture one bounded platform process table and project every requested pane
+/// root into descendant pid trees and, when requested, command lines. Keeping
+/// both projections behind this boundary lets periodic CWD and agent scans
+/// share the expensive OS snapshot without coupling their app-level cadence.
+#[cfg(unix)]
+fn pane_process_snapshot(
+    roots: &[u32],
+    include_trees: bool,
+    include_commands: bool,
+) -> (ProcessTrees, Option<ProcessCommands>) {
+    use std::collections::{HashMap, HashSet};
+    let Some((commands_by_pid, children)) = ps_table() else {
+        return (HashMap::new(), None);
+    };
+    let trees: ProcessTrees = if include_trees {
+        roots
+            .iter()
+            .copied()
+            .map(|root| {
+                let mut nodes = Vec::new();
+                let mut seen = HashSet::new();
+                let mut stack = vec![(root, 0_u16)];
+                while let Some((pid, depth)) = stack.pop() {
+                    if !seen.insert(pid) || nodes.len() >= 64 {
+                        continue;
+                    }
+                    nodes.push((pid, depth));
+                    if let Some(kids) = children.get(&pid) {
+                        for &child in kids.iter().rev() {
+                            stack.push((child, depth.saturating_add(1)));
+                        }
+                    }
+                }
+                (root, nodes)
+            })
+            .collect()
+    } else {
+        HashMap::new()
+    };
+    let commands = include_commands.then(|| {
+        roots
+            .iter()
+            .copied()
+            .map(|root| {
+                // Preserve the command projection's established traversal
+                // order independently of the depth-first CWD projection.
+                let mut found = Vec::new();
+                let mut seen = HashSet::new();
+                let mut stack = vec![root];
+                while let Some(pid) = stack.pop() {
+                    if !seen.insert(pid) || found.len() >= 64 {
+                        continue;
+                    }
+                    if let Some(command) = commands_by_pid.get(&pid) {
+                        found.push(command.clone());
+                    }
+                    if let Some(kids) = children.get(&pid) {
+                        stack.extend(kids.iter().copied());
+                    }
+                }
+                (root, found)
+            })
+            .collect()
+    });
+    (trees, commands)
+}
+
+#[cfg(windows)]
+fn pane_process_snapshot(
+    roots: &[u32],
+    include_trees: bool,
+    include_commands: bool,
+) -> (ProcessTrees, Option<ProcessCommands>) {
+    windows::pane_process_snapshot(roots, include_trees, include_commands)
+        .unwrap_or_else(|| (ProcessTrees::new(), None))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn pane_process_snapshot(
+    _roots: &[u32],
+    _include_trees: bool,
+    _include_commands: bool,
+) -> (ProcessTrees, Option<ProcessCommands>) {
+    (ProcessTrees::new(), None)
+}
+
 /// Process identities running under each of `roots` (the root's own included),
 /// from one platform snapshot. This batched form lets agent detection cover
 /// every pane without one process-table operation per pane. `None` means the
 /// platform cannot tell.
-#[cfg(unix)]
-pub fn descendant_commands(roots: &[u32]) -> Option<std::collections::HashMap<u32, Vec<String>>> {
-    use std::collections::{HashMap, HashSet};
-    let (cmd, children) = ps_table()?;
-    let mut out: HashMap<u32, Vec<String>> = HashMap::new();
-    for &root in roots {
-        let mut found = Vec::new();
-        let mut seen = HashSet::new();
-        let mut stack = vec![root];
-        while let Some(pid) = stack.pop() {
-            // Same bounds as `process_tree`: a visited set survives pid reuse,
-            // and the cap stops a pathological tree from being unbounded work.
-            if !seen.insert(pid) || found.len() >= 64 {
-                continue;
-            }
-            if let Some(c) = cmd.get(&pid) {
-                found.push(c.clone());
-            }
-            if let Some(kids) = children.get(&pid) {
-                stack.extend(kids.iter().copied());
-            }
-        }
-        out.insert(root, found);
-    }
-    Some(out)
-}
-
-#[cfg(windows)]
-pub fn descendant_commands(roots: &[u32]) -> Option<std::collections::HashMap<u32, Vec<String>>> {
-    windows::descendant_commands(roots)
-}
-
-#[cfg(not(any(unix, windows)))]
-pub fn descendant_commands(_roots: &[u32]) -> Option<std::collections::HashMap<u32, Vec<String>>> {
-    None
+pub fn descendant_commands(roots: &[u32]) -> Option<ProcessCommands> {
+    pane_process_snapshot(roots, false, true).1
 }
 
 /// Every process running under `root` (inclusive), depth-first, newest branch
@@ -569,57 +625,30 @@ pub struct PaneCwdEvidence {
     pub descendant_git_root: Option<PathBuf>,
 }
 
-/// Resolve every pane root from **one** process-table snapshot. Git-root
-/// probes are cached per directory for this scan. Call off the app loop.
-pub fn scan_pane_cwds(roots: &[u32]) -> Vec<PaneCwdEvidence> {
+/// Resolve CWD evidence and, optionally, process identities from one platform
+/// snapshot. The optional command projection is used only when the independent
+/// agent-detection deadline coincides with this CWD scan.
+pub fn scan_pane_runtime(
+    roots: &[u32],
+    include_commands: bool,
+) -> (Vec<PaneCwdEvidence>, Option<ProcessCommands>) {
     let mut cache = std::collections::HashMap::new();
-    let trees = descendant_pid_trees(roots);
-    roots
+    let (trees, commands) = pane_process_snapshot(roots, true, include_commands);
+    let evidence = roots
         .iter()
         .map(|&root| {
             let nodes = trees.get(&root).map(Vec::as_slice).unwrap_or(&[]);
             evidence_from_tree(root, nodes, &mut cache)
         })
-        .collect()
+        .collect();
+    (evidence, commands)
 }
 
-fn descendant_pid_trees(roots: &[u32]) -> std::collections::HashMap<u32, Vec<(u32, u16)>> {
-    #[cfg(unix)]
-    {
-        use std::collections::{HashMap, HashSet};
-        let Some((_, children)) = ps_table() else {
-            return HashMap::new();
-        };
-        roots
-            .iter()
-            .map(|&root| {
-                let mut out = Vec::new();
-                let mut seen = HashSet::new();
-                let mut stack = vec![(root, 0u16)];
-                while let Some((pid, depth)) = stack.pop() {
-                    if !seen.insert(pid) || out.len() >= 64 {
-                        continue;
-                    }
-                    out.push((pid, depth));
-                    if let Some(kids) = children.get(&pid) {
-                        for &k in kids.iter().rev() {
-                            stack.push((k, depth.saturating_add(1)));
-                        }
-                    }
-                }
-                (root, out)
-            })
-            .collect()
-    }
-    #[cfg(windows)]
-    {
-        windows::descendant_pid_trees(roots)
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = roots;
-        std::collections::HashMap::new()
-    }
+/// Resolve every pane root from **one** process-table snapshot. Git-root
+/// probes are cached per directory for this scan. Call off the app loop.
+#[cfg(test)]
+pub fn scan_pane_cwds(roots: &[u32]) -> Vec<PaneCwdEvidence> {
+    scan_pane_runtime(roots, false).0
 }
 
 fn evidence_from_tree(
@@ -851,6 +880,28 @@ mod tests {
         );
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn pane_runtime_scan_projects_cwd_and_commands_from_one_snapshot() {
+        let pid = std::process::id();
+        let (evidence, commands) = super::scan_pane_runtime(&[pid], true);
+        assert_eq!(evidence.len(), 1);
+        assert_eq!(evidence[0].pid, pid);
+        assert!(
+            evidence[0].owner_cwd.is_some(),
+            "the current process cwd is visible"
+        );
+        let commands = commands.expect("the process table is supported");
+        assert!(
+            commands.get(&pid).is_some_and(|items| !items.is_empty()),
+            "the same snapshot includes the root command"
+        );
+
+        let (cwd_only, commands) = super::scan_pane_runtime(&[pid], false);
+        assert_eq!(cwd_only.len(), 1);
+        assert!(commands.is_none(), "command projection is demand-driven");
     }
 
     #[test]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -216,6 +216,10 @@ struct ProcessSnapshot {
     command_lines: HashMap<u32, String>,
 }
 
+type ProcessTrees = HashMap<u32, Vec<(u32, u16)>>;
+type ProcessCommands = HashMap<u32, Vec<String>>;
+type PaneProcessSnapshot = (ProcessTrees, Option<ProcessCommands>);
+
 impl ProcessSnapshot {
     fn capture() -> Option<Self> {
         // SAFETY: ToolHelp owns the returned snapshot handle; the guard closes it.
@@ -307,10 +311,7 @@ pub(super) fn pane_process_snapshot(
     roots: &[u32],
     include_trees: bool,
     include_commands: bool,
-) -> Option<(
-    HashMap<u32, Vec<(u32, u16)>>,
-    Option<HashMap<u32, Vec<String>>>,
-)> {
+) -> Option<PaneProcessSnapshot> {
     let mut snapshot = ProcessSnapshot::capture()?;
     let mut trees = HashMap::new();
     let mut commands = include_commands.then(HashMap::new);

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -303,22 +303,33 @@ impl ProcessSnapshot {
     }
 }
 
-pub(super) fn descendant_commands(roots: &[u32]) -> Option<HashMap<u32, Vec<String>>> {
+pub(super) fn pane_process_snapshot(
+    roots: &[u32],
+    include_trees: bool,
+    include_commands: bool,
+) -> Option<(
+    HashMap<u32, Vec<(u32, u16)>>,
+    Option<HashMap<u32, Vec<String>>>,
+)> {
     let mut snapshot = ProcessSnapshot::capture()?;
-    Some(
-        roots
-            .iter()
-            .copied()
-            .map(|root| {
-                let commands = snapshot
-                    .descendants(root)
-                    .into_iter()
-                    .map(|(pid, _)| snapshot.command(pid))
-                    .collect();
-                (root, commands)
-            })
-            .collect(),
-    )
+    let mut trees = HashMap::new();
+    let mut commands = include_commands.then(HashMap::new);
+    for &root in roots {
+        let nodes = snapshot.descendants(root);
+        if let Some(commands) = commands.as_mut() {
+            commands.insert(
+                root,
+                nodes
+                    .iter()
+                    .map(|(pid, _)| snapshot.command(*pid))
+                    .collect(),
+            );
+        }
+        if include_trees {
+            trees.insert(root, nodes);
+        }
+    }
+    Some((trees, commands))
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -400,19 +411,6 @@ fn trim_windows_cwd(path: &str) -> &str {
     }
 }
 
-pub(super) fn descendant_pid_trees(
-    roots: &[u32],
-) -> std::collections::HashMap<u32, Vec<(u32, u16)>> {
-    let Some(snapshot) = ProcessSnapshot::capture() else {
-        return std::collections::HashMap::new();
-    };
-    roots
-        .iter()
-        .copied()
-        .map(|root| (root, snapshot.descendants(root)))
-        .collect()
-}
-
 #[cfg(not(target_arch = "x86_64"))]
 pub(super) fn process_cwd(_pid: u32) -> Option<std::path::PathBuf> {
     None
@@ -479,7 +477,10 @@ mod tests {
             .args(["/C", "ping.exe -n 3 127.0.0.1 > nul"])
             .spawn()
             .expect("spawn cmd");
-        let commands = descendant_commands(&[child.id()]).expect("capture process tree");
+        let commands = pane_process_snapshot(&[child.id()], false, true)
+            .expect("capture process tree")
+            .1
+            .expect("command projection");
         let command = commands
             .get(&child.id())
             .and_then(|commands| commands.first())


### PR DESCRIPTION
## Summary

- share one bounded OS process-table snapshot when the 1-second CWD scan and 2-second agent-detection scan coincide
- preserve independent scan cadences, inflight guards, fallback scans, and off-loop execution
- project CWD trees and command identities from the same Unix or Windows snapshot only when both are requested
- keep standalone agent scans demand-driven so they do not build unused CWD trees

## Performance

Measured with the existing isolated release benchmark on macOS 15.7.9 / Apple M3 Pro. Each result uses three 10-second idle CPU trials and matching layouts. CPU is the percentage of one logical core.

| Layout | Before | After | Difference |
|---|---:|---:|---:|
| 10 panes | 0.80% | 0.73% | about 8% lower |
| 20 panes | 0.87% | 0.73% | about 15% lower |

Combined physical memory remained effectively unchanged. At 20 panes, CLI median/p95 moved from 2.53/3.19 ms to 2.47/2.79 ms. All benchmark sessions cleaned up without errors.

## Behavior

- CWD tracking remains on its one-second cadence.
- Agent process detection remains on its two-second cadence.
- If the deadlines do not coincide, the existing standalone agent scan still runs.
- Process and Git work remain off the app loop.
- No CLI, API, UHP, persistence, configuration, or UI contract changes.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test platform::tests::pane_runtime_scan_projects_cwd_and_commands_from_one_snapshot -- --exact`
- `cargo test app::cwd::tests -- --nocapture`
- `cargo test --locked` — 1,082 unit tests plus integration suites passed
- `cargo build --release --locked`
- matched 10-pane and 20-pane before/after benchmarks

Local Windows cross-compilation could not pass the SQLite build script because MinGW is not installed on the macOS host; the repository Windows CI remains the authoritative platform validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved runtime monitoring efficiency by combining related background scans when they occur together.
  * Reduced redundant process information collection, helping monitoring complete with less overhead.

* **Reliability**
  * Improved consistency between pane working-directory and process data by collecting them from the same system snapshot.
  * Preserved existing runtime detection behavior across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->