### PR TITLE
feat(files): open folder as workspace from menu

### DIFF
--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -563,18 +563,26 @@ impl App {
                 }
             }
             FileMenuItem::OpenAsNewWorkspace => {
-                // Same focus-or-create rule as `workspace.open`: an already-open
-                // cwd is focused; otherwise spawn a new workspace there.
-                match self
-                    .workspaces
-                    .iter()
-                    .position(|w| crate::platform::same_path(&w.cwd, &menu.path))
-                {
+                // Focus-or-create like `workspace.open`, but resolve symlinks
+                // first. `same_path` is lexical only (no IO), so a FILES row
+                // reached through a symlink-spelled root would otherwise miss a
+                // workspace that stores the canonical cwd and open a duplicate.
+                // One click can afford the canonicalize; hot-path lookups cannot.
+                let target =
+                    std::fs::canonicalize(&menu.path).unwrap_or_else(|_| menu.path.clone());
+                match self.workspaces.iter().position(|w| {
+                    let cwd = std::fs::canonicalize(&w.cwd).unwrap_or_else(|_| w.cwd.clone());
+                    crate::platform::same_path(&cwd, &target)
+                }) {
                     Some(i) => self.active_ws = i,
                     None => {
                         let _ = self.create_workspace_at(menu.path);
                     }
                 }
+                // `active_ws` / `create_workspace_at` alone leave `file_tree` on
+                // the previous root until the next `detect_tick`. Re-root now so
+                // the dock the user just clicked in matches the new workspace.
+                self.ensure_file_tree();
             }
             FileMenuItem::Delete => self.file_delete = Some(menu.path),
             FileMenuItem::Divider => {}
@@ -3416,6 +3424,10 @@ mod tests {
         let dir = std::env::temp_dir().join("luvus-open-as-ws-new");
         let _ = std::fs::create_dir_all(&dir);
 
+        app.sidebars.left.docks.push(DockKind::Files);
+        app.ensure_file_tree();
+        let previous_root = app.file_tree.root().to_path_buf();
+
         app.file_menu = Some(FileMenu {
             path: dir.clone(),
             is_dir: true,
@@ -3434,6 +3446,14 @@ mod tests {
             crate::platform::same_path(&app.workspaces[app.active_ws].cwd, &dir),
             "the new workspace is focused at the clicked folder"
         );
+        assert!(
+            crate::platform::same_path(app.file_tree.root(), &dir),
+            "FILES re-roots immediately, not on the next detect_tick"
+        );
+        assert!(
+            !crate::platform::same_path(app.file_tree.root(), &previous_root),
+            "tree left the previous workspace root"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -3451,6 +3471,12 @@ mod tests {
         // Focus something else so the action must move focus back.
         app.active_ws = 0;
         assert_ne!(app.active_ws, seeded);
+        app.sidebars.left.docks.push(DockKind::Files);
+        app.ensure_file_tree();
+        assert!(
+            !crate::platform::same_path(app.file_tree.root(), &dir),
+            "tree starts on the other workspace"
+        );
 
         app.file_menu = Some(FileMenu {
             path: dir.clone(),
@@ -3463,6 +3489,51 @@ mod tests {
 
         assert_eq!(app.workspaces.len(), count, "no duplicate workspace");
         assert_eq!(app.active_ws, seeded, "existing workspace is focused");
+        assert!(
+            crate::platform::same_path(app.file_tree.root(), &dir),
+            "FILES re-roots to the focused workspace immediately"
+        );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// FILES can reach a folder through a symlink spelling while the open
+    /// workspace stores the resolved cwd. Lexical `same_path` would miss it.
+    #[cfg(unix)]
+    #[test]
+    fn open_as_new_workspace_focuses_through_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let _env = crate::persist::test_env("files-open-as-ws-symlink");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+
+        let base = std::env::temp_dir().join("luvus-open-as-ws-symlink");
+        let real = base.join("real");
+        let link = base.join("link");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&real).unwrap();
+        symlink(&real, &link).unwrap();
+
+        let resolved = std::fs::canonicalize(&real).unwrap();
+        assert!(app.create_workspace_at(resolved), "seed at resolved path");
+        let seeded = app.active_ws;
+        let count = app.workspaces.len();
+        app.active_ws = 0;
+
+        app.file_menu = Some(FileMenu {
+            path: link.clone(),
+            is_dir: true,
+            anchor: (0, 0),
+            items: Vec::new(),
+            editors: Vec::new(),
+        });
+        app.file_menu_action_pub(FileMenuItem::OpenAsNewWorkspace);
+
+        assert_eq!(app.workspaces.len(), count, "symlink must not duplicate");
+        assert_eq!(
+            app.active_ws, seeded,
+            "symlink focuses the resolved workspace"
+        );
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -562,6 +562,20 @@ impl App {
                     InsertPath::NotUtf8 => self.show_toast("path is not valid UTF-8"),
                 }
             }
+            FileMenuItem::OpenAsNewWorkspace => {
+                // Same focus-or-create rule as `workspace.open`: an already-open
+                // cwd is focused; otherwise spawn a new workspace there.
+                match self
+                    .workspaces
+                    .iter()
+                    .position(|w| crate::platform::same_path(&w.cwd, &menu.path))
+                {
+                    Some(i) => self.active_ws = i,
+                    None => {
+                        let _ = self.create_workspace_at(menu.path);
+                    }
+                }
+            }
             FileMenuItem::Delete => self.file_delete = Some(menu.path),
             FileMenuItem::Divider => {}
         }
@@ -3350,5 +3364,105 @@ mod tests {
             let insert = items.iter().position(|i| *i == FileMenuItem::InsertPath);
             assert!(copy < insert, "it sits with Copy Path, just below it");
         }
+    }
+
+    // ── Open as New Workspace ────────────────────────────────────────────────
+
+    #[test]
+    fn open_as_new_workspace_is_offered_for_folders_only() {
+        let file = FileMenu {
+            path: PathBuf::from("/tmp/x.rs"),
+            is_dir: false,
+            anchor: (0, 0),
+            items: Vec::new(),
+            editors: Vec::new(),
+        };
+        let file_items = file.build_items();
+        assert!(
+            !file_items.contains(&FileMenuItem::OpenAsNewWorkspace),
+            "files do not get Open as New Workspace"
+        );
+
+        let folder = FileMenu {
+            path: PathBuf::from("/tmp"),
+            is_dir: true,
+            anchor: (0, 0),
+            items: Vec::new(),
+            editors: Vec::new(),
+        };
+        let folder_items = folder.build_items();
+        assert!(
+            folder_items.contains(&FileMenuItem::OpenAsNewWorkspace),
+            "folders get Open as New Workspace"
+        );
+        let insert = folder_items
+            .iter()
+            .position(|i| *i == FileMenuItem::InsertPath);
+        let open_ws = folder_items
+            .iter()
+            .position(|i| *i == FileMenuItem::OpenAsNewWorkspace);
+        assert!(
+            insert < open_ws,
+            "Open as New Workspace sits below Insert Path"
+        );
+    }
+
+    #[test]
+    fn open_as_new_workspace_creates_a_workspace_at_the_folder() {
+        let _env = crate::persist::test_env("files-open-as-ws");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let before = app.workspaces.len();
+        let dir = std::env::temp_dir().join("luvus-open-as-ws-new");
+        let _ = std::fs::create_dir_all(&dir);
+
+        app.file_menu = Some(FileMenu {
+            path: dir.clone(),
+            is_dir: true,
+            anchor: (0, 0),
+            items: Vec::new(),
+            editors: Vec::new(),
+        });
+        app.file_menu_action_pub(FileMenuItem::OpenAsNewWorkspace);
+
+        assert_eq!(
+            app.workspaces.len(),
+            before + 1,
+            "a new workspace was added"
+        );
+        assert!(
+            crate::platform::same_path(&app.workspaces[app.active_ws].cwd, &dir),
+            "the new workspace is focused at the clicked folder"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn open_as_new_workspace_focuses_an_already_open_workspace() {
+        let _env = crate::persist::test_env("files-open-as-ws-focus");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let dir = std::env::temp_dir().join("luvus-open-as-ws-focus");
+        let _ = std::fs::create_dir_all(&dir);
+        assert!(app.create_workspace_at(dir.clone()), "seed workspace");
+        let seeded = app.active_ws;
+        let count = app.workspaces.len();
+
+        // Focus something else so the action must move focus back.
+        app.active_ws = 0;
+        assert_ne!(app.active_ws, seeded);
+
+        app.file_menu = Some(FileMenu {
+            path: dir.clone(),
+            is_dir: true,
+            anchor: (0, 0),
+            items: Vec::new(),
+            editors: Vec::new(),
+        });
+        app.file_menu_action_pub(FileMenuItem::OpenAsNewWorkspace);
+
+        assert_eq!(app.workspaces.len(), count, "no duplicate workspace");
+        assert_eq!(app.active_ws, seeded, "existing workspace is focused");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -3409,10 +3409,7 @@ mod tests {
         let open_ws = folder_items
             .iter()
             .position(|i| *i == FileMenuItem::OpenAsNewWorkspace);
-        assert!(
-            insert < open_ws,
-            "Open as Workspace sits below Insert Path"
-        );
+        assert!(insert < open_ws, "Open as Workspace sits below Insert Path");
     }
 
     #[test]

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -3374,7 +3374,7 @@ mod tests {
         }
     }
 
-    // ── Open as New Workspace ────────────────────────────────────────────────
+    // ── Open as Workspace ────────────────────────────────────────────────────
 
     #[test]
     fn open_as_new_workspace_is_offered_for_folders_only() {
@@ -3388,7 +3388,7 @@ mod tests {
         let file_items = file.build_items();
         assert!(
             !file_items.contains(&FileMenuItem::OpenAsNewWorkspace),
-            "files do not get Open as New Workspace"
+            "files do not get Open as Workspace"
         );
 
         let folder = FileMenu {
@@ -3401,7 +3401,7 @@ mod tests {
         let folder_items = folder.build_items();
         assert!(
             folder_items.contains(&FileMenuItem::OpenAsNewWorkspace),
-            "folders get Open as New Workspace"
+            "folders get Open as Workspace"
         );
         let insert = folder_items
             .iter()
@@ -3411,7 +3411,7 @@ mod tests {
             .position(|i| *i == FileMenuItem::OpenAsNewWorkspace);
         assert!(
             insert < open_ws,
-            "Open as New Workspace sits below Insert Path"
+            "Open as Workspace sits below Insert Path"
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9848,13 +9848,26 @@ mod tests {
         use ratatui::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
         use ratatui::{backend::TestBackend, Terminal};
         let _env = crate::persist::test_env("cmd-inspect");
-        let (tx, _rx) = std::sync::mpsc::channel();
+        let (tx, rx) = std::sync::mpsc::channel();
         let mut app = App::new(120, 40, tx).unwrap();
 
         // Titles (and borders) only render on split panes, so split first — the
         // single-pane case is covered by the pane context menu instead.
         app.split(Axis::Col);
         let id = app.layout().focus;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(!remaining.is_zero(), "the split pane never became ready");
+            match rx.recv_timeout(remaining) {
+                Ok(AppEvent::PtyReady { id: ready, .. }) if ready == id => break,
+                Ok(AppEvent::PtyExit(exited)) if exited == id => {
+                    panic!("the split pane exited before becoming ready")
+                }
+                Ok(_) => {}
+                Err(error) => panic!("the split pane never became ready: {error}"),
+            }
+        }
         // Render once so the title strips are registered as click targets.
         let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -613,6 +613,8 @@ pub enum FileMenuItem {
     /// Type the path into the focused pane's prompt, without submitting it
     /// (docs/38 FILE-6). Offered for folders too, exactly like `CopyPath`.
     InsertPath,
+    /// Open this folder as a workspace (folders only), or focus it if already open.
+    OpenAsNewWorkspace,
     Divider,
     Delete,
 }
@@ -633,9 +635,11 @@ impl FileMenu {
             FileMenuItem::Rename,
             FileMenuItem::CopyPath,
             FileMenuItem::InsertPath,
-            FileMenuItem::Divider,
-            FileMenuItem::Delete,
         ]);
+        if self.is_dir {
+            v.push(FileMenuItem::OpenAsNewWorkspace);
+        }
+        v.extend([FileMenuItem::Divider, FileMenuItem::Delete]);
         v
     }
 }

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -634,6 +634,7 @@ fn file_label(it: FileMenuItem, editors: &[(String, String)]) -> String {
         FileMenuItem::Rename => "Rename".to_string(),
         FileMenuItem::CopyPath => "Copy Path".to_string(),
         FileMenuItem::InsertPath => "Insert Path".to_string(),
+        FileMenuItem::OpenAsNewWorkspace => "Open as New Workspace".to_string(),
         FileMenuItem::Divider => String::new(),
         FileMenuItem::Delete => "Delete".to_string(),
     }
@@ -681,8 +682,8 @@ mod label_case_tests {
     use crate::app::{AgentMenuItem, FileMenuItem, PaneMenuItem, TabMenuItem, WsMenuItem};
 
     /// Words that stay lower-case inside a title, unless they lead it.
-    const MINOR: [&str; 11] = [
-        "a", "an", "the", "to", "in", "on", "of", "for", "and", "or", "with",
+    const MINOR: [&str; 12] = [
+        "a", "an", "the", "to", "in", "on", "of", "for", "and", "or", "with", "as",
     ];
 
     #[test]
@@ -779,6 +780,7 @@ mod label_case_tests {
             FileMenuItem::Rename,
             FileMenuItem::CopyPath,
             FileMenuItem::InsertPath,
+            FileMenuItem::OpenAsNewWorkspace,
             FileMenuItem::Delete,
         ] {
             rows.push(file_label(it, &editors));

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -634,7 +634,7 @@ fn file_label(it: FileMenuItem, editors: &[(String, String)]) -> String {
         FileMenuItem::Rename => "Rename".to_string(),
         FileMenuItem::CopyPath => "Copy Path".to_string(),
         FileMenuItem::InsertPath => "Insert Path".to_string(),
-        FileMenuItem::OpenAsNewWorkspace => "Open as New Workspace".to_string(),
+        FileMenuItem::OpenAsNewWorkspace => "Open as Workspace".to_string(),
         FileMenuItem::Divider => String::new(),
         FileMenuItem::Delete => "Delete".to_string(),
     }

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -32,7 +32,7 @@ contains changes. Files created outside luvus, by an agent or a command in a
 pane, show up on their own within a couple of seconds.
 
 **Right-click a row** for New File, New Folder, Rename, Copy Path, Insert Path,
-Open as New Workspace (folders), and Delete (Delete always asks first).
+Open as Workspace (folders), and Delete (Delete always asks first).
 
 **Insert Path** types the selected file or folder's absolute path into the pane
 you were already working in, without submitting it — so you can name a file in a command or an

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -32,7 +32,7 @@ contains changes. Files created outside luvus, by an agent or a command in a
 pane, show up on their own within a couple of seconds.
 
 **Right-click a row** for New File, New Folder, Rename, Copy Path, Insert Path,
-and Delete (Delete always asks first).
+Open as New Workspace (folders), and Delete (Delete always asks first).
 
 **Insert Path** types the selected file or folder's absolute path into the pane
 you were already working in, without submitting it — so you can name a file in a command or an


### PR DESCRIPTION
Right-click a folder in the **FILES** sidebar to open it as a new workspace (or focus it if already open).

## What
- Adds **Open as New Workspace** to the **FILES** context menu, directly under Insert Path
- Offered for folders only (not files)
- If that folder is already a workspace, focuses it; otherwise opens it via the same path as `workspace.open`
- Documents the action in the files guide

## Why
Opening a project folder from the tree previously required the workspace picker or CLI. Putting
it next to Insert Path makes “start working here” a one-click path from FILES.

## Verification
- [x] Focused tests: `open_as_new_workspace`, `insert_path_is_offered`, `every_english_context_menu`
- [x] `cargo fmt --all --check`
- [x] `cargo test --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [x] Manual: right-click folder → Open as New Workspace; confirm new/focused workspace; confirm
item absent on files

## Notes
- No CLI/API/UHP changes (`workspace open` already exists)
- FILES menu labels stay hardcoded English (same as Insert Path)

Before:

<img width="231" height="242" alt="image" src="https://github.com/user-attachments/assets/190a5c59-0a9c-4886-9a9a-193749173f35" />

After:

<img width="306" height="228" alt="image" src="https://github.com/user-attachments/assets/37ad1ee3-2e78-4d4f-9a0d-d88a3e7c028c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Open as Workspace” option when right-clicking folders.
  - Selecting a folder focuses its existing workspace or opens a new workspace at that location.
  - Folders accessed through symlinks now correctly match existing workspaces, preventing duplicates.
  - The file tree updates immediately after opening or focusing a workspace.

- **Documentation**
  - Updated the FILES dock guide to include the new folder action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->