### PR TITLE
feat(workspace): keep a terminal after the final project closes

### DIFF
--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -275,6 +275,13 @@ luvus workspace pin <workspace-index>
 luvus workspace unpin <workspace-index>
 ```
 
+Closing the final project does not stop the client or leave it without a shell.
+Luvus immediately creates a neutral workspace and terminal at the user's home
+directory. Its displayed path follows the focused pane's live cwd. An empty
+`workspace list` is therefore an exceptional restore or spawn failure, not proof
+that the server is offline. Use `workspace open <path>` when the user named a
+specific project.
+
 From a managed pane, use `LUVUS_PANE_ID` as the caller or split anchor. From an
 external terminal, select an explicit pane returned by live state.
 

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -275,6 +275,13 @@ luvus workspace pin <workspace-index>
 luvus workspace unpin <workspace-index>
 ```
 
+Closing the final project does not stop the client or leave it without a shell.
+Luvus immediately creates a neutral workspace and terminal at the user's home
+directory. Its displayed path follows the focused pane's live cwd. An empty
+`workspace list` is therefore an exceptional restore or spawn failure, not proof
+that the server is offline. Use `workspace open <path>` when the user named a
+specific project.
+
 From a managed pane, use `LUVUS_PANE_ID` as the caller or split anchor. From an
 external terminal, select an explicit pane returned by live state.
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1009,11 +1009,9 @@ impl App {
             return self.handle_terminal_backend(req);
         }
         // No node open: most methods reach `layout()`, which would index an empty
-        // `workspaces`. This was written when an empty session only ever existed
-        // for the moment before the app quit; since docs/43 §3.3 a server *stays*
-        // empty after its last node closes, so the methods that open one — the
-        // only way back — must get through, or the server is a brick that only
-        // `server stop` can clear.
+        // `workspaces`. Normal close paths immediately create a neutral home
+        // terminal, but restore or shell startup can still fail. Methods that
+        // recover or inspect that exceptional state must get through.
         // Only methods that are safe with no node: they either take an explicit
         // path or touch no node at all. Notably absent is `workspace.new`, which
         // derives its folder from the focused pane and would fall back to the
@@ -1034,6 +1032,8 @@ impl App {
             "workspace.list",
             "node.list",
             "worktree.open",
+            "tab.new",
+            "pane.split",
             "ui.bar.list",
             "ui.bar.push",
             "ui.bar.move",
@@ -1280,6 +1280,12 @@ impl App {
                 }))
             }
             "pane.split" => {
+                if self.workspaces.is_empty() && !self.ensure_workspace_for_terminal() {
+                    return Err((
+                        "spawn_failed".to_string(),
+                        "could not create a terminal in the home directory".to_string(),
+                    ));
+                }
                 let base = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
                 self.layout_mut().focus = base;
                 let dir = p
@@ -1483,11 +1489,17 @@ impl App {
                     .iter()
                     .enumerate()
                     .map(|(i, w)| {
+                        let terminal_cwd = self
+                            .workspace_terminal_cwd(i)
+                            .unwrap_or(&w.cwd)
+                            .display()
+                            .to_string();
                         json!({
                             "workspace": i.to_string(),
                             "workspace_id": w.id,
                             "name": w.name,
                             "cwd": w.cwd.display().to_string(),
+                            "terminal_cwd": terminal_cwd,
                             "pinned": w.pinned,
                             "display_position": display_positions[i].to_string(),
                             "active": i == active,
@@ -1754,7 +1766,16 @@ impl App {
                 self.socket_tab(workspace, tab)
             }
             "tab.new" => {
-                self.new_tab();
+                if self.workspaces.is_empty() {
+                    if !self.ensure_workspace_for_terminal() {
+                        return Err((
+                            "spawn_failed".to_string(),
+                            "could not create a terminal in the home directory".to_string(),
+                        ));
+                    }
+                } else {
+                    self.new_tab();
+                }
                 Ok(json!({
                     "type":"tab",
                     "tab": (self.ws().active_tab + 1).to_string()
@@ -4900,10 +4921,16 @@ impl App {
             .workspaces
             .get(index)
             .ok_or_else(|| workspace_update_error(index, WorkspaceUpdateError::NotFound))?;
+        let terminal_cwd = self
+            .workspace_terminal_cwd(index)
+            .unwrap_or(&workspace.cwd)
+            .display()
+            .to_string();
         Ok(json!({
             "type":"workspace", "workspace":index.to_string(), "workspace_id":workspace.id,
             "name":workspace.name,
             "cwd":workspace.cwd.display().to_string(), "branch":workspace.branch,
+            "terminal_cwd":terminal_cwd,
             "ahead":workspace.git_ahead_behind.map(|value| value.0),
             "behind":workspace.git_ahead_behind.map(|value| value.1),
             "pinned":workspace.pinned, "active":index == self.active_ws,
@@ -6859,11 +6886,16 @@ command = ["true"]
         assert_eq!(rows[0]["workspace"], "0", "API order stays stable");
         assert_eq!(rows[1]["name"], "Luvus website");
         assert_eq!(rows[1]["cwd"], a.display().to_string());
+        assert_eq!(rows[1]["terminal_cwd"], a.display().to_string());
         assert_eq!(rows[1]["pinned"], false);
         assert_eq!(rows[1]["display_position"], "2");
         assert_eq!(rows[2]["workspace"], "2");
         assert_eq!(rows[2]["pinned"], true);
         assert_eq!(rows[2]["display_position"], "0");
+        let fetched = app
+            .dispatch("workspace.get", &json!({"workspace": 1}))
+            .expect("workspace get");
+        assert_eq!(fetched["terminal_cwd"], a.display().to_string());
 
         let unpinned = app
             .dispatch("workspace.pin", &json!({"workspace": "2", "pinned": false}))

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -438,10 +438,9 @@ impl App {
             other => other,
         };
         // Control-API requests and parked `wait.output` replies must be answered
-        // even with no workspace open. A server that has closed its last node
-        // stays alive (docs/43 §3.3), and the methods that reopen one are the
-        // only way back; dropping the reply channel here would leave the caller
-        // reading EOF instead of a `workspace.open` / `server.stop` answer.
+        // even if restore or shell startup left no workspace. Normal close paths
+        // immediately create a neutral home terminal; this guard keeps the
+        // exceptional recovery path from dropping replies or indexing a layout.
         if self.workspaces.is_empty() {
             match ev {
                 AppEvent::ThemeReloaded {
@@ -506,18 +505,16 @@ impl App {
                     );
                     return true;
                 }
-                // The worker may finish after the last workspace closes. Drop
-                // its stale result, but release the guard so CWD tracking can
-                // start again if another workspace is opened.
+                // A worker may finish after the previous workspace closes while
+                // replacement shell startup fails. Drop its stale result, but
+                // release the guard so CWD tracking can recover later.
                 AppEvent::CwdScanned { .. } => {
                     self.cwd_scan_inflight = false;
                     return false;
                 }
-                // Closing the last workspace empties `workspaces` and sets
-                // `should_quit`; the loop drains the rest of the event batch
-                // before it checks that flag, so ignore everything else here
-                // once there's nothing left to act on (`layout()` would
-                // otherwise index an empty `workspaces`).
+                // Late pane and worker events may arrive after the final project
+                // closes. If replacement startup failed, ignore them rather than
+                // indexing a layout that does not exist.
                 _ => return false,
             }
         }
@@ -3567,15 +3564,15 @@ mod tests {
         );
     }
 
-    // A server that has closed its last node keeps running (docs/43 §3.3), so
-    // control-API requests routed through the event channel must still be
-    // answered — otherwise the reply channel drops and the CLI reads EOF.
+    // A server that has closed its last project keeps running with a neutral
+    // home terminal, so control-API requests routed through the event channel
+    // must still be answered rather than dropping the CLI reply channel.
     #[test]
-    fn api_requests_are_answered_with_no_workspace_open() {
+    fn api_requests_are_answered_after_the_last_project_closes() {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = crate::app::App::new(80, 24, tx).unwrap();
         app.close_workspace(0);
-        assert!(app.workspaces.is_empty(), "the only node is gone");
+        assert_eq!(app.workspaces.len(), 1, "the home terminal replaced it");
         let (reply, rx) = std::sync::mpsc::channel();
         let req = crate::ipc::api::ApiRequest {
             id: "ping".into(),
@@ -3597,7 +3594,7 @@ mod tests {
         let mut app = crate::app::App::new(80, 24, tx).unwrap();
         app.cwd_scan_inflight = true;
         app.close_workspace(0);
-        assert!(app.workspaces.is_empty(), "the only workspace is gone");
+        assert_eq!(app.workspaces.len(), 1, "the home terminal replaced it");
 
         let dirty = app.handle_event(AppEvent::CwdScanned {
             panes: Vec::new(),
@@ -3605,7 +3602,7 @@ mod tests {
             workspace_candidates: Vec::new(),
         });
 
-        assert!(!dirty, "discarding an invisible scan needs no repaint");
+        assert!(!dirty, "an empty scan needs no repaint");
         assert!(
             !app.cwd_scan_inflight,
             "a reopened workspace must be allowed to start another scan"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1506,9 +1506,8 @@ pub struct App {
     pub zoomed: bool,
     pub should_quit: bool,
     /// True when this `App` is owned by the background server. A server session
-    /// outlives its windows: closing the last workspace resets to a fresh one
-    /// instead of quitting — only `server stop` ends it. The single-process
-    /// `--local` run leaves this false and quits like a normal terminal app.
+    /// outlives its windows. Closing the last project replaces it with a neutral
+    /// terminal rooted at `$HOME`; only `server stop` ends the server.
     pub server_mode: bool,
     pub spinner: u64,
     /// Structure changed since the last save; the loop persists when set.
@@ -1575,11 +1574,10 @@ pub struct App {
     /// finder. The server consumes this once and sends a logical handoff only
     /// to that client.
     pub pending_session_switch: Option<String>,
-    /// The last node was closed, ending the session (docs/43 §3.3). *Every*
-    /// client detaches, so the window closes, while the server stays up with no
-    /// nodes — distinct from `detach_requested` (one client leaves, session
-    /// continues) and from `should_quit` (the server itself exits).
-    pub end_session: bool,
+    /// Persist structural state immediately after the last project workspace is
+    /// replaced by the neutral home terminal. This prevents a crash inside the
+    /// normal debounce window from restoring the project the user closed.
+    pub persist_session_now: bool,
     /// Force the next frame to be a **full** repaint (not a diff), so a terminal
     /// whose screen was damaged outside luvus's knowledge — a window move/resize,
     /// regaining focus, another program's output — repaints cleanly. The render
@@ -2053,7 +2051,7 @@ impl App {
             last_cursor: None,
             detach_requested: false,
             pending_session_switch: None,
-            end_session: false,
+            persist_session_now: false,
             force_redraw: false,
             pending_notify: Vec::new(),
             pending_sound: None,
@@ -2605,7 +2603,7 @@ impl App {
             last_cursor: None,
             detach_requested: false,
             pending_session_switch: None,
-            end_session: false,
+            persist_session_now: false,
             force_redraw: false,
             pending_notify: Vec::new(),
             pending_sound: None,
@@ -3052,6 +3050,20 @@ impl App {
         &self.workspaces[self.active_ws]
     }
 
+    /// Exact cwd of the pane currently selected in a workspace. The workspace's
+    /// project root remains `Workspace::cwd`; this display value follows `cd`
+    /// and pane focus so the sidebar describes the terminal the user can type in.
+    pub fn workspace_terminal_cwd(&self, index: usize) -> Option<&std::path::Path> {
+        let workspace = self.workspaces.get(index)?;
+        workspace
+            .tabs
+            .get(workspace.active_tab)
+            .map(|tab| tab.layout.focus)
+            .and_then(|pane| self.panes.get(&pane))
+            .map(|pane| pane.cwd.as_path())
+            .or(Some(workspace.cwd.as_path()))
+    }
+
     pub fn layout(&self) -> &TileLayout {
         let ws = self.ws();
         &ws.tabs[ws.active_tab].layout
@@ -3492,6 +3504,7 @@ impl App {
             active_tab: 0,
         });
         self.active_ws = self.workspaces.len() - 1;
+        self.session_dirty = true;
         let ws = self.active_ws;
         self.emit_event(
             "workspace.created",
@@ -3502,6 +3515,20 @@ impl App {
             &[crate::logging::Field::WorkspaceIndex(ws as u64)],
         );
         true
+    }
+
+    /// Restore the workspace hierarchy when an exceptional empty state reaches
+    /// an action that needs a terminal. Normal close paths create this neutral
+    /// home terminal immediately; this guard also covers restore/spawn failures.
+    pub(crate) fn ensure_workspace_for_terminal(&mut self) -> bool {
+        if !self.workspaces.is_empty() {
+            return true;
+        }
+        let Some(home) = crate::platform::home_dir().filter(|path| path.is_dir()) else {
+            self.show_toast(self.catalog.home_unavailable);
+            return false;
+        };
+        self.create_workspace_at(home)
     }
 
     /// The order the WORKSPACES sidebar draws nodes in: each linked worktree is
@@ -4940,7 +4967,7 @@ impl App {
                 .iter()
                 .position(|w| crate::platform::same_path(&w.cwd, &s.cwd))
         } else {
-            Some(self.active_ws)
+            (!self.workspaces.is_empty()).then_some(self.active_ws)
         };
         if let Some(wi) = target {
             self.active_ws = wi;
@@ -5403,30 +5430,15 @@ impl App {
         }
     }
 
-    /// The last node just closed, so the **session** is over (docs/43 §3.3).
-    ///
-    /// This used to reset to a fresh node at `std::env::current_dir()` — the
-    /// *server's* cwd, i.e. the folder it was first launched from. Closing every
-    /// node therefore resurrected the folder you closed first, the window never
-    /// went away, and the snapshot kept that folder so it came back after a
-    /// restart too. It also made `persist::save`'s empty-snapshot branch — which
-    /// exists precisely because "the user deliberately closed everything" must
-    /// not resurrect anything — unreachable in server mode.
-    ///
-    /// Now the *window* ends and the *server* survives, which is what
-    /// `server_mode` was for: clients detach, no node is recreated, and the empty
-    /// snapshot clears `session.json`. `server stop` still ends the server, and a
-    /// later `luvus` attaches and opens its launch folder fresh. `--local` has no
-    /// server to outlive, so it quits like a normal terminal app.
+    /// Keep the client usable after its final project closes by immediately
+    /// creating a neutral terminal at `$HOME`. It uses the ordinary workspace,
+    /// tab, pane, and PTY paths, so there is no separate Home UI or terminal mode.
     fn all_workspaces_closed(&mut self) {
         self.session_dirty = true;
+        self.persist_session_now = true;
         self.fail_pending_files_api("no active workspace while FILES was loading");
         self.fail_pending_diff_api("no active workspace while DIFF was refreshing");
-        if self.server_mode {
-            self.end_session = true;
-        } else {
-            self.should_quit = true;
-        }
+        self.ensure_workspace_for_terminal();
     }
 
     /// Close a workspace and all of its panes.
@@ -5456,11 +5468,6 @@ impl App {
         }
         self.clear_workspace_transients(&closed_workspace_id);
         self.workspaces.remove(index);
-        if self.workspaces.is_empty() {
-            self.all_workspaces_closed();
-        } else if self.active_ws >= self.workspaces.len() {
-            self.active_ws = self.workspaces.len() - 1;
-        }
         self.session_dirty = true;
         self.emit_event(
             "workspace.closed",
@@ -5470,6 +5477,11 @@ impl App {
             crate::logging::EventKind::WorkspaceClose,
             &[crate::logging::Field::WorkspaceIndex(index as u64)],
         );
+        if self.workspaces.is_empty() {
+            self.all_workspaces_closed();
+        } else if self.active_ws >= self.workspaces.len() {
+            self.active_ws = self.workspaces.len() - 1;
+        }
     }
 
     /// Dismiss deferred UI actions whose stable target is being removed.
@@ -5667,6 +5679,22 @@ mod tests {
     use std::sync::mpsc;
 
     use crate::persist::TEST_ENV_LOCK as ENV_GUARD;
+
+    /// Exercise guards for a restore/spawn failure that leaves no layout. Normal
+    /// user close paths immediately create a neutral home terminal instead.
+    fn force_empty_session(app: &mut App) {
+        let panes: Vec<PaneId> = app
+            .workspaces
+            .iter()
+            .flat_map(|workspace| workspace.tabs.iter())
+            .flat_map(|tab| tab.layout.leaves())
+            .collect();
+        for pane in panes {
+            app.drop_leaf_runtime(pane);
+        }
+        app.workspaces.clear();
+        app.active_ws = 0;
+    }
 
     /// The new-pane cwd resolver hands back the chain of directories that still
     /// exist, in preference order, and never a directory it has already found
@@ -6205,10 +6233,10 @@ mod tests {
     /// `std::env::current_dir()`, which in the server is the folder it was
     /// launched from, i.e. projectA.
     ///
-    /// The server still outlives its windows (that part was always intended);
-    /// what ends now is the *session*.
+    /// The server and attached client now remain usable with a neutral terminal
+    /// at `$HOME`, while the replacement snapshot is persisted immediately.
     #[test]
-    fn closing_the_last_node_ends_the_session_without_resurrecting_one() {
+    fn closing_the_last_workspace_opens_a_home_terminal_without_resurrecting_one() {
         let _env = crate::persist::test_env("server-outlives");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
@@ -6226,28 +6254,29 @@ mod tests {
         assert_eq!(app.workspaces.len(), 1, "the other node stays open");
         app.close_workspace(0);
 
+        let home = crate::platform::home_dir().expect("the test host has a home directory");
+        assert_eq!(app.workspaces.len(), 1, "a neutral workspace remains");
         assert!(
-            app.workspaces.is_empty(),
-            "no node is resurrected — least of all the server's launch folder"
+            crate::platform::same_path(&app.workspaces[0].cwd, &home),
+            "the replacement is rooted at home, not a project or server launch folder"
+        );
+        assert_eq!(app.layout().len(), 1, "the user gets one real terminal");
+        assert!(
+            app.panes.contains_key(&app.layout().focus),
+            "the replacement layout owns a live pane"
         );
         assert!(
             !app.should_quit,
-            "the server itself still outlives its windows; `server stop` ends it"
+            "the attached client remains connected; `server stop` ends the server"
         );
         assert!(
-            app.end_session,
-            "every client is told to detach, so the window actually closes"
+            app.persist_session_now,
+            "the replacement snapshot is persisted without waiting for the debounce"
         );
 
-        // The server keeps ticking after the session ends, with no clients
-        // attached. `detect_tick` reaches `layout()`, so an unguarded empty
-        // session panics the whole server here — which is exactly what happened,
-        // and what no assertion above would have caught.
+        // The server keeps ticking while clients remain attached to the home terminal.
         for _ in 0..3 {
-            assert!(
-                !app.detect_tick(Instant::now()),
-                "an empty session has nothing to detect"
-            );
+            app.detect_tick(Instant::now());
         }
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -6262,7 +6291,7 @@ mod tests {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         app.server_mode = true;
-        app.close_workspace(0);
+        force_empty_session(&mut app);
         assert!(app.workspaces.is_empty());
 
         let call = |app: &mut App, method: &str, params: serde_json::Value| {
@@ -6280,7 +6309,6 @@ mod tests {
             "workspace.rename",
             "workspace.pin",
             "tab.list",
-            "tab.new",
             "tab.move",
             "tab.swap",
             "tab.close",
@@ -6305,6 +6333,23 @@ mod tests {
             "listing nodes with none open is not an error: {res}"
         );
 
+        let res = call(&mut app, "tab.new", serde_json::json!({}));
+        assert!(
+            res.get("error").is_none(),
+            "a tab command from an empty session creates a neutral workspace: {res}"
+        );
+        assert_eq!(app.workspaces.len(), 1);
+        assert_eq!(app.ws().tabs.len(), 1);
+        force_empty_session(&mut app);
+
+        let res = call(&mut app, "pane.split", serde_json::json!({}));
+        assert!(
+            res.get("error").is_none(),
+            "a split command from an empty session creates its anchor first: {res}"
+        );
+        assert_eq!(app.layout().len(), 2);
+        force_empty_session(&mut app);
+
         let dir = std::env::temp_dir().join("luvus-recover-4b1c9f");
         std::fs::create_dir_all(&dir).expect("temp dir");
         let res = call(
@@ -6320,9 +6365,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The same empty session must render. A client can still be attached for the
-    /// frame or two before it detaches, and `luvus attach` / `--remote` can attach
-    /// before any folder is opened — every draw fn below `render` assumes a node.
+    /// A restore or replacement-shell failure may leave no workspace. Rendering
+    /// stays safe and does not substitute a landing screen for the terminal.
     #[test]
     fn an_empty_session_still_renders() {
         let _env = crate::persist::test_env("render-no-node");
@@ -6331,8 +6375,9 @@ mod tests {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         app.server_mode = true;
-        app.close_workspace(0);
+        force_empty_session(&mut app);
         assert!(app.workspaces.is_empty());
+        app.pane_rects.push((PaneId(999), Rect::new(1, 1, 2, 2)));
 
         let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
@@ -6344,27 +6389,69 @@ mod tests {
             .map(|c| c.symbol())
             .collect();
         assert!(
-            text.contains("no folders open"),
-            "the empty session says so instead of drawing a broken frame"
+            !text.contains("No workspace open") && !text.contains("Open Workspace"),
+            "an empty session does not replace Luvus with a landing card"
         );
+        assert!(app.pane_rects.is_empty(), "stale terminal hits are cleared");
+        assert!(app.new_ws_rect.is_none(), "no synthetic action is rendered");
     }
 
     #[test]
-    fn closing_last_pane_quits_and_ignores_further_events() {
+    fn closing_last_pane_opens_a_home_terminal_and_accepts_new_tab() {
         let _env = crate::persist::test_env("close-last-pane");
-        // Closing the last pane empties `workspaces` and sets `should_quit`; the
-        // server loop drains the rest of the event batch before checking that
-        // flag, so late events must be no-ops, not panics on an empty Vec.
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         let id = app.layout().focus;
         app.handle_event(AppEvent::PtyExit(id)); // the only pane's shell exits
-        assert!(app.should_quit, "closing the last pane quits the session");
-        assert!(app.workspaces.is_empty());
-        // Late events in the same batch must not panic.
+        assert!(
+            !app.should_quit,
+            "closing the last pane keeps the client open"
+        );
+        assert_eq!(app.workspaces.len(), 1);
+        assert_ne!(app.layout().focus, id, "the dead pane is replaced");
+        assert!(app.panes.contains_key(&app.layout().focus));
         app.handle_event(key(' ', KeyModifiers::CONTROL));
         app.handle_event(key('c', KeyModifiers::NONE));
+        assert_eq!(
+            app.ws().tabs.len(),
+            2,
+            "new tab works immediately in the neutral workspace"
+        );
+        // A stale exit from the old PTY remains harmless after re-entry.
         app.handle_event(AppEvent::PtyExit(id));
+    }
+
+    #[test]
+    fn workspace_terminal_cwd_follows_the_focused_pane() {
+        let _env = crate::persist::test_env("workspace-focused-pane-cwd");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let root = app.layout().focus;
+        app.split(Axis::Col);
+        let second = app.layout().focus;
+        let root_cwd = app.ws().cwd.join("root-pane");
+        let second_cwd = app.ws().cwd.join("focused-pane");
+        app.rename_workspace(0, "My project").unwrap();
+        app.panes.get_mut(&root).unwrap().cwd = root_cwd.clone();
+        app.panes.get_mut(&second).unwrap().cwd = second_cwd;
+
+        app.layout_mut().focus = second;
+        assert_eq!(
+            app.workspace_terminal_cwd(0),
+            app.panes.get(&second).map(|pane| pane.cwd.as_path()),
+            "the sidebar follows the terminal the user can type in"
+        );
+        assert_eq!(
+            app.workspaces[0].name, "My project",
+            "live pane paths never overwrite a custom workspace label"
+        );
+
+        app.layout_mut().focus = root;
+        assert_eq!(
+            app.workspace_terminal_cwd(0),
+            Some(root_cwd.as_path()),
+            "moving focus changes the displayed terminal path"
+        );
     }
 
     #[test]
@@ -9078,6 +9165,27 @@ mod tests {
         assert_eq!(s.agent, "claude");
         assert_eq!(s.agent_session.as_ref().unwrap().session_id, "abc");
         assert!(app.resumable.is_empty(), "session dropped from the list");
+    }
+
+    #[test]
+    fn resume_session_from_empty_creates_its_workspace() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.config.layout.resume_in_new_workspace = false;
+        force_empty_session(&mut app);
+        assert!(app.workspaces.is_empty());
+
+        app.resumable = vec![crate::agent::SessionInfo {
+            agent: "claude".into(),
+            session_id: "empty-session-resume".into(),
+            cwd: std::env::current_dir().expect("repository directory"),
+            updated: std::time::SystemTime::now(),
+        }];
+        app.resume_session(0);
+
+        assert_eq!(app.workspaces.len(), 1);
+        assert_eq!(app.ws().tabs.len(), 1);
+        assert!(app.resumable.is_empty());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,7 +131,7 @@ workspaces:
 
 tabs:
   tab list                   list tabs in the current workspace
-  tab new                    new tab
+  tab new                    new tab (creates a workspace if none is open)
   tab focus <n>              focus tab n (1-based)
   tab move <from> <to>       move a tab to an exact position (1-based)
   tab move left|right        move the active tab one position (--tab N targets one)
@@ -141,7 +141,7 @@ tabs:
 
 panes / agents:
   pane list                  list panes and read-only history metrics in the current tab
-  pane split [<id>] [--down] [--no-focus]   split a pane (default: side by side)
+  pane split [<id>] [--down] [--no-focus]   split a pane (side by side, creates a workspace if empty)
   pane focus <id>            focus a pane (jumps to its workspace/tab)
   pane move [<id>] (--tab <n> | --new-tab)  move a pane within its workspace
   pane run [<id>] <cmd...>   run a command in a pane

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,7 +141,7 @@ tabs:
 
 panes / agents:
   pane list                  list panes and read-only history metrics in the current tab
-  pane split [<id>] [--down] [--no-focus]   split a pane (side by side, creates a workspace if empty)
+  pane split [<id>] [--down] [--no-focus]   split a pane (default: side by side, creates a workspace if empty)
   pane focus <id>            focus a pane (jumps to its workspace/tab)
   pane move [<id>] (--tab <n> | --new-tab)  move a pane within its workspace
   pane run [<id>] <cmd...>   run a command in a pane

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -1201,15 +1201,15 @@ static HELP: &[Translation] = &[
         "현재 탭의 패널과 읽기 전용 기록 지표 나열"
     ),
     tr!(
-        "split a pane (side by side, creates a workspace if empty)",
-        "dividir un panel (lado a lado, crea un espacio de trabajo si está vacío)",
-        "dividir um painel (lado a lado, cria um espaço de trabalho se estiver vazio)",
-        "diviser un volet (côte à côte, crée un espace de travail si vide)",
-        "Bereich teilen (nebeneinander, erstellt bei Leerstand einen Arbeitsbereich)",
-        "bagi panel (berdampingan, membuat ruang kerja jika kosong)",
-        "拆分窗格（左右并排，空状态时创建工作区）",
-        "ペインを分割（横並び、空の場合はワークスペースを作成）",
-        "패널 분할 (좌우 분할, 비어 있으면 작업 공간 생성)"
+        "split a pane (default: side by side, creates a workspace if empty)",
+        "dividir un panel (predeterminado: lado a lado, crea un espacio de trabajo si está vacío)",
+        "dividir um painel (padrão: lado a lado, cria um espaço de trabalho se estiver vazio)",
+        "diviser un volet (par défaut : côte à côte, crée un espace de travail si vide)",
+        "Bereich teilen (Standard: nebeneinander, erstellt bei Leerstand einen Arbeitsbereich)",
+        "bagi panel (bawaan: berdampingan, membuat ruang kerja jika kosong)",
+        "拆分窗格（默认：左右并排，空状态时创建工作区）",
+        "ペインを分割（既定：横並び、空の場合はワークスペースを作成）",
+        "패널 분할 (기본값: 좌우 분할, 비어 있으면 작업 공간 생성)"
     ),
     tr!(
         "focus a pane (jumps to its workspace/tab)",

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -1113,15 +1113,15 @@ static HELP: &[Translation] = &[
         "현재 작업 공간의 탭 나열"
     ),
     tr!(
-        "new tab",
-        "nueva pestaña",
-        "nova aba",
-        "nouvel onglet",
-        "neuer Tab",
-        "tab baru",
-        "新建标签页",
-        "新しいタブ",
-        "새 탭"
+        "new tab (creates a workspace if none is open)",
+        "nueva pestaña (crea un espacio de trabajo si no hay ninguno abierto)",
+        "nova aba (cria um espaço de trabalho se nenhum estiver aberto)",
+        "nouvel onglet (crée un espace de travail si aucun n'est ouvert)",
+        "neuer Tab (erstellt einen Arbeitsbereich, wenn keiner geöffnet ist)",
+        "tab baru (membuat ruang kerja jika belum ada yang terbuka)",
+        "新建标签页（没有打开的工作区时创建一个）",
+        "新しいタブ（ワークスペースがない場合は作成）",
+        "새 탭 (열린 작업 공간이 없으면 생성)"
     ),
     tr!(
         "focus tab n (1-based)",
@@ -1201,15 +1201,15 @@ static HELP: &[Translation] = &[
         "현재 탭의 패널과 읽기 전용 기록 지표 나열"
     ),
     tr!(
-        "split a pane (default: side by side)",
-        "dividir un panel (predeterminado: lado a lado)",
-        "dividir um painel (padrão: lado a lado)",
-        "diviser un volet (par défaut : côte à côte)",
-        "Bereich teilen (Standard: nebeneinander)",
-        "bagi panel (bawaan: berdampingan)",
-        "拆分窗格（默认：左右并排）",
-        "ペインを分割（既定：横並び）",
-        "패널 분할 (기본값: 좌우 분할)"
+        "split a pane (side by side, creates a workspace if empty)",
+        "dividir un panel (lado a lado, crea un espacio de trabajo si está vacío)",
+        "dividir um painel (lado a lado, cria um espaço de trabalho se estiver vazio)",
+        "diviser un volet (côte à côte, crée un espace de travail si vide)",
+        "Bereich teilen (nebeneinander, erstellt bei Leerstand einen Arbeitsbereich)",
+        "bagi panel (berdampingan, membuat ruang kerja jika kosong)",
+        "拆分窗格（左右并排，空状态时创建工作区）",
+        "ペインを分割（横並び、空の場合はワークスペースを作成）",
+        "패널 분할 (좌우 분할, 비어 있으면 작업 공간 생성)"
     ),
     tr!(
         "focus a pane (jumps to its workspace/tab)",

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -386,6 +386,7 @@ pub fn run() -> Result<()> {
     let mut next_activity = 1u64;
     let mut last_render_attempt = Instant::now();
     let mut last_save = Instant::now();
+    let mut immediate_save_attempted = false;
     // Un-rendered activity waiting for the frame cap to expire — drives a trailing
     // render so a change that lands mid-interval isn't stuck until the next event.
     let mut render_request = RenderRequest::default();
@@ -479,13 +480,20 @@ pub fn run() -> Result<()> {
             );
             break;
         }
-        // Closing the last project keeps the client attached and replaces the
-        // project with a neutral home terminal. Persist immediately rather than
-        // waiting out the debounce, so a crash cannot resurrect the closed project.
-        if app.persist_session_now {
-            app.persist_session_now = false;
-            persist::save(&app);
-            app.session_dirty = false;
+        if !app.persist_session_now {
+            immediate_save_attempted = false;
+        }
+        // Closing the final project bypasses the debounce once. Failed writes
+        // retain both flags and retry at the normal cadence instead of hot-looping.
+        let immediate_save_due = app.persist_session_now && !immediate_save_attempted;
+        let debounced_save_due = app.session_dirty && last_save.elapsed() > Duration::from_secs(2);
+        if immediate_save_due || debounced_save_due {
+            immediate_save_attempted = app.persist_session_now;
+            if persist::save(&app) {
+                app.persist_session_now = false;
+                app.session_dirty = false;
+                immediate_save_attempted = false;
+            }
             last_save = Instant::now();
         }
         if app.detach_requested {
@@ -510,12 +518,6 @@ pub fn run() -> Result<()> {
             } else {
                 app.show_toast("no attached client to switch".to_string());
             }
-        }
-
-        if app.session_dirty && last_save.elapsed() > Duration::from_secs(2) {
-            persist::save(&app);
-            app.session_dirty = false;
-            last_save = Instant::now();
         }
 
         // A state transition here (e.g. a silent agent reaching Done) has no PtyData

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -479,23 +479,11 @@ pub fn run() -> Result<()> {
             );
             break;
         }
-        // The last node closed (docs/43 §3.3): the *session* is over, so every
-        // window goes away — not just the foreground one, which would leave other
-        // clients staring at a session with nothing in it. The server stays up
-        // with no nodes; `server stop` is still what ends it.
-        if app.end_session {
-            app.end_session = false;
-            // Detach is a reliable control message. It does not compete with the
-            // one-frame backpressure slot, so a busy or remote client cannot
-            // lose it and cannot block this loop.
-            for (_, client) in clients.drain() {
-                let _ = client.send_control(ServerMessage::Detach);
-            }
-            foreground = None;
-            // Persist immediately rather than waiting out the 2s debounce: the
-            // snapshot is now empty, which *removes* `session.json`, and a kill
-            // inside that window would otherwise leave the closed nodes on disk
-            // to be restored on the next start.
+        // Closing the last project keeps the client attached and replaces the
+        // project with a neutral home terminal. Persist immediately rather than
+        // waiting out the debounce, so a crash cannot resurrect the closed project.
+        if app.persist_session_now {
+            app.persist_session_now = false;
             persist::save(&app);
             app.session_dirty = false;
             last_save = Instant::now();
@@ -1356,11 +1344,10 @@ mod tests {
         );
     }
 
-    /// Session detach is carried by the same reliable control path. Preserve the
-    /// earlier guarantee that closing the last node cannot strand a client just
-    /// because its writer already has a frame waiting.
+    /// Explicit client detach is carried by the same reliable control path and
+    /// cannot be lost behind a queued frame.
     #[test]
-    fn ending_a_session_delivers_detach_behind_a_queued_frame() {
+    fn explicit_detach_is_delivered_behind_a_queued_frame() {
         let (messages, rx) = mpsc::channel();
         let client = ClientSender {
             messages,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1048,6 +1048,7 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
     terminal.draw(|f| ui::render(f, &mut app))?;
     let mut last_draw = Instant::now();
     let mut last_save = Instant::now();
+    let mut immediate_save_attempted = false;
     let mut last_spin = Instant::now();
 
     loop {
@@ -1071,20 +1072,20 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
             break;
         }
 
-        // Closing the final project replaces it with a neutral home terminal.
-        // Match the server path and persist that structural change immediately,
-        // so a local-mode crash cannot restore the project the user just closed.
-        if app.persist_session_now {
-            app.persist_session_now = false;
-            persist::save(&app);
-            app.session_dirty = false;
-            last_save = Instant::now();
+        if !app.persist_session_now {
+            immediate_save_attempted = false;
         }
-
-        // Debounced session save.
-        if app.session_dirty && last_save.elapsed() > Duration::from_secs(2) {
-            persist::save(&app);
-            app.session_dirty = false;
+        // Closing the final project bypasses the debounce once. Failed writes
+        // retain both flags and retry at the normal cadence instead of hot-looping.
+        let immediate_save_due = app.persist_session_now && !immediate_save_attempted;
+        let debounced_save_due = app.session_dirty && last_save.elapsed() > Duration::from_secs(2);
+        if immediate_save_due || debounced_save_due {
+            immediate_save_attempted = app.persist_session_now;
+            if persist::save(&app) {
+                app.persist_session_now = false;
+                app.session_dirty = false;
+                immediate_save_attempted = false;
+            }
             last_save = Instant::now();
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1071,6 +1071,16 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
             break;
         }
 
+        // Closing the final project replaces it with a neutral home terminal.
+        // Match the server path and persist that structural change immediately,
+        // so a local-mode crash cannot restore the project the user just closed.
+        if app.persist_session_now {
+            app.persist_session_now = false;
+            persist::save(&app);
+            app.session_dirty = false;
+            last_save = Instant::now();
+        }
+
         // Debounced session save.
         if app.session_dirty && last_save.elapsed() > Duration::from_secs(2) {
             persist::save(&app);

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -900,47 +900,53 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
 /// Save the app's session atomically. A truly empty session can only remain after
 /// restore or shell startup failure; clear its stale snapshot so the next start
 /// cannot resurrect panes the user already closed.
-pub fn save(app: &App) {
+pub fn save(app: &App) -> bool {
     let snap = snapshot(app);
     if snap.workspaces.is_empty() {
-        let _ = fs::remove_file(session_path());
+        if let Err(error) = fs::remove_file(session_path()) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                log_persist_failure("persist_clear");
+                return false;
+            }
+        }
         crate::logging::event(
             crate::logging::EventKind::PersistCleared,
             &[crate::logging::Field::Reason(crate::logging::Reason::Empty)],
         );
-        return;
+        return true;
     }
     let dir = ensure_session_dir();
     if !dir.is_dir() {
         log_persist_failure("persist_dir");
-        return;
+        return false;
     }
     let Ok(json) = serde_json::to_string_pretty(&snap) else {
         log_persist_failure("persist_serialize");
-        return;
+        return false;
     };
     let path = session_path();
     let tmp = path.with_extension("json.tmp");
     let Ok(mut file) = fs::File::create(&tmp) else {
         log_persist_failure("persist_create");
-        return;
+        return false;
     };
     if file.write_all(json.as_bytes()).is_err() {
         log_persist_failure("persist_write");
-        return;
+        return false;
     }
     if file.flush().is_err() {
         log_persist_failure("persist_flush");
-        return;
+        return false;
     }
     if fs::rename(&tmp, &path).is_err() {
         log_persist_failure("persist_rename");
-        return;
+        return false;
     }
     crate::logging::event(
         crate::logging::EventKind::PersistSave,
         &[crate::logging::Field::Outcome(crate::logging::Outcome::Ok)],
     );
+    true
 }
 
 fn log_persist_failure(error_code: &'static str) {
@@ -1163,7 +1169,7 @@ mod tests {
         let _env = test_env("home-replacement-save");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
-        save(&app);
+        assert!(save(&app));
         assert!(session_path().exists(), "a live session snapshots");
         // Close the only pane. The project must not come back, but Luvus remains
         // usable through one neutral terminal rooted at home.
@@ -1172,10 +1178,22 @@ mod tests {
         let home = crate::platform::home_dir().expect("test host has a home directory");
         assert_eq!(app.workspaces.len(), 1);
         assert!(crate::platform::same_path(&app.workspaces[0].cwd, &home));
-        save(&app);
+        assert!(save(&app));
         let saved = load().expect("the replacement terminal is persisted");
         assert_eq!(saved.workspaces.len(), 1);
         assert!(crate::platform::same_path(&saved.workspaces[0].cwd, &home));
+    }
+
+    #[test]
+    fn save_reports_failure_when_the_atomic_temp_file_cannot_be_created() {
+        let _env = test_env("save-failure");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let app = App::new(80, 24, tx).unwrap();
+        let tmp = session_path().with_extension("json.tmp");
+        fs::create_dir_all(&tmp).unwrap();
+
+        assert!(!save(&app), "the caller must retain its retry state");
+        assert!(tmp.is_dir(), "the failure fixture remains in place");
     }
 
     #[test]

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -897,9 +897,9 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
     }
 }
 
-/// Save the app's session atomically. An *empty* session clears the snapshot:
-/// the user deliberately closed everything, and a leftover file would resurrect
-/// those panes (re-running agent resume commands) on the next start.
+/// Save the app's session atomically. A truly empty session can only remain after
+/// restore or shell startup failure; clear its stale snapshot so the next start
+/// cannot resurrect panes the user already closed.
 pub fn save(app: &App) {
     let snap = snapshot(app);
     if snap.workspaces.is_empty() {
@@ -1159,23 +1159,23 @@ mod tests {
     // dir must be owner-only (0700) and each bound socket 0600 — regardless of
     // the process umask (see `ensure_config_dir` / `transport::bind`).
     #[test]
-    fn empty_session_save_clears_the_snapshot() {
-        let _env = test_env("empty-save");
+    fn closing_the_final_project_saves_the_home_terminal_replacement() {
+        let _env = test_env("home-replacement-save");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         save(&app);
         assert!(session_path().exists(), "a live session snapshots");
-        // Close the only pane — the session is now deliberately empty, and the
-        // snapshot must go with it, or the next start would resurrect panes the
-        // user closed (re-running agent resume commands).
+        // Close the only pane. The project must not come back, but Luvus remains
+        // usable through one neutral terminal rooted at home.
         let id = app.layout().focus;
         app.handle_event(crate::event::AppEvent::PtyExit(id));
-        assert!(app.workspaces.is_empty());
+        let home = crate::platform::home_dir().expect("test host has a home directory");
+        assert_eq!(app.workspaces.len(), 1);
+        assert!(crate::platform::same_path(&app.workspaces[0].cwd, &home));
         save(&app);
-        assert!(
-            !session_path().exists(),
-            "an empty session clears the snapshot"
-        );
+        let saved = load().expect("the replacement terminal is persisted");
+        assert_eq!(saved.workspaces.len(), 1);
+        assert!(crate::platform::same_path(&saved.workspaces[0].cwd, &home));
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -418,20 +418,24 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
         return;
     }
 
-    // No nodes at all (docs/43 §3.3): the last one was closed, so the session is
-    // over and every client has been told to detach. A client can still be
-    // attached for the frame or two before it goes (or attach fresh via
-    // `luvus attach` / `--remote` before opening a folder), and every draw fn
-    // below assumes an active node — `app.ws()` indexes `workspaces[active_ws]`.
-    // One guard here covers the whole tree rather than each call site.
+    // Restore or shell startup can fail before a workspace exists. Keep this
+    // guard before every renderer that indexes `app.ws()`. Normal close paths
+    // immediately create a real home terminal and never use this surface.
     if app.workspaces.is_empty() {
-        let msg = "no folders open — run `luvus` in a folder";
-        let y = area.y + area.height / 2;
-        f.render_widget(
-            Paragraph::new(Line::from(Span::styled(msg, Style::new().fg(t.overlay1))))
-                .alignment(ratatui::layout::Alignment::Center),
-            Rect::new(area.x, y, area.width, 1),
-        );
+        f.render_widget(Block::new().style(Style::new().bg(t.mantle)), area);
+        app.pane_rects.clear();
+        app.pane_content_rects.clear();
+        app.pane_title_rects.clear();
+        app.tab_rects.clear();
+        app.tab_close_rects.clear();
+        app.ws_rects.clear();
+        app.agent_rects.clear();
+        app.session_rects.clear();
+        app.new_ws_rect = None;
+        app.last_cursor = None;
+        if let Some((text, _)) = &app.toast {
+            draw_toast(f, area, text, &t);
+        }
         return;
     }
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -369,6 +369,7 @@ fn draw_workspaces_dock(
         ws_rects.push((i, Rect::new(area.x, y, area.width, 2)));
         let st = rollup(app, i);
         let ws = &app.workspaces[i];
+        let terminal_cwd = app.workspace_terminal_cwd(i).unwrap_or(&ws.cwd);
         let name_style = if active {
             Style::new().fg(t.accent).bold()
         } else {
@@ -421,7 +422,7 @@ fn draw_workspaces_dock(
                 format!(
                     "{}{}",
                     " ".repeat(pad),
-                    short_path(&ws.cwd, cw.saturating_sub(pad as u16))
+                    short_path(terminal_cwd, cw.saturating_sub(pad as u16))
                 ),
                 Style::new().fg(if active { t.subtext0 } else { t.overlay0 }),
             )),

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -113,13 +113,15 @@ Reason about targets in this order:
 
 1. A session is one independent server namespace. Named sessions have separate
    processes, panes, and state.
-2. A workspace represents a project directory and owns tabs.
-3. A tab is an ordered layout inside one workspace.
-4. A pane is a real terminal and PTY owned by the server.
-5. An agent is a recognized process or resumable native session associated
+2. Closing the final project keeps the session usable by replacing it with a
+   neutral workspace and terminal rooted at the user's home directory.
+3. A workspace represents a project directory and owns tabs.
+4. A tab is an ordered layout inside one workspace.
+5. A pane is a real terminal and PTY owned by the server.
+6. An agent is a recognized process or resumable native session associated
    with a pane.
-6. A task coordinates dependencies, leases, worktrees, workers, and gates.
-7. A module is an explicitly installed extension using declared actions,
+7. A task coordinates dependencies, leases, worktrees, workers, and gates.
+8. A module is an explicitly installed extension using declared actions,
    panes, docks, events, settings, or Luvus Bar widgets.
 
 Tab positions are 1-based. Workspace indexes shown by the CLI are 0-based.
@@ -242,6 +244,10 @@ luvus agent start reviewer --kind codex --anchor <pane-id> --timeout 60
 luvus agent prompt reviewer "Review the current diff" --wait --timeout 600
 luvus wait agent-status <pane-id> --status done --timeout 600
 ```
+
+The neutral home workspace supports ordinary tabs and panes, and its displayed
+path follows the focused pane's live cwd. Use `workspace open <path>` when the
+user named a specific project.
 
 `agent prompt` submits one complete prompt and can wait semantically. Prefer it
 to separate text and Enter operations. A timeout does not prove that an agent

--- a/website/src/content/docs/docs/getting-started/concepts.mdx
+++ b/website/src/content/docs/docs/getting-started/concepts.mdx
@@ -15,8 +15,9 @@ display it. The client is disposable. The server is durable.
   lives**. Every shell and agent keeps running exactly where it was.
 - `luvus` again → a new client attaches to the same live session. Nothing
   restarts and no command reruns, you are just looking at it again.
-- Close every workspace → the server stays up with a fresh one. Nothing you do
-  in the UI can kill the session by accident.
+- Close every project workspace → the client stays attached and immediately
+  opens one neutral terminal at your home directory. It uses the normal terminal
+  surface, tabs, panes, and sidebar without a separate landing screen.
 - `luvus server stop` → the only way to actually end everything (the session
   snapshot is kept).
 - `luvus server status` → what's running, and whether a newer binary is
@@ -50,15 +51,20 @@ known sessions without starting any server or background manager.
 ## 2. Workspace → Tab → Pane
 
 ```
-Session
-└── Workspace   one per project folder (fixed cwd, shows its git branch)
+Session         normally contains one or more workspaces
+└── Workspace   one per project folder (fixed project root, shows its git branch)
     └── Tab     a layout of panes (or a special tab: git, orchestration)
         └── Pane   a real terminal running a shell or an agent
 ```
 
+- After the **final project closes**, Luvus creates a neutral workspace and real
+  terminal rooted at your home directory. You can immediately type, create tabs
+  or splits, change directory, or browse to another project.
 - **Workspaces** are the sidebar's top list. `Ctrl+Space N` opens the folder
   picker. Running `luvus` inside a folder adds it automatically. A workspace's
-  cwd is fixed at creation, so `cd`-ing inside a pane never moves it.
+  project `cwd` stays fixed, while its displayed terminal path follows the
+  focused pane's live cwd. With several splits, focusing a different pane shows
+  that pane's path, and every pane keeps its own working directory.
 - **Tabs** hold split layouts. Two special tabs exist: the
   [git tab](/docs/guides/git/) and the
   [orchestration board](/docs/guides/orchestration/).

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -78,6 +78,13 @@ A **workspace** is one project folder, fixed at its `cwd` (see
 [Core Concepts](/docs/getting-started/concepts/#2-workspace--tab--pane)). They
 live in the sidebar's top list.
 
+Closing the final workspace leaves the client attached with the normal Luvus
+chrome instead of closing the app or showing a separate landing screen. Luvus
+immediately replaces it with a neutral workspace and real terminal rooted at
+your home directory. You can type, change directory, create tabs or splits, and
+open the folder picker normally. The sidebar path follows the focused pane, so
+split terminals with different working directories remain unambiguous.
+
 - **Open one:** the `+` button above the list, or `Ctrl+Space N`, opens a
   **folder picker**. Browse with the arrows / wheel, use the **Home** row to jump
   home, or press `g` (also clickable in the footer) to type an absolute, relative,
@@ -121,7 +128,11 @@ luvus workspace unpin 2
 ```
 
 `workspace list` reports both the stable API index and `display_position`, so a
-pin never changes which workspace a later command targets.
+pin never changes which workspace a later command targets. It also reports two
+paths. `cwd` is the stable project root. `terminal_cwd` is the exact live path
+of the focused pane in the active tab. Changing focus updates `terminal_cwd`, so
+split panes with different directories report whichever terminal is currently
+selected. The stable `cwd` and a custom workspace name remain unchanged.
 
 Mission Control is also available without a mouse. Press `Ctrl+Space m`, choose
 it from the desktop switcher with `Ctrl+Space M`, or open it through automation:

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -359,12 +359,21 @@ on a parent or linked worktree floats that complete worktree group while
 preserving its internal order.
 
 `workspace.list` remains in API-index order. Each row includes `workspace_id`,
-`workspace`, `name`, `cwd`, `pinned`, `display_position`, `active`, and `tabs`.
-Both `workspace` and `display_position` are 0-based; callers can therefore
-target a current position or use the stable ID and separately verify where it
-appears in the sidebar.
+`workspace`, `name`, `cwd`, `terminal_cwd`, `pinned`, `display_position`,
+`active`, and `tabs`. `workspace.get` exposes the same two paths. `cwd` is the
+stable project root. `terminal_cwd` follows the focused pane of the workspace's
+active tab and changes when focus moves to another split. Both
+`workspace` and `display_position` are 0-based; callers can therefore target a
+current position or use the stable ID and separately verify where it appears in
+the sidebar.
 Missing or malformed parameters return `invalid_request`, while an out-of-range
 workspace returns `not_found` without changing state.
+
+After the final project workspace closes, the server and client remain available
+and Luvus immediately creates a neutral workspace with one terminal rooted at
+the user's home directory. Normal tab and pane methods keep working. If a restore
+or shell failure leaves the server truly empty, layout-scoped methods return
+`no_session`; `workspace.open`, `tab.new`, and `pane.split` remain recovery paths.
 
 ## Moving panes and tabs
 

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -72,7 +72,7 @@ workspaces:
 
 tabs:
   tab list                   list tabs in the current workspace
-  tab new                    new tab
+  tab new                    new tab (creates a workspace if none is open)
   tab focus <n>              focus tab n (1-based)
   tab move <from> <to>       move a tab to an exact position (1-based)
   tab move left|right        move the active tab one position (--tab N targets one)
@@ -82,7 +82,7 @@ tabs:
 
 panes / agents:
   pane list                  list panes and read-only history metrics in the current tab
-  pane split [<id>] [--down] [--no-focus]   split a pane (default: side by side)
+  pane split [<id>] [--down] [--no-focus]   split a pane (side by side, creates a workspace if empty)
   pane focus <id>            focus a pane (jumps to its workspace/tab)
   pane move [<id>] (--tab <n> | --new-tab)  move a pane within its workspace
   pane run [<id>] <cmd...>   run a command in a pane

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -82,7 +82,7 @@ tabs:
 
 panes / agents:
   pane list                  list panes and read-only history metrics in the current tab
-  pane split [<id>] [--down] [--no-focus]   split a pane (side by side, creates a workspace if empty)
+  pane split [<id>] [--down] [--no-focus]   split a pane (default: side by side, creates a workspace if empty)
   pane focus <id>            focus a pane (jumps to its workspace/tab)
   pane move [<id>] (--tab <n> | --new-tab)  move a pane within its workspace
   pane run [<id>] <cmd...>   run a command in a pane


### PR DESCRIPTION
## Summary

Closing the final project workspace now keeps Luvus usable by immediately creating one neutral terminal rooted at the user's home directory.

The replacement uses the normal workspace, tab, pane, PTY, rendering, input, and persistence paths. There is no landing card, special Home interface, or second terminal mode.

## What changed

- Keep attached clients open after the final project closes
- Create one ordinary home workspace with one real shell pane
- Persist the replacement immediately so the closed project cannot return after a crash or restart
- Keep tab creation, pane splitting, typing, session resume, and automation working normally
- Show the focused pane's live working directory in the workspace sidebar
- Expose `terminal_cwd` through `workspace.list` and `workspace.get` while preserving the stable project `cwd`
- Retain guarded API and rendering behavior if restore or shell startup leaves the server with no workspace
- Update compact CLI help in every registered language
- Update public docs, agent guidance, and both bundled Luvus skill copies

## Performance and compatibility

The normal render and event loops gain no new polling, background workers, dependencies, or platform branches. The only intentional resource cost after the final project closes is one ordinary shell PTY, which is the terminal the user continues working in.

An isolated release server with the replacement terminal settled at 0.0 percent sampled idle CPU, 13.5 MB RSS, and 12 open descriptors.

The implementation reuses the existing cross-platform home directory, shell resolution, and PTY creation paths. macOS ARM runtime and macOS Intel compilation were verified locally. Windows and Linux runtime behavior remains covered by the repository CI matrix. A local Windows GNU cross-check could not finish because the host does not have `x86_64-w64-mingw32-gcc` for the bundled SQLite build.

## Verification

- `cargo test --locked` with 1,099 passing tests
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release --locked`
- `cargo check --locked --target x86_64-apple-darwin`
- Focused project-close, pane-exit, persistence, empty-recovery, and focused-cwd tests
- Isolated debug and release server lifecycle tests
- UHP core and terminal schema validation with 88 fixtures
- Website production build
- Bundled skill validation and byte-for-byte parity
- `cargo fmt --all --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Closing the final project keeps the session open with a neutral home-directory workspace and terminal.
  - New tabs and pane splits recover empty sessions automatically.
  - Workspace listings show the focused terminal’s live working directory.

- **Bug Fixes**
  - Improved recovery after restore or shell-startup failures.
  - Replacement home workspaces are persisted immediately, with failed saves retried safely.

- **Documentation**
  - Updated CLI help, API references, guides, and multilingual help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->