### PR TITLE
feat(terminal): answer pane appearance queries

### DIFF
--- a/src/app/backend.rs
+++ b/src/app/backend.rs
@@ -690,6 +690,7 @@ impl App {
         let pane_id = PaneId::alloc();
         let shell = crate::platform::resolve_shell(&self.config.shell);
         let history_budget = self.config.scrollback_bytes();
+        let appearance = self.pane_appearance;
         let app_tx = self.app_tx.clone();
         let event_tx = self.app_tx.clone();
         std::thread::spawn(move || {
@@ -716,6 +717,7 @@ impl App {
                             command,
                             &[],
                             history_budget,
+                            appearance,
                         ),
                         None => crate::terminal::pty::Pane::spawn(
                             pane_id,
@@ -726,6 +728,7 @@ impl App {
                             None,
                             &shell,
                             history_budget,
+                            appearance,
                         ),
                     }
                     .map_err(|_| "PTY or root process failed to start".to_string());

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -304,6 +304,38 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn config_patch_updates_child_appearance_and_notifies_mode_2031() {
+        let (_env, mut app) = app("socket-theme-appearance");
+        let pane_id = app.layout().focus;
+        let (response_tx, response_rx) = std::sync::mpsc::channel();
+        let mut engine = crate::terminal::vt::alacritty::AlacrittyEngine::with_appearance(
+            80,
+            24,
+            response_tx,
+            crate::config::SCROLLBACK_BYTES_DEFAULT,
+            crate::terminal::appearance::PaneAppearance::default(),
+        );
+        crate::terminal::vt::VtEngine::advance(&mut engine, b"\x1b[?2031h");
+        app.panes.get_mut(&pane_id).unwrap().engine =
+            std::sync::Arc::new(std::sync::Mutex::new(engine));
+
+        app.dispatch("config.patch", &json!({"patch":{"theme":"gruvbox-light"}}))
+            .unwrap();
+        let recv_bytes = || match response_rx.recv().unwrap() {
+            crate::terminal::pty::InputAction::Bytes(bytes) => bytes,
+            crate::terminal::pty::InputAction::Submit { .. } => panic!("unexpected submit"),
+        };
+        assert_eq!(recv_bytes(), b"\x1b[?997;2n");
+
+        app.panes[&pane_id]
+            .engine
+            .lock()
+            .unwrap()
+            .advance(b"\x1b]11;?\x07");
+        assert_eq!(recv_bytes(), b"\x1b]11;rgb:f2f2/e5e5/bcbc\x07");
+    }
+
+    #[test]
     fn workspace_metadata_partial_updates_preserve_the_other_counter() {
         let (_env, mut app) = app("socket-workspace-metadata");
         app.dispatch(
@@ -5133,14 +5165,11 @@ impl App {
                 format!("theme `{}` is not installed", next.theme),
             ));
         }
-        let mut theme = self.theme_registry.theme_or_default(&next.theme);
-        if self.downsample {
-            theme = theme.to_256();
-        }
+        let theme = self.theme_registry.theme_or_default(&next.theme);
         let sidebars = Sidebars::from_config(&next.sidebars());
         let keymap = keys::build_keymap(&next.keybindings);
         let history_budget = next.scrollback_bytes();
-        self.theme = theme;
+        self.set_effective_theme(&next.theme, theme);
         self.catalog = crate::i18n::by_code(&next.language);
         self.prefix = prefix;
         self.keymap = keymap;

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -420,6 +420,7 @@ impl App {
             &argv,
             &[],
             history_budget_bytes,
+            self.pane_appearance,
         ) {
             Ok(pane) => {
                 let cmd = pane.command.clone();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1444,6 +1444,10 @@ pub struct App {
     pub workspaces: Vec<Workspace>,
     pub active_ws: usize,
     pub theme: Theme,
+    /// Appearance reported to programs running inside panes.
+    pane_appearance: crate::terminal::appearance::PaneAppearance,
+    /// Last foreground-client palette used to resolve the virtual Terminal theme.
+    probed_appearance: Option<crate::terminal::appearance::PaneAppearance>,
     /// Built-in, installed, and virtual themes in Settings display order.
     /// Loaded from the shared home-level `themes/` directory; rendering reads
     /// this in-memory snapshot and never touches the filesystem.
@@ -1946,6 +1950,19 @@ pub struct ModuleSettingEdit {
     pub secret: bool,
 }
 
+fn child_appearance(
+    registry: &crate::theme::ThemeRegistry,
+    theme_id: &str,
+    theme: &Theme,
+    probed: Option<crate::terminal::appearance::PaneAppearance>,
+) -> crate::terminal::appearance::PaneAppearance {
+    let declared = registry
+        .get(theme_id)
+        .map(|entry| entry.appearance)
+        .unwrap_or(crate::theme::format::Appearance::Dark);
+    crate::terminal::appearance::PaneAppearance::resolve(theme.mantle, declared, probed)
+}
+
 impl App {
     pub fn new(cols: u16, rows: u16, app_tx: Sender<AppEvent>) -> Result<App> {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
@@ -1957,6 +1974,7 @@ impl App {
         crate::layout::set_gaps(config.layout.col_gap, config.layout.row_gap);
         let theme_registry = crate::theme::ThemeRegistry::load();
         let theme = theme_registry.theme_or_default(&config.theme);
+        let pane_appearance = child_appearance(&theme_registry, &config.theme, &theme, None);
         let catalog = crate::i18n::by_code(&config.language);
         let sidebars = Sidebars::from_config(&config.sidebars());
         let shell = crate::platform::resolve_shell(&config.shell);
@@ -1976,6 +1994,7 @@ impl App {
             None,
             &shell,
             config.scrollback_bytes(),
+            pane_appearance,
         )?;
         let command = pane.command.clone();
         let mut panes = HashMap::new();
@@ -2015,6 +2034,8 @@ impl App {
             }],
             active_ws: 0,
             theme,
+            pane_appearance,
+            probed_appearance: None,
             theme_registry,
             catalog,
             config,
@@ -2260,6 +2281,9 @@ impl App {
         let config = crate::config::load();
         let files_show_hidden = config.layout.files_show_hidden;
         let agents_active_only = config.agents_active_only;
+        let theme_registry = crate::theme::ThemeRegistry::load();
+        let theme = theme_registry.theme_or_default(&config.theme);
+        let pane_appearance = child_appearance(&theme_registry, &config.theme, &theme, None);
         let keymap = keys::build_keymap(&config.keybindings);
         let prefix = keys::PrefixSpec::parse(&config.prefix).unwrap_or_default();
         let shell = crate::platform::resolve_shell(&config.shell);
@@ -2447,7 +2471,15 @@ impl App {
                     // A module pane re-runs its entrypoint if the module is still
                     // installed + runnable; otherwise it falls back to a shell.
                     let restored = ps.module.as_ref().and_then(|(mid, ep)| {
-                        restore_module_pane(&modules, mid, ep, id, &app_tx, history_budget_bytes)
+                        restore_module_pane(
+                            &modules,
+                            mid,
+                            ep,
+                            id,
+                            &app_tx,
+                            history_budget_bytes,
+                            pane_appearance,
+                        )
                     });
                     let (pane, module_rec) = match restored {
                         Some((p, rec)) => (p, Some(rec)),
@@ -2479,6 +2511,7 @@ impl App {
                                     &shell,
                                     argv,
                                     history_budget_bytes,
+                                    pane_appearance,
                                 )
                                 .ok(),
                                 None => Some(Pane::spawn_restored(
@@ -2491,6 +2524,7 @@ impl App {
                                     ps.screen.as_deref(),
                                     &shell,
                                     history_budget_bytes,
+                                    pane_appearance,
                                 )),
                             };
                             let Some(pane) = pane else {
@@ -2571,8 +2605,6 @@ impl App {
             .collect();
 
         crate::layout::set_gaps(config.layout.col_gap, config.layout.row_gap);
-        let theme_registry = crate::theme::ThemeRegistry::load();
-        let theme = theme_registry.theme_or_default(&config.theme);
         let catalog = crate::i18n::by_code(&config.language);
         let sidebars = Sidebars::from_config(&config.sidebars());
         let mut bar = crate::bar::BarState::default();
@@ -2596,6 +2628,8 @@ impl App {
             workspaces,
             active_ws,
             theme,
+            pane_appearance,
+            probed_appearance: None,
             theme_registry,
             catalog,
             config,
@@ -2836,10 +2870,32 @@ impl App {
 
     /// Apply colors reported by the terminal displaying the foreground client.
     pub fn apply_terminal_colors(&mut self, colors: &crate::terminal::theme_probe::TerminalColors) {
-        self.theme = crate::ui::theme::Theme::from_terminal(colors);
-        if self.downsample {
-            self.theme = self.theme.to_256();
+        self.probed_appearance =
+            Some(crate::terminal::appearance::PaneAppearance::from_terminal_colors(colors));
+        let derived = crate::ui::theme::Theme::from_terminal(colors);
+        self.set_effective_theme("terminal", derived);
+    }
+
+    /// Install one resolved UI theme and broadcast its pane appearance through
+    /// the VT interface. Keeping both mutations here prevents config, Settings,
+    /// and terminal-probe paths from leaving child query state stale.
+    pub(crate) fn set_effective_theme(&mut self, theme_id: &str, mut theme: Theme) {
+        let appearance = child_appearance(
+            &self.theme_registry,
+            theme_id,
+            &theme,
+            self.probed_appearance,
+        );
+        self.pane_appearance = appearance;
+        for pane in self.panes.values() {
+            if let Ok(mut engine) = pane.engine.lock() {
+                engine.set_appearance(appearance);
+            }
         }
+        if self.downsample {
+            theme = theme.to_256();
+        }
+        self.theme = theme;
     }
 
     /// Set a sidebar's width, clamped to the supported range, and persist.
@@ -3215,6 +3271,7 @@ impl App {
             None,
             &shell,
             history_budget_bytes,
+            self.pane_appearance,
         ) {
             Ok(pane) => {
                 let cmd = pane.command.clone();
@@ -3269,6 +3326,7 @@ impl App {
             self.app_tx.clone(),
             &shell,
             history_budget_bytes,
+            self.pane_appearance,
         );
         let cmd = pane.command.clone();
         self.panes.insert(id, pane);
@@ -3301,6 +3359,7 @@ impl App {
                 &shell,
                 a,
                 history_budget_bytes,
+                self.pane_appearance,
             ),
             None => Pane::spawn(
                 id,
@@ -3311,6 +3370,7 @@ impl App {
                 None,
                 &shell,
                 history_budget_bytes,
+                self.pane_appearance,
             ),
         };
         match spawned {
@@ -5724,6 +5784,7 @@ fn restore_module_pane(
     id: PaneId,
     app_tx: &Sender<AppEvent>,
     history_budget_bytes: usize,
+    appearance: crate::terminal::appearance::PaneAppearance,
 ) -> Option<(Pane, crate::module::ModulePaneRecord)> {
     let m = modules.find(mid).filter(|m| m.is_runnable())?;
     let argv = m
@@ -5747,6 +5808,7 @@ fn restore_module_pane(
         &argv,
         &env,
         history_budget_bytes,
+        appearance,
     )
     .ok()?;
     Some((

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -530,6 +530,7 @@ impl App {
             &argv,
             &env,
             history_budget_bytes,
+            self.pane_appearance,
         )
         .map_err(|e| format!("cannot spawn module pane: {e}"))?;
         let cmd = pane.command.clone();

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -916,15 +916,13 @@ impl App {
     }
 
     pub(crate) fn apply_theme(&mut self, name: &str) {
-        let Some(mut selected) = self.theme_registry.theme(name) else {
+        let Some(selected) = self.theme_registry.theme(name) else {
             return;
         };
         self.config.theme = theme::canonical(name).to_string();
         self.theme_selection_revision = self.theme_selection_revision.wrapping_add(1);
-        if self.downsample {
-            selected = selected.to_256();
-        }
-        self.theme = selected;
+        let theme_id = self.config.theme.clone();
+        self.set_effective_theme(&theme_id, selected);
         self.changelog_rows = None;
         config::save(&self.config);
     }
@@ -934,14 +932,12 @@ impl App {
     /// restoring the file and reloading brings the selection back.
     pub(crate) fn replace_theme_registry(&mut self, registry: crate::theme::ThemeRegistry) -> bool {
         let selected_exists = registry.get(&self.config.theme).is_some();
-        if self.config.theme != "terminal" {
-            let mut selected = registry.theme_or_default(&self.config.theme);
-            if self.downsample {
-                selected = selected.to_256();
-            }
-            self.theme = selected;
-        }
         self.theme_registry = registry;
+        if self.config.theme != "terminal" {
+            let selected = self.theme_registry.theme_or_default(&self.config.theme);
+            let theme_id = self.config.theme.clone();
+            self.set_effective_theme(&theme_id, selected);
+        }
         self.clamp_settings_cursor();
         self.changelog_rows = None;
         selected_exists

--- a/src/terminal/appearance.rs
+++ b/src/terminal/appearance.rs
@@ -1,0 +1,151 @@
+//! Effective pane appearance exposed to child terminal applications.
+//!
+//! Static themes provide an explicit dark/light preference. The virtual
+//! Terminal theme instead follows the last host-terminal probe. Each VT engine
+//! owns a copy so OSC 11 and DEC mode 2031 stay correct without process-global
+//! mutable state.
+
+use ratatui::style::Color;
+
+use crate::terminal::theme_probe::TerminalColors;
+use crate::theme::format::Appearance as ThemeAppearance;
+
+/// Bundled fallback pane background (Quattro Rally mantle) used until a
+/// Terminal-theme host probe is available.
+pub const DEFAULT_BG: [u8; 3] = [0x1e, 0x20, 0x30];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ColorScheme {
+    Dark,
+    Light,
+}
+
+impl ColorScheme {
+    /// Infer the virtual Terminal theme's scheme from its probed foreground and
+    /// background. Static themes use their declared appearance instead.
+    pub fn from_terminal_colors(colors: &TerminalColors) -> Self {
+        if luminance(colors.bg) < luminance(colors.fg) {
+            Self::Dark
+        } else {
+            Self::Light
+        }
+    }
+
+    pub fn is_dark(self) -> bool {
+        self == Self::Dark
+    }
+
+    pub fn dsr(self) -> &'static [u8] {
+        match self {
+            Self::Dark => b"\x1b[?997;1n",
+            Self::Light => b"\x1b[?997;2n",
+        }
+    }
+}
+
+/// The background and declared color-scheme preference visible to one child.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PaneAppearance {
+    pub background: [u8; 3],
+    pub scheme: ColorScheme,
+}
+
+impl PaneAppearance {
+    pub fn resolve(
+        background_color: Color,
+        declared: ThemeAppearance,
+        probed: Option<Self>,
+    ) -> Self {
+        let background = rgb_color(background_color)
+            .or_else(|| probed.map(|appearance| appearance.background))
+            .unwrap_or(DEFAULT_BG);
+        let scheme = match declared {
+            ThemeAppearance::Dark => ColorScheme::Dark,
+            ThemeAppearance::Light => ColorScheme::Light,
+            ThemeAppearance::Terminal => probed
+                .map(|appearance| appearance.scheme)
+                .unwrap_or(ColorScheme::Dark),
+        };
+        Self { background, scheme }
+    }
+
+    pub fn from_terminal_colors(colors: &TerminalColors) -> Self {
+        Self {
+            background: colors.bg,
+            scheme: ColorScheme::from_terminal_colors(colors),
+        }
+    }
+}
+
+impl Default for PaneAppearance {
+    fn default() -> Self {
+        Self {
+            background: DEFAULT_BG,
+            scheme: ColorScheme::Dark,
+        }
+    }
+}
+
+fn luminance(rgb: [u8; 3]) -> f32 {
+    0.2126 * (rgb[0] as f32 / 255.0)
+        + 0.7152 * (rgb[1] as f32 / 255.0)
+        + 0.0722 * (rgb[2] as f32 / 255.0)
+}
+
+fn rgb_color(color: Color) -> Option<[u8; 3]> {
+    match color {
+        Color::Rgb(r, g, b) => Some([r, g, b]),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_probed_terminal_colors_from_their_contrast() {
+        let mut colors = TerminalColors {
+            fg: [0xca, 0xd3, 0xf5],
+            bg: [0x1e, 0x20, 0x30],
+            palette: [[0; 3]; 16],
+        };
+        assert_eq!(
+            ColorScheme::from_terminal_colors(&colors),
+            ColorScheme::Dark
+        );
+        colors.fg = [0x4c, 0x4f, 0x69];
+        colors.bg = [0xef, 0xf1, 0xf5];
+        assert_eq!(
+            ColorScheme::from_terminal_colors(&colors),
+            ColorScheme::Light
+        );
+        assert_eq!(ColorScheme::Dark.dsr(), b"\x1b[?997;1n");
+        assert_eq!(ColorScheme::Light.dsr(), b"\x1b[?997;2n");
+    }
+
+    #[test]
+    fn static_theme_declaration_outranks_color_guessing() {
+        assert_eq!(
+            PaneAppearance::resolve(Color::Rgb(0xee, 0xee, 0xee), ThemeAppearance::Dark, None,)
+                .scheme,
+            ColorScheme::Dark
+        );
+    }
+
+    #[test]
+    fn terminal_reset_uses_probe_then_fallback() {
+        let probed = PaneAppearance {
+            background: [0xf2, 0xe5, 0xbc],
+            scheme: ColorScheme::Light,
+        };
+        assert_eq!(
+            PaneAppearance::resolve(Color::Reset, ThemeAppearance::Terminal, Some(probed)),
+            probed
+        );
+        assert_eq!(
+            PaneAppearance::resolve(Color::Reset, ThemeAppearance::Terminal, None),
+            PaneAppearance::default()
+        );
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,6 +1,7 @@
 //! Terminal layer: the PTY actor (`pty`) and the pure-Rust VT engine (`vt`).
 //! See docs/05-pty-and-terminal.md.
 
+pub mod appearance;
 pub mod backend;
 pub mod pty;
 pub mod theme_probe;

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -15,6 +15,7 @@ use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 
 use crate::event::AppEvent;
 use crate::ids::PaneId;
+use crate::terminal::appearance::PaneAppearance;
 use crate::terminal::backend::TerminalRuntime;
 use crate::terminal::vt::{create_engine, VtEngine, VtEngineKind};
 
@@ -254,6 +255,7 @@ impl Pane {
         initial: Option<&str>,
         shell: &str,
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Result<Pane> {
         let cmd = CommandBuilder::new(shell);
         Self::build(
@@ -267,6 +269,7 @@ impl Pane {
             basename(shell),
             &[],
             history_budget_bytes,
+            appearance,
         )
     }
 
@@ -285,6 +288,7 @@ impl Pane {
         shell: &str,
         argv: &[String],
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Result<Pane> {
         let Some((program, args)) = argv.split_first() else {
             return Err(anyhow::anyhow!("empty shell command"));
@@ -304,6 +308,7 @@ impl Pane {
             basename(shell),
             &[],
             history_budget_bytes,
+            appearance,
         )
     }
 
@@ -319,6 +324,7 @@ impl Pane {
         argv: &[String],
         env: &[(String, String)],
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Result<Pane> {
         let Some((program, args)) = argv.split_first() else {
             return Err(anyhow::anyhow!("empty module command"));
@@ -338,6 +344,7 @@ impl Pane {
             basename(program),
             env,
             history_budget_bytes,
+            appearance,
         )
     }
 
@@ -356,6 +363,7 @@ impl Pane {
         app_tx: Sender<AppEvent>,
         shell: &str,
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Pane {
         let cmd = CommandBuilder::new(shell);
         Self::build_deferred(
@@ -370,6 +378,7 @@ impl Pane {
             basename(shell),
             &[],
             history_budget_bytes,
+            appearance,
         )
     }
 
@@ -388,6 +397,7 @@ impl Pane {
         initial: Option<&str>,
         shell: &str,
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Pane {
         let cmd = CommandBuilder::new(shell);
         Self::build_deferred(
@@ -402,6 +412,7 @@ impl Pane {
             basename(shell),
             &[],
             history_budget_bytes,
+            appearance,
         )
     }
 
@@ -419,6 +430,7 @@ impl Pane {
         shell: &str,
         argv: &[String],
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Result<Pane> {
         let Some((program, args)) = argv.split_first() else {
             return Err(anyhow::anyhow!("empty shell command"));
@@ -439,6 +451,7 @@ impl Pane {
             basename(shell),
             &[],
             history_budget_bytes,
+            appearance,
         ))
     }
 
@@ -454,6 +467,7 @@ impl Pane {
         command: String,
         extra_env: &[(String, String)],
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Result<Pane> {
         let pty_system = native_pty_system();
         let pair = pty_system.openpty(PtySize {
@@ -486,6 +500,7 @@ impl Pane {
             rows,
             input_tx.clone(),
             history_budget_bytes,
+            appearance,
         );
         // Replay the saved screen so a restored pane shows its prior content.
         if let Some(screen) = initial {
@@ -553,6 +568,7 @@ impl Pane {
         command: String,
         extra_env: &[(String, String)],
         history_budget_bytes: usize,
+        appearance: PaneAppearance,
     ) -> Pane {
         // Everything a caller can observe before the child exists: the engine
         // (pane.read, detection, rendering) and the input queue.
@@ -563,6 +579,7 @@ impl Pane {
             rows,
             input_tx.clone(),
             history_budget_bytes,
+            appearance,
         );
         if let Some(screen) = initial {
             if let Ok(mut engine) = engine.lock() {
@@ -1236,6 +1253,7 @@ mod reap_tests {
             None,
             "/bin/sh",
             500,
+            PaneAppearance::default(),
         )
         .expect("spawn")
     }
@@ -1266,6 +1284,7 @@ mod reap_tests {
             tx,
             "/bin/sh",
             500,
+            PaneAppearance::default(),
         );
         assert_eq!(
             pane.child_pid.load(Ordering::SeqCst),
@@ -1311,6 +1330,7 @@ mod reap_tests {
             Some("RESTORED-SCREEN\r\n"),
             "/bin/sh",
             500,
+            PaneAppearance::default(),
         );
         assert!(
             pane.engine
@@ -1338,6 +1358,7 @@ mod reap_tests {
             None,
             "/bin/sh",
             500,
+            PaneAppearance::default(),
         );
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
@@ -1379,6 +1400,7 @@ mod reap_tests {
             tx,
             "/bin/sh",
             500,
+            PaneAppearance::default(),
         );
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
@@ -1414,6 +1436,7 @@ mod reap_tests {
             tx,
             "/bin/sh",
             500,
+            PaneAppearance::default(),
         );
         // The spawn has not forked yet: this is the racing resize.
         assert!(pane.resize(132, 40));

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -8,7 +8,7 @@ use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Column, Line, Point};
 use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::{Config, Term, TermMode};
-use alacritty_terminal::vte::ansi::{Color as VtColor, Processor};
+use alacritty_terminal::vte::ansi::{Color as VtColor, NamedColor, Processor, Rgb};
 
 use ratatui::style::{Color, Modifier};
 
@@ -16,6 +16,7 @@ use super::{
     AlignedRows, CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, RetainedRowLayout,
     VtEngine, ALIGNED_WIDE_CELL,
 };
+use crate::terminal::appearance::PaneAppearance;
 use crate::terminal::backend::{CaptureMode, CaptureResult};
 use crate::terminal::pty::InputAction;
 
@@ -28,6 +29,7 @@ type TitleSlot = Arc<Mutex<Option<String>>>;
 pub struct EventProxy {
     tx: Sender<InputAction>,
     title: TitleSlot,
+    appearance: Arc<Mutex<PaneAppearance>>,
 }
 
 impl EventListener for EventProxy {
@@ -35,6 +37,23 @@ impl EventListener for EventProxy {
         match event {
             Event::PtyWrite(text) => {
                 let _ = self.tx.send(InputAction::Bytes(text.into_bytes()));
+            }
+            Event::ColorRequest(index, format) => {
+                if index == NamedColor::Background as usize {
+                    if let Ok(appearance) = self.appearance.lock() {
+                        let [r, g, b] = appearance.background;
+                        let _ = self
+                            .tx
+                            .send(InputAction::Bytes(format(Rgb { r, g, b }).into_bytes()));
+                    }
+                }
+            }
+            Event::ColorSchemeRequest => {
+                if let Ok(appearance) = self.appearance.lock() {
+                    let _ = self
+                        .tx
+                        .send(InputAction::Bytes(appearance.scheme.dsr().to_vec()));
+                }
             }
             Event::Title(t) => {
                 if let Ok(mut g) = self.title.lock() {
@@ -74,25 +93,46 @@ pub struct AlacrittyEngine {
     term: Term<EventProxy>,
     parser: Processor,
     title: TitleSlot,
+    response_tx: Sender<InputAction>,
+    appearance: Arc<Mutex<PaneAppearance>>,
     history_budget_bytes: usize,
     output_generation: u64,
 }
 
 impl AlacrittyEngine {
+    #[cfg(test)]
     pub fn new(
         cols: u16,
         rows: u16,
         resp_tx: Sender<InputAction>,
         history_budget_bytes: usize,
     ) -> Self {
+        Self::with_appearance(
+            cols,
+            rows,
+            resp_tx,
+            history_budget_bytes,
+            PaneAppearance::default(),
+        )
+    }
+
+    pub(crate) fn with_appearance(
+        cols: u16,
+        rows: u16,
+        resp_tx: Sender<InputAction>,
+        history_budget_bytes: usize,
+        initial_appearance: PaneAppearance,
+    ) -> Self {
         let dims = Dims {
             cols: cols.max(1) as usize,
             rows: rows.max(1) as usize,
         };
         let title: TitleSlot = Arc::new(Mutex::new(None));
+        let appearance = Arc::new(Mutex::new(initial_appearance));
         let proxy = EventProxy {
-            tx: resp_tx,
+            tx: resp_tx.clone(),
             title: title.clone(),
+            appearance: appearance.clone(),
         };
         // Alacritty retains history by rows, not bytes. Derive a conservative
         // capacity from Luvus's per-pane byte budget and current width. The
@@ -107,6 +147,8 @@ impl AlacrittyEngine {
             term,
             parser: Processor::new(),
             title,
+            response_tx: resp_tx,
+            appearance,
             history_budget_bytes,
             output_generation: 0,
         }
@@ -910,6 +952,19 @@ impl VtEngine for AlacrittyEngine {
         self.term.mode().contains(TermMode::BRACKETED_PASTE)
     }
 
+    fn set_appearance(&mut self, next: PaneAppearance) {
+        let changed = self.appearance.lock().is_ok_and(|mut current| {
+            let changed = *current != next;
+            *current = next;
+            changed
+        });
+        if changed && self.term.mode().contains(TermMode::REPORT_APPEARANCE) {
+            let _ = self
+                .response_tx
+                .send(InputAction::Bytes(next.scheme.dsr().to_vec()));
+        }
+    }
+
     fn snapshot_ansi(&self) -> String {
         let grid = self.term.grid();
         let rows = grid.screen_lines();
@@ -1046,6 +1101,8 @@ fn map_flags(fl: Flags) -> Modifier {
 mod tests {
     use super::*;
     use std::sync::mpsc::channel;
+
+    use crate::terminal::appearance::ColorScheme;
 
     fn feed_lines(e: &mut AlacrittyEngine, n: usize) {
         for i in 0..n {
@@ -1722,5 +1779,79 @@ mod tests {
         assert_eq!(reversed.len(), 1, "one reverse caret: {reversed:?}");
         assert_eq!(reversed[0].0, 0);
         assert_eq!(reversed[0].1, 2);
+    }
+
+    fn appearance_engine(
+        background: [u8; 3],
+        scheme: ColorScheme,
+    ) -> (AlacrittyEngine, std::sync::mpsc::Receiver<InputAction>) {
+        let (tx, rx) = channel();
+        let appearance = PaneAppearance { background, scheme };
+        let engine =
+            AlacrittyEngine::with_appearance(40, 5, tx, budget_for_rows(40, 20), appearance);
+        (engine, rx)
+    }
+
+    fn recv_bytes(rx: &std::sync::mpsc::Receiver<InputAction>) -> Vec<u8> {
+        match rx.try_recv() {
+            Ok(InputAction::Bytes(bytes)) => bytes,
+            Ok(InputAction::Submit { .. }) => panic!("expected PTY reply, got submit"),
+            Err(error) => panic!("expected PTY reply: {error}"),
+        }
+    }
+
+    #[test]
+    fn osc11_query_replies_with_theme_background_for_bel_and_st() {
+        let bg = [0x1e, 0x20, 0x30];
+        let (mut engine, rx) = appearance_engine(bg, ColorScheme::Dark);
+        engine.advance(b"\x1b]11;?\x07");
+        let bel = recv_bytes(&rx);
+        assert_eq!(bel, b"\x1b]11;rgb:1e1e/2020/3030\x07");
+        assert_eq!(engine.visible_rows()[0].trim(), "");
+
+        engine.advance(b"\x1b]11;?\x1b\\");
+        let st = recv_bytes(&rx);
+        assert_eq!(st, b"\x1b]11;rgb:1e1e/2020/3030\x1b\\");
+        assert_eq!(engine.visible_rows()[0].trim(), "");
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn osc11_set_color_does_not_reply_or_print_the_payload() {
+        let (mut engine, rx) = appearance_engine([0x11, 0x22, 0x33], ColorScheme::Dark);
+        engine.advance(b"\x1b]11;rgb:aa/bb/cc\x07hello");
+        assert!(
+            rx.try_recv().is_err(),
+            "OSC 11 set must not emit a query reply"
+        );
+        assert_eq!(engine.visible_rows()[0].trim_end(), "hello");
+    }
+
+    #[test]
+    fn mode_2031_queries_and_notifications_follow_engine_appearance() {
+        let (mut engine, rx) = appearance_engine([0x1e, 0x20, 0x30], ColorScheme::Dark);
+
+        engine.advance(b"\x1b[?2031$p\x1b[?996n");
+        assert_eq!(recv_bytes(&rx), b"\x1b[?2031;2$y");
+        assert_eq!(recv_bytes(&rx), b"\x1b[?997;1n");
+
+        engine.advance(b"\x1b[?2031h\x1b[?2031$p");
+        assert_eq!(recv_bytes(&rx), b"\x1b[?2031;1$y");
+
+        engine.set_appearance(PaneAppearance {
+            background: [0xf2, 0xe5, 0xbc],
+            scheme: ColorScheme::Light,
+        });
+        assert_eq!(recv_bytes(&rx), b"\x1b[?997;2n");
+        engine.advance(b"\x1b[?996n");
+        assert_eq!(recv_bytes(&rx), b"\x1b[?997;2n");
+
+        engine.advance(b"\x1b[?2031l\x1b[?2031$p");
+        assert_eq!(recv_bytes(&rx), b"\x1b[?2031;2$y");
+        engine.set_appearance(PaneAppearance::default());
+        assert!(rx.try_recv().is_err(), "disabled mode must not notify");
+
+        engine.advance(b"\x1b[?2040$p");
+        assert_eq!(recv_bytes(&rx), b"\x1b[?2040;0$y");
     }
 }

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use ratatui::style::{Color, Modifier};
 
+use crate::terminal::appearance::PaneAppearance;
 use crate::terminal::pty::InputAction;
 
 /// Internal continuation marker used by [`VtEngine::visible_rows_aligned`].
@@ -89,14 +90,18 @@ pub(crate) fn create_engine(
     rows: u16,
     resp_tx: Sender<InputAction>,
     history_budget_bytes: usize,
+    appearance: PaneAppearance,
 ) -> Arc<Mutex<dyn VtEngine>> {
     match kind {
-        VtEngineKind::Alacritty => Arc::new(Mutex::new(alacritty::AlacrittyEngine::new(
-            cols,
-            rows,
-            resp_tx,
-            history_budget_bytes,
-        ))),
+        VtEngineKind::Alacritty => {
+            Arc::new(Mutex::new(alacritty::AlacrittyEngine::with_appearance(
+                cols,
+                rows,
+                resp_tx,
+                history_budget_bytes,
+                appearance,
+            )))
+        }
     }
 }
 
@@ -341,6 +346,10 @@ pub trait VtEngine: Send {
     /// an attachment, and how vim auto-indents pasted code into a staircase.
     fn bracketed_paste(&self) -> bool;
 
+    /// Update the effective pane appearance. Engines that implement DEC mode
+    /// 2031 notify subscribed children from inside this interface.
+    fn set_appearance(&mut self, _appearance: PaneAppearance) {}
+
     /// Dump the visible screen as ANSI so it can be replayed into a fresh
     /// engine on restore (session persistence). Trailing blanks are trimmed.
     fn snapshot_ansi(&self) -> String;
@@ -354,7 +363,14 @@ mod tests {
     #[test]
     fn factory_builds_a_working_default_engine() {
         let (tx, _rx) = mpsc::channel();
-        let engine = create_engine(VtEngineKind::default(), 20, 3, tx, 64 * 1024);
+        let engine = create_engine(
+            VtEngineKind::default(),
+            20,
+            3,
+            tx,
+            64 * 1024,
+            PaneAppearance::default(),
+        );
         let mut engine = engine.lock().expect("engine lock");
         engine.advance(b"hi");
         assert_eq!(engine.visible_rows()[0].trim_end(), "hi");

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -6,12 +6,6 @@ use ratatui::style::Color;
 
 // ── Theme derivation from terminal colors ───────────────────────────────────
 
-fn luminance(rgb: [u8; 3]) -> f32 {
-    0.2126 * (rgb[0] as f32 / 255.0)
-        + 0.7152 * (rgb[1] as f32 / 255.0)
-        + 0.0722 * (rgb[2] as f32 / 255.0)
-}
-
 fn blend_rgb(a: [u8; 3], b: [u8; 3], t: f32) -> Color {
     let f = |i: usize| (a[i] as f32 + (b[i] as f32 - a[i] as f32) * t).clamp(0.0, 255.0) as u8;
     Color::Rgb(f(0), f(1), f(2))
@@ -65,7 +59,7 @@ impl Theme {
 
     pub fn from_terminal(c: &TerminalColors) -> Self {
         let (bg, fg) = (c.bg, c.fg);
-        let is_dark = luminance(bg) < luminance(fg);
+        let is_dark = crate::terminal::appearance::ColorScheme::from_terminal_colors(c).is_dark();
         // palette[8] (bright black) is the terminal designer's chosen "dim/elevated"
         // color — blend toward it for surfaces so the tint matches the scheme.
         let dim = c.palette[8];

--- a/vendor/alacritty_terminal/src/event.rs
+++ b/vendor/alacritty_terminal/src/event.rs
@@ -36,6 +36,9 @@ pub enum Event {
     /// expected escape sequence format.
     ColorRequest(usize, Arc<dyn Fn(Rgb) -> String + Sync + Send + 'static>),
 
+    /// Request the current dark/light color-scheme preference.
+    ColorSchemeRequest,
+
     /// Write some text to the PTY.
     PtyWrite(String),
 
@@ -65,6 +68,7 @@ impl Debug for Event {
             Event::ClipboardLoad(ty, _) => write!(f, "ClipboardLoad({ty:?})"),
             Event::TextAreaSizeRequest(_) => write!(f, "TextAreaSizeRequest"),
             Event::ColorRequest(index, _) => write!(f, "ColorRequest({index})"),
+            Event::ColorSchemeRequest => write!(f, "ColorSchemeRequest"),
             Event::PtyWrite(text) => write!(f, "PtyWrite({text})"),
             Event::Title(title) => write!(f, "Title({title})"),
             Event::CursorBlinkingChange => write!(f, "CursorBlinkingChange"),

--- a/vendor/alacritty_terminal/src/term/mod.rs
+++ b/vendor/alacritty_terminal/src/term/mod.rs
@@ -77,6 +77,8 @@ bitflags! {
         const REPORT_ALTERNATE_KEYS   = 1 << 20;
         const REPORT_ALL_KEYS_AS_ESC  = 1 << 21;
         const REPORT_ASSOCIATED_TEXT  = 1 << 22;
+        /// DEC private mode 2031: subscribe to dark/light appearance reports.
+        const REPORT_APPEARANCE       = 1 << 23;
         const MOUSE_MODE              = Self::MOUSE_REPORT_CLICK.bits() | Self::MOUSE_MOTION.bits() | Self::MOUSE_DRAG.bits();
         const KITTY_KEYBOARD_PROTOCOL = Self::DISAMBIGUATE_ESC_CODES.bits()
                                       | Self::REPORT_EVENT_TYPES.bits()
@@ -1432,6 +1434,16 @@ impl<T: EventListener> Handler for Term<T> {
     }
 
     #[inline]
+    fn private_device_status(&mut self, arg: usize) {
+        trace!("Reporting private device status: {arg}");
+        if arg == 996 {
+            self.event_proxy.send_event(Event::ColorSchemeRequest);
+        } else {
+            debug!("unknown private device status query: {arg}");
+        }
+    }
+
+    #[inline]
     fn move_down_and_cr(&mut self, lines: usize) {
         trace!("Moving down and cr: {lines}");
 
@@ -2054,6 +2066,9 @@ impl<T: EventListener> Handler for Term<T> {
             },
             NamedPrivateMode::ReportFocusInOut => self.mode.insert(TermMode::FOCUS_IN_OUT),
             NamedPrivateMode::BracketedPaste => self.mode.insert(TermMode::BRACKETED_PASTE),
+            NamedPrivateMode::ReportColorScheme => {
+                self.mode.insert(TermMode::REPORT_APPEARANCE)
+            },
             // Mouse encodings are mutually exclusive.
             NamedPrivateMode::SgrMouse => {
                 self.mode.remove(TermMode::UTF8_MOUSE);
@@ -2113,6 +2128,9 @@ impl<T: EventListener> Handler for Term<T> {
             },
             NamedPrivateMode::ReportFocusInOut => self.mode.remove(TermMode::FOCUS_IN_OUT),
             NamedPrivateMode::BracketedPaste => self.mode.remove(TermMode::BRACKETED_PASTE),
+            NamedPrivateMode::ReportColorScheme => {
+                self.mode.remove(TermMode::REPORT_APPEARANCE)
+            },
             NamedPrivateMode::SgrMouse => self.mode.remove(TermMode::SGR_MOUSE),
             NamedPrivateMode::Utf8Mouse => self.mode.remove(TermMode::UTF8_MOUSE),
             NamedPrivateMode::AlternateScroll => self.mode.remove(TermMode::ALTERNATE_SCROLL),
@@ -2166,6 +2184,9 @@ impl<T: EventListener> Handler for Term<T> {
                 },
                 NamedPrivateMode::BracketedPaste => {
                     self.mode.contains(TermMode::BRACKETED_PASTE).into()
+                },
+                NamedPrivateMode::ReportColorScheme => {
+                    self.mode.contains(TermMode::REPORT_APPEARANCE).into()
                 },
                 NamedPrivateMode::SyncUpdate => ModeState::Reset,
                 NamedPrivateMode::ColumnMode => ModeState::NotSupported,

--- a/vendor/vte/src/ansi.rs
+++ b/vendor/vte/src/ansi.rs
@@ -532,6 +532,9 @@ pub trait Handler {
     /// Report device status.
     fn device_status(&mut self, _: usize) {}
 
+    /// Report private device status.
+    fn private_device_status(&mut self, _: usize) {}
+
     /// Move cursor forward `cols`.
     fn move_forward(&mut self, _col: usize) {}
 
@@ -917,6 +920,7 @@ impl PrivateMode {
             1049 => Self::Named(NamedPrivateMode::SwapScreenAndSetRestoreCursor),
             2004 => Self::Named(NamedPrivateMode::BracketedPaste),
             2026 => Self::Named(NamedPrivateMode::SyncUpdate),
+            2031 => Self::Named(NamedPrivateMode::ReportColorScheme),
             _ => Self::Unknown(mode),
         }
     }
@@ -968,6 +972,8 @@ pub enum NamedPrivateMode {
     BracketedPaste = 2004,
     /// The mode is handled automatically by [`Processor`].
     SyncUpdate = 2026,
+    /// Send unsolicited dark/light color-scheme reports.
+    ReportColorScheme = 2031,
 }
 
 /// Mode for clearing line.
@@ -1702,6 +1708,7 @@ where
                 }
             },
             ('n', []) => handler.device_status(next_param_or(0) as usize),
+            ('n', [b'?']) => handler.private_device_status(next_param_or(0) as usize),
             ('P', []) => handler.delete_chars(next_param_or(1) as usize),
             ('p', [b'$']) => {
                 let mode = next_param_or(0);

--- a/website/src/content/docs/docs/guides/themes.mdx
+++ b/website/src/content/docs/docs/guides/themes.mdx
@@ -182,3 +182,11 @@ Normal custom themes are rendered by the server, so every attached client sees
 the same palette. **Terminal** remains special and client-derived. A custom
 palette containing `reset` may also depend on the foreground terminal and is
 reported with a warning unless its appearance is `terminal`.
+
+Programs running inside panes can query that pane background with OSC 11
+(`ESC]11;?`, BEL or ST). Luvus replies with the active theme's mantle color. If
+the Terminal theme keeps that color as `reset`, Luvus uses the last host-terminal
+probe when available and otherwise its bundled fallback palette. DEC private
+mode 2031 is supported: `CSI ? 996 n` queries the current scheme,
+`CSI ? 2031 h/l` subscribes, DECRQM reports set or reset, and a theme change
+sends `CSI ? 997;1n` (dark) or `CSI ? 997;2n` (light) to subscribed panes.


### PR DESCRIPTION
Programs running inside Luvus panes can now detect the effective pane appearance at startup and follow later Luvus theme changes.

## What

- Reply to child OSC 11 background-color queries using the active theme's pane background.
- Preserve BEL and ST query terminators and keep OSC 11 set-color sequences reply-free.
- Implement the synchronous `CSI ? 996 n` dark/light query plus DEC private mode 2031 set/reset and DECRQM reporting in the patched Alacritty engine.
- Keep appearance state per VT engine and send `CSI ? 997;1n` / `CSI ? 997;2n` to subscribed panes when the effective dark/light appearance changes.
- Use explicit theme appearance metadata for static themes; use the last host-terminal probe for the virtual Terminal theme, with a bundled fallback before a probe arrives.
- Document the pane-facing behavior and add deterministic protocol coverage.

## Why

Terminal applications such as Oh My Pi query OSC 11 to choose a dark or light theme and use mode 2031 to learn about later appearance changes. Luvus already consumes pane output through its VT engine, but previously discarded Alacritty's `ColorRequest` event and reported mode 2031 as unsupported. As a result, the same application detected its terminal correctly when launched directly but defaulted incorrectly inside a Luvus pane.

The response stays at the existing VT/PTY seam: query bytes are parsed once by the terminal engine, and generated replies return to the same child PTY without entering the visible grid.

## Verification

- [x] `cargo test --locked` — 1158 passed
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --locked`
- [x] Manual testing in an isolated `LUVUS_HOME` and named server session:
  - OSC 11 returned the dark Gruvbox pane background with both BEL and ST.
  - `CSI ? 996 n` returned dark before the switch and light afterward.
  - DECRQM returned reset before `CSI ? 2031 h` and set afterward.
  - Switching to Gruvbox Light emitted `CSI ? 997;2n` to the subscribed pane.
  - A subsequent OSC 11 query returned the new light pane background.

## Notes

- The isolated live test was run on macOS; no production Luvus server was attached to or restarted.
- Automatically changing Luvus's own theme when the host terminal appearance changes is intentionally left for a separate focused change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal panes now inherit the selected theme’s background and dark/light appearance.
  * Applications can query the active background color and subscribe to appearance changes.
  * Appearance updates remain synchronized when themes change or sessions are restored.
  * The Agents sidebar filter setting is now loaded from configuration and can be changed during use.
* **Documentation**
  * Added guidance on terminal background queries, fallback colors, and appearance-change notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
