### PR TITLE
fix(mission): select agent sessions on click

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2123,8 +2123,8 @@ impl App {
             }
             return;
         }
-        // Clicking an agent row in Mission Control jumps straight to that session's
-        // pane (or resumes it), the whole point of the tab (docs/54).
+        // Mission Control mouse controls use geometry published by its renderer,
+        // so responsive rows select the same stable item shown on screen.
         if self.active_is_mission() {
             // A click dismisses an open overlay (detail / answer) rather than
             // acting behind it.
@@ -2139,8 +2139,14 @@ impl App {
                 self.set_mission_scope(*scope);
                 return;
             }
-            // Agent rows are intentionally keyboard-only for now. A plain click
-            // must never jump away from Mission Control unexpectedly.
+            let row = self
+                .mission_row_rects
+                .iter()
+                .find(|(_, rect)| hit(*rect))
+                .map(|(index, _)| *index);
+            if let Some(index) = row.filter(|index| *index < self.mission_rows.len()) {
+                self.mission_cursor = index;
+            }
             return;
         }
         if let Some((id, _)) = self.pane_rects.iter().find(|(_, rect)| hit(*rect)) {

--- a/src/app/mission.rs
+++ b/src/app/mission.rs
@@ -257,7 +257,7 @@ impl App {
     }
 
     /// Keyboard activation for the row at `idx`: jump to a live agent's pane, or
-    /// resume a dead session (MC-4). Plain row clicks are intentionally inert.
+    /// resume a dead session (MC-4). Mouse clicks select a row before this action.
     pub fn mission_activate(&mut self, idx: usize) {
         let Some(row) = self.mission_rows.get(idx).map(|r| r.row) else {
             return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1543,8 +1543,9 @@ pub struct App {
     pub mission_cursor: usize,
     /// Current workspace only, or every open workspace.
     pub mission_scope: crate::mission::MissionScope,
-    /// Click targets for the two scope tabs. Agent rows remain keyboard-only.
+    /// Click targets for the two scope tabs and visible agent rows.
     pub mission_scope_rects: Vec<(crate::mission::MissionScope, Rect)>,
+    pub mission_row_rects: Vec<(usize, Rect)>,
     /// Click target for the explicit Mission Control usage refresh action.
     pub mission_refresh_rect: Option<Rect>,
     pub mission_area: Rect,
@@ -2043,6 +2044,7 @@ impl App {
             mission_cursor: 0,
             mission_scope: crate::mission::MissionScope::Workspace,
             mission_scope_rects: Vec::new(),
+            mission_row_rects: Vec::new(),
             mission_refresh_rect: None,
             mission_area: Rect::ZERO,
             mission_rows: Vec::new(),
@@ -2595,6 +2597,7 @@ impl App {
             mission_cursor: 0,
             mission_scope: crate::mission::MissionScope::Workspace,
             mission_scope_rects: Vec::new(),
+            mission_row_rects: Vec::new(),
             mission_refresh_rect: None,
             mission_area: Rect::ZERO,
             mission_rows: Vec::new(),
@@ -10690,6 +10693,24 @@ mod tests {
             assert!(text.contains('█'), "a telemetry bar draws");
         }
 
+        let wide_second_row = app
+            .mission_row_rects
+            .iter()
+            .find_map(|(index, rect)| (*index == 1).then_some(*rect))
+            .expect("wide dashboard exposes the second session row");
+        app.handle_event(crate::event::AppEvent::Mouse(
+            ratatui::crossterm::event::MouseEvent {
+                kind: ratatui::crossterm::event::MouseEventKind::Down(
+                    ratatui::crossterm::event::MouseButton::Left,
+                ),
+                column: wide_second_row.x.saturating_add(1),
+                row: wide_second_row.y,
+                modifiers: KeyModifiers::NONE,
+            },
+        ));
+        assert_eq!(app.mission_cursor, 1, "wide row click selects the session");
+        app.mission_cursor = 0;
+
         // A narrow terminal falls back to a full-width, single-column agent list.
         {
             use ratatui::{backend::TestBackend, Terminal};
@@ -10705,17 +10726,22 @@ mod tests {
             assert!(text.contains("AGENT SESSIONS"), "compact agent panel draws");
         }
 
-        // Plain clicks are intentionally inert: opening a pane is an explicit
-        // keyboard action through Enter, not an accidental dashboard click.
+        // A plain click selects the exact rendered row without activating it.
+        // Enter remains the explicit open/resume action.
         let active_tab = app.ws().active_tab;
-        let cursor = app.mission_cursor;
+        app.mission_cursor = 0;
+        let second_row = app
+            .mission_row_rects
+            .iter()
+            .find_map(|(index, rect)| (*index == 1).then_some(*rect))
+            .expect("second visible session row has a hit target");
         app.handle_event(crate::event::AppEvent::Mouse(
             ratatui::crossterm::event::MouseEvent {
                 kind: ratatui::crossterm::event::MouseEventKind::Down(
                     ratatui::crossterm::event::MouseButton::Left,
                 ),
-                column: app.mission_area.x.saturating_add(2),
-                row: app.mission_area.y.saturating_add(7),
+                column: second_row.x.saturating_add(1),
+                row: second_row.y,
                 modifiers: KeyModifiers::NONE,
             },
         ));
@@ -10725,10 +10751,7 @@ mod tests {
             active_tab,
             "click does not open a pane"
         );
-        assert_eq!(
-            app.mission_cursor, cursor,
-            "click does not change selection"
-        );
+        assert_eq!(app.mission_cursor, 1, "click selects the rendered row");
 
         // The detail overlay opens on `o` and closes on esc. (`render` publishes
         // `mission_rows`, so it's set now.)

--- a/src/ui/mission.rs
+++ b/src/ui/mission.rs
@@ -583,6 +583,12 @@ fn draw_agent_row(
     f.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
+#[derive(Default)]
+struct RosterRender {
+    scroll: usize,
+    row_rects: Vec<(usize, Rect)>,
+}
+
 fn draw_roster(
     f: &mut RenderTarget,
     area: Rect,
@@ -591,12 +597,12 @@ fn draw_roster(
     requested_scroll: usize,
     cat: &Catalog,
     t: &Theme,
-) -> usize {
+) -> RosterRender {
     let block = deck_block("AGENT SESSIONS", t, true);
     let inner = block.inner(area);
     f.render_widget(block, area);
     if inner.height == 0 {
-        return 0;
+        return RosterRender::default();
     }
     let content = Rect::new(
         inner.x.saturating_add(2),
@@ -623,7 +629,7 @@ fn draw_roster(
                 inner.height.saturating_sub(1),
             ),
         );
-        return 0;
+        return RosterRender::default();
     }
     let rows_area = Rect::new(inner.x, inner.y + 1, inner.width, inner.height - 1);
     let visible = rows_area.height.max(1) as usize;
@@ -635,11 +641,13 @@ fn draw_roster(
         scroll = cursor + 1 - visible;
     }
     scroll = scroll.min(rows.len().saturating_sub(visible));
+    let mut row_rects = Vec::with_capacity(visible.min(rows.len()));
     for (slot, idx) in (scroll..rows.len().min(scroll + visible)).enumerate() {
         let rect = Rect::new(rows_area.x, rows_area.y + slot as u16, rows_area.width, 1);
         draw_agent_row(f, rect, &rows[idx], idx + 1, idx == cursor, columns, t);
+        row_rects.push((idx, rect));
     }
-    scroll
+    RosterRender { scroll, row_rects }
 }
 
 fn draw_selected(f: &mut RenderTarget, area: Rect, row: Option<&MissionRowView>, t: &Theme) {
@@ -813,6 +821,7 @@ pub(super) fn render(
             scroll: 0,
             scope_rects: Vec::new(),
             refresh_rect: None,
+            row_rects: Vec::new(),
         };
     }
     fill_bg(f, area, t.mantle);
@@ -868,9 +877,10 @@ pub(super) fn render(
         );
     }
     MissionRender {
-        scroll: rendered,
+        scroll: rendered.scroll,
         scope_rects,
         refresh_rect,
+        row_rects: rendered.row_rects,
     }
 }
 
@@ -878,6 +888,7 @@ pub(super) struct MissionRender {
     pub scroll: usize,
     pub scope_rects: Vec<(MissionScope, Rect)>,
     pub refresh_rect: Option<Rect>,
+    pub row_rects: Vec<(usize, Rect)>,
 }
 
 /// The row-detail overlay (MC-5): a small modal with the selected agent's full

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -199,6 +199,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     let switcher_scope_rects = std::mem::take(&mut app.switcher_scope_rects);
     let mission_rows = std::mem::take(&mut app.mission_rows);
     let mission_scope_rects = std::mem::take(&mut app.mission_scope_rects);
+    let mission_row_rects = std::mem::take(&mut app.mission_row_rects);
     let bar_hits = std::mem::take(&mut app.bar.hits);
     let bar_overflow_hits = std::mem::take(&mut app.bar.overflow_hits);
     let bar_overflow = app.bar.overflow.clone();
@@ -323,6 +324,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     app.switcher_scope_rects = switcher_scope_rects;
     app.mission_rows = mission_rows;
     app.mission_scope_rects = mission_scope_rects;
+    app.mission_row_rects = mission_row_rects;
     app.bar.hits = bar_hits;
     app.bar.overflow_hits = bar_overflow_hits;
     app.bar.overflow = bar_overflow;
@@ -400,6 +402,7 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
     app.bar.hits.clear();
     app.bar.overflow_hits.clear();
     app.menu_scroll.begin_frame();
+    app.mission_row_rects.clear();
     app.mobile_pane_prev_rect = None;
     app.mobile_pane_next_rect = None;
 
@@ -661,6 +664,7 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
         app.mission_scroll = rendered.scroll;
         app.mission_scope_rects = rendered.scope_rects;
         app.mission_refresh_rect = rendered.refresh_rect;
+        app.mission_row_rects = rendered.row_rects;
         app.mission_rows = rows;
         None
     } else if let Some(g) = app.active_git_mut() {

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -51,6 +51,9 @@ stores for its own session. It shows input, output, and cache tokens, context
 usage when the agent records its context limit, and cost when the agent records
 one or Luvus has pricing for the model.
 
+Click a session row to select it and update the Selected Agent panel. Use
+`Enter` to open its live pane or resume the selected historical session.
+
 | Native usage reader | Data source |
 |---|---|
 | Claude Code | project transcript |


### PR DESCRIPTION
## Summary

Mission Control rendered a selected session and supported keyboard navigation, but deliberately ignored mouse clicks on session rows. This made the Selected Agent panel appear stuck unless the user used the arrow keys.

This change makes a single click select the exact visible agent session row.

- publish bounded row hit targets from the Mission Control renderer
- map each visible hit target back to its stable row index
- update the selected row and Selected Agent panel without opening or resuming the session
- keep `Enter` as the explicit open or resume action
- preserve active-client hit geometry while rendering secondary client projections
- cover both wide and narrow Mission Control layouts
- document the mouse and keyboard behavior

## Performance and safety

The renderer stores hit geometry only for rows visible in the current viewport. The vector is bounded by terminal height and does not scan processes, sessions, or files. Mouse selection uses the same row collection already used by keyboard activation.

A single click never opens a pane, resumes a historical session, or changes workspace state. It only changes the Mission Control cursor.

## Verification

- `cargo test --locked mission -- --nocapture` with 25 passing tests
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `npm run build` in `website/`

No production Luvus server was started, stopped, or modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mission Control agent rows can now be selected with a mouse click.
  * The Selected Agent panel updates when a row is selected.
  * Press **Enter** to open a live session or resume a historical session.

* **Documentation**
  * Updated the agents guide with instructions for selecting and opening sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->