### PR TITLE
feat(agent): add native Hermes CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Keyboard → Keyboard Shortcuts → Input Sources** to free `Ctrl+Space`.
 | opencode | ✓ | ✓ | ✓ |
 | Kimi | ✓ | ✓ | ✓ |
 | Grok | ✓ | ✓ | ✓ |
+| Hermes CLI | ✓ | ✓ | No |
 | Pi | ✓ | ✓ | No |
 | Oh My Pi (omp) | ✓ | ✓ | ✓ |
 | Muse Code | ✓ | ✓ | No |

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -375,6 +375,8 @@ surface:
   optional native session-resume hooks and must not be used merely to make an
   agent appear in the sidebar. Install or remove an integration only when the
   user explicitly requests that lifecycle integration.
+- For Hermes, `luvus integration install hermes` adds exact per-pane session
+  ownership while native read-only session discovery remains the fallback.
 - Subscribe to events only for a live monitoring request. Stop when its
   condition is satisfied and never retain an unbounded stream.
 

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -375,6 +375,8 @@ surface:
   optional native session-resume hooks and must not be used merely to make an
   agent appear in the sidebar. Install or remove an integration only when the
   user explicitly requests that lifecycle integration.
+- For Hermes, `luvus integration install hermes` adds exact per-pane session
+  ownership while native read-only session discovery remains the fallback.
 - Subscribe to events only for a live monitoring request. Stop when its
   condition is satisfied and never retain an unbounded stream.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -25,6 +25,7 @@ pub(crate) mod droid;
 pub(crate) mod fx;
 pub(crate) mod gemini;
 pub(crate) mod grok;
+pub(crate) mod hermes;
 pub(crate) mod kimi;
 pub(crate) mod kiro;
 pub(crate) mod muse;
@@ -142,6 +143,15 @@ fn filter_launch_flags(agent: &str, launch: &[String]) -> Vec<String> {
     while i < launch.len() {
         let t = launch[i].as_str();
         let head = t.split('=').next().unwrap_or(t);
+        // Hermes accepts an optional name after continue. Neither the selector
+        // nor its value may survive into an exact-id restore.
+        if agent == "hermes" && matches!(head, "--continue" | "-c") {
+            i += 1;
+            if !t.contains('=') && launch.get(i).is_some_and(|value| !value.starts_with('-')) {
+                i += 1;
+            }
+            continue;
+        }
         if t.contains('=') && TAKES_VALUE.contains(&head) {
             i += 1; // glued form, e.g. --resume=<id>
             continue;
@@ -375,6 +385,11 @@ mod tests {
             resume_command("fx", "f1").as_deref(),
             Some("fx session resume 'f1'\r")
         );
+        assert_eq!(
+            resume_command("hermes-agent", "20260830_120000_a1b2c3").as_deref(),
+            Some("hermes --resume '20260830_120000_a1b2c3'\r")
+        );
+        assert!(is_resumable("hermes"));
         assert!(resume_command("unknown", "x").is_none());
         assert!(resume_command("claude", "").is_none()); // empty id
         assert!(resume_command("claude", "a b").is_none()); // unsafe char
@@ -662,6 +677,11 @@ mod tests {
         assert_eq!(
             f("muse", &["resume", "muse-id", "--reasoning-effort", "high"]),
             vec!["--reasoning-effort", "high"]
+        );
+        assert_eq!(
+            f("hermes", &["--continue", "old title", "--tui"]),
+            vec!["--tui"],
+            "Hermes drops its optional continue title"
         );
         // A kept flag keeps its value.
         assert_eq!(

--- a/src/agent/hermes/integration.rs
+++ b/src/agent/hermes/integration.rs
@@ -215,12 +215,27 @@ fn top_level_plugins(lines: &[String]) -> Option<usize> {
     })
 }
 
-fn nested_key(lines: &[String], plugins: usize, key: &str) -> Option<usize> {
+fn child_indent(lines: &[String], parent: usize, parent_indent: usize) -> usize {
+    let end = block_end(lines, parent, parent_indent);
+    (parent + 1..end)
+        .filter_map(|index| {
+            meaningful(&lines[index])
+                .then(|| leading_spaces(&lines[index]))
+                .flatten()
+                .filter(|indent| *indent > parent_indent)
+        })
+        .min()
+        .unwrap_or(parent_indent + 2)
+}
+
+fn nested_key(lines: &[String], plugins: usize, key: &str) -> Option<(usize, usize)> {
+    let plugins_indent = child_indent(lines, plugins, 0);
     let end = block_end(lines, plugins, 0);
     let expected = format!("{key}:");
-    (plugins + 1..end).find(|index| {
-        leading_spaces(&lines[*index]) == Some(2)
-            && lines[*index].trim_start().starts_with(&expected)
+    (plugins + 1..end).find_map(|index| {
+        (leading_spaces(&lines[index]) == Some(plugins_indent)
+            && lines[index].trim_start().starts_with(&expected))
+        .then_some((index, plugins_indent))
     })
 }
 
@@ -228,7 +243,7 @@ fn remove_from_nested_list(lines: &mut Vec<String>, key: &str) -> Result<()> {
     let Some(plugins) = top_level_plugins(lines) else {
         return Ok(());
     };
-    let Some(section) = nested_key(lines, plugins, key) else {
+    let Some((section, section_indent)) = nested_key(lines, plugins, key) else {
         return Ok(());
     };
     let value = lines[section]
@@ -241,11 +256,12 @@ fn remove_from_nested_list(lines: &mut Vec<String>, key: &str) -> Result<()> {
             "cannot safely edit inline Hermes plugins.{key}; use a YAML list"
         ));
     }
-    let end = block_end(lines, section, 2);
-    remove_list_item(lines, section + 1, end, 4);
-    let end = block_end(lines, section, 2);
-    if !(section + 1..end).any(|index| list_item(&lines[index], 4).is_some()) {
-        lines[section] = format!("  {key}: []");
+    let item_indent = child_indent(lines, section, section_indent);
+    let end = block_end(lines, section, section_indent);
+    remove_list_item(lines, section + 1, end, item_indent);
+    let end = block_end(lines, section, section_indent);
+    if !(section + 1..end).any(|index| list_item(&lines[index], item_indent).is_some()) {
+        lines[section] = format!("{}{key}: []", " ".repeat(section_indent));
     }
     Ok(())
 }
@@ -260,15 +276,18 @@ fn remove_list_item(lines: &mut Vec<String>, start: usize, end: usize, indent: u
 
 fn add_to_nested_list(lines: &mut Vec<String>, key: &str) -> Result<()> {
     let plugins = top_level_plugins(lines).expect("plugins section exists");
-    if let Some(section) = nested_key(lines, plugins, key) {
+    if let Some((section, section_indent)) = nested_key(lines, plugins, key) {
         let value = lines[section]
             .trim_start()
             .strip_prefix(&format!("{key}:"))
             .unwrap_or_default()
             .trim();
         if value == "[]" {
-            lines[section] = format!("  {key}:");
-            lines.insert(section + 1, format!("    - {PLUGIN_NAME}"));
+            lines[section] = format!("{}{key}:", " ".repeat(section_indent));
+            lines.insert(
+                section + 1,
+                format!("{}- {PLUGIN_NAME}", " ".repeat(section_indent + 2)),
+            );
             return Ok(());
         }
         if !value.is_empty() {
@@ -276,18 +295,23 @@ fn add_to_nested_list(lines: &mut Vec<String>, key: &str) -> Result<()> {
                 "cannot safely edit inline Hermes plugins.{key}; use a YAML list"
             ));
         }
-        let end = block_end(lines, section, 2);
-        if (section + 1..end)
-            .any(|index| list_item(&lines[index], 4).is_some_and(|item| item_is(item, PLUGIN_NAME)))
-        {
+        let item_indent = child_indent(lines, section, section_indent);
+        let end = block_end(lines, section, section_indent);
+        if (section + 1..end).any(|index| {
+            list_item(&lines[index], item_indent).is_some_and(|item| item_is(item, PLUGIN_NAME))
+        }) {
             return Ok(());
         }
-        lines.insert(end, format!("    - {PLUGIN_NAME}"));
+        lines.insert(end, format!("{}- {PLUGIN_NAME}", " ".repeat(item_indent)));
         return Ok(());
     }
 
-    lines.insert(plugins + 1, format!("  {key}:"));
-    lines.insert(plugins + 2, format!("    - {PLUGIN_NAME}"));
+    let section_indent = child_indent(lines, plugins, 0);
+    lines.insert(plugins + 1, format!("{}{key}:", " ".repeat(section_indent)));
+    lines.insert(
+        plugins + 2,
+        format!("{}- {PLUGIN_NAME}", " ".repeat(section_indent + 2)),
+    );
     Ok(())
 }
 
@@ -329,12 +353,15 @@ fn enable_plugin(content: &str) -> Result<String> {
                 );
             } else if declaration == "plugins:" {
                 let end = block_end(&lines, index, 0);
-                let flat = (index + 1..end).any(|line| list_item(&lines[line], 2).is_some());
+                let item_indent = child_indent(&lines, index, 0);
+                let flat =
+                    (index + 1..end).any(|line| list_item(&lines[line], item_indent).is_some());
                 if flat {
                     if !(index + 1..end).any(|line| {
-                        list_item(&lines[line], 2).is_some_and(|item| item_is(item, PLUGIN_NAME))
+                        list_item(&lines[line], item_indent)
+                            .is_some_and(|item| item_is(item, PLUGIN_NAME))
                     }) {
-                        lines.insert(end, format!("  - {PLUGIN_NAME}"));
+                        lines.insert(end, format!("{}- {PLUGIN_NAME}", " ".repeat(item_indent)));
                     }
                 } else {
                     remove_from_nested_list(&mut lines, "disabled")?;
@@ -369,9 +396,10 @@ fn disable_plugin(content: &str) -> Result<String> {
         ));
     }
     let end = block_end(&lines, plugins, 0);
-    let flat = (plugins + 1..end).any(|line| list_item(&lines[line], 2).is_some());
+    let item_indent = child_indent(&lines, plugins, 0);
+    let flat = (plugins + 1..end).any(|line| list_item(&lines[line], item_indent).is_some());
     if flat {
-        remove_list_item(&mut lines, plugins + 1, end, 2);
+        remove_list_item(&mut lines, plugins + 1, end, item_indent);
     } else {
         remove_from_nested_list(&mut lines, "enabled")?;
         remove_from_nested_list(&mut lines, "disabled")?;
@@ -385,22 +413,28 @@ fn plugin_enabled(content: &str) -> bool {
         return false;
     };
     let end = block_end(&lines, plugins, 0);
-    if (plugins + 1..end)
-        .any(|index| list_item(&lines[index], 2).is_some_and(|item| item_is(item, PLUGIN_NAME)))
-    {
+    let plugins_indent = child_indent(&lines, plugins, 0);
+    if (plugins + 1..end).any(|index| {
+        list_item(&lines[index], plugins_indent).is_some_and(|item| item_is(item, PLUGIN_NAME))
+    }) {
         return true;
     }
-    let Some(enabled) = nested_key(&lines, plugins, "enabled") else {
+    let Some((enabled, enabled_indent)) = nested_key(&lines, plugins, "enabled") else {
         return false;
     };
-    let end = block_end(&lines, enabled, 2);
-    let active = (enabled + 1..end)
-        .any(|index| list_item(&lines[index], 4).is_some_and(|item| item_is(item, PLUGIN_NAME)));
-    let disabled = nested_key(&lines, plugins, "disabled").is_some_and(|disabled| {
-        let end = block_end(&lines, disabled, 2);
-        (disabled + 1..end)
-            .any(|index| list_item(&lines[index], 4).is_some_and(|item| item_is(item, PLUGIN_NAME)))
+    let enabled_item_indent = child_indent(&lines, enabled, enabled_indent);
+    let end = block_end(&lines, enabled, enabled_indent);
+    let active = (enabled + 1..end).any(|index| {
+        list_item(&lines[index], enabled_item_indent).is_some_and(|item| item_is(item, PLUGIN_NAME))
     });
+    let disabled =
+        nested_key(&lines, plugins, "disabled").is_some_and(|(disabled, disabled_indent)| {
+            let item_indent = child_indent(&lines, disabled, disabled_indent);
+            let end = block_end(&lines, disabled, disabled_indent);
+            (disabled + 1..end).any(|index| {
+                list_item(&lines[index], item_indent).is_some_and(|item| item_is(item, PLUGIN_NAME))
+            })
+        });
     active && !disabled
 }
 
@@ -439,6 +473,21 @@ mod tests {
         let input = "plugins:\n  enabled: [mine]\n";
         assert!(enable_plugin(input).is_err());
         assert_eq!(input, "plugins:\n  enabled: [mine]\n");
+    }
+
+    #[test]
+    fn config_edit_preserves_four_space_nested_indentation() {
+        let input = "plugins:\n    enabled:\n        - mine\n    disabled:\n        - luvus-agent-state\n        - theirs\ngateway:\n    enabled: true\n";
+        let enabled = enable_plugin(input).unwrap();
+        assert!(enabled.contains("    enabled:\n        - mine\n        - luvus-agent-state\n"));
+        assert!(enabled.contains("    disabled:\n        - theirs\n"));
+        assert!(!enabled.contains("\n  enabled:"));
+        assert!(plugin_enabled(&enabled));
+
+        let removed = disable_plugin(&enabled).unwrap();
+        assert!(!removed.contains(PLUGIN_NAME));
+        assert!(removed.contains("    enabled:\n        - mine\n"));
+        assert!(removed.contains("    disabled:\n        - theirs\n"));
     }
 
     #[test]

--- a/src/agent/hermes/integration.rs
+++ b/src/agent/hermes/integration.rs
@@ -1,0 +1,484 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+
+use super::super::types::IntegrationOperations;
+
+pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
+    install,
+    uninstall,
+    is_installed,
+    legacy_is_installed,
+};
+
+const PLUGIN_NAME: &str = "luvus-agent-state";
+const MANIFEST: &str = r#"name: luvus-agent-state
+version: "1.0.0"
+description: Report exact Hermes CLI session identity to Luvus
+provides_hooks:
+  - on_session_start
+  - on_session_reset
+  - pre_llm_call
+"#;
+const PLUGIN: &str = r#""""Luvus integration for exact Hermes CLI session ownership."""
+
+# LUVUS_INTEGRATION_ID=hermes
+# LUVUS_INTEGRATION_VERSION=1
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+_AGENT = "hermes"
+_INTERACTIVE_PLATFORMS = {"cli", "tui", "desktop", "acp"}
+_last_reported: dict[str, str] = {}
+
+
+def _pane_id() -> str | None:
+    if os.environ.get("LUVUS_ENV") != "1":
+        return None
+    return os.environ.get("LUVUS_PANE_ID", "").strip() or None
+
+
+def _report_session(session_id: str, platform: str | None) -> None:
+    pane_id = _pane_id()
+    if pane_id is None or platform not in _INTERACTIVE_PLATFORMS:
+        return
+    if _last_reported.get(pane_id) == session_id:
+        return
+
+    command = [
+        os.environ.get("LUVUS_BIN_PATH") or "luvus",
+        "pane",
+        "report",
+        "--agent",
+        _AGENT,
+        "--session",
+        session_id,
+    ]
+    try:
+        options = {
+            "timeout": 1,
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
+        }
+        if os.name == "nt":
+            options["creationflags"] = subprocess.CREATE_NO_WINDOW
+        result = subprocess.run(command, check=False, **options)
+        if result.returncode == 0:
+            _last_reported[pane_id] = session_id
+    except Exception:
+        pass
+
+
+def _observe_session(**kwargs) -> None:
+    session_id = kwargs.get("session_id")
+    if isinstance(session_id, str) and session_id:
+        _report_session(session_id, kwargs.get("platform"))
+
+
+def register(ctx):
+    ctx.register_hook("on_session_start", _observe_session)
+    ctx.register_hook("on_session_reset", _observe_session)
+    # Continued CLI sessions do not emit on_session_start. This callback is
+    # deduplicated, so it launches at most one reporter per Hermes session.
+    ctx.register_hook("pre_llm_call", _observe_session)
+"#;
+
+fn base() -> PathBuf {
+    super::sessions::base()
+}
+
+fn plugin_dir() -> PathBuf {
+    base().join("plugins").join(PLUGIN_NAME)
+}
+
+fn config_path() -> PathBuf {
+    base().join("config.yaml")
+}
+
+fn install() -> Result<()> {
+    let root = base();
+    if !root.is_dir() {
+        return Err(anyhow!(
+            "Hermes config directory not found at {}. Install and run Hermes first.",
+            root.display()
+        ));
+    }
+
+    let config = config_path();
+    let original = match fs::read_to_string(&config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error.into()),
+    };
+    let updated = enable_plugin(&original)?;
+
+    let dir = plugin_dir();
+    let already_installed = dir.is_dir();
+    fs::create_dir_all(&dir)?;
+    if let Err(error) = fs::write(dir.join("plugin.yaml"), MANIFEST)
+        .and_then(|_| fs::write(dir.join("__init__.py"), PLUGIN))
+        .and_then(|_| {
+            if updated == original {
+                Ok(())
+            } else {
+                fs::write(&config, updated)
+            }
+        })
+    {
+        if !already_installed {
+            let _ = fs::remove_dir_all(&dir);
+        }
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+fn uninstall() -> Result<()> {
+    let config = config_path();
+    match fs::read_to_string(&config) {
+        Ok(original) => {
+            let updated = disable_plugin(&original)?;
+            if updated != original {
+                fs::write(&config, updated)?;
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let _ = fs::remove_dir_all(plugin_dir());
+    Ok(())
+}
+
+fn is_installed() -> bool {
+    let dir = plugin_dir();
+    if !dir.join("plugin.yaml").is_file() || !dir.join("__init__.py").is_file() {
+        return false;
+    }
+    fs::read_to_string(config_path())
+        .ok()
+        .is_some_and(|contents| plugin_enabled(&contents))
+}
+
+fn legacy_is_installed() -> bool {
+    false
+}
+
+fn leading_spaces(line: &str) -> Option<usize> {
+    let prefix = line
+        .as_bytes()
+        .iter()
+        .take_while(|byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    (!line.as_bytes()[..prefix].contains(&b'\t')).then_some(prefix)
+}
+
+fn meaningful(line: &str) -> bool {
+    let trimmed = line.trim();
+    !trimmed.is_empty() && !trimmed.starts_with('#')
+}
+
+fn block_end(lines: &[String], start: usize, indent: usize) -> usize {
+    lines
+        .iter()
+        .enumerate()
+        .skip(start + 1)
+        .find_map(|(index, line)| {
+            (meaningful(line) && leading_spaces(line).is_some_and(|level| level <= indent))
+                .then_some(index)
+        })
+        .unwrap_or(lines.len())
+}
+
+fn list_item(line: &str, indent: usize) -> Option<&str> {
+    (leading_spaces(line)? == indent)
+        .then(|| line.trim_start().strip_prefix("- "))
+        .flatten()
+        .map(str::trim)
+}
+
+fn item_is(value: &str, expected: &str) -> bool {
+    value.trim_matches(['\'', '"']) == expected
+}
+
+fn top_level_plugins(lines: &[String]) -> Option<usize> {
+    lines.iter().position(|line| {
+        leading_spaces(line) == Some(0)
+            && line
+                .split_once('#')
+                .map_or(line.as_str(), |(before, _)| before)
+                .trim_start()
+                .starts_with("plugins:")
+    })
+}
+
+fn nested_key(lines: &[String], plugins: usize, key: &str) -> Option<usize> {
+    let end = block_end(lines, plugins, 0);
+    let expected = format!("{key}:");
+    (plugins + 1..end).find(|index| {
+        leading_spaces(&lines[*index]) == Some(2)
+            && lines[*index].trim_start().starts_with(&expected)
+    })
+}
+
+fn remove_from_nested_list(lines: &mut Vec<String>, key: &str) -> Result<()> {
+    let Some(plugins) = top_level_plugins(lines) else {
+        return Ok(());
+    };
+    let Some(section) = nested_key(lines, plugins, key) else {
+        return Ok(());
+    };
+    let value = lines[section]
+        .trim_start()
+        .strip_prefix(&format!("{key}:"))
+        .unwrap_or_default()
+        .trim();
+    if !value.is_empty() && value != "[]" {
+        return Err(anyhow!(
+            "cannot safely edit inline Hermes plugins.{key}; use a YAML list"
+        ));
+    }
+    let end = block_end(lines, section, 2);
+    remove_list_item(lines, section + 1, end, 4);
+    let end = block_end(lines, section, 2);
+    if !(section + 1..end).any(|index| list_item(&lines[index], 4).is_some()) {
+        lines[section] = format!("  {key}: []");
+    }
+    Ok(())
+}
+
+fn remove_list_item(lines: &mut Vec<String>, start: usize, end: usize, indent: usize) {
+    for index in (start..end).rev() {
+        if list_item(&lines[index], indent).is_some_and(|item| item_is(item, PLUGIN_NAME)) {
+            lines.remove(index);
+        }
+    }
+}
+
+fn add_to_nested_list(lines: &mut Vec<String>, key: &str) -> Result<()> {
+    let plugins = top_level_plugins(lines).expect("plugins section exists");
+    if let Some(section) = nested_key(lines, plugins, key) {
+        let value = lines[section]
+            .trim_start()
+            .strip_prefix(&format!("{key}:"))
+            .unwrap_or_default()
+            .trim();
+        if value == "[]" {
+            lines[section] = format!("  {key}:");
+            lines.insert(section + 1, format!("    - {PLUGIN_NAME}"));
+            return Ok(());
+        }
+        if !value.is_empty() {
+            return Err(anyhow!(
+                "cannot safely edit inline Hermes plugins.{key}; use a YAML list"
+            ));
+        }
+        let end = block_end(lines, section, 2);
+        if (section + 1..end)
+            .any(|index| list_item(&lines[index], 4).is_some_and(|item| item_is(item, PLUGIN_NAME)))
+        {
+            return Ok(());
+        }
+        lines.insert(end, format!("    - {PLUGIN_NAME}"));
+        return Ok(());
+    }
+
+    lines.insert(plugins + 1, format!("  {key}:"));
+    lines.insert(plugins + 2, format!("    - {PLUGIN_NAME}"));
+    Ok(())
+}
+
+fn join_lines(lines: Vec<String>, trailing_newline: bool) -> String {
+    let mut output = lines.join("\n");
+    if trailing_newline {
+        output.push('\n');
+    }
+    output
+}
+
+fn enable_plugin(content: &str) -> Result<String> {
+    let trailing_newline = content.is_empty() || content.ends_with('\n');
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+    match top_level_plugins(&lines) {
+        None => {
+            if !lines.is_empty() && !lines.last().is_some_and(String::is_empty) {
+                lines.push(String::new());
+            }
+            lines.extend([
+                "plugins:".to_string(),
+                "  enabled:".to_string(),
+                format!("    - {PLUGIN_NAME}"),
+            ]);
+        }
+        Some(index) => {
+            let declaration = lines[index]
+                .split_once('#')
+                .map_or(lines[index].as_str(), |(before, _)| before)
+                .trim();
+            if declaration == "plugins: []" {
+                lines.splice(
+                    index..=index,
+                    [
+                        "plugins:".to_string(),
+                        "  enabled:".to_string(),
+                        format!("    - {PLUGIN_NAME}"),
+                    ],
+                );
+            } else if declaration == "plugins:" {
+                let end = block_end(&lines, index, 0);
+                let flat = (index + 1..end).any(|line| list_item(&lines[line], 2).is_some());
+                if flat {
+                    if !(index + 1..end).any(|line| {
+                        list_item(&lines[line], 2).is_some_and(|item| item_is(item, PLUGIN_NAME))
+                    }) {
+                        lines.insert(end, format!("  - {PLUGIN_NAME}"));
+                    }
+                } else {
+                    remove_from_nested_list(&mut lines, "disabled")?;
+                    add_to_nested_list(&mut lines, "enabled")?;
+                }
+            } else {
+                return Err(anyhow!(
+                    "cannot safely edit Hermes plugins configuration: unsupported plugins value"
+                ));
+            }
+        }
+    }
+    Ok(join_lines(lines, trailing_newline))
+}
+
+fn disable_plugin(content: &str) -> Result<String> {
+    let trailing_newline = content.ends_with('\n');
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+    let Some(plugins) = top_level_plugins(&lines) else {
+        return Ok(content.to_string());
+    };
+    let declaration = lines[plugins]
+        .split_once('#')
+        .map_or(lines[plugins].as_str(), |(before, _)| before)
+        .trim();
+    if declaration == "plugins: []" {
+        return Ok(content.to_string());
+    }
+    if declaration != "plugins:" {
+        return Err(anyhow!(
+            "cannot safely edit Hermes plugins configuration: unsupported plugins value"
+        ));
+    }
+    let end = block_end(&lines, plugins, 0);
+    let flat = (plugins + 1..end).any(|line| list_item(&lines[line], 2).is_some());
+    if flat {
+        remove_list_item(&mut lines, plugins + 1, end, 2);
+    } else {
+        remove_from_nested_list(&mut lines, "enabled")?;
+        remove_from_nested_list(&mut lines, "disabled")?;
+    }
+    Ok(join_lines(lines, trailing_newline))
+}
+
+fn plugin_enabled(content: &str) -> bool {
+    let lines: Vec<String> = content.lines().map(str::to_string).collect();
+    let Some(plugins) = top_level_plugins(&lines) else {
+        return false;
+    };
+    let end = block_end(&lines, plugins, 0);
+    if (plugins + 1..end)
+        .any(|index| list_item(&lines[index], 2).is_some_and(|item| item_is(item, PLUGIN_NAME)))
+    {
+        return true;
+    }
+    let Some(enabled) = nested_key(&lines, plugins, "enabled") else {
+        return false;
+    };
+    let end = block_end(&lines, enabled, 2);
+    let active = (enabled + 1..end)
+        .any(|index| list_item(&lines[index], 4).is_some_and(|item| item_is(item, PLUGIN_NAME)));
+    let disabled = nested_key(&lines, plugins, "disabled").is_some_and(|disabled| {
+        let end = block_end(&lines, disabled, 2);
+        (disabled + 1..end)
+            .any(|index| list_item(&lines[index], 4).is_some_and(|item| item_is(item, PLUGIN_NAME)))
+    });
+    active && !disabled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_edit_preserves_other_plugins_and_removes_a_disabled_entry() {
+        let input = "model: test\nplugins:\n  enabled:\n    - mine\n  disabled:\n    - luvus-agent-state\n    - theirs\ngateway:\n  enabled: true\n";
+        let enabled = enable_plugin(input).unwrap();
+        assert!(enabled.contains("    - mine\n    - luvus-agent-state\n"));
+        assert!(!enabled.contains("  disabled:\n    - luvus-agent-state"));
+        assert!(enabled.contains("    - theirs"));
+        assert!(enabled.contains("gateway:\n  enabled: true"));
+        assert!(plugin_enabled(&enabled));
+
+        let removed = disable_plugin(&enabled).unwrap();
+        assert!(!removed.contains("luvus-agent-state"));
+        assert!(removed.contains("    - mine"));
+        assert!(removed.contains("    - theirs"));
+    }
+
+    #[test]
+    fn config_edit_handles_missing_empty_and_flat_plugin_sections() {
+        for input in ["model: test\n", "plugins: []\n", "plugins:\n  - mine\n"] {
+            let enabled = enable_plugin(input).unwrap();
+            assert!(plugin_enabled(&enabled), "{enabled}");
+            let disabled = disable_plugin(&enabled).unwrap();
+            assert!(!disabled.contains(PLUGIN_NAME), "{disabled}");
+        }
+    }
+
+    #[test]
+    fn config_edit_refuses_ambiguous_inline_lists() {
+        let input = "plugins:\n  enabled: [mine]\n";
+        assert!(enable_plugin(input).is_err());
+        assert_eq!(input, "plugins:\n  enabled: [mine]\n");
+    }
+
+    #[test]
+    fn plugin_reports_each_session_once_and_hides_windows_processes() {
+        assert!(PLUGIN.starts_with("\"\"\""));
+        assert!(PLUGIN.contains("_last_reported.get(pane_id) == session_id"));
+        assert!(PLUGIN.contains("subprocess.CREATE_NO_WINDOW"));
+        assert!(PLUGIN.contains("LUVUS_BIN_PATH"));
+        assert!(PLUGIN.contains("ctx.register_hook(\"pre_llm_call\""));
+    }
+
+    #[test]
+    fn install_and_uninstall_touch_only_the_managed_hermes_plugin() {
+        let _env = crate::persist::test_env("hermes-integration");
+        let previous = std::env::var_os("HERMES_HOME");
+        let root = crate::persist::skills_dir().join("hermes-home");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("config.yaml"), "model: keep-me\n").unwrap();
+        std::env::set_var("HERMES_HOME", &root);
+
+        install().unwrap();
+        install().unwrap();
+        assert!(is_installed());
+        assert_eq!(
+            fs::read_to_string(plugin_dir().join("plugin.yaml")).unwrap(),
+            MANIFEST
+        );
+        let configured = fs::read_to_string(root.join("config.yaml")).unwrap();
+        assert!(configured.contains("model: keep-me"));
+        assert_eq!(configured.matches(PLUGIN_NAME).count(), 1);
+
+        uninstall().unwrap();
+        assert!(!plugin_dir().exists());
+        let configured = fs::read_to_string(root.join("config.yaml")).unwrap();
+        assert!(configured.contains("model: keep-me"));
+        assert!(!configured.contains(PLUGIN_NAME));
+
+        match previous {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+    }
+}

--- a/src/agent/hermes/mod.rs
+++ b/src/agent/hermes/mod.rs
@@ -1,0 +1,38 @@
+//! Native Nous Research Hermes CLI support.
+//!
+//! Hermes keeps canonical session metadata in a SQLite database under its
+//! selected `HERMES_HOME`. Luvus reads only the session identity, workspace,
+//! and activity timestamp through a bounded read-only query. Conversation
+//! messages, credentials, configuration, and memory are never opened here.
+
+use super::types::{AgentDescriptor, DiscoveryOperations, IdentityDescriptor, SessionOperations};
+
+pub(in crate::agent) mod sessions;
+
+pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
+    id: "hermes",
+    aliases: &["hermes-agent"],
+    identity: IdentityDescriptor {
+        // `hermes` is an ordinary proper name, so trust it only in deliberate
+        // command/title evidence. The launcher and Python module identities are
+        // distinctive enough to recognize from interpreter process trees.
+        distinct: &["hermes-agent", "hermes-cli", "hermes_cli.main"],
+        ambiguous: &["hermes"],
+        binary_matcher: None,
+        interpreter_packages: &[],
+        overlap_priority: 0,
+    },
+    sessions: Some(SessionOperations {
+        discovery: Some(DiscoveryOperations {
+            base: sessions::base,
+            recent: sessions::recent,
+            latest: sessions::latest,
+            list: Some(sessions::list),
+        }),
+        resume: |session| format!("hermes --resume {session}\r"),
+        // Hermes exposes `/branch` and `/fork` inside a live CLI, but does not
+        // document an external command that safely forks a stored session.
+        fork: None,
+    }),
+    integration: None,
+};

--- a/src/agent/hermes/mod.rs
+++ b/src/agent/hermes/mod.rs
@@ -7,6 +7,7 @@
 
 use super::types::{AgentDescriptor, DiscoveryOperations, IdentityDescriptor, SessionOperations};
 
+mod integration;
 pub(in crate::agent) mod sessions;
 
 pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
@@ -34,5 +35,5 @@ pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
         // document an external command that safely forks a stored session.
         fork: None,
     }),
-    integration: None,
+    integration: Some(integration::OPERATIONS),
 };

--- a/src/agent/hermes/sessions.rs
+++ b/src/agent/hermes/sessions.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
 
 use rusqlite::{Connection, OpenFlags};
@@ -8,6 +9,29 @@ use super::super::SessionInfo;
 
 const MAX_QUERY_ROWS: usize = 256;
 
+#[derive(Clone, PartialEq, Eq)]
+struct FileStamp {
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct DatabaseStamp {
+    database: FileStamp,
+    wal: Option<FileStamp>,
+}
+
+struct RowsCache {
+    path: PathBuf,
+    stamp: DatabaseStamp,
+    rows: Vec<SessionInfo>,
+}
+
+static ROWS_CACHE: OnceLock<Mutex<Option<RowsCache>>> = OnceLock::new();
+
+#[cfg(test)]
+static DATABASE_OPENS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 pub(in crate::agent) fn base() -> PathBuf {
     std::env::var_os("HERMES_HOME")
         .filter(|value| !value.is_empty())
@@ -15,16 +39,36 @@ pub(in crate::agent) fn base() -> PathBuf {
         .unwrap_or_else(|| super::super::home().join(".hermes"))
 }
 
-fn open_database(base: &Path) -> Option<Connection> {
-    let path = base.join("state.db");
+fn file_stamp(path: &Path) -> Option<FileStamp> {
+    let metadata = path.metadata().ok()?;
+    metadata.is_file().then(|| FileStamp {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+fn database_stamp(path: &Path) -> Option<DatabaseStamp> {
+    Some(DatabaseStamp {
+        database: file_stamp(path)?,
+        // SQLite may keep new rows exclusively in the WAL, leaving the main
+        // database unchanged. Include it so a new Hermes session cannot be
+        // hidden behind a stale cache entry.
+        wal: file_stamp(&path.with_file_name("state.db-wal")),
+    })
+}
+
+fn open_database(path: &Path) -> Option<Connection> {
     if !path.is_file() {
         return None;
     }
-    Connection::open_with_flags(
+    let connection = Connection::open_with_flags(
         path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
-    .ok()
+    .ok()?;
+    #[cfg(test)]
+    DATABASE_OPENS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Some(connection)
 }
 
 fn session_columns(connection: &Connection) -> Option<HashSet<String>> {
@@ -63,18 +107,14 @@ fn safe_session_id(session_id: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
-fn rows(base: &Path, limit: usize) -> Vec<SessionInfo> {
-    let Some(connection) = open_database(base) else {
-        return Vec::new();
-    };
-    let Some(columns) = session_columns(&connection) else {
-        return Vec::new();
-    };
+fn load_rows(path: &Path) -> Option<Vec<SessionInfo>> {
+    let connection = open_database(path)?;
+    let columns = session_columns(&connection)?;
     if !["id", "source", "cwd", "started_at"]
         .iter()
         .all(|column| columns.contains(*column))
     {
-        return Vec::new();
+        return None;
     }
 
     let timestamp = timestamp_expression(&columns);
@@ -89,30 +129,76 @@ fn rows(base: &Path, limit: usize) -> Vec<SessionInfo> {
          WHERE source = 'cli' AND cwd IS NOT NULL AND TRIM(cwd) <> '' {visibility} \
          ORDER BY activity DESC, started_at DESC, id DESC LIMIT ?1"
     );
-    let Ok(mut statement) = connection.prepare(&sql) else {
-        return Vec::new();
-    };
-    let Ok(found) = statement.query_map([limit.min(MAX_QUERY_ROWS) as i64], |row| {
-        let id: String = row.get(0)?;
-        let cwd: String = row.get(1)?;
-        let timestamp: f64 = row.get(2)?;
-        Ok((id, cwd, timestamp))
-    }) else {
-        return Vec::new();
-    };
-
-    found
-        .filter_map(Result::ok)
-        .filter_map(|(session_id, cwd, timestamp)| {
-            let cwd = PathBuf::from(cwd);
-            (safe_session_id(&session_id) && cwd.is_absolute()).then_some(SessionInfo {
-                agent: "hermes".to_string(),
-                session_id,
-                cwd,
-                updated: system_time(timestamp)?,
-            })
+    let mut statement = connection.prepare(&sql).ok()?;
+    let found = statement
+        .query_map([MAX_QUERY_ROWS as i64], |row| {
+            let id: String = row.get(0)?;
+            let cwd: String = row.get(1)?;
+            let timestamp: f64 = row.get(2)?;
+            Ok((id, cwd, timestamp))
         })
-        .collect()
+        .ok()?;
+
+    Some(
+        found
+            .filter_map(Result::ok)
+            .filter_map(|(session_id, cwd, timestamp)| {
+                let cwd = PathBuf::from(cwd);
+                (safe_session_id(&session_id) && cwd.is_absolute()).then_some(SessionInfo {
+                    agent: "hermes".to_string(),
+                    session_id,
+                    cwd,
+                    updated: system_time(timestamp)?,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn cached_rows(path: &Path, stamp: &DatabaseStamp, limit: usize) -> Option<Vec<SessionInfo>> {
+    let cache = ROWS_CACHE.get_or_init(|| Mutex::new(None)).lock().ok()?;
+    cache
+        .as_ref()
+        .filter(|entry| entry.path == path && &entry.stamp == stamp)
+        .map(|entry| {
+            entry
+                .rows
+                .iter()
+                .take(limit.min(MAX_QUERY_ROWS))
+                .cloned()
+                .collect()
+        })
+}
+
+fn cache_rows(path: &Path, stamp: DatabaseStamp, rows: &[SessionInfo]) {
+    if let Ok(mut cache) = ROWS_CACHE.get_or_init(|| Mutex::new(None)).lock() {
+        *cache = Some(RowsCache {
+            path: path.to_path_buf(),
+            stamp,
+            rows: rows.to_vec(),
+        });
+    }
+}
+
+fn rows(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let path = base.join("state.db");
+    let Some(stamp) = database_stamp(&path) else {
+        return Vec::new();
+    };
+    if let Some(rows) = cached_rows(&path, &stamp, limit) {
+        return rows;
+    }
+    let Some(mut rows) = load_rows(&path) else {
+        // A busy or partially replaced database is retried on the next bounded
+        // scan instead of turning a transient failure into a sticky cache hit.
+        return Vec::new();
+    };
+    cache_rows(&path, stamp, &rows);
+    rows.truncate(limit.min(MAX_QUERY_ROWS));
+    rows
 }
 
 pub(in crate::agent) fn list(base: &Path, cwd: &Path) -> Vec<String> {
@@ -226,6 +312,7 @@ mod tests {
         );
 
         assert_eq!(list(&root, &app), ["newer", "older"]);
+        let opens = DATABASE_OPENS.load(std::sync::atomic::Ordering::Relaxed);
         assert_eq!(latest(&root, &app).as_deref(), Some("newer"));
         let found = recent(&root, 10);
         assert_eq!(found.len(), 2, "one newest session per workspace");
@@ -235,6 +322,11 @@ mod tests {
             recent(&root, usize::MAX).len(),
             2,
             "caller limits larger than the query bound remain safe"
+        );
+        assert_eq!(
+            DATABASE_OPENS.load(std::sync::atomic::Ordering::Relaxed),
+            opens,
+            "an unchanged Hermes database reuses the bounded row cache"
         );
 
         fs::remove_dir_all(root).unwrap();

--- a/src/agent/hermes/sessions.rs
+++ b/src/agent/hermes/sessions.rs
@@ -1,0 +1,284 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use rusqlite::{Connection, OpenFlags};
+
+use super::super::SessionInfo;
+
+const MAX_QUERY_ROWS: usize = 256;
+
+pub(in crate::agent) fn base() -> PathBuf {
+    std::env::var_os("HERMES_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| super::super::home().join(".hermes"))
+}
+
+fn open_database(base: &Path) -> Option<Connection> {
+    let path = base.join("state.db");
+    if !path.is_file() {
+        return None;
+    }
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()
+}
+
+fn session_columns(connection: &Connection) -> Option<HashSet<String>> {
+    let mut statement = connection.prepare("PRAGMA table_info(sessions)").ok()?;
+    let rows = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .ok()?;
+    Some(rows.filter_map(Result::ok).collect())
+}
+
+fn timestamp_expression(columns: &HashSet<String>) -> String {
+    let mut candidates = Vec::with_capacity(3);
+    if columns.contains("last_activity_at") {
+        candidates.push("last_activity_at");
+    }
+    if columns.contains("ended_at") {
+        candidates.push("ended_at");
+    }
+    candidates.push("started_at");
+    match candidates.as_slice() {
+        [only] => (*only).to_string(),
+        _ => format!("COALESCE({})", candidates.join(", ")),
+    }
+}
+
+fn system_time(timestamp: f64) -> Option<SystemTime> {
+    let duration = Duration::try_from_secs_f64(timestamp).ok()?;
+    SystemTime::UNIX_EPOCH.checked_add(duration)
+}
+
+fn safe_session_id(session_id: &str) -> bool {
+    !session_id.is_empty()
+        && session_id.len() <= 256
+        && session_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+fn rows(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    let Some(connection) = open_database(base) else {
+        return Vec::new();
+    };
+    let Some(columns) = session_columns(&connection) else {
+        return Vec::new();
+    };
+    if !["id", "source", "cwd", "started_at"]
+        .iter()
+        .all(|column| columns.contains(*column))
+    {
+        return Vec::new();
+    }
+
+    let timestamp = timestamp_expression(&columns);
+    let visibility = if columns.contains("hidden") {
+        "AND COALESCE(hidden, 0) = 0"
+    } else {
+        ""
+    };
+    let sql = format!(
+        "SELECT id, cwd, {timestamp} AS activity \
+         FROM sessions \
+         WHERE source = 'cli' AND cwd IS NOT NULL AND TRIM(cwd) <> '' {visibility} \
+         ORDER BY activity DESC, started_at DESC, id DESC LIMIT ?1"
+    );
+    let Ok(mut statement) = connection.prepare(&sql) else {
+        return Vec::new();
+    };
+    let Ok(found) = statement.query_map([limit.min(MAX_QUERY_ROWS) as i64], |row| {
+        let id: String = row.get(0)?;
+        let cwd: String = row.get(1)?;
+        let timestamp: f64 = row.get(2)?;
+        Ok((id, cwd, timestamp))
+    }) else {
+        return Vec::new();
+    };
+
+    found
+        .filter_map(Result::ok)
+        .filter_map(|(session_id, cwd, timestamp)| {
+            let cwd = PathBuf::from(cwd);
+            (safe_session_id(&session_id) && cwd.is_absolute()).then_some(SessionInfo {
+                agent: "hermes".to_string(),
+                session_id,
+                cwd,
+                updated: system_time(timestamp)?,
+            })
+        })
+        .collect()
+}
+
+pub(in crate::agent) fn list(base: &Path, cwd: &Path) -> Vec<String> {
+    rows(base, MAX_QUERY_ROWS)
+        .into_iter()
+        .filter(|session| crate::platform::same_path(&session.cwd, cwd))
+        .map(|session| session.session_id)
+        .collect()
+}
+
+pub(in crate::agent) fn latest(base: &Path, cwd: &Path) -> Option<String> {
+    list(base, cwd).into_iter().next()
+}
+
+pub(in crate::agent) fn recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let mut seen = Vec::<PathBuf>::new();
+    rows(base, limit.saturating_mul(8).min(MAX_QUERY_ROWS))
+        .into_iter()
+        .filter(|session| {
+            if seen
+                .iter()
+                .any(|cwd| crate::platform::same_path(cwd, &session.cwd))
+            {
+                false
+            } else {
+                seen.push(session.cwd.clone());
+                true
+            }
+        })
+        .take(limit)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use rusqlite::params;
+
+    use super::*;
+
+    fn fixture(tag: &str) -> PathBuf {
+        let root = crate::persist::skills_dir().join(format!("hermes-session-{tag}"));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let connection = Connection::open(root.join("state.db")).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    started_at REAL NOT NULL,
+                    ended_at REAL,
+                    cwd TEXT,
+                    last_activity_at REAL,
+                    hidden INTEGER DEFAULT 0
+                );",
+            )
+            .unwrap();
+        root
+    }
+
+    fn insert(root: &Path, id: &str, source: &str, cwd: &str, activity: f64, hidden: bool) {
+        let connection = Connection::open(root.join("state.db")).unwrap();
+        connection
+            .execute(
+                "INSERT INTO sessions
+                 (id, source, started_at, cwd, last_activity_at, hidden)
+                 VALUES (?1, ?2, ?3, ?4, ?3, ?5)",
+                params![id, source, activity, cwd, hidden],
+            )
+            .unwrap();
+    }
+
+    fn workspace(name: &str) -> PathBuf {
+        if cfg!(windows) {
+            PathBuf::from(format!(r"C:\work\{name}"))
+        } else {
+            PathBuf::from(format!("/work/{name}"))
+        }
+    }
+
+    #[test]
+    fn discovers_only_visible_cli_sessions_by_workspace() {
+        let _env = crate::persist::test_env("hermes-session-scoped");
+        let root = fixture("scoped");
+        let app = workspace("app");
+        let api = workspace("api");
+        insert(&root, "older", "cli", &app.to_string_lossy(), 10.0, false);
+        insert(&root, "newer", "cli", &app.to_string_lossy(), 30.0, false);
+        insert(&root, "api", "cli", &api.to_string_lossy(), 20.0, false);
+        insert(
+            &root,
+            "telegram",
+            "telegram",
+            &app.to_string_lossy(),
+            50.0,
+            false,
+        );
+        insert(&root, "hidden", "cli", &app.to_string_lossy(), 40.0, true);
+        insert(
+            &root,
+            "unsafe id",
+            "cli",
+            &app.to_string_lossy(),
+            60.0,
+            false,
+        );
+
+        assert_eq!(list(&root, &app), ["newer", "older"]);
+        assert_eq!(latest(&root, &app).as_deref(), Some("newer"));
+        let found = recent(&root, 10);
+        assert_eq!(found.len(), 2, "one newest session per workspace");
+        assert_eq!(found[0].session_id, "newer");
+        assert_eq!(found[1].session_id, "api");
+        assert_eq!(
+            recent(&root, usize::MAX).len(),
+            2,
+            "caller limits larger than the query bound remain safe"
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn older_schema_without_activity_or_hidden_columns_remains_readable() {
+        let _env = crate::persist::test_env("hermes-session-legacy");
+        let root = crate::persist::skills_dir().join("hermes-session-legacy");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let connection = Connection::open(root.join("state.db")).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    started_at REAL NOT NULL,
+                    cwd TEXT
+                );",
+            )
+            .unwrap();
+
+        let expected = workspace("legacy");
+        connection
+            .execute(
+                "INSERT INTO sessions VALUES ('legacy', 'cli', 12, ?1)",
+                [expected.to_string_lossy().as_ref()],
+            )
+            .unwrap();
+        assert_eq!(latest(&root, &expected).as_deref(), Some("legacy"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn missing_or_malformed_databases_fail_closed() {
+        let _env = crate::persist::test_env("hermes-session-malformed");
+        let missing = crate::persist::skills_dir().join("hermes-session-missing");
+        let _ = fs::remove_dir_all(&missing);
+        assert!(recent(&missing, 10).is_empty());
+
+        fs::create_dir_all(&missing).unwrap();
+        fs::write(missing.join("state.db"), b"not sqlite").unwrap();
+        assert!(list(&missing, &workspace("app")).is_empty());
+        fs::remove_dir_all(missing).unwrap();
+    }
+}

--- a/src/agent/hermes/sessions.rs
+++ b/src/agent/hermes/sessions.rs
@@ -126,7 +126,7 @@ fn load_rows(path: &Path) -> Option<Vec<SessionInfo>> {
     let sql = format!(
         "SELECT id, cwd, {timestamp} AS activity \
          FROM sessions \
-         WHERE source = 'cli' AND cwd IS NOT NULL AND TRIM(cwd) <> '' {visibility} \
+         WHERE source IN ('cli', 'tui') AND cwd IS NOT NULL AND TRIM(cwd) <> '' {visibility} \
          ORDER BY activity DESC, started_at DESC, id DESC LIMIT ?1"
     );
     let mut statement = connection.prepare(&sql).ok()?;
@@ -285,12 +285,13 @@ mod tests {
     }
 
     #[test]
-    fn discovers_only_visible_cli_sessions_by_workspace() {
+    fn discovers_only_visible_terminal_sessions_by_workspace() {
         let _env = crate::persist::test_env("hermes-session-scoped");
         let root = fixture("scoped");
         let app = workspace("app");
         let api = workspace("api");
         insert(&root, "older", "cli", &app.to_string_lossy(), 10.0, false);
+        insert(&root, "tui", "tui", &app.to_string_lossy(), 25.0, false);
         insert(&root, "newer", "cli", &app.to_string_lossy(), 30.0, false);
         insert(&root, "api", "cli", &api.to_string_lossy(), 20.0, false);
         insert(
@@ -311,7 +312,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(list(&root, &app), ["newer", "older"]);
+        assert_eq!(list(&root, &app), ["newer", "tui", "older"]);
         let opens = DATABASE_OPENS.load(std::sync::atomic::Ordering::Relaxed);
         assert_eq!(latest(&root, &app).as_deref(), Some("newer"));
         let found = recent(&root, 10);

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -30,6 +30,7 @@ static INTEGRATIONS: &[&AgentDescriptor] = &[
     &super::opencode::DESCRIPTOR,
     &super::kimi::DESCRIPTOR,
     &super::grok::DESCRIPTOR,
+    &super::hermes::DESCRIPTOR,
     &super::omp::DESCRIPTOR,
 ];
 

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -223,7 +223,7 @@ mod tests {
                 .iter()
                 .map(|descriptor| descriptor.id)
                 .collect::<Vec<_>>(),
-            ["claude", "copilot", "codex", "opencode", "kimi", "grok", "omp"]
+            ["claude", "copilot", "codex", "opencode", "kimi", "grok", "hermes", "omp",]
         );
     }
 }

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -14,6 +14,7 @@ pub(crate) static BUILTINS: &[&AgentDescriptor] = &[
     &super::amp::DESCRIPTOR,
     &super::droid::DESCRIPTOR,
     &super::grok::DESCRIPTOR,
+    &super::hermes::DESCRIPTOR,
     &super::muse::DESCRIPTOR,
     &super::omp::DESCRIPTOR,
     &super::pi::DESCRIPTOR,
@@ -148,6 +149,11 @@ mod tests {
             ("droid", &[][..], &["droid"][..]),
             ("grok", &[][..], &["grok"][..]),
             (
+                "hermes",
+                &["hermes-agent", "hermes-cli", "hermes_cli.main"][..],
+                &["hermes"][..],
+            ),
+            (
                 "muse",
                 &["muse-code", "muse-cli", "muse code"][..],
                 &["muse"][..],
@@ -175,7 +181,7 @@ mod tests {
             resumable,
             [
                 "claude", "codex", "gemini", "opencode", "copilot", "kimi", "qwen", "cursor",
-                "grok", "muse", "omp", "pi", "fx",
+                "grok", "hermes", "muse", "omp", "pi", "fx",
             ]
         );
 
@@ -193,8 +199,8 @@ mod tests {
         assert_eq!(
             discoverable,
             [
-                "claude", "codex", "gemini", "opencode", "copilot", "kimi", "qwen", "grok", "muse",
-                "omp", "pi", "fx",
+                "claude", "codex", "gemini", "opencode", "copilot", "kimi", "qwen", "grok",
+                "hermes", "muse", "omp", "pi", "fx",
             ]
         );
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -92,6 +92,31 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn settled_working_pane_waits_for_output_instead_of_polling_forever() {
+        let (_env, mut app) = app("settled-working-cadence");
+        let pane = app.layout().focus;
+        let now = Instant::now();
+        app.last_detect_at = now - DETECTION_INTERVAL;
+        app.last_detection_audit_at = now;
+        let status = app.status.get_mut(&pane).unwrap();
+        status.force_detect = false;
+        status.state = State::Working;
+        status.candidate = State::Working;
+        status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+
+        let considered = app.detection_panes_considered;
+        app.detect_tick(now);
+        assert_eq!(
+            app.detection_panes_considered, considered,
+            "unchanged working panes do not force a permanent 100 ms poll"
+        );
+
+        assert!(app.handle_event(AppEvent::PtyData(pane)));
+        app.detect_tick(now + DETECTION_INTERVAL);
+        assert_eq!(app.detection_panes_considered, considered + 1);
+    }
+
+    #[test]
     fn hidden_pty_title_change_is_a_presentation_invalidation() {
         let (_env, mut app) = app("hidden-title-invalidation");
         let hidden = app.layout().focus;
@@ -652,8 +677,10 @@ impl App {
                     || self.status.get(id).is_some_and(|status| {
                         status.force_detect
                             || status.candidate != status.state
-                            || status.state == State::Working
                             || status.agent_report.is_some()
+                            || (status.state == State::Working
+                                && now.saturating_duration_since(status.last_activity)
+                                    < ACTIVITY_WINDOW + QUIET_DWELL)
                     })
             })
             .collect();
@@ -703,15 +730,31 @@ impl App {
                 .status
                 .get(&id)
                 .and_then(|status| status.agent_report.clone());
-            let detection_rows = detect::screen_rows(
-                self.status
-                    .get(&id)
-                    .map(|status| status.agent.as_str())
-                    .unwrap_or(""),
-                self.proc_commands
-                    .get(&id)
-                    .map(Vec::as_slice)
-                    .unwrap_or(&[]),
+            let known_agent = self
+                .status
+                .get(&id)
+                .map(|status| {
+                    if self.manifests.is_agent(&status.agent) {
+                        status.agent.clone()
+                    } else {
+                        status
+                            .agent_session
+                            .as_ref()
+                            .map(|session| session.agent.clone())
+                            .unwrap_or_default()
+                    }
+                })
+                .unwrap_or_default();
+            let running_for_detection = self
+                .proc_commands
+                .get(&id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let detection_rows =
+                detect::screen_rows(&known_agent, running_for_detection, &self.manifests);
+            let non_empty_rows = detect::screen_uses_non_empty_rows(
+                &known_agent,
+                running_for_detection,
                 &self.manifests,
             );
             let (last_generation, force_detect) = self
@@ -728,10 +771,15 @@ impl App {
                     Ok(engine) => {
                         let generation = engine.output_generation();
                         if force_detect || last_generation != Some(generation) {
+                            let text = if non_empty_rows {
+                                engine.detection_text_non_empty(detection_rows)
+                            } else {
+                                engine.detection_text(detection_rows)
+                            };
                             Some((
                                 generation,
                                 engine.title().map(Arc::<str>::from),
-                                Arc::<str>::from(engine.detection_text(detection_rows)),
+                                Arc::<str>::from(text),
                             ))
                         } else {
                             None
@@ -777,20 +825,7 @@ impl App {
             // What this pane is already known to be: the last resolved agent, or
             // the one a hook/disk-discovery bound to it. Keeps identity stable
             // across frames where the agent's UI doesn't show its own name.
-            let known = self
-                .status
-                .get(&id)
-                .map(|s| {
-                    if self.manifests.is_agent(&s.agent) {
-                        s.agent.clone()
-                    } else {
-                        s.agent_session
-                            .as_ref()
-                            .map(|a| a.agent.clone())
-                            .unwrap_or_default()
-                    }
-                })
-                .unwrap_or_default();
+            let known = known_agent;
             // Ground truth for identity, when the last scan could see this pane.
             let running = self
                 .proc_commands

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -314,7 +314,7 @@ server:
   server restart             stop + start (load a newly-installed binary)
   server update-manifest     fetch the latest agent-detection rules from luvus.dev
                              (applies live if the server is up; else on next start)
-  integration install|uninstall <claude|copilot|codex|opencode|kimi|grok|omp>
+  integration install|uninstall <claude|copilot|codex|opencode|kimi|grok|hermes|omp>
                              add/remove luvus's session-resume hook (uninstall
                              removes only luvus's hook, never the agent)
 ";
@@ -4704,13 +4704,13 @@ mod tests {
         // different agent with no hook integration, so neither the help text
         // nor the published CLI reference may advertise `pi` here — and both
         // must list `omp`.
-        assert!(DETAILED_USAGE.contains("grok|omp>"));
-        assert!(!DETAILED_USAGE.contains("grok|pi>"));
+        assert!(DETAILED_USAGE.contains("|omp>"));
+        assert!(!DETAILED_USAGE.contains("|pi>"));
         let page = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("website/src/content/docs/docs/reference/cli.mdx");
         if let Ok(text) = fs::read_to_string(page) {
-            assert!(text.contains("grok|omp>"));
-            assert!(!text.contains("grok|pi>"));
+            assert!(text.contains("|omp>"));
+            assert!(!text.contains("|pi>"));
         }
     }
 }

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -530,6 +530,92 @@ fn builtin_rules() -> Vec<Rule> {
             Region::Screen,
             vec![any(&["send a message to interrupt"])],
         ),
+        // Hermes publishes compact OSC-title state markers. The explicit idle
+        // marker outranks retained working text from the completed turn, while
+        // visible confirmation panels still outrank both title states.
+        per(
+            "hermes",
+            State::Blocked,
+            325,
+            Region::Title,
+            vec![any(&["⚠"])],
+        ),
+        per(
+            "hermes",
+            State::Working,
+            125,
+            Region::Title,
+            vec![any(&["⏳"])],
+        ),
+        per("hermes", State::Idle, 210, Region::Title, vec![any(&["✓"])]),
+        // Require both a Hermes interaction label and its controls. Matching
+        // either half alone would turn ordinary transcript prose into a false
+        // blocked state.
+        per(
+            "hermes",
+            State::Blocked,
+            315,
+            Region::Screen,
+            vec![
+                any(&["dangerous", "approval", "allow once", "1. allow"]),
+                any(&[
+                    "enter confirm",
+                    "enter to confirm",
+                    "↑/↓ to select",
+                    "show full command",
+                ]),
+            ],
+        ),
+        per(
+            "hermes",
+            State::Blocked,
+            315,
+            Region::Screen,
+            vec![
+                any(&["hermes needs your", "type your answer", "other (type"]),
+                any(&[
+                    "enter confirm",
+                    "enter to confirm",
+                    "enter send",
+                    "press enter",
+                    "↑/↓ select",
+                    "↑/↓ to select",
+                ]),
+            ],
+        ),
+        per(
+            "hermes",
+            State::Blocked,
+            315,
+            Region::Screen,
+            vec![
+                any(&["approve once", "start a new session", "keep going"]),
+                any(&[
+                    "cancel",
+                    "enter to confirm",
+                    "enter confirm",
+                    "type 1/2/3",
+                    "y/n quick",
+                ]),
+            ],
+        ),
+        per(
+            "hermes",
+            State::Blocked,
+            315,
+            Region::Screen,
+            vec![
+                any(&["sudo password", "skill setup"]),
+                any(&["password", "press enter", "enter confirm"]),
+            ],
+        ),
+        per(
+            "hermes",
+            State::Working,
+            125,
+            Region::Screen,
+            vec![any(&["msg=interrupt", "ctrl+c cancel"])],
+        ),
         // Muse question, trust, and approval overlays. These paired controls
         // outrank its generic `esc to interrupt` working hint, including the
         // multi-select question UI that deliberately retains that phrase.
@@ -1339,6 +1425,87 @@ mod tests {
         assert_eq!(
             incidental.agent, "zsh",
             "bare muse is never trusted from pane output"
+        );
+    }
+
+    #[test]
+    fn hermes_identity_accepts_native_and_python_launchers_without_trusting_prose() {
+        let manifests = Manifests::builtin();
+        for command in [
+            "/Users/me/.local/bin/hermes --tui",
+            r"C:\Users\me\.local\bin\hermes.exe --resume 20260830_120000_a1b2c3",
+            "/usr/bin/python3 /Users/me/.local/bin/hermes --tui",
+            "/usr/bin/python3 -m hermes_cli.main --tui",
+        ] {
+            assert_eq!(
+                manifests.agent_in_processes(&[command.to_string()]),
+                Some("hermes".to_string()),
+                "failed to recognize {command}"
+            );
+        }
+
+        let incidental = classify(
+            Some("zsh"),
+            "Hermes was the messenger of the gods",
+            true,
+            false,
+            "zsh",
+            "",
+            &[],
+            &manifests,
+        );
+        assert_eq!(
+            incidental.agent, "zsh",
+            "the ordinary proper name must not identify a shell as Hermes CLI"
+        );
+    }
+
+    #[test]
+    fn hermes_state_requires_visible_interaction_evidence() {
+        let manifests = Manifests::builtin();
+        let detect = |title: &str, screen: &str| {
+            classify(
+                Some(title),
+                screen,
+                false,
+                false,
+                "zsh",
+                "hermes",
+                &["/Users/me/.local/bin/hermes --tui".to_string()],
+                &manifests,
+            )
+            .state
+        };
+
+        assert_eq!(detect("⏳ Hermes", ""), State::Working);
+        assert_eq!(detect("⚠ Hermes", ""), State::Blocked);
+        assert_eq!(
+            detect("✓ Hermes", "Ctrl+C to interrupt"),
+            State::Idle,
+            "the current title wins over a retained interrupt hint"
+        );
+        assert_eq!(
+            detect(
+                "Hermes",
+                "Dangerous command\n1. Allow once\nEnter to confirm"
+            ),
+            State::Blocked
+        );
+        assert_eq!(
+            detect(
+                "Hermes",
+                "Hermes needs your input\nType your answer\nEnter send"
+            ),
+            State::Blocked
+        );
+        assert_eq!(
+            detect("Hermes", "running tool · msg=interrupt"),
+            State::Working
+        );
+        assert_eq!(
+            detect("Hermes", "documentation about dangerous command approval"),
+            State::Idle,
+            "labels without interactive controls are ordinary output"
         );
     }
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -158,6 +158,8 @@ enum Cond {
     All(Vec<String>),
     /// The region contains none of these substrings.
     Not(Vec<String>),
+    /// The region starts with one of these values.
+    StartsWith(Vec<String>),
     /// A line in the region starts with a spinner glyph — a braille cell
     /// (U+2800..=U+28FF, what most CLIs animate) or a moon phase (U+1F311..=
     /// U+1F318, Kimi's background-agent spinner). A running spinner means work.
@@ -170,6 +172,7 @@ impl Cond {
             Cond::Any(subs) => subs.iter().any(|s| low.contains(s)),
             Cond::All(subs) => subs.iter().all(|s| low.contains(s)),
             Cond::Not(subs) => !subs.iter().any(|s| low.contains(s)),
+            Cond::StartsWith(prefixes) => prefixes.iter().any(|prefix| low.starts_with(prefix)),
             Cond::Spinner => low
                 .lines()
                 .any(|l| l.trim_start().chars().next().is_some_and(is_spinner_glyph)),
@@ -302,6 +305,9 @@ fn any(subs: &[&str]) -> Cond {
 fn all(subs: &[&str]) -> Cond {
     Cond::All(subs.iter().map(|s| s.to_lowercase()).collect())
 }
+fn starts_with(prefixes: &[&str]) -> Cond {
+    Cond::StartsWith(prefixes.iter().map(|value| value.to_lowercase()).collect())
+}
 
 /// How much of the live terminal grid must reach the rule engine. Most agents
 /// keep state beside their bottom prompt, but fx can pin its transient activity
@@ -313,6 +319,14 @@ pub(crate) fn screen_rows(known_agent: &str, running: &[String], manifests: &Man
     } else {
         14
     }
+}
+
+pub(crate) fn screen_uses_non_empty_rows(
+    known_agent: &str,
+    running: &[String],
+    manifests: &Manifests,
+) -> bool {
+    known_agent.eq_ignore_ascii_case("hermes") || manifests.process_has_agent(running, "hermes")
 }
 
 /// The compiled-in default rules (generic first, then per-agent).
@@ -538,16 +552,22 @@ fn builtin_rules() -> Vec<Rule> {
             State::Blocked,
             325,
             Region::Title,
-            vec![any(&["⚠"])],
+            vec![starts_with(&["⚠"])],
         ),
         per(
             "hermes",
             State::Working,
             125,
             Region::Title,
-            vec![any(&["⏳"])],
+            vec![starts_with(&["⏳"])],
         ),
-        per("hermes", State::Idle, 210, Region::Title, vec![any(&["✓"])]),
+        per(
+            "hermes",
+            State::Idle,
+            210,
+            Region::Title,
+            vec![starts_with(&["✓"])],
+        ),
         // Require both a Hermes interaction label and its controls. Matching
         // either half alone would turn ordinary transcript prose into a false
         // blocked state.
@@ -572,7 +592,12 @@ fn builtin_rules() -> Vec<Rule> {
             315,
             Region::Screen,
             vec![
-                any(&["hermes needs your", "type your answer", "other (type"]),
+                any(&[
+                    "hermes needs your",
+                    "type your answer",
+                    "other (type",
+                    "ask ",
+                ]),
                 any(&[
                     "enter confirm",
                     "enter to confirm",
@@ -580,6 +605,7 @@ fn builtin_rules() -> Vec<Rule> {
                     "press enter",
                     "↑/↓ select",
                     "↑/↓ to select",
+                    "other (type",
                 ]),
             ],
         ),
@@ -605,8 +631,8 @@ fn builtin_rules() -> Vec<Rule> {
             315,
             Region::Screen,
             vec![
-                any(&["sudo password", "skill setup"]),
-                any(&["password", "press enter", "enter confirm"]),
+                any(&["sudo password", "skill setup", "🔑"]),
+                any(&["password", "press enter", "enter confirm", "for "]),
             ],
         ),
         per(
@@ -614,7 +640,11 @@ fn builtin_rules() -> Vec<Rule> {
             State::Working,
             125,
             Region::Screen,
-            vec![any(&["msg=interrupt", "ctrl+c cancel"])],
+            vec![any(&[
+                "msg=interrupt",
+                "ctrl+c cancel",
+                "ctrl+c to interrupt",
+            ])],
         ),
         // Muse question, trust, and approval overlays. These paired controls
         // outrank its generic `esc to interrupt` working hint, including the
@@ -1480,6 +1510,11 @@ mod tests {
         assert_eq!(detect("⏳ Hermes", ""), State::Working);
         assert_eq!(detect("⚠ Hermes", ""), State::Blocked);
         assert_eq!(
+            detect("Hermes status ✓", ""),
+            State::Idle,
+            "an incidental marker later in the title is not state authority"
+        );
+        assert_eq!(
             detect("✓ Hermes", "Ctrl+C to interrupt"),
             State::Idle,
             "the current title wins over a retained interrupt hint"
@@ -1502,6 +1537,12 @@ mod tests {
             detect("Hermes", "running tool · msg=interrupt"),
             State::Working
         );
+        assert_eq!(
+            detect("Hermes", "Ask repository owner\nOther (type answer)"),
+            State::Blocked
+        );
+        assert_eq!(detect("Hermes", "🔑 API key for provider"), State::Blocked);
+        assert_eq!(detect("Hermes", "Ctrl+C to interrupt"), State::Working);
         assert_eq!(
             detect("Hermes", "documentation about dangerous command approval"),
             State::Idle,

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -62,10 +62,11 @@ pub enum SkillHost {
     Qwen,
     Kiro,
     Omp,
+    Hermes,
 }
 
 impl SkillHost {
-    const ALL: [Self; 8] = [
+    const ALL: [Self; 9] = [
         Self::Shared,
         Self::Claude,
         Self::Opencode,
@@ -74,6 +75,7 @@ impl SkillHost {
         Self::Qwen,
         Self::Kiro,
         Self::Omp,
+        Self::Hermes,
     ];
 
     pub fn as_str(self) -> &'static str {
@@ -86,6 +88,7 @@ impl SkillHost {
             Self::Qwen => "qwen",
             Self::Kiro => "kiro",
             Self::Omp => "omp",
+            Self::Hermes => "hermes",
         }
     }
 
@@ -384,6 +387,7 @@ fn target_dir_at(host: SkillHost, home: &Path, xdg_config: Option<&Path>) -> Pat
         SkillHost::Qwen => home.join(".qwen").join("skills").join("luvus"),
         SkillHost::Kiro => home.join(".kiro").join("skills").join("luvus"),
         SkillHost::Omp => crate::agent::omp::default_skill_dir_at(home),
+        SkillHost::Hermes => home.join(".hermes").join("skills").join("luvus"),
     }
 }
 
@@ -399,6 +403,11 @@ fn target_dir(host: SkillHost) -> Result<PathBuf> {
     }
     if host == SkillHost::Kimi {
         if let Some(config) = std::env::var_os("KIMI_CODE_HOME") {
+            return Ok(PathBuf::from(config).join("skills").join("luvus"));
+        }
+    }
+    if host == SkillHost::Hermes {
+        if let Some(config) = std::env::var_os("HERMES_HOME").filter(|value| !value.is_empty()) {
             return Ok(PathBuf::from(config).join("skills").join("luvus"));
         }
     }
@@ -539,6 +548,7 @@ fn host_commands(host: SkillHost) -> &'static [&'static str] {
         SkillHost::Qwen => &["qwen"],
         SkillHost::Kiro => &["kiro", "kiro-cli"],
         SkillHost::Omp => &["omp"],
+        SkillHost::Hermes => &["hermes"],
     }
 }
 
@@ -578,6 +588,7 @@ fn host_config_dirs(
         SkillHost::Qwen => vec![home.join(".qwen")],
         SkillHost::Kiro => vec![home.join(".kiro")],
         SkillHost::Omp => vec![crate::agent::omp::default_agent_dir_at(home)],
+        SkillHost::Hermes => vec![home.join(".hermes")],
     }
 }
 
@@ -1120,6 +1131,10 @@ mod tests {
         assert_eq!(
             target_dir_at(SkillHost::Kiro, home, None),
             PathBuf::from("/home/tester/.kiro/skills/luvus")
+        );
+        assert_eq!(
+            target_dir_at(SkillHost::Hermes, home, None),
+            PathBuf::from("/home/tester/.hermes/skills/luvus")
         );
         assert_eq!(SkillHost::Shared.state_key(), "codex");
     }

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -559,6 +559,7 @@ fn host_config_dirs(
     claude_config: Option<&Path>,
     codex_home: Option<&Path>,
     kimi_home: Option<&Path>,
+    hermes_home: Option<&Path>,
 ) -> Vec<PathBuf> {
     let xdg = xdg_config
         .map(Path::to_path_buf)
@@ -588,7 +589,9 @@ fn host_config_dirs(
         SkillHost::Qwen => vec![home.join(".qwen")],
         SkillHost::Kiro => vec![home.join(".kiro")],
         SkillHost::Omp => vec![crate::agent::omp::default_agent_dir_at(home)],
-        SkillHost::Hermes => vec![home.join(".hermes")],
+        SkillHost::Hermes => vec![hermes_home
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| home.join(".hermes"))],
     }
 }
 
@@ -601,6 +604,9 @@ fn host_detected(host: SkillHost, state: &SkillState, target: &Path) -> Result<b
     let claude = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
     let codex = std::env::var_os("CODEX_HOME").map(PathBuf::from);
     let kimi = std::env::var_os("KIMI_CODE_HOME").map(PathBuf::from);
+    let hermes = std::env::var_os("HERMES_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
     if host == SkillHost::Omp && crate::agent::omp::agent_dir().is_ok_and(|path| path.is_dir()) {
         return Ok(true);
     }
@@ -611,6 +617,7 @@ fn host_detected(host: SkillHost, state: &SkillState, target: &Path) -> Result<b
         claude.as_deref(),
         codex.as_deref(),
         kimi.as_deref(),
+        hermes.as_deref(),
     )) || any_command_on_path(host_commands(host)))
 }
 
@@ -1143,10 +1150,16 @@ mod tests {
     fn every_native_skill_host_has_detection_markers() {
         for host in SkillHost::ALL {
             assert!(!host_commands(host).is_empty());
-            assert!(
-                !host_config_dirs(host, Path::new("/home/tester"), None, None, None, None)
-                    .is_empty()
-            );
+            assert!(!host_config_dirs(
+                host,
+                Path::new("/home/tester"),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .is_empty());
         }
         let shared = host_commands(SkillHost::Shared);
         for agent in [
@@ -1379,12 +1392,33 @@ mod tests {
         let agent_dir = root.join(".omp").join("agent");
         fs::create_dir_all(&agent_dir).unwrap();
 
-        let dirs = host_config_dirs(SkillHost::Omp, &root, None, None, None, None);
+        let dirs = host_config_dirs(SkillHost::Omp, &root, None, None, None, None, None);
         assert_eq!(dirs, vec![agent_dir.clone()]);
         assert!(any_dir(&dirs), "config dir presence detects the omp host");
         assert_eq!(host_commands(SkillHost::Omp), &["omp"]);
         assert_eq!(SkillHost::Omp.as_str(), "omp");
         assert!(SkillHost::ALL.contains(&SkillHost::Omp));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn hermes_detection_respects_a_custom_home_without_a_path_binary() {
+        let root = crate::persist::skills_dir().join("hermes-custom-home");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        let dirs = host_config_dirs(
+            SkillHost::Hermes,
+            Path::new("/home/tester"),
+            None,
+            None,
+            None,
+            None,
+            Some(&root),
+        );
+        assert_eq!(dirs, vec![root.clone()]);
+        assert!(any_dir(&dirs));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -451,6 +451,37 @@ impl VtEngine for AlacrittyEngine {
         out
     }
 
+    fn detection_text_non_empty(&self, n: u16) -> String {
+        let grid = self.term.grid();
+        let rows = grid.screen_lines();
+        let cols = grid.columns();
+        let mut selected = Vec::with_capacity(usize::from(n).min(rows));
+        for r in (0..rows).rev() {
+            let row = &grid[Line(r as i32)];
+            let mut line = String::with_capacity(cols);
+            for c in 0..cols {
+                let cell = &row[Column(c)];
+                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                    continue;
+                }
+                line.push(if cell.c == '\0' { ' ' } else { cell.c });
+                if let Some(zerowidth) = cell.zerowidth() {
+                    line.extend(zerowidth);
+                }
+            }
+            let line = line.trim_end();
+            if line.is_empty() {
+                continue;
+            }
+            selected.push(line.to_string());
+            if selected.len() == usize::from(n) {
+                break;
+            }
+        }
+        selected.reverse();
+        selected.join("\n")
+    }
+
     fn visible_rows(&self) -> Vec<String> {
         // Same offset shift as `for_each_cell` — these are the rows the user can
         // see, so a selection made while scrolled back must copy the history
@@ -1413,6 +1444,22 @@ mod tests {
                 e.scroll_offset()
             );
         }
+    }
+
+    #[test]
+    fn non_empty_detection_reaches_prompts_above_blank_footer_rows() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(60, 8, tx, budget_for_rows(60, 2_000));
+        engine.advance(b"Hermes needs your approval\r\nEnter to confirm");
+
+        assert!(
+            engine.detection_text(2).trim().is_empty(),
+            "the ordinary two-row window is the blank terminal footer"
+        );
+        assert_eq!(
+            engine.detection_text_non_empty(2),
+            "Hermes needs your approval\nEnter to confirm"
+        );
     }
 
     #[test]

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -212,6 +212,12 @@ pub trait VtEngine: Send {
     /// the user's scroll position.
     fn detection_text(&self, n: u16) -> String;
 
+    /// Bottom `n` non-empty live-screen rows. Agents with a tall blank footer
+    /// use this without pulling scrollback into state detection.
+    fn detection_text_non_empty(&self, n: u16) -> String {
+        self.detection_text(n)
+    }
+
     /// Every visible row as normalized plain text. Wide-character spacer cells
     /// are omitted, so callers must not use string indexes as terminal columns.
     fn visible_rows(&self) -> Vec<String>;

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -265,6 +265,9 @@ discovery rather than inferring support from an agent name.
   and terminal state.
 - Supported agents can reopen their own conversation through native session
   discovery and resume commands.
+- Hermes session discovery works without setup. When exact pane ownership is
+  required, `luvus integration install hermes` adds an opt-in Hermes plugin
+  that reports each session once while retaining the native database fallback.
 
 Do not claim every shell command resumes after restart. Do not guess native
 session IDs. List sessions and use the exact returned identifier.

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -82,9 +82,9 @@ for an agent to receive it:
 skill into detected native skill locations without overwriting external or
 modified content. The shared `~/.agents/skills/luvus/` copy serves Codex,
 GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx. Dedicated
-adapters serve Claude Code, OpenCode, Kimi Code CLI, Grok Build, Qwen Code,
-and Kiro. Aider has no native Agent Skills installation surface, so use
-`luvus skill show` when an Aider conversation needs the instructions.
+adapters serve Claude Code, OpenCode, Kimi Code CLI, Grok Build, Hermes CLI,
+Qwen Code, and Kiro. Aider has no native Agent Skills installation surface, so
+use `luvus skill show` when an Aider conversation needs the instructions.
 
 Start a new agent conversation after installation, or use that agent's skill
 reload command when it provides one. To remove unchanged Luvus-managed copies:

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -29,8 +29,9 @@ Run `luvus doctor`. Local views need `git`. PRs/issues need an authenticated
 
 luvus identifies an agent by the program running in the pane, matched against a
 list of names it knows (Claude Code, Copilot, Codex, opencode, Kimi, Cursor,
-Gemini, Aider, Amp, Droid, Grok, Muse, Qwen, Kiro). If your agent runs under a name
-luvus does not know, teach it one in `~/.luvus/manifests/<agent>.toml`:
+Gemini, Aider, Amp, Droid, Grok, Hermes, Muse, Qwen, Kiro). If your agent runs
+under a name luvus does not know, teach it one in
+`~/.luvus/manifests/<agent>.toml`:
 
 ```toml
 agent = "myagent"

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -195,7 +195,7 @@ Screen-based detection needs no setup and works for everything. The optional
 lifecycle events (permission prompt raised, turn ended) into luvus:
 
 ```sh
-luvus integration install claude    # or: copilot · codex · opencode · kimi · grok · omp
+luvus integration install claude    # or: copilot · codex · opencode · kimi · grok · hermes · omp
 ```
 
 or toggle it in **Settings → Integrations**. What it does per agent:
@@ -207,6 +207,10 @@ or toggle it in **Settings → Integrations**. What it does per agent:
   place so your API keys, comments, and own hooks are left untouched.
 - **grok**: installs its own hook file without editing Grok's authentication
   configuration.
+- **hermes**: installs an opt-in plugin under the active `HERMES_HOME`. It
+  reports an exact session id once per session while the read-only SQLite
+  adapter remains the zero-setup fallback. Luvus preserves unrelated YAML
+  settings and removes only its own plugin entry on uninstall.
 - **omp**: installs one managed TypeScript extension in OMP's active agent
   directory. It reports exact session identity and authoritative
   idle/working/blocked/done transitions while preserving Luvus's native

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -10,8 +10,8 @@ back after a restart, all without wrapping or modifying the agents themselves.
 ## The AGENTS sidebar
 
 Every pane running a recognized agent (Claude Code, Copilot, Codex, opencode,
-Kimi, Grok, Muse Code, Pi, Oh My Pi (OMP), Cursor, Gemini, Qwen, Kiro, Aider,
-Amp, Droid, or fx) appears in the sidebar with a live state:
+Kimi, Grok, Hermes CLI, Muse Code, Pi, Oh My Pi (OMP), Cursor, Gemini, Qwen,
+Kiro, Aider, Amp, Droid, or fx) appears in the sidebar with a live state:
 
 | State | Meaning | How it's detected |
 |---|---|---|
@@ -124,6 +124,7 @@ command for you:
 | opencode | its session storage |
 | Kimi | its session index (`~/.kimi-code/session_index.jsonl`) |
 | Grok | its session directory (`~/.grok/sessions`) |
+| Hermes CLI | its active SQLite session store (`$HERMES_HOME/state.db` or `~/.hermes/state.db`) |
 | Pi | its session store (`~/.pi/agent/sessions`) |
 | Oh My Pi (OMP) | its profile-, XDG-, and override-aware native session store |
 | Muse Code | its XDG data store (`$XDG_DATA_HOME/muse/sessions`) |
@@ -182,6 +183,10 @@ and resumed Codex panes to their exact rollout.
 Muse Code supports native detection and resume, but not **Fork to New Pane**.
 Its `/fork` command exists only inside the active TUI, and its CLI refuses to
 resume the same live session in a sibling pane.
+
+Hermes CLI has the same external boundary. Luvus can resume its native
+sessions, but Hermes exposes `/branch` and `/fork` only inside the active TUI,
+so it is not listed as a native pane-fork target.
 
 ## Precise events: the integration hook
 

--- a/website/src/content/docs/docs/guides/codex-plugin.mdx
+++ b/website/src/content/docs/docs/guides/codex-plugin.mdx
@@ -42,9 +42,10 @@ The command makes no network request. It detects supported coding-agent
 environments and installs the one bundled Luvus skill through their native
 skill directories. The shared `~/.agents/skills/luvus/` destination serves
 Codex, GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx.
-Claude Code, OpenCode, Kimi Code CLI, Grok Build, Qwen Code, and Kiro use their
-native dedicated destinations. It does not add an always-on pointer to
-`~/.codex/AGENTS.md`, and it never overwrites an installation it does not own.
+Claude Code, OpenCode, Kimi Code CLI, Grok Build, Hermes CLI, Qwen Code, and
+Kiro use their native dedicated destinations. It does not add an always-on
+pointer to `~/.codex/AGENTS.md`, and it never overwrites an installation it
+does not own.
 
 Start a new Codex thread after enabling the skill. Confirm its release, path,
 and integrity at any time with:

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -11,6 +11,7 @@ description: What luvus supports per agent, covering live status, session resume
 | opencode | ✓ | ✓ | no | ✓ |
 | Kimi Code CLI | ✓ | ✓ | no | ✓ |
 | Grok Build | ✓ | ✓ | ✓ | ✓ |
+| Hermes CLI | ✓ | ✓ | no | no |
 | Pi | ✓ | ✓ | ✓ | no |
 | Oh My Pi (omp) | ✓ | ✓ | ✓ | ✓ |
 | Muse Code | ✓ | ✓ | no | no |
@@ -51,6 +52,12 @@ description: What luvus supports per agent, covering live status, session resume
   file is edited. Named profiles, `PI_CODING_AGENT_DIR`, `PI_CONFIG_DIR`, and
   OMP's XDG session store remain supported.
 
+Hermes CLI sessions are discovered read-only from the active
+`$HERMES_HOME/state.db`, or `~/.hermes/state.db` when `HERMES_HOME` is unset.
+Luvus resumes them with `hermes --resume <id>`. Hermes currently exposes
+branching only from inside its own TUI, so Luvus does not present **Fork to New
+Pane** for Hermes.
+
 Missing your agent? You can add it yourself without waiting for a release: drop
 an `[identity]` block in `~/.luvus/manifests/<agent>.toml` and luvus will
 recognize it, as described in
@@ -69,9 +76,9 @@ Print the release-matched instructions for one conversation with
 The shared `~/.agents/skills/luvus/` destination is understood by Codex,
 GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx. Luvus uses
 dedicated native destinations for Claude Code, OpenCode, Kimi Code CLI, Grok
-Build, Qwen Code, Oh My Pi (omp), and Kiro. Aider does not expose a native
-Agent Skills installation directory, so use `luvus skill show` when an Aider
-conversation needs the instructions.
+Build, Hermes CLI, Qwen Code, Oh My Pi (omp), and Kiro. Aider does not expose a
+native Agent Skills installation directory, so use `luvus skill show` when an
+Aider conversation needs the instructions.
 
 `luvus skill status` reports the bundled release separately from its managed
 filesystem installations. Codex marketplace plugins are managed by Codex and

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -52,6 +52,11 @@ description: What luvus supports per agent, covering live status, session resume
   file is edited. Named profiles, `PI_CODING_AGENT_DIR`, `PI_CONFIG_DIR`, and
   OMP's XDG session store remain supported.
 
+  Hermes installs `~/.hermes/plugins/luvus-agent-state`, or the equivalent
+  directory under `HERMES_HOME`, and enables only that plugin in
+  `config.yaml`. Its callbacks report each exact CLI session once. Native
+  read-only database discovery continues to work when the plugin is absent.
+
 Hermes CLI sessions are discovered read-only from the active
 `$HERMES_HOME/state.db`, or `~/.hermes/state.db` when `HERMES_HOME` is unset.
 Luvus resumes them with `hermes --resume <id>`. Hermes currently exposes

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -255,7 +255,7 @@ server:
   server restart             stop + start (load a newly-installed binary)
   server update-manifest     fetch the latest agent-detection rules from luvus.dev
                              (applies live if the server is up; else on next start)
-  integration install|uninstall <claude|copilot|codex|opencode|kimi|grok|omp>
+  integration install|uninstall <claude|copilot|codex|opencode|kimi|grok|hermes|omp>
                              add/remove luvus's session-resume hook (uninstall
                              removes only luvus's hook, never the agent)
 


### PR DESCRIPTION
## Summary

Add Hermes CLI as a first-class Luvus agent with native detection, live state tracking, session discovery and resume, and Agent Skill installation.

## What changed

- recognize the `hermes`, `hermes-agent`, and Python `hermes_cli.main` launch paths without treating ordinary uses of the word Hermes as agent identity
- classify Hermes working, blocked, and idle states from its title markers and paired interactive prompt evidence
- discover CLI sessions from the active `HERMES_HOME/state.db`, falling back to `~/.hermes/state.db`
- read only bounded session metadata and ignore messages, credentials, memory, hidden rows, non-CLI sources, malformed IDs, and invalid paths
- resume an exact native session with `hermes --resume <id>` and remove stale `--continue`, `-c`, `--resume`, and `-r` selectors from restored launch arguments
- install the bundled Luvus skill into the active Hermes skills directory
- document Hermes support across the README, agent guide, reference table, FAQ, Codex plugin guidance, and public agent handoff

## Design and safety

The SQLite reader opens `state.db` read-only, performs a schema-tolerant query capped at 256 rows, and runs through Luvus's existing off-loop session scan. It never reads conversation bodies or writes to Hermes state. No dependency was added.

Hermes is intentionally not marked forkable or hook-enabled. Its `/branch` and `/fork` operations are currently available only inside the live Hermes interface, and no external lifecycle hook contract is documented.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked` with 1117 unit tests, 10 CLI help tests, 4 named-session tests, and 1 theme CLI test passing
- focused Hermes identity, state, session schema, resume argument, registry, and skill destination tests
- `cargo build --release --locked`
- `npm run build` in `website/`
- `git diff --check`
- `hermes --version` and `hermes --help` against Hermes Agent 0.20.6

A live model turn was not run because it would use the user's Hermes configuration and provider credentials. The native integration paths are covered with isolated fixtures and parser tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for Hermes CLI, including automatic detection and status reporting.
- Added Hermes session discovery and resume functionality.
- Added Hermes as a supported skill host with dedicated installation support.
- Added recognition of Hermes working, idle, blocked, and interaction states.
- Added optional Hermes integration for exact per-pane session ownership.
- Improved detection for non-empty terminal content and reduced unnecessary polling.

## Documentation
- Updated support tables, guides, FAQ content, CLI references, and agent documentation to cover Hermes capabilities and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->