### PR TITLE
fix(orch): isolate ledger path during tests

### DIFF
--- a/src/orch/mod.rs
+++ b/src/orch/mod.rs
@@ -114,6 +114,10 @@ pub struct OrchState {
     next_task: u64,
     #[serde(default)]
     next_lease: u64,
+    /// Captured at load so later `save()` does not follow a process-global
+    /// session-dir change. Empty only on `Default` (in-memory, no persistence).
+    #[serde(skip)]
+    persist_path: PathBuf,
 }
 
 /// Why a mutation was rejected — carried to the API as a `(code, message)` error.
@@ -423,16 +427,26 @@ impl OrchState {
     // ── persistence (separate file; never touches session.json) ────────────
 
     pub fn load() -> OrchState {
-        match std::fs::read_to_string(orch_path()) {
+        Self::load_from(persist_path())
+    }
+
+    pub fn load_from(path: PathBuf) -> OrchState {
+        let mut state = match std::fs::read_to_string(&path) {
             Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
             Err(_) => OrchState::default(),
-        }
+        };
+        state.persist_path = path;
+        state
     }
 
     /// Atomic save (temp + rename), best-effort — a failed write never breaks
     /// the app; the ledger is a convenience layer, not core session state.
+    /// `Default` (empty `persist_path`) is in-memory only and does not write.
     pub fn save(&self) {
-        let path = orch_path();
+        let path = &self.persist_path;
+        if path.as_os_str().is_empty() {
+            return;
+        }
         if let Some(dir) = path.parent() {
             let _ = std::fs::create_dir_all(dir);
         }
@@ -441,13 +455,34 @@ impl OrchState {
         };
         let tmp = path.with_extension("json.tmp");
         if std::fs::write(&tmp, json).is_ok() {
-            let _ = std::fs::rename(&tmp, &path);
+            let _ = std::fs::rename(&tmp, path);
         }
     }
 }
 
-fn orch_path() -> PathBuf {
-    crate::persist::session_dir().join("orch.json")
+fn persist_path() -> PathBuf {
+    #[cfg(test)]
+    {
+        isolated_test_persist_path()
+    }
+    #[cfg(not(test))]
+    {
+        crate::persist::session_dir().join("orch.json")
+    }
+}
+
+/// Each `load()` in the test binary gets its own file so a test that never
+/// takes `test_env` cannot read or write whichever `$LUVUS_HOME` is currently
+/// active on another thread.
+#[cfg(test)]
+fn isolated_test_persist_path() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    std::env::temp_dir().join(format!(
+        "luvus-orch-test-{}-{}.json",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ))
 }
 
 fn unix_now() -> u64 {
@@ -717,5 +752,63 @@ mod tests {
         assert!(!paths_overlap("src/auth/**", "src/api/**"));
         assert!(!paths_overlap("src/a", "src/ab")); // segment boundary
         assert!(paths_overlap("src", "src/anything/deep"));
+    }
+
+    #[test]
+    fn load_from_roundtrips_through_an_explicit_path() {
+        let dir = std::env::temp_dir().join(format!("luvus-orch-roundtrip-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("orch.json");
+        let mut a = OrchState::load_from(path.clone());
+        a.add_task("auth".into(), vec![], vec![], None).unwrap();
+        a.save();
+        let b = OrchState::load_from(path);
+        assert_eq!(b.tasks.len(), 1);
+        assert_eq!(b.tasks[0].title, "auth");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_isolates_each_ledger_in_tests() {
+        let mut a = OrchState::load();
+        a.add_task("polluter".into(), vec![], vec![], None).unwrap();
+        a.save();
+        let b = OrchState::load();
+        assert!(
+            b.tasks.is_empty(),
+            "a later load must not pick up another ledger"
+        );
+    }
+
+    #[test]
+    fn save_stays_on_the_path_captured_at_load() {
+        let dir = std::env::temp_dir().join(format!("luvus-orch-captured-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("orch.json");
+        let mut a = OrchState::load_from(path.clone());
+        let _env = crate::persist::test_env("orch-captured-path");
+        a.add_task("stays".into(), vec![], vec![], None).unwrap();
+        a.save();
+        assert!(path.exists(), "saved to the captured path");
+        let leaked = crate::persist::session_dir().join("orch.json");
+        assert!(
+            !leaked.exists(),
+            "must not follow a later $LUVUS_HOME into session_dir"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn default_save_is_a_no_op() {
+        let _env = crate::persist::test_env("orch-default-noop");
+        let mut s = OrchState::default();
+        s.add_task("ghost".into(), vec![], vec![], None).unwrap();
+        s.save();
+        assert!(
+            !crate::persist::session_dir().join("orch.json").exists(),
+            "in-memory Default must not write the session ledger"
+        );
     }
 }


### PR DESCRIPTION
Test isolation no longer lets one orch test leak tasks into another via process-global `$LUVUS_HOME`.

Fixes #163

## What

- `OrchState` now stores the `orch.json` path captured at load. Later `save()` writes that path instead of re-reading the ambient session dir.
- In the test binary, each `load()` gets a unique temp file, so a test that never takes `test_env` cannot read or write whichever home another test currently holds.
- `OrchState::default()` stays in-memory: `save()` is a no-op without a captured path.
- Added tests for explicit-path roundtrip, per-load isolation, captured-path save, and default no-op.

## Why

`app::board::tests::wheel_scroll_moves_the_cursor_clamped` sometimes saw four tasks instead of the three it created. `OrchState::load()`/`save()` used `session_dir()`, which follows process-global `$LUVUS_HOME`. `test_env` serializes only callers that opt in; a parallel test that mutates orch without the lock can write into the home currently held by another test. The next `App::new()` under that home loads the stray task.

## Verification

- [x] `cargo test --locked orch::`
- [x] `cargo test app::board::`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] `cargo test --locked` (full suite not completed here: Windows run hung on existing PTY/`test_env` tests after the focused checks passed)
- [x] `cargo test --locked diff_api_status_scan_is_off_loop` (passes in isolation)

## Notes

- Production path is unchanged: `load()` still reads `<session_dir>/orch.json` and `save()` now pins that captured path for the `App` lifetime.
- `app::dispatch::tests::agent_list_labels_a_pane_with_its_node_name` still fails in a linked git worktree (`worktree == false` cannot hold). That is the separate issue called out in #163, not this race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured orchestration state saves to the location captured when it was loaded, even if the session directory changes later.
  * Prevented unintended file writes for in-memory orchestration state.
  * Improved isolation between test session data.

* **New Features**
  * Added support for loading orchestration state from an explicitly specified path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->