### PR TITLE
perf(logging): remove dedicated writer resources

### DIFF
--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -792,10 +792,12 @@ fn finish_request_log(response: &str) {
             .min(u128::from(u64::MAX)) as u64,
     );
     count += 1;
-    crate::logging::event(
-        crate::logging::EventKind::UhpRequestComplete,
-        &fields[..count],
-    );
+    let event = if outcome == crate::logging::Outcome::Error {
+        crate::logging::EventKind::UhpRequestFailed
+    } else {
+        crate::logging::EventKind::UhpRequestComplete
+    };
+    crate::logging::event(event, &fields[..count]);
 }
 
 fn request_id_method_fields(request: RequestLog, fields: &mut [crate::logging::Field]) -> usize {

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -73,11 +73,8 @@ fn configured_level_value(value: Option<&str>) -> Option<Level> {
         "error" => Some(Level::Error),
         "warn" => Some(Level::Warn),
         "debug" => Some(Level::Debug),
-        "info" => Some(Level::Info),
-        // Logging is opt-in so normal server and client processes reserve no
-        // queue or writer thread. Unknown values fail closed for the same
-        // reason instead of silently enabling background work.
-        _ => None,
+        "" | "info" => Some(Level::Info),
+        _ => Some(Level::Info),
     }
 }
 
@@ -86,9 +83,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unset_level_disables_logging() {
-        assert_eq!(configured_level_value(None), None);
-        assert_eq!(configured_level_value(Some("")), None);
+    fn unset_level_uses_info_logging() {
+        assert_eq!(configured_level_value(None), Some(Level::Info));
+        assert_eq!(configured_level_value(Some("")), Some(Level::Info));
         assert_eq!(configured_level_value(Some("off")), None);
     }
 
@@ -99,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_level_disables_logging() {
-        assert_eq!(configured_level_value(Some("surprise")), None);
+    fn unknown_level_uses_info_logging() {
+        assert_eq!(configured_level_value(Some("surprise")), Some(Level::Info));
     }
 }

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -58,7 +58,12 @@ pub(crate) fn log_dir_writable() -> bool {
 }
 
 fn configured_level() -> Option<Level> {
-    match std::env::var("LUVUS_LOG")
+    let value = std::env::var("LUVUS_LOG").ok();
+    configured_level_value(value.as_deref())
+}
+
+fn configured_level_value(value: Option<&str>) -> Option<Level> {
+    match value
         .unwrap_or_default()
         .trim()
         .to_ascii_lowercase()
@@ -68,8 +73,11 @@ fn configured_level() -> Option<Level> {
         "error" => Some(Level::Error),
         "warn" => Some(Level::Warn),
         "debug" => Some(Level::Debug),
-        "" | "info" => Some(Level::Info),
-        _ => Some(Level::Info),
+        "info" => Some(Level::Info),
+        // Logging is opt-in so normal server and client processes reserve no
+        // queue or writer thread. Unknown values fail closed for the same
+        // reason instead of silently enabling background work.
+        _ => None,
     }
 }
 
@@ -78,9 +86,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unknown_level_is_info() {
-        std::env::set_var("LUVUS_LOG", "surprise");
-        assert_eq!(configured_level(), Some(Level::Info));
-        std::env::remove_var("LUVUS_LOG");
+    fn unset_level_disables_logging() {
+        assert_eq!(configured_level_value(None), None);
+        assert_eq!(configured_level_value(Some("")), None);
+        assert_eq!(configured_level_value(Some("off")), None);
+    }
+
+    #[test]
+    fn explicit_info_level_enables_logging() {
+        assert_eq!(configured_level_value(Some("info")), Some(Level::Info));
+        assert_eq!(configured_level_value(Some(" DEBUG ")), Some(Level::Debug));
+    }
+
+    #[test]
+    fn unknown_level_disables_logging() {
+        assert_eq!(configured_level_value(Some("surprise")), None);
     }
 }

--- a/src/logging/redact.rs
+++ b/src/logging/redact.rs
@@ -488,12 +488,12 @@ pub enum EventKind {
     ClientResize,
     ClientFrameError,
     ClientRenderFailed,
-    LogOverflow,
     LogWriteRecovered,
     UhpConnectionOpen,
     UhpConnectionClose,
     UhpRequestStart,
     UhpRequestComplete,
+    UhpRequestFailed,
     UhpRequestRejected,
     UhpSubscriptionOpen,
     UhpSubscriptionClose,
@@ -540,12 +540,12 @@ impl EventKind {
             Self::ClientResize => "client.resize",
             Self::ClientFrameError => "client.frame_error",
             Self::ClientRenderFailed => "client.render_failed",
-            Self::LogOverflow => "log.overflow",
             Self::LogWriteRecovered => "log.write_recovered",
             Self::UhpConnectionOpen => "uhp.connection.open",
             Self::UhpConnectionClose => "uhp.connection.close",
             Self::UhpRequestStart => "uhp.request.start",
             Self::UhpRequestComplete => "uhp.request.complete",
+            Self::UhpRequestFailed => "uhp.request.failed",
             Self::UhpRequestRejected => "uhp.request.rejected",
             Self::UhpSubscriptionOpen => "uhp.subscription.open",
             Self::UhpSubscriptionClose => "uhp.subscription.close",
@@ -563,8 +563,8 @@ impl EventKind {
             | Self::WorkerFailed
             | Self::ClientDisconnect
             | Self::ClientFrameError
-            | Self::LogOverflow
             | Self::LogWriteRecovered
+            | Self::UhpRequestFailed
             | Self::UhpRequestRejected => Level::Warn,
             Self::PersistSave
             | Self::ServerClientResize
@@ -574,7 +574,8 @@ impl EventKind {
             | Self::ClientResize
             | Self::UhpConnectionOpen
             | Self::UhpConnectionClose
-            | Self::UhpRequestStart => Level::Debug,
+            | Self::UhpRequestStart
+            | Self::UhpRequestComplete => Level::Debug,
             _ => Level::Info,
         }
     }
@@ -591,7 +592,7 @@ impl EventKind {
             | Self::ClientResize
             | Self::ClientFrameError
             | Self::ClientRenderFailed => Some(LoggerKind::Client),
-            Self::LogOverflow | Self::LogWriteRecovered => None,
+            Self::LogWriteRecovered => None,
             _ => Some(LoggerKind::Server),
         }
     }
@@ -650,10 +651,9 @@ impl EventKind {
             E::ClientDisconnect => matches!(key, F::Reason),
             E::ClientResize => matches!(key, F::Cols | F::Rows),
             E::ClientFrameError => matches!(key, F::ErrorCode),
-            E::LogOverflow => matches!(key, F::Dropped),
             E::LogWriteRecovered => matches!(key, F::ErrorCode | F::Dropped),
             E::UhpRequestStart => matches!(key, F::RequestId | F::Method | F::IdOmitted),
-            E::UhpRequestComplete => matches!(
+            E::UhpRequestComplete | E::UhpRequestFailed => matches!(
                 key,
                 F::RequestId | F::Method | F::Outcome | F::ErrorCode | F::DurationMs | F::IdOmitted
             ),
@@ -695,5 +695,8 @@ mod tests {
         assert!(!EventKind::PaneOpen.allows(FieldKey::RequestId));
         assert!(EventKind::UhpRequestComplete.allows(FieldKey::DurationMs));
         assert!(!EventKind::UhpRequestComplete.allows(FieldKey::PaneId));
+        assert_eq!(EventKind::UhpRequestComplete.level(), Level::Debug);
+        assert_eq!(EventKind::UhpRequestFailed.level(), Level::Warn);
+        assert!(EventKind::UhpRequestFailed.allows(FieldKey::ErrorCode));
     }
 }

--- a/src/logging/writer.rs
+++ b/src/logging/writer.rs
@@ -1,22 +1,13 @@
 use std::array;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
-use std::sync::{Arc, Mutex};
-use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant, SystemTime};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
 
 use serde_json::{Map, Value};
 
 use super::redact::{EventKind, Field, Level, LoggerKind, Role, MAX_FIELDS};
 use super::{rotate, timestamp};
 
-// Logging is opt-in. Keep its explicitly enabled footprint small while retaining
-// enough room to absorb short lifecycle and UHP bursts without blocking callers.
-const QUEUE_CAPACITY: usize = 32;
-const WRITER_STACK_BYTES: usize = 128 * 1024;
 const MAX_RECORD_BYTES: usize = 4096;
-const MAX_BATCH: usize = 64;
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[derive(Clone, Copy)]
 pub(crate) struct Record {
@@ -55,50 +46,18 @@ impl Record {
     }
 }
 
-// Boxing `Record` would allocate on every producer call. The size difference is
-// deliberate: the fixed record keeps the app-loop path allocation-free.
-#[allow(clippy::large_enum_variant)]
-enum Message {
-    Record(Record),
-    Shutdown(mpsc::SyncSender<()>),
-}
-
 pub(crate) struct Logger {
     role: Role,
     threshold: Option<Level>,
-    sender: Option<SyncSender<Message>>,
-    dropped: Arc<[AtomicU64; 2]>,
-    handle: Mutex<Option<JoinHandle<()>>>,
-    shutting_down: AtomicBool,
+    io_dropped: [AtomicU64; 2],
 }
 
 impl Logger {
     pub(crate) fn start(role: Role, threshold: Option<Level>) -> Self {
-        let dropped = Arc::new(array::from_fn(|_| AtomicU64::new(0)));
-        let Some(threshold) = threshold else {
-            return Self {
-                role,
-                threshold: None,
-                sender: None,
-                dropped,
-                handle: Mutex::new(None),
-                shutting_down: AtomicBool::new(false),
-            };
-        };
-        let (sender, receiver) = mpsc::sync_channel(QUEUE_CAPACITY);
-        let writer_drops = Arc::clone(&dropped);
-        let handle = thread::Builder::new()
-            .name("luvus-log-writer".into())
-            .stack_size(WRITER_STACK_BYTES)
-            .spawn(move || writer_loop(receiver, role, writer_drops))
-            .ok();
         Self {
             role,
-            threshold: Some(threshold),
-            sender: handle.as_ref().map(|_| sender),
-            dropped,
-            handle: Mutex::new(handle),
-            shutting_down: AtomicBool::new(false),
+            threshold,
+            io_dropped: array::from_fn(|_| AtomicU64::new(0)),
         }
     }
 
@@ -109,134 +68,38 @@ impl Logger {
         let Some(logger) = kind.logger() else {
             return;
         };
-        if kind.level() > threshold
-            || !self.role.permits(logger)
-            || self.shutting_down.load(Ordering::Relaxed)
-        {
+        if kind.level() > threshold || !self.role.permits(logger) {
             return;
         }
-        let Some(sender) = &self.sender else {
-            return;
-        };
-        match sender.try_send(Message::Record(Record::new(kind, fields))) {
-            Ok(()) => {}
-            Err(TrySendError::Full(Message::Record(record)))
-            | Err(TrySendError::Disconnected(Message::Record(record))) => {
-                self.dropped[index(record.logger(self.role))].fetch_add(1, Ordering::Relaxed);
-            }
-            Err(TrySendError::Full(Message::Shutdown(_)))
-            | Err(TrySendError::Disconnected(Message::Shutdown(_))) => {}
-        }
+        write_record(self.role, Record::new(kind, fields), &self.io_dropped);
     }
 
-    pub(crate) fn shutdown(&self) {
-        if self.shutting_down.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        let Some(sender) = &self.sender else {
-            return;
-        };
-        let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
-        let (ack_sender, ack_receiver) = mpsc::sync_channel(0);
-        let mut message = Message::Shutdown(ack_sender);
-        loop {
-            match sender.try_send(message) {
-                Ok(()) => break,
-                Err(TrySendError::Full(returned)) if Instant::now() < deadline => {
-                    message = returned;
-                    thread::yield_now();
-                }
-                Err(_) => return,
-            }
-        }
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if ack_receiver.recv_timeout(remaining).is_ok() {
-            if let Ok(mut handle) = self.handle.lock() {
-                if let Some(handle) = handle.take() {
-                    let _ = handle.join();
-                }
-            }
-        }
-    }
+    pub(crate) fn shutdown(&self) {}
 }
 
-fn writer_loop(receiver: Receiver<Message>, role: Role, dropped: Arc<[AtomicU64; 2]>) {
-    // I/O failures are tracked only by the writer. Producer-side queue drops use
-    // the atomics above, so a temporary disk failure cannot turn the hot path
-    // into an error-reporting or retry path.
-    let mut io_dropped = [0_u64; 2];
-    loop {
-        let Ok(first) = receiver.recv() else {
-            return;
-        };
-        let mut records = Vec::with_capacity(MAX_BATCH);
-        let mut shutdown = None;
-        match first {
-            Message::Record(record) => records.push(record),
-            Message::Shutdown(ack) => shutdown = Some(ack),
-        }
-        while shutdown.is_none() && records.len() < MAX_BATCH {
-            match receiver.try_recv() {
-                Ok(Message::Record(record)) => records.push(record),
-                Ok(Message::Shutdown(ack)) => shutdown = Some(ack),
-                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
-            }
-        }
-        write_batch(role, &records, &dropped, &mut io_dropped);
-        if let Some(ack) = shutdown {
-            let _ = ack.send(());
-            return;
+fn write_record(role: Role, record: Record, io_dropped: &[AtomicU64; 2]) {
+    let kind = record.logger(role);
+    let Some(line) = encode(record, kind) else {
+        io_dropped[index(kind)].fetch_add(1, Ordering::Relaxed);
+        return;
+    };
+    let dropped_count = io_dropped[index(kind)].swap(0, Ordering::AcqRel);
+    let mut encoded = Vec::with_capacity(usize::from(dropped_count > 0) + 1);
+    if dropped_count > 0 {
+        let recovered = Record::new(
+            EventKind::LogWriteRecovered,
+            &[
+                Field::ErrorCode(super::SafeId::new("io").expect("static safe id")),
+                Field::Dropped(dropped_count),
+            ],
+        );
+        if let Some(recovered) = encode(recovered, kind) {
+            encoded.push(recovered);
         }
     }
-}
-
-fn write_batch(
-    role: Role,
-    records: &[Record],
-    dropped: &[AtomicU64; 2],
-    io_dropped: &mut [u64; 2],
-) {
-    for kind in [LoggerKind::Server, LoggerKind::Client] {
-        if !role.permits(kind) {
-            continue;
-        }
-        let mut encoded = Vec::new();
-        let dropped_count = dropped[index(kind)].swap(0, Ordering::AcqRel);
-        if dropped_count > 0 {
-            let overflow = Record::new(EventKind::LogOverflow, &[Field::Dropped(dropped_count)]);
-            if let Some(line) = encode(overflow, kind) {
-                encoded.push(line);
-            }
-        }
-        if io_dropped[index(kind)] > 0 {
-            let recovered = Record::new(
-                EventKind::LogWriteRecovered,
-                &[
-                    Field::ErrorCode(super::SafeId::new("io").expect("static safe id")),
-                    Field::Dropped(io_dropped[index(kind)]),
-                ],
-            );
-            if let Some(line) = encode(recovered, kind) {
-                encoded.push(line);
-            }
-        }
-        for record in records
-            .iter()
-            .copied()
-            .filter(|record| record.logger(role) == kind)
-        {
-            if let Some(line) = encode(record, kind) {
-                encoded.push(line);
-            } else {
-                dropped[index(kind)].fetch_add(1, Ordering::Relaxed);
-            }
-        }
-        if let Err(_error) = rotate::append_records(kind, &encoded) {
-            io_dropped[index(kind)] = io_dropped[index(kind)]
-                .saturating_add(u64::try_from(encoded.len()).unwrap_or(u64::MAX));
-        } else {
-            io_dropped[index(kind)] = 0;
-        }
+    encoded.push(line);
+    if rotate::append_records(kind, &encoded).is_err() {
+        io_dropped[index(kind)].fetch_add(dropped_count.saturating_add(1), Ordering::Relaxed);
     }
 }
 
@@ -294,8 +157,6 @@ mod tests {
     fn off_starts_no_writer_and_creates_no_directory() {
         let _env = crate::persist::test_env("logging-off");
         let logger = Logger::start(Role::Server, None);
-        assert!(logger.sender.is_none());
-        assert!(logger.handle.lock().unwrap().is_none());
         logger.event(EventKind::ServerStart, &[Field::Role(Role::Server)]);
         logger.shutdown();
         assert!(!super::super::path::log_dir().exists());
@@ -306,11 +167,11 @@ mod tests {
         let _env = crate::persist::test_env("logging-writer");
         let logger = Logger::start(Role::Server, Some(Level::Info));
         logger.event(EventKind::ServerStart, &[Field::Role(Role::Server)]);
-        logger.shutdown();
         let text =
             std::fs::read_to_string(super::super::path::log_path(LoggerKind::Server)).unwrap();
         assert!(text.contains("\"event\":\"server.start\""));
         assert!(!text.contains("prompt text"));
+        logger.shutdown();
     }
 
     #[test]
@@ -355,49 +216,31 @@ mod tests {
         let dir = super::super::path::log_dir();
         std::fs::create_dir_all(dir.parent().expect("log dir has a session parent")).unwrap();
         std::fs::write(&dir, b"not a directory").unwrap();
-        let dropped = array::from_fn(|_| AtomicU64::new(0));
-        let mut io_dropped = [0_u64; 2];
-        write_batch(
+        let io_dropped = array::from_fn(|_| AtomicU64::new(0));
+        write_record(
             Role::Server,
-            &[Record::new(EventKind::ServerStart, &[])],
-            &dropped,
-            &mut io_dropped,
+            Record::new(EventKind::ServerStart, &[]),
+            &io_dropped,
         );
-        assert_eq!(io_dropped[index(LoggerKind::Server)], 1);
+        assert_eq!(
+            io_dropped[index(LoggerKind::Server)].load(Ordering::Relaxed),
+            1
+        );
 
         std::fs::remove_file(&dir).unwrap();
-        write_batch(
+        write_record(
             Role::Server,
-            &[Record::new(EventKind::ServerReady, &[])],
-            &dropped,
-            &mut io_dropped,
+            Record::new(EventKind::ServerReady, &[]),
+            &io_dropped,
         );
-        assert_eq!(io_dropped[index(LoggerKind::Server)], 0);
+        assert_eq!(
+            io_dropped[index(LoggerKind::Server)].load(Ordering::Relaxed),
+            0
+        );
         let text =
             std::fs::read_to_string(super::super::path::log_path(LoggerKind::Server)).unwrap();
         assert!(text.contains("\"event\":\"log.write_recovered\""));
         assert!(text.contains("\"error_code\":\"io\""));
         assert!(text.contains("\"dropped\":1"));
-    }
-
-    #[test]
-    fn full_producer_queue_drops_without_waiting_for_a_reader() {
-        let (sender, _receiver) = mpsc::sync_channel(1);
-        let logger = Logger {
-            role: Role::Server,
-            threshold: Some(Level::Info),
-            sender: Some(sender),
-            dropped: Arc::new(array::from_fn(|_| AtomicU64::new(0))),
-            handle: Mutex::new(None),
-            shutting_down: AtomicBool::new(false),
-        };
-        logger.event(EventKind::ServerStart, &[]);
-        let started = Instant::now();
-        logger.event(EventKind::ServerReady, &[]);
-        assert!(started.elapsed() < Duration::from_millis(10));
-        assert_eq!(
-            logger.dropped[index(LoggerKind::Server)].load(Ordering::Relaxed),
-            1
-        );
     }
 }

--- a/src/logging/writer.rs
+++ b/src/logging/writer.rs
@@ -49,7 +49,21 @@ impl Record {
 pub(crate) struct Logger {
     role: Role,
     threshold: Option<Level>,
-    io_dropped: [AtomicU64; 2],
+    dropped: DropCounters,
+}
+
+struct DropCounters {
+    encode: [AtomicU64; 2],
+    io: [AtomicU64; 2],
+}
+
+impl DropCounters {
+    fn new() -> Self {
+        Self {
+            encode: array::from_fn(|_| AtomicU64::new(0)),
+            io: array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
 }
 
 impl Logger {
@@ -57,7 +71,7 @@ impl Logger {
         Self {
             role,
             threshold,
-            io_dropped: array::from_fn(|_| AtomicU64::new(0)),
+            dropped: DropCounters::new(),
         }
     }
 
@@ -71,36 +85,65 @@ impl Logger {
         if kind.level() > threshold || !self.role.permits(logger) {
             return;
         }
-        write_record(self.role, Record::new(kind, fields), &self.io_dropped);
+        write_record(self.role, Record::new(kind, fields), &self.dropped);
     }
 
     pub(crate) fn shutdown(&self) {}
 }
 
-fn write_record(role: Role, record: Record, io_dropped: &[AtomicU64; 2]) {
+fn write_record(role: Role, record: Record, dropped: &DropCounters) {
     let kind = record.logger(role);
+    let counter = index(kind);
     let Some(line) = encode(record, kind) else {
-        io_dropped[index(kind)].fetch_add(1, Ordering::Relaxed);
+        dropped.encode[counter].fetch_add(1, Ordering::Relaxed);
         return;
     };
-    let dropped_count = io_dropped[index(kind)].swap(0, Ordering::AcqRel);
-    let mut encoded = Vec::with_capacity(usize::from(dropped_count > 0) + 1);
-    if dropped_count > 0 {
-        let recovered = Record::new(
-            EventKind::LogWriteRecovered,
-            &[
-                Field::ErrorCode(super::SafeId::new("io").expect("static safe id")),
-                Field::Dropped(dropped_count),
-            ],
-        );
-        if let Some(recovered) = encode(recovered, kind) {
-            encoded.push(recovered);
-        }
+    let encode_count = dropped.encode[counter].swap(0, Ordering::AcqRel);
+    let io_count = dropped.io[counter].swap(0, Ordering::AcqRel);
+    let mut encoded =
+        Vec::with_capacity(usize::from(encode_count > 0) + usize::from(io_count > 0) + 1);
+    let encode_recovery = recovery_line(kind, "encode", encode_count);
+    let encode_recovery_pending = encode_recovery.is_some();
+    if let Some(recovery) = encode_recovery {
+        encoded.push(recovery);
+    } else if encode_count > 0 {
+        dropped.encode[counter].fetch_add(encode_count.saturating_add(1), Ordering::Relaxed);
+    }
+    let io_recovery = recovery_line(kind, "io", io_count);
+    let io_recovery_pending = io_recovery.is_some();
+    if let Some(recovery) = io_recovery {
+        encoded.push(recovery);
+    } else if io_count > 0 {
+        dropped.io[counter].fetch_add(io_count, Ordering::Relaxed);
+        dropped.encode[counter].fetch_add(1, Ordering::Relaxed);
     }
     encoded.push(line);
     if rotate::append_records(kind, &encoded).is_err() {
-        io_dropped[index(kind)].fetch_add(dropped_count.saturating_add(1), Ordering::Relaxed);
+        if encode_recovery_pending {
+            dropped.encode[counter].fetch_add(encode_count, Ordering::Relaxed);
+        }
+        if io_recovery_pending {
+            dropped.io[counter].fetch_add(io_count, Ordering::Relaxed);
+        }
+        dropped.io[counter].fetch_add(1, Ordering::Relaxed);
     }
+}
+
+fn recovery_line(kind: LoggerKind, error_code: &'static str, count: u64) -> Option<Vec<u8>> {
+    (count > 0).then(|| {
+        encode(
+            Record::new(
+                EventKind::LogWriteRecovered,
+                &[
+                    Field::ErrorCode(
+                        super::SafeId::new(error_code).expect("static safe identifier"),
+                    ),
+                    Field::Dropped(count),
+                ],
+            ),
+            kind,
+        )
+    })?
 }
 
 fn encode(record: Record, logger: LoggerKind) -> Option<Vec<u8>> {
@@ -216,25 +259,29 @@ mod tests {
         let dir = super::super::path::log_dir();
         std::fs::create_dir_all(dir.parent().expect("log dir has a session parent")).unwrap();
         std::fs::write(&dir, b"not a directory").unwrap();
-        let io_dropped = array::from_fn(|_| AtomicU64::new(0));
+        let dropped = DropCounters::new();
         write_record(
             Role::Server,
             Record::new(EventKind::ServerStart, &[]),
-            &io_dropped,
+            &dropped,
         );
         assert_eq!(
-            io_dropped[index(LoggerKind::Server)].load(Ordering::Relaxed),
+            dropped.io[index(LoggerKind::Server)].load(Ordering::Relaxed),
             1
+        );
+        assert_eq!(
+            dropped.encode[index(LoggerKind::Server)].load(Ordering::Relaxed),
+            0
         );
 
         std::fs::remove_file(&dir).unwrap();
         write_record(
             Role::Server,
             Record::new(EventKind::ServerReady, &[]),
-            &io_dropped,
+            &dropped,
         );
         assert_eq!(
-            io_dropped[index(LoggerKind::Server)].load(Ordering::Relaxed),
+            dropped.io[index(LoggerKind::Server)].load(Ordering::Relaxed),
             0
         );
         let text =
@@ -242,5 +289,25 @@ mod tests {
         assert!(text.contains("\"event\":\"log.write_recovered\""));
         assert!(text.contains("\"error_code\":\"io\""));
         assert!(text.contains("\"dropped\":1"));
+    }
+
+    #[test]
+    fn writer_reports_encode_recovery_separately_from_io() {
+        let _env = crate::persist::test_env("logging-encode-recovery");
+        let dropped = DropCounters::new();
+        dropped.encode[index(LoggerKind::Server)].store(2, Ordering::Relaxed);
+
+        write_record(
+            Role::Server,
+            Record::new(EventKind::ServerReady, &[]),
+            &dropped,
+        );
+
+        let text =
+            std::fs::read_to_string(super::super::path::log_path(LoggerKind::Server)).unwrap();
+        assert!(text.contains("\"event\":\"log.write_recovered\""));
+        assert!(text.contains("\"error_code\":\"encode\""));
+        assert!(text.contains("\"dropped\":2"));
+        assert!(!text.contains("\"error_code\":\"io\""));
     }
 }

--- a/src/logging/writer.rs
+++ b/src/logging/writer.rs
@@ -10,8 +10,10 @@ use serde_json::{Map, Value};
 use super::redact::{EventKind, Field, Level, LoggerKind, Role, MAX_FIELDS};
 use super::{rotate, timestamp};
 
-const QUEUE_CAPACITY: usize = 256;
-const WRITER_STACK_BYTES: usize = 256 * 1024;
+// Logging is opt-in. Keep its explicitly enabled footprint small while retaining
+// enough room to absorb short lifecycle and UHP bursts without blocking callers.
+const QUEUE_CAPACITY: usize = 32;
+const WRITER_STACK_BYTES: usize = 128 * 1024;
 const MAX_RECORD_BYTES: usize = 4096;
 const MAX_BATCH: usize = 64;
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(100);
@@ -292,6 +294,8 @@ mod tests {
     fn off_starts_no_writer_and_creates_no_directory() {
         let _env = crate::persist::test_env("logging-off");
         let logger = Logger::start(Role::Server, None);
+        assert!(logger.sender.is_none());
+        assert!(logger.handle.lock().unwrap().is_none());
         logger.event(EventKind::ServerStart, &[Field::Role(Role::Server)]);
         logger.shutdown();
         assert!(!super::super::path::log_dir().exists());

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -53,12 +53,12 @@ pane was running.
 
 ## Where can I find runtime diagnostics?
 
-Luvus can keep private structured diagnostics in the selected session
-directory. Logging is disabled by default; start the relevant process with
-`LUVUS_LOG=info` to enable it. The default session then writes
+Luvus keeps private structured diagnostics in the selected session directory at
+the `info` level by default. The default session writes
 `~/.luvus/logs/server.log` and `~/.luvus/logs/client.log`. Read recent records
 with ordinary tools such as `tail -n 200 ~/.luvus/logs/server.log`. Named
-sessions keep the same files under `~/.luvus/sessions/<name>/logs/`.
+sessions keep the same files under `~/.luvus/sessions/<name>/logs/`. Set
+`LUVUS_LOG=off` before starting a process only when you need to disable logging.
 
 Logs never include pane output, prompts, keystrokes, file contents, command
 arguments, or UHP request bodies. They can still describe your local runtime,

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -53,11 +53,12 @@ pane was running.
 
 ## Where can I find runtime diagnostics?
 
-Luvus keeps private structured diagnostics in the selected session directory.
-The default session writes `~/.luvus/logs/server.log` and
-`~/.luvus/logs/client.log`. Read recent records with ordinary tools such as
-`tail -n 200 ~/.luvus/logs/server.log`. Named sessions keep the same files under
-`~/.luvus/sessions/<name>/logs/`.
+Luvus can keep private structured diagnostics in the selected session
+directory. Logging is disabled by default; start the relevant process with
+`LUVUS_LOG=info` to enable it. The default session then writes
+`~/.luvus/logs/server.log` and `~/.luvus/logs/client.log`. Read recent records
+with ordinary tools such as `tail -n 200 ~/.luvus/logs/server.log`. Named
+sessions keep the same files under `~/.luvus/sessions/<name>/logs/`.
 
 Logs never include pane output, prompts, keystrokes, file contents, command
 arguments, or UHP request bodies. They can still describe your local runtime,

--- a/website/src/content/docs/docs/guides/runtime-logs.mdx
+++ b/website/src/content/docs/docs/guides/runtime-logs.mdx
@@ -3,8 +3,10 @@ title: Runtime Logs
 description: Diagnose Luvus server, client, pane, agent, and UHP failures with private structured logs.
 ---
 
-Luvus records bounded structured diagnostics for long-lived server and display
-client processes. Logging is local only. Nothing is uploaded.
+Luvus can record bounded structured diagnostics for long-lived server and
+display client processes. Logging is local only. Nothing is uploaded, and
+logging is disabled by default so normal processes reserve no logging thread or
+queue.
 
 ## Read the logs
 
@@ -21,18 +23,21 @@ its nearest existing parent is writable.
 Each line is one JSON record. `server.log` and `client.log` rotate at 3 MiB and
 keep one archived file, which caps both streams at 12 MiB per session.
 
-## Choose a level
+## Enable logging
 
-The default is `info`. Set `LUVUS_LOG` before starting the relevant process:
+Set `LUVUS_LOG` before starting the relevant process:
 
 ```sh
+LUVUS_LOG=info luvus server restart
 LUVUS_LOG=debug luvus server restart
 LUVUS_LOG=off luvus server restart
 ```
 
-Supported values are `debug`, `info`, `warn`, `error`, and `off`. `off` starts
-no writer thread and creates no log directory. A running server keeps the level
-it had at startup, so restart it after changing the variable.
+Supported values are `debug`, `info`, `warn`, `error`, and `off`. An unset,
+empty, `off`, or unrecognized value starts no writer thread and creates no log
+directory. Explicitly enabled logging uses a small bounded background queue so
+filesystem writes never block the application loop. A running server keeps the
+level it had at startup, so restart it after changing the variable.
 
 ## Privacy
 

--- a/website/src/content/docs/docs/guides/runtime-logs.mdx
+++ b/website/src/content/docs/docs/guides/runtime-logs.mdx
@@ -3,10 +3,8 @@ title: Runtime Logs
 description: Diagnose Luvus server, client, pane, agent, and UHP failures with private structured logs.
 ---
 
-Luvus can record bounded structured diagnostics for long-lived server and
-display client processes. Logging is local only. Nothing is uploaded, and
-logging is disabled by default so normal processes reserve no logging thread or
-queue.
+Luvus records bounded structured diagnostics for long-lived server and display
+client processes. Logging is local only. Nothing is uploaded.
 
 ## Read the logs
 
@@ -23,9 +21,10 @@ its nearest existing parent is writable.
 Each line is one JSON record. `server.log` and `client.log` rotate at 3 MiB and
 keep one archived file, which caps both streams at 12 MiB per session.
 
-## Enable logging
+## Choose a level
 
-Set `LUVUS_LOG` before starting the relevant process:
+Logging uses the `info` level by default. Set `LUVUS_LOG` before starting the
+relevant process to change or disable it:
 
 ```sh
 LUVUS_LOG=info luvus server restart
@@ -33,11 +32,11 @@ LUVUS_LOG=debug luvus server restart
 LUVUS_LOG=off luvus server restart
 ```
 
-Supported values are `debug`, `info`, `warn`, `error`, and `off`. An unset,
-empty, `off`, or unrecognized value starts no writer thread and creates no log
-directory. Explicitly enabled logging uses a small bounded background queue so
-filesystem writes never block the application loop. A running server keeps the
-level it had at startup, so restart it after changing the variable.
+Supported values are `debug`, `info`, `warn`, `error`, and `off`. Unset, empty,
+and unrecognized values use `info`. Logging writes directly through the bounded
+rotating file writer and starts no logging thread or record queue. `off` also
+avoids creating the log directory. A running server keeps the level it had at
+startup, so restart it after changing the variable.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary

- keep private structured runtime logging enabled at the `info` level by default
- remove the dedicated logging thread, record channel, queue storage, and shutdown handoff
- write records directly through the existing private rotating file writer and cross-process lock
- move successful routine UHP completion records to `debug` while keeping failed requests at `warn`
- preserve allowlisted fields, 4 KiB record limits, 3 MiB rotation, one archive, and write-recovery reporting
- document the default level, supported `LUVUS_LOG` values, and threadless writer behavior

## Runtime behavior

Unset, empty, and unrecognized `LUVUS_LOG` values use `info`. Supported overrides are `error`, `warn`, `info`, `debug`, and `off`. Only `off` disables file creation.

The logger now has no dedicated thread or queue. Direct writes can briefly wait for the filesystem lock or storage, so routine successful UHP request telemetry is filtered at the default level. Domain lifecycle events and failures remain available.

## Performance check

The isolated 10-pane quick benchmark reported:

- release server: 26 threads
- release client: 2 threads
- combined idle physical memory: 18.94 MiB
- release CLI p95: 3.40 ms
- cleanup errors: none

This removes one writer thread from both the server and client processes.

## Validation

- `cargo test logging:: -- --nocapture`
- `cargo test request_log_preserves_missing_and_valid_id_state -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release --locked`
- isolated quick runtime benchmark with 10 panes
- `git diff --check`

Focused tests and the runtime benchmark passed on macOS. Windows runtime behavior remains covered by CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Runtime diagnostics logging now defaults to the `info` level.
  * Unset, empty, or unrecognized `LUVUS_LOG` values use `info`; set `LUVUS_LOG=off` to disable logging.
  * Log records are written directly, without a background logging queue.
  * Failed requests are reported as warnings, while successful completions are recorded at debug level.
  * Recovery messages now distinguish between records dropped during encoding and writing.

* **Documentation**
  * Updated the FAQ and runtime logging guide with the new defaults, configuration instructions, and log access details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->