### PR TITLE
feat(files): open Ctrl+clicked paths where File click behavior says

### DIFF
--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -271,12 +271,14 @@ impl App {
     }
 
     /// What a plain left click on a FILES row does, from `layout.file_click`
-    /// (docs/38). `Preview` is the default: one reused native read-only pane,
-    /// VS Code style. `Tab` is what a click did before this setting existed
-    /// and the *only* mode that consults `layout.file_open`, so it is also the
-    /// only mode that can launch an editor PTY. An unrecognized value — a config
-    /// touched by a newer Luvus — reads back as the default rather than leaving
-    /// a click doing nothing.
+    /// (docs/38) — and a `Ctrl`+click on a path printed in a pane (docs/58),
+    /// which is the same "open this file" with a different pointer. `Preview`
+    /// is the default: one reused native read-only pane, VS Code style. `Tab`
+    /// is what a click did before this setting existed and the *only* mode
+    /// that consults `layout.file_open`, so it is also the only mode that can
+    /// launch an editor PTY. An unrecognized value — a config touched by a
+    /// newer Luvus — reads back as the default rather than leaving a click
+    /// doing nothing.
     pub fn file_click_target(&self) -> OpenTarget {
         match self.config.layout.file_click.trim() {
             crate::config::FILE_CLICK_TAB => OpenTarget::Tab,
@@ -308,9 +310,10 @@ impl App {
 
     /// Open `path` in a new **tab** (docs/38), through the configured viewer:
     /// read-only or a terminal editor. This is the "open in tab" click
-    /// behavior, the fuzzy finder's action, and what `Ctrl`+clicking a path
-    /// printed in a pane always does (docs/58) — a *preview* click never comes
-    /// through here, which is why it can never reach an editor.
+    /// behavior, the fuzzy finder's action, and the tab half of `Ctrl`+clicking
+    /// a path printed in a pane (docs/58, [`open_file_link`](Self::open_file_link))
+    /// — a *preview* never comes through here, which is why it can never reach
+    /// an editor.
     ///
     /// `line` scrolls the built-in viewer to that line. It survives the async read
     /// because `FileView::apply` keeps `scroll` and clamps it to the file's length.
@@ -330,6 +333,34 @@ impl App {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    /// Open a path activated from a pane (docs/58) at `target`, jumping to
+    /// `line`. `Tab` is [`open_file_at`](Self::open_file_at): the configured
+    /// viewer, editor included. `Preview` and `Pane` mirror the FILES gestures
+    /// they share a name with and stay in the native viewer, so a `Ctrl`+click
+    /// under the default click behavior lands beside the pane that printed the
+    /// path instead of in a tab that hides it.
+    ///
+    /// The line lands on whichever view `open_file_view` left focused — the one
+    /// it opened, the preview it recycled, or the permanent view it deferred
+    /// to — checked against `path` so a reused leaf that is still loading
+    /// something else is never scrolled.
+    pub fn open_file_link(&mut self, path: PathBuf, line: Option<u32>, target: OpenTarget) {
+        if target == OpenTarget::Tab {
+            self.open_file_at(path, line);
+            return;
+        }
+        self.open_file_view(path.clone(), target);
+        let Some(l) = line else {
+            return;
+        };
+        let id = self.layout().focus;
+        if let Some(crate::app::ViewKind::File(v)) = self.views.get_mut(&id) {
+            if v.path == path {
+                v.scroll = l.saturating_sub(1) as usize;
             }
         }
     }

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -337,17 +337,24 @@ impl App {
         }
     }
 
-    /// Open a path activated from a pane (docs/58) at `target`, jumping to
-    /// `line`. `Tab` is [`open_file_at`](Self::open_file_at): the configured
-    /// viewer, editor included. `Preview` and `Pane` mirror the FILES gestures
-    /// they share a name with and stay in the native viewer, so a `Ctrl`+click
-    /// under the default click behavior lands beside the pane that printed the
-    /// path instead of in a tab that hides it.
+    /// Open a path activated from a pane (docs/58) at `target`. `Tab` is
+    /// [`open_file_at`](Self::open_file_at): the configured viewer, editor
+    /// included. `Preview` and `Pane` mirror the FILES gestures they share a
+    /// name with and stay in the native viewer, so a `Ctrl`+click under the
+    /// default click behavior lands beside the pane that printed the path
+    /// instead of in a tab that hides it.
     ///
-    /// The line lands on whichever view `open_file_view` left focused — the one
-    /// it opened, the preview it recycled, or the permanent view it deferred
-    /// to — checked against `path` so a reused leaf that is still loading
-    /// something else is never scrolled.
+    /// `line` is honored in every placement that ends in a native view. It is
+    /// **not** honored by a configured terminal editor: `open_file_at`
+    /// deliberately does not pass it on, because the flag for starting at a
+    /// line differs per editor and guessing it wrong is worse than not
+    /// jumping. So a `Tab` target preserves the line only when `Open files
+    /// with` is the built-in read-only viewer.
+    ///
+    /// Where it is honored, the line lands on whichever view `open_file_view`
+    /// left focused — the one it opened, the preview it recycled, or the
+    /// permanent view it deferred to — checked against `path` so a reused leaf
+    /// that is still loading something else is never scrolled.
     pub fn open_file_link(&mut self, path: PathBuf, line: Option<u32>, target: OpenTarget) {
         if target == OpenTarget::Tab {
             self.open_file_at(path, line);

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1530,6 +1530,7 @@ impl App {
                         self.link_press = Some(LinkPress {
                             target: h.target,
                             at: (m.column, m.row),
+                            beside: m.modifiers.contains(KeyModifiers::SHIFT),
                         });
                         return;
                     }
@@ -1648,7 +1649,11 @@ impl App {
                 }
                 if let Some(p) = self.link_press.take() {
                     if (m.column, m.row) == p.at {
-                        self.activate_link(p.target);
+                        if p.beside {
+                            self.activate_link_in(p.target, crate::app::files::OpenTarget::Pane);
+                        } else {
+                            self.activate_link(p.target);
+                        }
                     }
                     return;
                 }
@@ -2842,11 +2847,23 @@ impl App {
     }
 
     /// Act on a resolved link (docs/58): a URL goes to the client's browser, a
-    /// file opens in luvus itself.
+    /// file opens in luvus itself — where `File click behavior` says (docs/38),
+    /// exactly as a click on its FILES row would. That is a reused preview
+    /// pane beside the focus by default, so a path an agent printed lands
+    /// next to the conversation rather than in a tab that hides it.
     pub fn activate_link(&mut self, target: LinkTarget) {
+        let place = self.file_click_target();
+        self.activate_link_in(target, place);
+    }
+
+    /// [`activate_link`](Self::activate_link) with the placement the gesture
+    /// asked for: `Ctrl`+`Shift`+click is the tree's `Shift`+click, a
+    /// permanent pane beside the focus. A URL has no placement and goes to the
+    /// browser regardless.
+    pub fn activate_link_in(&mut self, target: LinkTarget, place: crate::app::files::OpenTarget) {
         match target {
             LinkTarget::Url(url) => self.open_url(url),
-            LinkTarget::File { path, line } => self.open_file_at(path, line),
+            LinkTarget::File { path, line } => self.open_file_link(path, line, place),
         }
     }
 
@@ -4470,15 +4487,47 @@ mod link_click_tests {
         (app, term, (content.x + at, content.y))
     }
 
-    /// A path an agent printed opens **in luvus**, in a new tab, not at the OS.
-    /// Tests run from the repo root, so `Cargo.toml` is a real relative path from
-    /// the pane's working directory.
-    #[test]
-    fn ctrl_click_on_a_file_path_opens_it_in_a_tab() {
-        let _env = crate::persist::test_env("link-file");
+    /// `Ctrl`+click a path, then return the view it landed on. Tests run from
+    /// the repo root, so `Cargo.toml` is a real relative path from the pane's
+    /// working directory.
+    fn click_cargo_toml(mods: KeyModifiers) -> (App, crate::ids::PaneId, usize) {
         let (mut app, _t, at) = fixture_showing("edit Cargo.toml now", 7);
         let tabs = app.ws().tabs.len();
+        app.handle_event(mouse(MouseEventKind::Down(MouseButton::Left), at, mods));
+        app.handle_event(mouse(MouseEventKind::Up(MouseButton::Left), at, mods));
+        assert!(
+            app.pending_open_url.is_none(),
+            "a file never goes to the browser"
+        );
+        let id = app.layout().focus;
+        match app.views.get(&id) {
+            Some(crate::app::ViewKind::File(v)) => {
+                assert!(v.path.ends_with("Cargo.toml"), "showing {:?}", v.path)
+            }
+            _ => panic!("the focus is a file view"),
+        }
+        (app, id, tabs)
+    }
 
+    /// A path an agent printed opens **in luvus**, not at the OS — and where
+    /// `File click behavior` says, which by default is the preview pane beside
+    /// the pane that printed it, so the agent stays on screen.
+    #[test]
+    fn ctrl_click_on_a_file_path_previews_it_beside_the_pane() {
+        let _env = crate::persist::test_env("link-file");
+        let (app, id, tabs) = click_cargo_toml(KeyModifiers::CONTROL);
+        assert_eq!(app.ws().tabs.len(), tabs, "no new tab");
+        assert!(app.preview_views.contains(&id), "it is the preview pane");
+    }
+
+    /// `Open in tab` is the other click behavior, and the only placement that
+    /// can reach a configured editor: the tab path is unchanged for it.
+    #[test]
+    fn ctrl_click_on_a_file_path_opens_a_tab_when_that_is_the_click_behavior() {
+        let _env = crate::persist::test_env("link-file-tab");
+        let (mut app, _t, at) = fixture_showing("edit Cargo.toml now", 7);
+        app.config.layout.file_click = crate::config::FILE_CLICK_TAB.to_string();
+        let tabs = app.ws().tabs.len();
         app.handle_event(mouse(
             MouseEventKind::Down(MouseButton::Left),
             at,
@@ -4489,19 +4538,27 @@ mod link_click_tests {
             at,
             KeyModifiers::CONTROL,
         ));
-
-        assert!(
-            app.pending_open_url.is_none(),
-            "a file never goes to the browser"
-        );
         assert_eq!(app.ws().tabs.len(), tabs + 1, "opened in a new tab");
         let id = app.layout().focus;
-        match app.views.get(&id) {
-            Some(crate::app::ViewKind::File(v)) => {
-                assert!(v.path.ends_with("Cargo.toml"), "showing {:?}", v.path)
-            }
-            _ => panic!("the new tab holds a file view"),
-        }
+        assert!(
+            matches!(app.views.get(&id), Some(crate::app::ViewKind::File(v)) if v.path.ends_with("Cargo.toml")),
+            "the new tab holds the file"
+        );
+        assert!(!app.preview_views.contains(&id), "a tab is permanent");
+    }
+
+    /// `Ctrl`+`Shift`+click is the tree's `Shift`+click: a permanent pane
+    /// beside the focus, whatever the click behavior is set to.
+    #[test]
+    fn ctrl_shift_click_on_a_file_path_opens_a_permanent_pane_beside() {
+        let _env = crate::persist::test_env("link-file-beside");
+        let (app, id, tabs) = click_cargo_toml(KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+        assert_eq!(app.ws().tabs.len(), tabs, "no new tab");
+        assert!(!app.preview_views.contains(&id), "not the recycled preview");
+        assert!(
+            app.layout().leaves().len() >= 2,
+            "split beside the pane that printed the path"
+        );
     }
 
     /// `src/main.rs:42` is one reference: the whole thing underlines, the path

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1094,9 +1094,10 @@ impl PaneStatus {
 pub enum LinkTarget {
     /// Hand to the client's browser.
     Url(String),
-    /// Open in luvus's own viewer or editor in a tab (docs/38), jumping to
-    /// `line` when the reference carried one. Always a tab: `File click
-    /// behavior` governs the FILES tree, not path activation.
+    /// Open in luvus itself (docs/38), jumping to `line` when the reference
+    /// carried one. Where it lands is `File click behavior` — the same choice
+    /// a click on the file's FILES row makes — and only the tab placement can
+    /// reach a configured editor.
     File { path: PathBuf, line: Option<u32> },
 }
 
@@ -1123,6 +1124,11 @@ pub struct LinkPress {
     pub target: LinkTarget,
     /// Screen cell of the press.
     pub at: (u16, u16),
+    /// `Shift` was down at the press: a file opens as a permanent pane beside
+    /// the focus, the way `Shift`+click does on a FILES row, instead of where
+    /// `File click behavior` would put it. Read at the press, not the release,
+    /// because the press is the gesture the user made.
+    pub beside: bool,
 }
 
 /// A drag text-selection inside a pane. Screen coordinates keep native file

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -238,8 +238,11 @@ behavior** choice:
   built-in read-only viewer, or your terminal editor if you set one.
 
 **`Ctrl`+`Shift`+click** opens a permanent pane beside the focus instead, the
-same as `Shift`+click on a FILES row. Either way, `path:42` still lands on
-line 42.
+same as `Shift`+click on a FILES row.
+
+`path:42` preserves the requested line in Preview, permanent-pane and built-in
+read-only tab placements. A configured terminal editor opens the file at the
+top, because line-jump arguments differ between editors.
 
 **A path only underlines if the file is really there.** Paths are resolved against
 that pane's working directory, so `src/main.rs` means what it means to the shell

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -223,16 +223,23 @@ follows it. If you would rather not hold a modifier, **right-click** and pick
 | `https://luvus.dev/docs` | opens in your browser |
 | `luvus.dev/docs` | same, with `https://` filled in |
 | `localhost:3000` | opens your dev server, over `http` |
-| `src/main.rs` | opens in a luvus tab, using **Open files with** |
-| `src/main.rs:42` | opens in a tab, scrolled to line 42 |
+| `src/main.rs` | opens in luvus, where **File click behavior** says |
+| `src/main.rs:42` | the same, scrolled to line 42 |
 
 ### Files
 
-A file path opens **in luvus**, not in some other app. It always opens in a
-**tab**, and respects your **Settings → General → Open files with** choice: the
-built-in read-only viewer by default, or your terminal editor if you set one.
-**File click behavior** does not apply here — that setting governs clicks in the
-FILES tree, which preview by default.
+A file path opens **in luvus**, not in some other app, and it lands where a
+click on that file's FILES row would — your **Settings → General → File click
+behavior** choice:
+
+- **Preview** (the default): the workspace's reused preview pane, beside the
+  pane you clicked in. The agent that printed the path stays on screen.
+- **Open in tab**: a new tab, through your **Open files with** choice — the
+  built-in read-only viewer, or your terminal editor if you set one.
+
+**`Ctrl`+`Shift`+click** opens a permanent pane beside the focus instead, the
+same as `Shift`+click on a FILES row. Either way, `path:42` still lands on
+line 42.
 
 **A path only underlines if the file is really there.** Paths are resolved against
 that pane's working directory, so `src/main.rs` means what it means to the shell


### PR DESCRIPTION
Closes #185.

Since #164, **File click behavior** decides where a FILES row click lands — the reused preview pane by default, or a tab. A `Ctrl`+click on a path an agent printed in a pane (docs/58) ignored it and always opened a tab, which is the one case where a tab hurts most: the agent that printed the path disappears behind it.

## What changes

| Gesture | Before | After |
|---|---|---|
| `Ctrl`+click on a path | tab (or the configured editor) | **File click behavior** — Preview by default; Tab keeps the old behavior, editor included |
| `Ctrl`+`Shift`+click | tab | a permanent split pane beside the focus, like `Shift`+click in FILES |
| right-click → Open File | tab | same as `Ctrl`+click |

`path:42` preserves the requested line in Preview, permanent-pane and built-in read-only tab placements. A configured terminal editor opens the file at the top, because line-jump arguments differ between editors — `open_file_at` deliberately does not pass the line on. URLs are untouched.

## How

- `LinkPress` records whether `Shift` was down at the press (the press is the gesture; `Ctrl`+drag still hands over to the divider resize as before).
- `activate_link` resolves `file_click_target()` and delegates to a new `activate_link_in(target, place)`; the mouse-up arm passes `Pane` for the Shift variant. The context menu's Open File goes through `activate_link`, so it follows the setting too.
- `App::open_file_link` (files.rs) routes `Tab` to `open_file_at` unchanged — still the only path that can spawn an editor — and `Preview`/`Pane` to `open_file_view`, then scrolls whichever file view that left focused, checked against the path.
- Docs: the "Opening links and files" section of the layout guide now describes the placement and the Shift gesture.

## Tests

- `ctrl_click_on_a_file_path_previews_it_beside_the_pane` — default: no new tab, the focus is the workspace's preview view.
- `ctrl_click_on_a_file_path_opens_a_tab_when_that_is_the_click_behavior` — `layout.file_click = "tab"`: one new tab, not a preview (the previous test, now under its setting).
- `ctrl_shift_click_on_a_file_path_opens_a_permanent_pane_beside` — split, not a preview.
- `a_line_suffix_scrolls_the_viewer_to_that_line` passes unchanged under the new default, covering the line jump on the preview path.

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (1113 passed) on Linux.

Known limitation, pre-existing: terminals that claim `Shift`+click for native selection never deliver the `Ctrl`+`Shift` variant (#170) — same as `Shift`+click in FILES today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File links now follow the configured **File click behavior**, including preview panes, tabs, or the configured viewer/editor.
  - `Ctrl`+`Shift`+click opens a file in a permanent pane beside the current pane.
  - File links with a line number open at that line when supported; configured terminal editors open at the top.
  - Web links continue opening externally.

- **Documentation**
  - Updated layout guidance to explain file-link placement and keyboard shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

