### PR TITLE
fix(agents): persist the sidebar filter

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -275,6 +275,32 @@ mod socket_api_tests {
             app.config.mission_pricing.get("new-model"),
             Some(&[1.0, 2.0, 0.5])
         );
+
+        app.agents_scroll = 9;
+        let result = app
+            .dispatch(
+                "config.patch",
+                &json!({"patch":{"agents_active_only":true}}),
+            )
+            .unwrap();
+        assert_eq!(result["config"]["agents_active_only"], true);
+        assert!(app.agents_active_only);
+        assert_eq!(app.agents_scroll, 0);
+    }
+
+    #[test]
+    fn config_reload_applies_the_agents_filter_live() {
+        let (_env, mut app) = app("socket-config-agents-reload");
+        app.agents_active_only = true;
+        app.config.agents_active_only = true;
+        app.agents_scroll = 8;
+
+        crate::config::save(&crate::config::Config::default());
+        let result = app.dispatch("server.reload_config", &json!({})).unwrap();
+
+        assert_eq!(result["config"]["agents_active_only"], false);
+        assert!(!app.agents_active_only);
+        assert_eq!(app.agents_scroll, 0);
     }
 
     #[test]
@@ -5121,6 +5147,7 @@ impl App {
         self.sidebars = sidebars;
         self.file_tree.show_hidden = next.layout.files_show_hidden;
         self.file_tree.scroll = 0;
+        self.apply_agents_filter(next.agents_active_only);
         crate::layout::set_gaps(next.layout.col_gap, next.layout.row_gap);
         for pane in self.panes.values() {
             pane.set_history_budget(history_budget);

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2046,10 +2046,7 @@ impl App {
         // The AGENTS All/Active filter toggle.
         if let Some((val, _)) = self.agents_filter_rects.iter().find(|(_, rect)| hit(*rect)) {
             let val = *val;
-            if self.agents_active_only != val {
-                self.agents_active_only = val;
-                self.agents_scroll = 0;
-            }
+            self.set_agents_filter(val);
             return;
         }
         if let Some((id, _)) = self.agent_rects.iter().find(|(_, rect)| hit(*rect)) {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -680,7 +680,9 @@ impl App {
             Cmd::OpenSettings => self.open_settings(),
             Cmd::ToggleSidebar => self.toggle_all_sides(),
             Cmd::ToggleRightSidebar => self.toggle_side(crate::app::Side::Right),
-            Cmd::ToggleAgents => self.agents_active_only = !self.agents_active_only,
+            Cmd::ToggleAgents => {
+                self.set_agents_filter(!self.agents_active_only);
+            }
             Cmd::ToggleFiles => self.toggle_files_dock(),
             Cmd::Switcher => self.toggle_switcher(),
             Cmd::GlobalSearch => self.toggle_search(),
@@ -1080,6 +1082,26 @@ mod tests {
         assert!(app.tab_rename.is_none());
         app.run_cmd(Cmd::RenameTab);
         assert!(app.tab_rename.is_some(), "rename tab opened the modal");
+    }
+
+    #[test]
+    fn toggle_agents_command_persists_both_filter_choices() {
+        let _env = crate::persist::test_env("toggle-agents-command");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        assert!(!app.agents_active_only);
+
+        app.agents_scroll = 7;
+        app.run_cmd(Cmd::ToggleAgents);
+        assert!(app.agents_active_only);
+        assert_eq!(app.agents_scroll, 0);
+        assert!(crate::config::load().agents_active_only);
+
+        app.agents_scroll = 5;
+        app.run_cmd(Cmd::ToggleAgents);
+        assert!(!app.agents_active_only);
+        assert_eq!(app.agents_scroll, 0);
+        assert!(!crate::config::load().agents_active_only);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1953,6 +1953,7 @@ impl App {
 
         let config = crate::config::load();
         let files_show_hidden = config.layout.files_show_hidden;
+        let agents_active_only = config.agents_active_only;
         crate::layout::set_gaps(config.layout.col_gap, config.layout.row_gap);
         let theme_registry = crate::theme::ThemeRegistry::load();
         let theme = theme_registry.theme_or_default(&config.theme);
@@ -2128,7 +2129,7 @@ impl App {
             last_output_wait_scan: Instant::now(),
             workspaces_scroll: 0,
             agents_scroll: 0,
-            agents_active_only: false,
+            agents_active_only,
             workspaces_area: Rect::ZERO,
             agents_area: Rect::ZERO,
             // Rooted at nothing; the first detect tick re-roots it to the active
@@ -2258,6 +2259,7 @@ impl App {
     fn from_snapshot(snap: SessionSnapshot, app_tx: Sender<AppEvent>) -> Option<App> {
         let config = crate::config::load();
         let files_show_hidden = config.layout.files_show_hidden;
+        let agents_active_only = config.agents_active_only;
         let keymap = keys::build_keymap(&config.keybindings);
         let prefix = keys::PrefixSpec::parse(&config.prefix).unwrap_or_default();
         let shell = crate::platform::resolve_shell(&config.shell);
@@ -2708,7 +2710,7 @@ impl App {
             last_output_wait_scan: Instant::now(),
             workspaces_scroll: 0,
             agents_scroll: 0,
-            agents_active_only: false,
+            agents_active_only,
             workspaces_area: Rect::ZERO,
             agents_area: Rect::ZERO,
             // Rooted at nothing; the first detect tick re-roots it to the active
@@ -2868,6 +2870,30 @@ impl App {
         self.config.sidebars = Some(self.sidebars.to_config());
         self.config.sidebar_width = self.sidebars.left.width;
         crate::config::save(&self.config);
+    }
+
+    /// Apply the AGENTS All / Active projection without performing I/O. This is
+    /// shared by direct UI changes and whole-config reloads so every control
+    /// keeps the runtime filter and its scroll position consistent.
+    pub(crate) fn apply_agents_filter(&mut self, active_only: bool) -> bool {
+        if self.agents_active_only == active_only {
+            return false;
+        }
+        self.agents_active_only = active_only;
+        self.agents_scroll = 0;
+        true
+    }
+
+    /// Persist a direct All / Active selection. This is an infrequent user
+    /// interaction, never a render-, detection-, or refresh-path write.
+    pub(crate) fn set_agents_filter(&mut self, active_only: bool) -> bool {
+        let runtime_changed = self.apply_agents_filter(active_only);
+        let config_changed = self.config.agents_active_only != active_only;
+        if config_changed {
+            self.config.agents_active_only = active_only;
+            crate::config::save(&self.config);
+        }
+        runtime_changed || config_changed
     }
 
     /// Every mounted dock in display order: left sidebar top→bottom, then right.
@@ -6028,6 +6054,40 @@ mod tests {
         assert_eq!(restored.layout().len(), 2);
         assert_eq!(restored.workspaces[0].name, "Luvus website");
         assert!(restored.workspaces[0].pinned);
+    }
+
+    #[test]
+    fn agents_filter_config_controls_fresh_and_restored_apps() {
+        let _env = crate::persist::test_env("agents-filter-construction");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let app = App::new(80, 24, tx).unwrap();
+        assert!(
+            !app.agents_active_only,
+            "missing preference defaults to All"
+        );
+        let snapshot = serde_json::to_string(&persist::snapshot(&app)).unwrap();
+
+        let (tx2, _rx2) = std::sync::mpsc::channel();
+        let restored = App::from_snapshot(serde_json::from_str(&snapshot).unwrap(), tx2).unwrap();
+        assert!(
+            !restored.agents_active_only,
+            "snapshot restoration also defaults to All"
+        );
+
+        let mut config = crate::config::load();
+        config.agents_active_only = true;
+        crate::config::save(&config);
+
+        let (tx3, _rx3) = std::sync::mpsc::channel();
+        let fresh = App::new(80, 24, tx3).unwrap();
+        assert!(fresh.agents_active_only, "fresh construction reads Active");
+
+        let (tx4, _rx4) = std::sync::mpsc::channel();
+        let restored = App::from_snapshot(serde_json::from_str(&snapshot).unwrap(), tx4).unwrap();
+        assert!(
+            restored.agents_active_only,
+            "snapshot restoration reads config instead of snapshot state"
+        );
     }
 
     // A saved pane whose cwd no longer exists (deleted project dir) must not

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,11 @@ pub struct Config {
     /// (`--permission-mode bypassPermissions`), so switching it on is deliberate.
     #[serde(default)]
     pub resume_launch_flags: bool,
+    /// Show only live agents in the AGENTS dock. Missing values retain the
+    /// historical All default so resumable sessions never appear lost after an
+    /// upgrade. The visible All / Active control updates this preference.
+    #[serde(default)]
+    pub agents_active_only: bool,
     /// Custom keybindings: command id → key string (overrides the defaults).
     /// An empty value means the command is explicitly unbound.
     #[serde(default)]
@@ -436,6 +441,7 @@ impl Default for Config {
             notifications: NotifyConfig::default(),
             check_updates: true,
             resume_launch_flags: false,
+            agents_active_only: false,
             keybindings: std::collections::HashMap::new(),
             prefix: default_prefix(),
             mission_pricing: std::collections::HashMap::new(),
@@ -617,6 +623,10 @@ mod tests {
         let from_empty: Config = serde_json::from_str("{}").unwrap();
         assert_eq!(from_empty.theme, "quattro-rally");
         assert_eq!(from_empty.sidebar_width, SIDEBAR_WIDTH_DEFAULT);
+        assert!(
+            !from_empty.agents_active_only,
+            "old configs retain the All agents default"
+        );
         assert_eq!(
             from_empty.bars.bottom_right,
             vec![crate::bar::CORE_RUNTIME.to_string()],
@@ -683,6 +693,21 @@ mod tests {
         )
         .unwrap();
         assert_eq!(old.notifications.sound_style, crate::sound::STYLE_RETRO);
+    }
+
+    #[test]
+    fn agents_filter_preference_persists_both_choices() {
+        let _env = crate::persist::test_env("config-agents-filter");
+        let mut config = Config::default();
+        assert!(!config.agents_active_only);
+
+        config.agents_active_only = true;
+        save(&config);
+        assert!(load().agents_active_only);
+
+        config.agents_active_only = false;
+        save(&config);
+        assert!(!load().agents_active_only);
     }
 
     #[test]

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -730,6 +730,8 @@ fn header(text: &str, t: &Theme) -> Line<'static> {
 #[cfg(test)]
 mod tests {
     use crate::app::App;
+    use crate::event::AppEvent;
+    use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
     use ratatui::{backend::TestBackend, buffer::Buffer, layout::Rect, Terminal};
 
     #[test]
@@ -943,14 +945,57 @@ mod tests {
             "All default shows session history"
         );
 
-        // Active: history is hidden when the user explicitly asks for live
-        // agents only.
-        app.agents_active_only = true;
+        // Clicking Active resets the filtered list and persists the choice.
+        app.agents_scroll = 7;
+        let active = app
+            .agents_filter_rects
+            .iter()
+            .find(|(active, _)| *active)
+            .map(|(_, rect)| *rect)
+            .expect("Active filter target");
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: active.x,
+            row: active.y,
+            modifiers: KeyModifiers::NONE,
+        }));
+        assert!(app.agents_active_only);
+        assert_eq!(app.agents_scroll, 0);
+        assert!(crate::config::load().agents_active_only);
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
         assert!(
             !buffer_contains(&term, "resume"),
             "Active hides session history"
         );
+
+        // Clicking the selected choice is a true no-op, including its scroll.
+        app.agents_scroll = 5;
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: active.x,
+            row: active.y,
+            modifiers: KeyModifiers::NONE,
+        }));
+        assert_eq!(app.agents_scroll, 5);
+
+        // All follows the same path and restores resumable history.
+        let all = app
+            .agents_filter_rects
+            .iter()
+            .find(|(active, _)| !*active)
+            .map(|(_, rect)| *rect)
+            .expect("All filter target");
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: all.x,
+            row: all.y,
+            modifiers: KeyModifiers::NONE,
+        }));
+        assert!(!app.agents_active_only);
+        assert_eq!(app.agents_scroll, 0);
+        assert!(!crate::config::load().agents_active_only);
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert!(buffer_contains(&term, "resume"));
     }
 }
 

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -37,8 +37,9 @@ proves nothing. A CLI printing its whole welcome screen at launch is idle, your
 keystrokes echoing while you compose a prompt are idle, a scrolling log is
 idle. That way you never get a false state or a false completion chime.
 
-The **All / Active** toggle in the header switches between live agents only
-(default) and the full resumable history.
+The **All / Active** toggle in the header switches between the full resumable
+history and live agents only. A new configuration starts with **All**, then
+luvus remembers whichever view you select across restarts.
 
 ## Usage in Mission Control
 

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -172,7 +172,8 @@ and your project list on the other. If you hide the left sidebar entirely, the
 :::tip
 The **Agents** dock header has an **All / Active** toggle: *Active* shows only
 running agents, while *All* also lists the resumable sessions luvus found on disk (click
-one to reopen it). See [Working with Agents](/docs/guides/agents/).
+one to reopen it). Luvus remembers the selected filter across restarts. See
+[Working with Agents](/docs/guides/agents/).
 :::
 
 ## Luvus Bar

--- a/website/src/content/docs/docs/reference/configuration.mdx
+++ b/website/src/content/docs/docs/reference/configuration.mdx
@@ -43,6 +43,7 @@ cleanly across versions because unknown fields get defaults.
 | `notifications.sound_style` | notification cue family: `retro` (default), `soft`, or `pulse` |
 | `notifications.sound_on_done` | play the selected done cue after an agent finishes; defaults to `false` |
 | `notifications.sound_on_blocked` | play the selected blocked cue when an agent needs attention; defaults to `false` |
+| `agents_active_only` | show only live agents in the AGENTS dock when `true`; defaults to `false`, which also shows resumable sessions |
 | `sidebars.files_side` | last side used by the FILES dock (`left` or `right`), retained while the dock is hidden |
 | `prefix` | the command-mode prefix (default `ctrl+space`). Accepts `f1`–`f12` as safe single keys, or a character/Space chord containing `Ctrl` or `Alt`, such as `ctrl+b`, `alt+\`, or `shift+f12` (see [Keybindings](/docs/reference/keybindings/)) |
 | `keybindings` | command id → key, overriding the defaults |


### PR DESCRIPTION
## Summary

- persist the Agents dock All or Active selection in config.json
- keep All as the backward-compatible default so resumable sessions remain visible after upgrades
- apply the saved preference during fresh startup, snapshot restoration, config patch, and config reload
- route mouse and keyboard changes through one guarded mutation path that resets scroll only when the selection changes
- document the default, persistence behavior, and configuration key

## Performance and safety

This adds no dependency, thread, timer, watcher, agent scan, or render-path work. A small atomic config write occurs only when the user changes the filter. Re-selecting the current filter is a no-op, and config reload applies the runtime value without a duplicate write.

The filter remains presentation-only. It does not alter agent detection, native session discovery, stored resumable sessions, or session snapshots.

## Verification

- cargo test agents_filter -- --nocapture
- cargo test agents_all_active_toggle_filters_history -- --nocapture
- cargo test toggle_agents_command_persists_both_filter_choices -- --nocapture
- cargo test config_patch_rejects_unknown_fields_without_mutation -- --nocapture
- cargo test config_reload_applies_the_agents_filter_live -- --nocapture
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test --locked --quiet
- cargo build --release --locked
- npm run build in website
- isolated debug named-session lifecycle covering All, Active, restart persistence, and restoration to All

Closes #194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The AGENTS sidebar now remembers the selected **All / Active** view across restarts.
  - The filter is applied immediately when configuration changes or reloads.
  - Switching filters resets the sidebar scroll position for easier navigation.

- **Documentation**
  - Updated guides and configuration reference to describe the filter behavior, default view, and saved preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->