### PR TITLE
fix(nix): link nixpkgs sqlite on darwin so the flake builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,15 @@ jobs:
   # output and builds the package, so a broken derivation fails CI instead of
   # only surfacing when a Nix user tries to install. Reproducible once flake.lock
   # is committed; until then it resolves nixos-unstable fresh each run.
+  # Both platforms: the macOS leg catches Darwin-only link failures (for
+  # example the system-sqlite link in Cargo.toml) that Ubuntu cannot see.
   nix:
-    name: nix flake
-    runs-on: ubuntu-latest
+    name: nix flake (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v5
       - uses: cachix/install-nix-action@v30

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,18 @@
 
           nativeBuildInputs = [ pkgs.makeWrapper ];
 
+          # On macOS, Cargo.toml deliberately links the SYSTEM sqlite
+          # (/usr/lib/libsqlite3.dylib) instead of bundling it, so the crate
+          # passes `-lsqlite3` at the final link. The Nix build sandbox has no
+          # /usr/lib, so the link fails with `ld: library not found for
+          # -lsqlite3`. Provide nixpkgs' sqlite on Darwin: the link resolves, and
+          # the dylib lands in the runtime closure — more hermetic than the
+          # release binary, which depends on an impure /usr/lib path. Linux keeps
+          # rusqlite's bundled engine and needs nothing extra.
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            pkgs.sqlite
+          ];
+
           # The suite spawns real PTYs, `ps`, and child processes, and reads
           # $HOME — all awkward inside the Nix build sandbox. CI runs the full
           # suite on every push (see .github/workflows/ci.yml); the package build

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,7 @@
   bashInteractive,
   coreutils,
   procps,
+  sqlite,
   stdenv,
 }:
 
@@ -37,6 +38,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = lib.fakeHash;
 
   nativeBuildInputs = [ makeWrapper ];
+
+  # On macOS, Cargo.toml deliberately links the SYSTEM sqlite
+  # (/usr/lib/libsqlite3.dylib) instead of bundling it, so the crate passes
+  # `-lsqlite3` at the final link. The Nix build sandbox has no /usr/lib, so
+  # the link fails with `ld: library not found for -lsqlite3`. Provide nixpkgs'
+  # sqlite on Darwin: the link resolves, and the dylib lands in the runtime
+  # closure. Linux keeps rusqlite's bundled engine and needs nothing extra.
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ sqlite ];
 
   # The test suite spawns real PTYs, `ps`, and child processes and reads $HOME,
   # all awkward inside the Nix sandbox; upstream CI runs the full suite on every


### PR DESCRIPTION
The nix flake and the nixpkgs package template now build on macOS, and the nix CI job covers darwin.

## What

- `flake.nix` and `nix/package.nix` add `sqlite` to `buildInputs` on darwin. `Cargo.toml` links the system sqlite on macOS by design, so the crate passes `-lsqlite3` at the final link. The nix darwin sandbox exposes no `/usr/lib/libsqlite3.dylib`, so the link fails. nixpkgs' sqlite resolves the link, and the dylib lands in the runtime closure.
- `.github/workflows/ci.yml` runs the nix job on `ubuntu-latest` and `macos-latest`. The darwin leg catches link failures that ubuntu cannot see.

## Why

`nix build .#default` and `nix run github:RizRiyz/luvus` fail on darwin at the final link:

```
ld: library not found for -lsqlite3
```

I found this while I packaged luvus for nix-darwin. The nixpkgs submission template (`nix/package.nix`) has the same failure, and ofborg evaluates darwin.

## Verification

- [x] `cargo fmt --all --check`
- [ ] `cargo test --locked` — not run locally; the diff touches no Rust code, and CI runs the suite.
- [ ] `cargo clippy --all-targets -- -D warnings` — not run locally; same reason.
- [x] Manual: `nix build .#default` on aarch64-darwin (macOS 15.7). It fails on unpatched `main` with the error above. With this change it passes, and `otool -L` shows `/nix/store/...-sqlite-3.53.3/lib/libsqlite3.dylib` linked into the binary.

## Notes

- The prebuilt release binaries still link `/usr/lib/libsqlite3.dylib` at runtime. Only the nix build path changes.
- Linux needs nothing extra; rusqlite bundles sqlite there.
- The darwin CI leg adds one macOS runner to the nix job. Drop that commit if the extra CI time is not wanted, but the darwin link failure then has no guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS package builds that could fail when linking SQLite.
  * Added the required SQLite build support for Darwin systems while preserving existing Linux behavior.

* **Tests**
  * Expanded continuous integration checks to include both Ubuntu and macOS builds.
  * macOS and Ubuntu checks now run independently so one failure does not prevent the other from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->