### PR TITLE
feat(uhp): add transport-neutral remote access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Console",
     "Win32_System_Kernel",
     "Win32_System_Threading",
 ] }

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -152,6 +152,14 @@ define the live protocol contract. Do not run them before routine CLI actions.
 selected local server. Validate the method and parameters against the installed
 schema before sending it.
 
+`luvus uhp access` is the transport-neutral foreground boundary for an
+explicit remote provider or client. It emits one machine-readable descriptor
+for an authenticated loopback endpoint and creates no public listener. Use
+`--control` only when the user explicitly authorizes the documented limited
+control surface. Keep the command running only for the requested access
+window, and never expose its loopback endpoint without a trusted encrypted
+transport.
+
 For stateful UHP automation:
 
 1. Read capabilities and limits.

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -24,6 +24,13 @@ response. A request has `id`, `method`, and `params`; add `auth` only for an
 explicit delegated token. Keep the inherited or explicitly selected session
 and socket when invoking it.
 
+`luvus uhp access [--control]` instead creates a temporary authenticated
+loopback gateway for a persistent third-party byte-stream provider. Its first
+stdout line is the access descriptor; it never contains the delegated token.
+The client pairs once, then uses the returned token on ordinary UHP frames.
+Keep the loopback endpoint private and require an encrypted, authenticated
+transport.
+
 ## Bootstrap and maintain state
 
 Use this order for a stateful harness:

--- a/protocol/uhp/v1/README.md
+++ b/protocol/uhp/v1/README.md
@@ -6,6 +6,8 @@ This package is the source-controlled Universal Harness Protocol 1.0 contract.
 - `schema/response.schema.json` defines success and error envelopes.
 - `schema/event.schema.json` defines sequenced event frames.
 - `schema/terminal/` contains strict terminal method and stream components.
+- `schema/access/descriptor.schema.json` defines transport-neutral remote
+  bootstrap metadata; `access/README.md` defines provider and pairing behavior.
 - `fixtures/` contains valid and invalid global wire examples.
 - `terminal/fixtures/` exercises terminal identities, input, streams, and errors.
 

--- a/protocol/uhp/v1/access/README.md
+++ b/protocol/uhp/v1/access/README.md
@@ -1,0 +1,40 @@
+# UHP Access 1
+
+UHP Access is a transport-neutral bootstrap boundary for carrying Luvus UHP
+1.0 through an independently chosen secure byte-stream provider.
+
+Start it with:
+
+```sh
+luvus uhp access
+luvus uhp access --control
+```
+
+The command writes exactly one JSON descriptor line to stdout and remains in
+the foreground. The descriptor schema is
+`../schema/access/descriptor.schema.json`. A provider forwards only the
+descriptor's `127.0.0.1` TCP endpoint; it never receives the owner-only Luvus
+socket or named pipe.
+
+The first connection sends one pairing frame:
+
+```json
+{"type":"pair","code":"ABCD-EFGH-JKLM"}
+```
+
+The response returns an in-memory delegated token, its scopes, and expiry.
+Pairing succeeds once, expires after five minutes, and is rejected after five
+failed attempts. Later connections carry ordinary LF-terminated UHP request
+frames with that token in `auth`. Ordinary requests use one connection per
+request. Event and terminal methods keep their connection open for the
+advertised stream lifetime.
+
+The provider must offer an authenticated, confidential, integrity-protected
+byte stream and preserve order, half-close, EOF, and backpressure. It must not
+rewrite JSON, terminate UHP authentication, persist credentials, expose the
+loopback port directly, or fall back to a public plaintext listener. Stopping
+the foreground command closes the endpoint and revokes its delegated token;
+the Luvus server and panes remain alive.
+
+UHP Access is not a new UHP version. Clients must discover live capabilities
+after pairing and validate frames against the installed UHP schema bundle.

--- a/protocol/uhp/v1/schema/access/descriptor.schema.json
+++ b/protocol/uhp/v1/schema/access/descriptor.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://luvus.dev/protocol/uhp/v1/schema/access/descriptor.schema.json",
+  "title": "Luvus UHP access descriptor",
+  "type": "object",
+  "properties": {
+    "$schema": { "const": "https://luvus.dev/protocol/uhp/v1/schema/access/descriptor.schema.json" },
+    "type": { "const": "luvus_uhp_access" },
+    "protocol": {
+      "type": "object",
+      "properties": {
+        "name": { "const": "luvus-uhp" },
+        "major": { "const": 1 },
+        "minor": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["name", "major", "minor"],
+      "additionalProperties": false
+    },
+    "access": {
+      "type": "object",
+      "properties": { "major": { "const": 1 } },
+      "required": ["major"],
+      "additionalProperties": false
+    },
+    "endpoint": {
+      "type": "object",
+      "properties": {
+        "transport": { "const": "tcp" },
+        "host": { "const": "127.0.0.1" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "framing": { "const": "ndjson" }
+      },
+      "required": ["transport", "host", "port", "framing"],
+      "additionalProperties": false
+    },
+    "pairing": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "one_use_code" },
+        "code": { "type": "string", "pattern": "^[2-9A-HJ-NP-Z]{4}-[2-9A-HJ-NP-Z]{4}-[2-9A-HJ-NP-Z]{4}$" },
+        "expires_at": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["type", "code", "expires_at"],
+      "additionalProperties": false
+    },
+    "authority": {
+      "type": "object",
+      "properties": {
+        "mode": { "enum": ["read_only", "control"] },
+        "scopes": {
+          "type": "array",
+          "items": { "enum": ["read", "workspace", "agent", "terminal"] },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "expires_at": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["mode", "scopes", "expires_at"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["$schema", "type", "protocol", "access", "endpoint", "pairing", "authority"],
+  "allOf": [
+    {
+      "if": { "properties": { "authority": { "properties": { "mode": { "const": "read_only" } }, "required": ["mode"] } } },
+      "then": { "properties": { "authority": { "properties": { "scopes": { "const": ["read"] } } } } }
+    },
+    {
+      "if": { "properties": { "authority": { "properties": { "mode": { "const": "control" } }, "required": ["mode"] } } },
+      "then": { "properties": { "authority": { "properties": { "scopes": { "const": ["read", "workspace", "agent", "terminal"] } } } } }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -152,6 +152,14 @@ define the live protocol contract. Do not run them before routine CLI actions.
 selected local server. Validate the method and parameters against the installed
 schema before sending it.
 
+`luvus uhp access` is the transport-neutral foreground boundary for an
+explicit remote provider or client. It emits one machine-readable descriptor
+for an authenticated loopback endpoint and creates no public listener. Use
+`--control` only when the user explicitly authorizes the documented limited
+control surface. Keep the command running only for the requested access
+window, and never expose its loopback endpoint without a trusted encrypted
+transport.
+
 For stateful UHP automation:
 
 1. Read capabilities and limits.

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -24,6 +24,13 @@ response. A request has `id`, `method`, and `params`; add `auth` only for an
 explicit delegated token. Keep the inherited or explicitly selected session
 and socket when invoking it.
 
+`luvus uhp access [--control]` instead creates a temporary authenticated
+loopback gateway for a persistent third-party byte-stream provider. Its first
+stdout line is the access descriptor; it never contains the delegated token.
+The client pairs once, then uses the returned token on ordinary UHP frames.
+Keep the loopback endpoint private and require an encrypted, authenticated
+transport.
+
 ## Bootstrap and maintain state
 
 Use this order for a stateful harness:

--- a/src/api/capabilities.rs
+++ b/src/api/capabilities.rs
@@ -257,7 +257,16 @@ pub fn is_read_only(method: &str) -> bool {
 }
 
 pub fn required_scope(method: &str) -> &'static str {
-    if matches!(method, "uhp.capabilities" | "uhp.stats" | "ping") {
+    if matches!(
+        method,
+        "uhp.capabilities"
+            | "uhp.stats"
+            | "ping"
+            | "session.snapshot"
+            | "events.subscribe"
+            | "events.wait"
+            | "wait.output"
+    ) {
         "read"
     } else if method.starts_with("terminal.backend.") {
         "terminal"
@@ -392,6 +401,8 @@ mod tests {
         assert!(is_idempotent("pane.list"));
         assert!(!is_read_only("mission.open"));
         assert_eq!(required_scope("mission.open"), "workspace");
+        assert_eq!(required_scope("session.snapshot"), "read");
+        assert_eq!(required_scope("events.subscribe"), "read");
         for stream in [
             "events.subscribe",
             "terminal.backend.events.subscribe",

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -13,6 +13,9 @@ pub fn schema_bundle() -> Value {
     let event = schema(include_str!(
         "../../protocol/uhp/v1/schema/event.schema.json"
     ));
+    let access_descriptor = schema(include_str!(
+        "../../protocol/uhp/v1/schema/access/descriptor.schema.json"
+    ));
     let terminal = crate::terminal::backend::schema_bundle();
     let mut documents = terminal["documents"]
         .as_object()
@@ -30,6 +33,10 @@ pub fn schema_bundle() -> Value {
         "https://luvus.dev/protocol/uhp/v1/event.schema.json".into(),
         event.clone(),
     );
+    documents.insert(
+        "https://luvus.dev/protocol/uhp/v1/schema/access/descriptor.schema.json".into(),
+        access_descriptor.clone(),
+    );
     json!({
         "protocol":{
             "name":super::PROTOCOL_NAME,
@@ -39,6 +46,7 @@ pub fn schema_bundle() -> Value {
         "request":request,
         "response":response,
         "event":event,
+        "access":{"descriptor":access_descriptor},
         "terminal":terminal,
         "documents":documents,
     })
@@ -71,7 +79,11 @@ mod tests {
         assert!(bundle.get("profiles").is_none());
         assert!(bundle["terminal"]["methods"]["observe"].is_object());
         assert!(bundle["terminal"]["methods"]["control"].is_object());
+        assert_eq!(bundle["access"]["descriptor"]["type"], "object");
         let documents = bundle["documents"].as_object().unwrap();
+        assert!(documents.contains_key(
+            "https://luvus.dev/protocol/uhp/v1/schema/access/descriptor.schema.json"
+        ));
         for branch in bundle["request"]["allOf"].as_array().unwrap() {
             let Some(reference) = branch["then"]["properties"]["params"]["$ref"].as_str() else {
                 continue;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -296,6 +296,7 @@ universal harness protocol:
   uhp schema                print the complete installed UHP JSON Schema bundle
   uhp snapshot              print a fenced session snapshot for harness bootstrap
   uhp events                stream sequenced UHP events
+  uhp access [--control]    expose scoped UHP through a private provider endpoint
   uhp proxy                 forward one JSON request from stdin to the selected server
 
 sessions:
@@ -407,6 +408,14 @@ fn run_inner(args: &[String]) -> Result<i32> {
     if args.get(1).map(String::as_str) == Some("theme") {
         return theme_cmd(
             &args[2.min(args.len())..],
+            crate::i18n::cli::Context::configured(),
+        );
+    }
+    if args.get(1).map(String::as_str) == Some("uhp")
+        && args.get(2).map(String::as_str) == Some("access")
+    {
+        return crate::uhp::run_cli(
+            &args[3.min(args.len())..],
             crate::i18n::cli::Context::configured(),
         );
     }
@@ -769,7 +778,7 @@ fn write_topic_help_english(
             detailed_section("events:\n", "\nuniversal harness protocol:\n"),
         ),
         "uhp" => (
-            "luvus uhp <capabilities|schema|snapshot|events|proxy>",
+            "luvus uhp <capabilities|schema|snapshot|events|access|proxy>",
             detailed_section("universal harness protocol:\n", "\nsessions:\n"),
         ),
         "remote" => (
@@ -2258,7 +2267,7 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
     if noun == "uhp" {
         if !rest.is_empty() {
             return Err(anyhow!(
-                "usage: luvus uhp <capabilities|schema|snapshot|events|proxy>"
+                "usage: luvus uhp <capabilities|schema|snapshot|events|access|proxy>"
             ));
         }
         return match verb {
@@ -2266,7 +2275,7 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             "snapshot" => Ok(("session.snapshot".into(), json!({}))),
             "events" => Ok(("events.subscribe".into(), json!({}))),
             _ => Err(anyhow!(
-                "usage: luvus uhp <capabilities|schema|snapshot|events|proxy>"
+                "usage: luvus uhp <capabilities|schema|snapshot|events|access|proxy>"
             )),
         };
     }
@@ -3927,6 +3936,7 @@ mod tests {
             ("luvus pane split --help", Some(("pane", Some("split")))),
             ("luvus module install -h", Some(("module", Some("install")))),
             ("luvus update --help", Some(("update", None))),
+            ("luvus uhp access --help", Some(("uhp", Some("access")))),
         ] {
             let args = argv(raw);
             assert_eq!(command_help_request(&args), expected, "{raw}");
@@ -3937,6 +3947,13 @@ mod tests {
     fn update_is_a_top_level_local_cli_command() {
         assert!(is_cli(&argv("luvus update")));
         assert!(!help_topic_has_subcommands("update"));
+    }
+
+    #[test]
+    fn uhp_help_includes_transport_neutral_access() {
+        let help = rendered_topic_help("uhp", None);
+        assert!(help.contains("uhp access [--control]"));
+        assert!(help.contains("private provider endpoint"));
     }
 
     #[test]

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -133,6 +133,17 @@ macro_rules! tr {
 /// suffix, so canonical syntax at the start of a row is never rewritten.
 static HELP: &[Translation] = &[
     tr!(
+        "expose scoped UHP through a private provider endpoint",
+        "exponer UHP con alcance mediante un endpoint privado para proveedores",
+        "expor UHP com escopo por um endpoint privado para provedores",
+        "exposer UHP avec une portée limitée via un endpoint privé pour fournisseurs",
+        "UHP mit begrenztem Umfang über einen privaten Anbieter-Endpunkt bereitstellen",
+        "ekspos UHP terbatas melalui endpoint penyedia privat",
+        "通过私有提供方端点公开限定范围的 UHP",
+        "スコープを限定した UHP をプライベートなプロバイダー用エンドポイントで公開",
+        "범위가 제한된 UHP를 비공개 공급자 엔드포인트로 노출"
+    ),
+    tr!(
         "Read local structured server and client diagnostics",
         "Leer diagnósticos estructurados locales del servidor y cliente",
         "Ler diagnósticos estruturados locais do servidor e cliente",
@@ -2503,6 +2514,39 @@ static HELP: &[Translation] = &[
 /// Local CLI labels and diagnostics. These are kept out of `HELP` so short
 /// labels such as `name` can never be mistaken for a help-row description.
 static TEXT: &[Translation] = &[
+    tr!(
+        "Could not authorize UHP access.",
+        "No se pudo autorizar el acceso UHP.",
+        "Não foi possível autorizar o acesso UHP.",
+        "Impossible d'autoriser l'accès UHP.",
+        "Der UHP-Zugriff konnte nicht autorisiert werden.",
+        "Akses UHP tidak dapat diotorisasi.",
+        "无法授权 UHP 访问。",
+        "UHP アクセスを承認できませんでした。",
+        "UHP 액세스를 승인할 수 없습니다."
+    ),
+    tr!(
+        "Could not start the private UHP access gateway.",
+        "No se pudo iniciar la puerta de enlace privada de acceso UHP.",
+        "Não foi possível iniciar o gateway privado de acesso UHP.",
+        "Impossible de démarrer la passerelle privée d'accès UHP.",
+        "Das private UHP-Zugriffs-Gateway konnte nicht gestartet werden.",
+        "Gateway akses UHP privat tidak dapat dimulai.",
+        "无法启动私有 UHP 访问网关。",
+        "プライベート UHP アクセスゲートウェイを起動できませんでした。",
+        "비공개 UHP 액세스 게이트웨이를 시작할 수 없습니다."
+    ),
+    tr!(
+        "Could not create a secure pairing code.",
+        "No se pudo crear un código de vinculación seguro.",
+        "Não foi possível criar um código de pareamento seguro.",
+        "Impossible de créer un code de jumelage sécurisé.",
+        "Es konnte kein sicherer Kopplungscode erstellt werden.",
+        "Kode pemasangan aman tidak dapat dibuat.",
+        "无法创建安全配对码。",
+        "安全なペアリングコードを作成できませんでした。",
+        "안전한 페어링 코드를 만들 수 없습니다."
+    ),
     tr!("name", "nombre", "nome", "nom", "Name", "nama", "名称", "名前",
         "이름"),
     tr!("status", "estado", "status", "état", "Status", "status", "状态", "状態",

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod skill;
 mod sound;
 mod terminal;
 mod theme;
+mod uhp;
 mod ui;
 mod update;
 

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -1,0 +1,989 @@
+use std::io::{self, BufReader, Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+
+use super::{pairing::Pairing, AccessMode};
+
+const INITIAL_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_CONNECTIONS: usize = 16;
+const MAX_REQUESTS_PER_MINUTE: u32 = 120;
+
+pub(super) struct Gateway {
+    address: SocketAddr,
+    cancelled: Arc<AtomicBool>,
+    accept_thread: Option<JoinHandle<()>>,
+}
+
+struct Shared {
+    socket_path: PathBuf,
+    token: String,
+    token_expires_unix: u64,
+    pairing: Mutex<Pairing>,
+    mode: AccessMode,
+    cancelled: Arc<AtomicBool>,
+    active: AtomicUsize,
+    rate: Mutex<RateWindow>,
+}
+
+struct ConnectionPermit<'a>(&'a AtomicUsize);
+
+impl Drop for ConnectionPermit<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+struct RateWindow {
+    started: Instant,
+    requests: u32,
+}
+
+impl RateWindow {
+    fn allow(&mut self, now: Instant) -> bool {
+        if now.duration_since(self.started) >= Duration::from_secs(60) {
+            self.started = now;
+            self.requests = 0;
+        }
+        if self.requests >= MAX_REQUESTS_PER_MINUTE {
+            return false;
+        }
+        self.requests += 1;
+        true
+    }
+}
+
+impl Gateway {
+    pub(super) fn start(
+        socket_path: PathBuf,
+        token: String,
+        token_expires_unix: u64,
+        pairing: Pairing,
+        mode: AccessMode,
+    ) -> Result<Self> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .context("cannot bind the private UHP access gateway")?;
+        let address = listener.local_addr()?;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let shared = Arc::new(Shared {
+            socket_path,
+            token,
+            token_expires_unix,
+            pairing: Mutex::new(pairing),
+            mode,
+            cancelled: cancelled.clone(),
+            active: AtomicUsize::new(0),
+            rate: Mutex::new(RateWindow {
+                started: Instant::now(),
+                requests: 0,
+            }),
+        });
+        let accept_shared = shared.clone();
+        let accept_thread = thread::Builder::new()
+            .name("luvus-uhp-access".into())
+            .stack_size(256 * 1024)
+            .spawn(move || accept_loop(listener, accept_shared))
+            .context("cannot start the private UHP access gateway")?;
+        Ok(Self {
+            address,
+            cancelled,
+            accept_thread: Some(accept_thread),
+        })
+    }
+
+    pub(super) fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    pub(super) fn stop(&mut self) {
+        if self.cancelled.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        // Wake the blocking loop without polling during active UHP access.
+        let _ = TcpStream::connect(self.address);
+        if let Some(thread) = self.accept_thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for Gateway {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn accept_loop(listener: TcpListener, shared: Arc<Shared>) {
+    while !shared.cancelled.load(Ordering::Acquire) {
+        let Ok((stream, peer)) = listener.accept() else {
+            if !shared.cancelled.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            continue;
+        };
+        if shared.cancelled.load(Ordering::Acquire) {
+            break;
+        }
+        if !peer.ip().is_loopback()
+            || shared
+                .active
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                    (active < MAX_CONNECTIONS).then_some(active + 1)
+                })
+                .is_err()
+        {
+            let _ = write_gateway_error(stream, Value::Null, "unavailable");
+            continue;
+        }
+        let connection_shared = shared.clone();
+        let fallback = stream.try_clone().ok();
+        if thread::Builder::new()
+            .name("luvus-uhp-access-request".into())
+            .stack_size(256 * 1024)
+            .spawn(move || {
+                let _permit = ConnectionPermit(&connection_shared.active);
+                if handle_connection(stream, &connection_shared).is_err() {
+                    if let Some(stream) = fallback {
+                        let _ = write_gateway_error(stream, Value::Null, "invalid_request");
+                    }
+                    // Intentionally omit request data, credentials, addresses,
+                    // and response contents from the UHP-access log.
+                    crate::logging::event(crate::logging::EventKind::UhpRequestRejected, &[]);
+                }
+            })
+            .is_err()
+        {
+            shared.active.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}
+
+fn handle_connection(mut stream: TcpStream, shared: &Shared) -> Result<()> {
+    stream.set_read_timeout(Some(INITIAL_FRAME_TIMEOUT))?;
+    stream.set_write_timeout(Some(WRITE_TIMEOUT))?;
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let frame =
+        crate::ipc::api::read_request_frame(&mut reader).context("invalid UHP-access frame")?;
+    let value: Value = serde_json::from_str(&frame).context("invalid UHP-access JSON")?;
+
+    if value.get("type").and_then(Value::as_str) == Some("pair") {
+        return handle_pairing(stream, shared, &value);
+    }
+
+    let id = value.get("id").cloned().unwrap_or(Value::Null);
+    if !shared
+        .rate
+        .lock()
+        .map_err(|_| anyhow!("gateway rate limiter unavailable"))?
+        .allow(Instant::now())
+    {
+        write_gateway_error(stream, id, "rate_limited")?;
+        return Ok(());
+    }
+    let Some(method) = value.get("method").and_then(Value::as_str) else {
+        write_gateway_error(stream, id, "invalid_request")?;
+        return Ok(());
+    };
+    let Some(auth) = value.get("auth").and_then(Value::as_str) else {
+        write_gateway_error(stream, id, "forbidden")?;
+        return Ok(());
+    };
+    if !constant_time_eq(shared.token.as_bytes(), auth.as_bytes())
+        || !allowed_method(shared.mode, method)
+    {
+        write_gateway_error(stream, id, "forbidden")?;
+        return Ok(());
+    }
+
+    let mut local = match crate::ipc::transport::connect(&shared.socket_path) {
+        Ok(local) => local,
+        Err(_) => {
+            write_gateway_error(stream, id, "unavailable")?;
+            return Ok(());
+        }
+    };
+    writeln!(local, "{frame}")?;
+    local.flush()?;
+
+    if matches!(
+        method,
+        "terminal.backend.observe" | "terminal.backend.control"
+    ) {
+        stream_terminal(
+            local,
+            stream,
+            reader,
+            &id,
+            shared,
+            method == "terminal.backend.control",
+        )
+    } else if matches!(
+        method,
+        "events.subscribe" | "terminal.backend.events.subscribe"
+    ) {
+        stream_events(local, stream, &id, shared)
+    } else {
+        let response = match crate::ipc::api::read_response_frame_with_deadline(
+            &mut local,
+            RESPONSE_TIMEOUT,
+        ) {
+            Ok(response) => response,
+            Err(_) => {
+                write_gateway_error(stream, id, "unavailable")?;
+                return Ok(());
+            }
+        };
+        validate_response_id(&response, &id)?;
+        writeln!(stream, "{response}")?;
+        stream.flush()?;
+        Ok(())
+    }
+}
+
+fn handle_pairing(mut stream: TcpStream, shared: &Shared, value: &Value) -> Result<()> {
+    let valid_shape = value.as_object().is_some_and(|object| {
+        object
+            .keys()
+            .all(|key| matches!(key.as_str(), "type" | "code"))
+    });
+    let candidate = value.get("code").and_then(Value::as_str).unwrap_or("");
+    let accepted = valid_shape
+        && shared
+            .pairing
+            .lock()
+            .map_err(|_| anyhow!("pairing unavailable"))?
+            .consume(candidate);
+    if !accepted {
+        write_gateway_error(stream, Value::Null, "forbidden")?;
+        return Ok(());
+    }
+    let response = json!({
+        "type":"paired",
+        "token":shared.token,
+        "scopes":shared.mode.scopes(),
+        "expires_at":shared.token_expires_unix,
+    });
+    writeln!(stream, "{response}")?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn allowed_method(mode: AccessMode, method: &str) -> bool {
+    let safe_read =
+        crate::api::capabilities::is_read_only(method) && !method.starts_with("uhp.token.");
+    safe_read
+        || (mode == AccessMode::Control
+            && matches!(
+                method,
+                "workspace.focus"
+                    | "tab.focus"
+                    | "pane.focus"
+                    | "agent.prompt"
+                    | "terminal.backend.control"
+            ))
+}
+
+fn stream_terminal(
+    mut local: crate::ipc::transport::Conn,
+    mut remote: TcpStream,
+    remote_reader: BufReader<TcpStream>,
+    expected_id: &Value,
+    shared: &Shared,
+    control: bool,
+) -> Result<()> {
+    let mut local_reader = LocalFrameReader::new(local.clone())?;
+    let first = local_reader.read_frame(RESPONSE_TIMEOUT)?.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "terminal stream closed before acknowledgement",
+        )
+    })?;
+    validate_response_id(&first, expected_id)?;
+    writeln!(remote, "{first}")?;
+    remote.flush()?;
+
+    let active = Arc::new(AtomicBool::new(true));
+    let forward_active = Arc::clone(&active);
+    let forward_cancelled = Arc::clone(&shared.cancelled);
+    let expires_at = shared.token_expires_unix;
+    let forwarder = thread::Builder::new()
+        .name("luvus-uhp-access-terminal".into())
+        .stack_size(256 * 1024)
+        .spawn(move || {
+            while forward_active.load(Ordering::Acquire)
+                && !forward_cancelled.load(Ordering::Acquire)
+                && !unix_expired(expires_at)
+            {
+                match local_reader.read_frame(Duration::from_millis(250)) {
+                    Ok(Some(frame)) => {
+                        if writeln!(remote, "{frame}")
+                            .and_then(|_| remote.flush())
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+                    Err(_) => break,
+                }
+            }
+            forward_active.store(false, Ordering::Release);
+        })
+        .context("cannot start terminal output relay")?;
+
+    let mut input = RemoteFrameReader::new(remote_reader)?;
+    while active.load(Ordering::Acquire)
+        && !shared.cancelled.load(Ordering::Acquire)
+        && !unix_expired(shared.token_expires_unix)
+    {
+        match input.read_frame(Duration::from_millis(250)) {
+            Ok(Some(frame)) if control && valid_terminal_control_frame(&frame) => {
+                if !shared
+                    .rate
+                    .lock()
+                    .map_err(|_| anyhow!("gateway rate limiter unavailable"))?
+                    .allow(Instant::now())
+                {
+                    break;
+                }
+                writeln!(local, "{frame}")?;
+                local.flush()?;
+            }
+            Ok(Some(_)) => break,
+            Ok(None) => break,
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+            Err(error) => {
+                active.store(false, Ordering::Release);
+                let _ = forwarder.join();
+                return Err(error.into());
+            }
+        }
+    }
+    active.store(false, Ordering::Release);
+    let _ = forwarder.join();
+    Ok(())
+}
+
+fn unix_expired(expires_at: u64) -> bool {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(true, |now| now.as_secs() >= expires_at)
+}
+
+fn valid_terminal_control_frame(frame: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(frame) else {
+        return false;
+    };
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if !object
+        .keys()
+        .all(|key| matches!(key.as_str(), "id" | "action" | "params"))
+    {
+        return false;
+    }
+    let valid_id = value.get("id").and_then(Value::as_str).is_some_and(|id| {
+        !id.is_empty()
+            && id.len() <= 128
+            && id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"._:-".contains(&byte))
+    });
+    let Some(params) = value.get("params").and_then(Value::as_object) else {
+        return false;
+    };
+    valid_id
+        && match value.get("action").and_then(Value::as_str) {
+            Some("type_literal" | "submit_text") => {
+                params.len() == 1
+                    && params
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| {
+                            !text.is_empty()
+                                && text.len() <= crate::terminal::backend::MAX_INPUT_BYTES
+                        })
+            }
+            Some("send_key") => {
+                params.len() == 1
+                    && params
+                        .get("key")
+                        .and_then(Value::as_str)
+                        .is_some_and(|key| {
+                            matches!(
+                                key,
+                                "enter"
+                                    | "escape"
+                                    | "tab"
+                                    | "backtab"
+                                    | "up"
+                                    | "down"
+                                    | "left"
+                                    | "right"
+                                    | "home"
+                                    | "end"
+                                    | "backspace"
+                                    | "delete"
+                                    | "pageup"
+                                    | "pagedown"
+                                    | "ctrl-c"
+                                    | "ctrl-d"
+                                    | "ctrl-u"
+                                    | "ctrl-w"
+                                    | "space"
+                                    | "digit-0"
+                                    | "digit-1"
+                                    | "digit-2"
+                                    | "digit-3"
+                                    | "digit-4"
+                                    | "digit-5"
+                                    | "digit-6"
+                                    | "digit-7"
+                                    | "digit-8"
+                                    | "digit-9"
+                            )
+                        })
+            }
+            _ => false,
+        }
+}
+
+fn stream_events(
+    local: crate::ipc::transport::Conn,
+    mut remote: TcpStream,
+    expected_id: &Value,
+    shared: &Shared,
+) -> Result<()> {
+    let mut reader = LocalFrameReader::new(local)?;
+    let first = reader.read_frame(RESPONSE_TIMEOUT)?.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "event stream closed before acknowledgement",
+        )
+    })?;
+    validate_response_id(&first, expected_id)?;
+    writeln!(remote, "{first}")?;
+    remote.flush()?;
+    remote.set_read_timeout(Some(Duration::from_millis(1)))?;
+    while !shared.cancelled.load(Ordering::Acquire) && !unix_expired(shared.token_expires_unix) {
+        if remote_closed(&remote) {
+            break;
+        }
+        match reader.read_frame(Duration::from_millis(250)) {
+            Ok(Some(event)) => {
+                writeln!(remote, "{event}")?;
+                remote.flush()?;
+            }
+            Ok(None) => break,
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+struct RemoteFrameReader {
+    connection: BufReader<TcpStream>,
+    buffered: Vec<u8>,
+}
+
+impl RemoteFrameReader {
+    fn new(connection: BufReader<TcpStream>) -> io::Result<Self> {
+        connection
+            .get_ref()
+            .set_read_timeout(Some(Duration::from_millis(50)))?;
+        Ok(Self {
+            connection,
+            buffered: Vec::new(),
+        })
+    }
+
+    fn read_frame(&mut self, timeout: Duration) -> io::Result<Option<String>> {
+        let deadline = Instant::now() + timeout;
+        let mut chunk = [0_u8; 4096];
+        loop {
+            if let Some(position) = self.buffered.iter().position(|byte| *byte == b'\n') {
+                if position.saturating_add(1) > crate::terminal::backend::MAX_FRAME_BYTES {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "remote terminal frame is too large",
+                    ));
+                }
+                let remaining = self.buffered.split_off(position + 1);
+                let mut frame = std::mem::replace(&mut self.buffered, remaining);
+                frame.pop();
+                return String::from_utf8(frame).map(Some).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "remote frame is not UTF-8")
+                });
+            }
+            if self.buffered.len() >= crate::terminal::backend::MAX_FRAME_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "remote terminal frame is too large",
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "remote terminal frame timed out",
+                ));
+            }
+            match self.connection.read(&mut chunk) {
+                Ok(0) => {
+                    return if self.buffered.is_empty() {
+                        Ok(None)
+                    } else {
+                        Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "remote terminal frame is missing LF",
+                        ))
+                    };
+                }
+                Ok(read) => self.buffered.extend_from_slice(&chunk[..read]),
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                    ) => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+}
+
+struct LocalFrameReader {
+    connection: crate::ipc::transport::Conn,
+    buffered: Vec<u8>,
+    #[cfg(not(windows))]
+    timeout_mode: crate::ipc::transport::TimeoutMode,
+}
+
+impl LocalFrameReader {
+    fn new(connection: crate::ipc::transport::Conn) -> io::Result<Self> {
+        #[cfg(not(windows))]
+        let timeout_mode = connection.set_recv_timeout(Duration::from_millis(50))?;
+        Ok(Self {
+            connection,
+            buffered: Vec::new(),
+            #[cfg(not(windows))]
+            timeout_mode,
+        })
+    }
+
+    fn read_frame(&mut self, timeout: Duration) -> io::Result<Option<String>> {
+        let deadline = Instant::now() + timeout;
+        let mut chunk = [0_u8; 4096];
+        loop {
+            if let Some(position) = self.buffered.iter().position(|byte| *byte == b'\n') {
+                if position.saturating_add(1) > crate::terminal::backend::MAX_FRAME_BYTES {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "local event frame is too large",
+                    ));
+                }
+                let remaining = self.buffered.split_off(position + 1);
+                let mut frame = std::mem::replace(&mut self.buffered, remaining);
+                frame.pop();
+                return String::from_utf8(frame).map(Some).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "local event frame is not UTF-8")
+                });
+            }
+            if self.buffered.len() >= crate::terminal::backend::MAX_FRAME_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "local event frame is too large",
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "local event frame timed out",
+                ));
+            }
+            #[cfg(windows)]
+            match self.connection.recv_has_data() {
+                Ok(false) => {
+                    thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                Ok(true) => {}
+                Err(error) => return Err(error),
+            }
+            match self.connection.read(&mut chunk) {
+                Ok(0) => {
+                    #[cfg(not(windows))]
+                    if self.timeout_mode == crate::ipc::transport::TimeoutMode::Nonblocking
+                        && crate::ipc::transport::nonblocking_zero_is_pending()
+                    {
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    if self.buffered.is_empty() {
+                        return Ok(None);
+                    }
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "local event frame is missing LF",
+                    ));
+                }
+                Ok(read) => self.buffered.extend_from_slice(&chunk[..read]),
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    #[cfg(not(windows))]
+                    if self.timeout_mode == crate::ipc::transport::TimeoutMode::Nonblocking {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                }
+                Err(error) => {
+                    #[cfg(not(windows))]
+                    if self.timeout_mode == crate::ipc::transport::TimeoutMode::Nonblocking
+                        && crate::ipc::transport::nonblocking_read_pending(&error)
+                    {
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+}
+
+fn remote_closed(remote: &TcpStream) -> bool {
+    let mut byte = [0_u8; 1];
+    match remote.peek(&mut byte) {
+        Ok(_) => true,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+            ) =>
+        {
+            false
+        }
+        Err(_) => true,
+    }
+}
+
+fn validate_response_id(response: &str, expected: &Value) -> Result<()> {
+    let value: Value = serde_json::from_str(response).context("invalid local UHP response")?;
+    if value.get("id") != Some(expected) {
+        return Err(anyhow!("local UHP response id mismatch"));
+    }
+    Ok(())
+}
+
+fn write_gateway_error(mut stream: TcpStream, id: Value, code: &'static str) -> io::Result<()> {
+    let message = match code {
+        "rate_limited" => "private gateway request limit reached",
+        "unavailable" => "private gateway unavailable",
+        "invalid_request" => "invalid private gateway request",
+        _ => "private gateway authorization failed",
+    };
+    writeln!(
+        stream,
+        "{}",
+        json!({"id":id,"error":{"code":code,"message":message}})
+    )?;
+    stream.flush()
+}
+
+fn constant_time_eq(expected: &[u8], candidate: &[u8]) -> bool {
+    let mut difference = expected.len() ^ candidate.len();
+    for index in 0..expected.len().max(candidate.len()) {
+        difference |= usize::from(
+            expected.get(index).copied().unwrap_or(0) ^ candidate.get(index).copied().unwrap_or(0),
+        );
+    }
+    difference == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interprocess::local_socket::traits::Listener as _;
+    use std::io::{BufReader, Write};
+
+    #[test]
+    fn access_allowlist_separates_observation_from_control() {
+        assert!(allowed_method(AccessMode::ReadOnly, "uhp.capabilities"));
+        assert!(allowed_method(AccessMode::ReadOnly, "session.snapshot"));
+        assert!(allowed_method(AccessMode::ReadOnly, "events.subscribe"));
+        assert!(!allowed_method(AccessMode::ReadOnly, "workspace.focus"));
+        assert!(allowed_method(AccessMode::Control, "workspace.focus"));
+        assert!(allowed_method(AccessMode::Control, "tab.focus"));
+        assert!(allowed_method(AccessMode::Control, "pane.focus"));
+        assert!(allowed_method(AccessMode::Control, "agent.prompt"));
+        assert!(allowed_method(
+            AccessMode::ReadOnly,
+            "terminal.backend.observe"
+        ));
+        assert!(!allowed_method(
+            AccessMode::ReadOnly,
+            "terminal.backend.control"
+        ));
+        assert!(allowed_method(
+            AccessMode::Control,
+            "terminal.backend.control"
+        ));
+        assert!(!allowed_method(AccessMode::Control, "pane.send_input"));
+        assert!(!allowed_method(AccessMode::Control, "pane.run"));
+        assert!(!allowed_method(AccessMode::Control, "pane.close"));
+        assert!(!allowed_method(AccessMode::Control, "agent.start"));
+        assert!(!allowed_method(AccessMode::Control, "agent.fork"));
+        assert!(!allowed_method(AccessMode::Control, "uhp.token.list"));
+        assert!(!allowed_method(
+            AccessMode::Control,
+            "terminal.backend.type_literal"
+        ));
+    }
+
+    #[test]
+    fn terminal_control_frames_are_strict_and_bounded() {
+        assert!(valid_terminal_control_frame(
+            r#"{"id":"input-1","action":"submit_text","params":{"text":"echo ok"}}"#
+        ));
+        assert!(valid_terminal_control_frame(
+            r#"{"id":"key-1","action":"send_key","params":{"key":"ctrl-c"}}"#
+        ));
+        assert!(!valid_terminal_control_frame(
+            r#"{"id":"run-1","action":"pane.run","params":{"text":"id"}}"#
+        ));
+        assert!(!valid_terminal_control_frame(
+            r#"{"id":"key-1","action":"send_key","params":{"key":"ctrl-z"}}"#
+        ));
+        assert!(!valid_terminal_control_frame(
+            r#"{"id":"input-1","action":"submit_text","params":{"text":"ok","extra":true}}"#
+        ));
+    }
+
+    #[test]
+    fn request_window_is_bounded_and_resets() {
+        let start = Instant::now();
+        let mut window = RateWindow {
+            started: start,
+            requests: 0,
+        };
+        for _ in 0..MAX_REQUESTS_PER_MINUTE {
+            assert!(window.allow(start));
+        }
+        assert!(!window.allow(start));
+        assert!(window.allow(start + Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn response_ids_must_match_exactly() {
+        assert!(validate_response_id(r#"{"id":"one","result":{}}"#, &json!("one")).is_ok());
+        assert!(validate_response_id(r#"{"id":"two","result":{}}"#, &json!("one")).is_err());
+    }
+
+    #[test]
+    fn gateway_pairs_once_and_denies_remote_mutation_before_local_ipc() {
+        let pairing = Pairing::new(Duration::from_secs(60)).unwrap();
+        let code = pairing.display_code().to_string();
+        let token = "luv_tok_test_only".to_string();
+        let mut gateway = Gateway::start(
+            PathBuf::from("target/test-state/web/no-server.sock"),
+            token.clone(),
+            4_000_000_000,
+            pairing,
+            AccessMode::ReadOnly,
+        )
+        .unwrap();
+
+        let paired = exchange(gateway.address(), &json!({"type":"pair","code":code}));
+        assert_eq!(paired["type"], "paired");
+        assert_eq!(paired["token"], token);
+
+        let replay = exchange(gateway.address(), &json!({"type":"pair","code":code}));
+        assert_eq!(replay["error"]["code"], "forbidden");
+        assert!(replay.get("token").is_none());
+
+        let mutation = exchange(
+            gateway.address(),
+            &json!({"id":"1","method":"pane.send_input","params":{"pane":"1","text":"x"},"auth":token}),
+        );
+        assert_eq!(mutation["id"], "1");
+        assert_eq!(mutation["error"]["code"], "forbidden");
+
+        let omitted_auth = exchange(
+            gateway.address(),
+            &json!({"id":"2","method":"session.snapshot","params":{}}),
+        );
+        assert_eq!(omitted_auth["error"]["code"], "forbidden");
+        gateway.stop();
+    }
+
+    #[test]
+    fn control_pairing_exposes_only_bounded_write_authority() {
+        let pairing = Pairing::new(Duration::from_secs(60)).unwrap();
+        let code = pairing.display_code().to_string();
+        let token = "luv_tok_control_test".to_string();
+        let mut gateway = Gateway::start(
+            PathBuf::from("target/test-state/web/no-control-server.sock"),
+            token.clone(),
+            4_000_000_000,
+            pairing,
+            AccessMode::Control,
+        )
+        .unwrap();
+
+        let paired = exchange(gateway.address(), &json!({"type":"pair","code":code}));
+        assert_eq!(
+            paired["scopes"],
+            json!(["read", "workspace", "agent", "terminal"])
+        );
+
+        // An allowlisted focus reaches the unavailable local endpoint. A raw
+        // terminal write is denied before any local connection is attempted.
+        let focus = exchange(
+            gateway.address(),
+            &json!({"id":"focus","method":"workspace.focus","params":{"workspace":0},"auth":token}),
+        );
+        assert_eq!(focus["error"]["code"], "unavailable");
+        let terminal_write = exchange(
+            gateway.address(),
+            &json!({"id":"write","method":"pane.send_input","params":{"pane":"1","text":"x"},"auth":token}),
+        );
+        assert_eq!(terminal_write["error"]["code"], "forbidden");
+
+        let one_shot_terminal_write = exchange(
+            gateway.address(),
+            &json!({"id":"write-2","method":"terminal.backend.type_literal","params":{
+                "server_generation":"11111111111111111111111111111111",
+                "terminal_id":"22222222222222222222222222222222",
+                "pane_id":"1","text":"x"
+            },"auth":token}),
+        );
+        assert_eq!(one_shot_terminal_write["error"]["code"], "forbidden");
+        gateway.stop();
+    }
+
+    #[test]
+    fn terminal_control_stream_relays_frames_and_bounded_actions() {
+        let _env = crate::persist::test_env("web-terminal-stream");
+        let socket_path = crate::persist::ensure_config_dir().join("web-terminal.sock");
+        let listener = crate::ipc::transport::bind(&socket_path).unwrap();
+        let local_server = thread::spawn(move || {
+            let mut connection = BufReader::new(listener.accept().unwrap());
+            let request = crate::ipc::api::read_response_frame(&mut connection).unwrap();
+            let request: Value = serde_json::from_str(&request).unwrap();
+            assert_eq!(request["method"], "terminal.backend.control");
+            writeln!(
+                connection.get_mut(),
+                "{}",
+                json!({"id":"terminal","result":{
+                    "type":"terminal_backend_stream","mode":"control"
+                }})
+            )
+            .unwrap();
+            writeln!(
+                connection.get_mut(),
+                "{}",
+                json!({"event":"terminal.frame","sequence":1,"data":{
+                    "text":"ready","content_revision":1,"truncated":false
+                }})
+            )
+            .unwrap();
+            connection.get_mut().flush().unwrap();
+
+            let action = crate::ipc::api::read_response_frame(&mut connection).unwrap();
+            let action: Value = serde_json::from_str(&action).unwrap();
+            assert_eq!(action["action"], "submit_text");
+            assert_eq!(action["params"]["text"], "echo ok");
+            writeln!(
+                connection.get_mut(),
+                "{}",
+                json!({"id":"input-1","result":{
+                    "type":"terminal_backend_action","state":"succeeded","dispatch":"queued"
+                }})
+            )
+            .unwrap();
+            connection.get_mut().flush().unwrap();
+        });
+
+        let pairing = Pairing::new(Duration::from_secs(60)).unwrap();
+        let code = pairing.display_code().to_string();
+        let token = "luv_tok_stream_test".to_string();
+        let mut gateway = Gateway::start(
+            socket_path,
+            token.clone(),
+            u64::MAX,
+            pairing,
+            AccessMode::Control,
+        )
+        .unwrap();
+        let paired = exchange(gateway.address(), &json!({"type":"pair","code":code}));
+        assert_eq!(paired["type"], "paired");
+
+        let mut stream = TcpStream::connect(gateway.address()).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        writeln!(
+            stream,
+            "{}",
+            json!({
+                "id":"terminal","method":"terminal.backend.control","params":{
+                    "server_generation":"11111111111111111111111111111111",
+                    "terminal_id":"22222222222222222222222222222222",
+                    "pane_id":"1","mode":"visible","lines":80,"ansi":false
+                },"auth":token
+            })
+        )
+        .unwrap();
+        stream.flush().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let response = crate::ipc::api::read_response_frame(&mut reader).unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&response).unwrap()["result"]["type"],
+            "terminal_backend_stream"
+        );
+        let frame = crate::ipc::api::read_response_frame(&mut reader).unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&frame).unwrap()["data"]["text"],
+            "ready"
+        );
+        writeln!(
+            stream,
+            "{}",
+            json!({"id":"input-1","action":"submit_text","params":{"text":"echo ok"}})
+        )
+        .unwrap();
+        stream.flush().unwrap();
+        let action = crate::ipc::api::read_response_frame(&mut reader).unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&action).unwrap()["result"]["state"],
+            "succeeded"
+        );
+
+        drop(stream);
+        local_server.join().unwrap();
+        gateway.stop();
+    }
+
+    fn exchange(address: SocketAddr, request: &Value) -> Value {
+        let mut stream = TcpStream::connect(address).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        writeln!(stream, "{request}").unwrap();
+        stream.flush().unwrap();
+        let line = crate::ipc::api::read_response_frame(&mut BufReader::new(stream)).unwrap();
+        serde_json::from_str(&line).unwrap()
+    }
+}

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -17,6 +17,7 @@ const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 const CANCELLATION_POLL: Duration = Duration::from_millis(250);
 const ACCEPT_ERROR_DELAY: Duration = Duration::from_millis(10);
+const ACCEPT_WAKE_ATTEMPTS: usize = 3;
 const MAX_CONNECTIONS: usize = 16;
 const MAX_REQUESTS_PER_MINUTE: u32 = 120;
 
@@ -122,7 +123,11 @@ impl Gateway {
         if !self.shared.cancelled.swap(true, Ordering::AcqRel) {
             // Wake the blocking accept loop without polling during active UHP
             // access. The loop owns and drains all request workers.
-            let _ = TcpStream::connect(self.address);
+            for _ in 0..ACCEPT_WAKE_ATTEMPTS {
+                if TcpStream::connect(self.address).is_ok() {
+                    break;
+                }
+            }
         }
     }
 

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::io::{self, BufReader, Read, Write};
-use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::net::{Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -14,12 +15,14 @@ use super::{pairing::Pairing, AccessMode};
 const INITIAL_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const CANCELLATION_POLL: Duration = Duration::from_millis(250);
+const ACCEPT_ERROR_DELAY: Duration = Duration::from_millis(10);
 const MAX_CONNECTIONS: usize = 16;
 const MAX_REQUESTS_PER_MINUTE: u32 = 120;
 
 pub(super) struct Gateway {
     address: SocketAddr,
-    cancelled: Arc<AtomicBool>,
+    shared: Arc<Shared>,
     accept_thread: Option<JoinHandle<()>>,
 }
 
@@ -31,14 +34,24 @@ struct Shared {
     mode: AccessMode,
     cancelled: Arc<AtomicBool>,
     active: AtomicUsize,
+    next_connection_id: AtomicUsize,
+    connections: Mutex<HashMap<usize, TcpStream>>,
     rate: Mutex<RateWindow>,
 }
 
-struct ConnectionPermit<'a>(&'a AtomicUsize);
+struct ConnectionPermit<'a> {
+    shared: &'a Shared,
+    id: usize,
+}
 
 impl Drop for ConnectionPermit<'_> {
     fn drop(&mut self) {
-        self.0.fetch_sub(1, Ordering::AcqRel);
+        self.shared.active.fetch_sub(1, Ordering::AcqRel);
+        self.shared
+            .connections
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.id);
     }
 }
 
@@ -81,6 +94,8 @@ impl Gateway {
             mode,
             cancelled: cancelled.clone(),
             active: AtomicUsize::new(0),
+            next_connection_id: AtomicUsize::new(0),
+            connections: Mutex::new(HashMap::new()),
             rate: Mutex::new(RateWindow {
                 started: Instant::now(),
                 requests: 0,
@@ -94,7 +109,7 @@ impl Gateway {
             .context("cannot start the private UHP access gateway")?;
         Ok(Self {
             address,
-            cancelled,
+            shared,
             accept_thread: Some(accept_thread),
         })
     }
@@ -103,15 +118,23 @@ impl Gateway {
         self.address
     }
 
-    pub(super) fn stop(&mut self) {
-        if self.cancelled.swap(true, Ordering::AcqRel) {
-            return;
+    pub(super) fn cancel(&self) {
+        if !self.shared.cancelled.swap(true, Ordering::AcqRel) {
+            // Wake the blocking accept loop without polling during active UHP
+            // access. The loop owns and drains all request workers.
+            let _ = TcpStream::connect(self.address);
         }
-        // Wake the blocking loop without polling during active UHP access.
-        let _ = TcpStream::connect(self.address);
+    }
+
+    pub(super) fn finish_stop(&mut self) {
         if let Some(thread) = self.accept_thread.take() {
             let _ = thread.join();
         }
+    }
+
+    pub(super) fn stop(&mut self) {
+        self.cancel();
+        self.finish_stop();
     }
 }
 
@@ -122,10 +145,11 @@ impl Drop for Gateway {
 }
 
 fn accept_loop(listener: TcpListener, shared: Arc<Shared>) {
+    let mut workers = Vec::new();
     while !shared.cancelled.load(Ordering::Acquire) {
         let Ok((stream, peer)) = listener.accept() else {
             if !shared.cancelled.load(Ordering::Acquire) {
-                thread::yield_now();
+                thread::sleep(ACCEPT_ERROR_DELAY);
             }
             continue;
         };
@@ -143,14 +167,33 @@ fn accept_loop(listener: TcpListener, shared: Arc<Shared>) {
             let _ = write_gateway_error(stream, Value::Null, "unavailable");
             continue;
         }
+        let connection_id = shared.next_connection_id.fetch_add(1, Ordering::Relaxed);
+        let shutdown_stream = match stream.try_clone() {
+            Ok(stream) => stream,
+            Err(_) => {
+                shared.active.fetch_sub(1, Ordering::AcqRel);
+                let _ = write_gateway_error(stream, Value::Null, "unavailable");
+                continue;
+            }
+        };
+        shared
+            .connections
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(connection_id, shutdown_stream);
         let connection_shared = shared.clone();
         let fallback = stream.try_clone().ok();
-        if thread::Builder::new()
+        match thread::Builder::new()
             .name("luvus-uhp-access-request".into())
             .stack_size(256 * 1024)
             .spawn(move || {
-                let _permit = ConnectionPermit(&connection_shared.active);
-                if handle_connection(stream, &connection_shared).is_err() {
+                let _permit = ConnectionPermit {
+                    shared: &connection_shared,
+                    id: connection_id,
+                };
+                if handle_connection(stream, &connection_shared).is_err()
+                    && !connection_shared.cancelled.load(Ordering::Acquire)
+                {
                     if let Some(stream) = fallback {
                         let _ = write_gateway_error(stream, Value::Null, "invalid_request");
                     }
@@ -158,11 +201,44 @@ fn accept_loop(listener: TcpListener, shared: Arc<Shared>) {
                     // and response contents from the UHP-access log.
                     crate::logging::event(crate::logging::EventKind::UhpRequestRejected, &[]);
                 }
-            })
-            .is_err()
-        {
-            shared.active.fetch_sub(1, Ordering::AcqRel);
+            }) {
+            Ok(worker) => workers.push(worker),
+            Err(_) => {
+                shared.active.fetch_sub(1, Ordering::AcqRel);
+                shared
+                    .connections
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .remove(&connection_id);
+            }
         }
+        reap_finished(&mut workers);
+    }
+    shutdown_connections(&shared);
+    for worker in workers {
+        let _ = worker.join();
+    }
+}
+
+fn reap_finished(workers: &mut Vec<JoinHandle<()>>) {
+    let mut index = 0;
+    while index < workers.len() {
+        if workers[index].is_finished() {
+            let worker = workers.swap_remove(index);
+            let _ = worker.join();
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn shutdown_connections(shared: &Shared) {
+    let connections = shared
+        .connections
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for stream in connections.values() {
+        let _ = stream.shutdown(Shutdown::Both);
     }
 }
 
@@ -173,6 +249,9 @@ fn handle_connection(mut stream: TcpStream, shared: &Shared) -> Result<()> {
     let frame =
         crate::ipc::api::read_request_frame(&mut reader).context("invalid UHP-access frame")?;
     let value: Value = serde_json::from_str(&frame).context("invalid UHP-access JSON")?;
+    if shared.cancelled.load(Ordering::Acquire) {
+        return Err(io::Error::new(io::ErrorKind::Interrupted, "UHP access stopped").into());
+    }
 
     if value.get("type").and_then(Value::as_str) == Some("pair") {
         return handle_pairing(stream, shared, &value);
@@ -202,6 +281,9 @@ fn handle_connection(mut stream: TcpStream, shared: &Shared) -> Result<()> {
         write_gateway_error(stream, id, "forbidden")?;
         return Ok(());
     }
+    if shared.cancelled.load(Ordering::Acquire) {
+        return Err(io::Error::new(io::ErrorKind::Interrupted, "UHP access stopped").into());
+    }
 
     let mut local = match crate::ipc::transport::connect(&shared.socket_path) {
         Ok(local) => local,
@@ -210,6 +292,9 @@ fn handle_connection(mut stream: TcpStream, shared: &Shared) -> Result<()> {
             return Ok(());
         }
     };
+    if shared.cancelled.load(Ordering::Acquire) {
+        return Err(io::Error::new(io::ErrorKind::Interrupted, "UHP access stopped").into());
+    }
     writeln!(local, "{frame}")?;
     local.flush()?;
 
@@ -231,12 +316,14 @@ fn handle_connection(mut stream: TcpStream, shared: &Shared) -> Result<()> {
     ) {
         stream_events(local, stream, &id, shared)
     } else {
-        let response = match crate::ipc::api::read_response_frame_with_deadline(
-            &mut local,
-            RESPONSE_TIMEOUT,
-        ) {
-            Ok(response) => response,
+        let mut local_reader = LocalFrameReader::new(local)?;
+        let response = match read_local_frame(&mut local_reader, RESPONSE_TIMEOUT, shared) {
+            Ok(Some(response)) => response,
             Err(_) => {
+                write_gateway_error(stream, id, "unavailable")?;
+                return Ok(());
+            }
+            Ok(None) => {
                 write_gateway_error(stream, id, "unavailable")?;
                 return Ok(());
             }
@@ -255,7 +342,8 @@ fn handle_pairing(mut stream: TcpStream, shared: &Shared, value: &Value) -> Resu
             .all(|key| matches!(key.as_str(), "type" | "code"))
     });
     let candidate = value.get("code").and_then(Value::as_str).unwrap_or("");
-    let accepted = valid_shape
+    let accepted = !shared.cancelled.load(Ordering::Acquire)
+        && valid_shape
         && shared
             .pairing
             .lock()
@@ -291,6 +379,69 @@ fn allowed_method(mode: AccessMode, method: &str) -> bool {
             ))
 }
 
+struct TerminalForwarder {
+    active: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl TerminalForwarder {
+    fn spawn(
+        mut local_reader: LocalFrameReader,
+        mut remote: TcpStream,
+        cancelled: Arc<AtomicBool>,
+        expires_at: u64,
+    ) -> Result<Self> {
+        let active = Arc::new(AtomicBool::new(true));
+        let forward_active = Arc::clone(&active);
+        let thread = thread::Builder::new()
+            .name("luvus-uhp-access-terminal".into())
+            .stack_size(256 * 1024)
+            .spawn(move || {
+                while forward_active.load(Ordering::Acquire)
+                    && !cancelled.load(Ordering::Acquire)
+                    && !unix_expired(expires_at)
+                {
+                    match local_reader.read_frame(CANCELLATION_POLL) {
+                        Ok(Some(frame)) => {
+                            if writeln!(remote, "{frame}")
+                                .and_then(|_| remote.flush())
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+                        Err(_) => break,
+                    }
+                }
+                forward_active.store(false, Ordering::Release);
+            })
+            .context("cannot start terminal output relay")?;
+        Ok(Self {
+            active,
+            thread: Some(thread),
+        })
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+
+    fn stop(&mut self) {
+        self.active.store(false, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for TerminalForwarder {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
 fn stream_terminal(
     mut local: crate::ipc::transport::Conn,
     mut remote: TcpStream,
@@ -300,48 +451,26 @@ fn stream_terminal(
     control: bool,
 ) -> Result<()> {
     let mut local_reader = LocalFrameReader::new(local.clone())?;
-    let first = local_reader.read_frame(RESPONSE_TIMEOUT)?.ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::UnexpectedEof,
-            "terminal stream closed before acknowledgement",
-        )
-    })?;
+    let first =
+        read_local_frame(&mut local_reader, RESPONSE_TIMEOUT, shared)?.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "terminal stream closed before acknowledgement",
+            )
+        })?;
     validate_response_id(&first, expected_id)?;
     writeln!(remote, "{first}")?;
     remote.flush()?;
 
-    let active = Arc::new(AtomicBool::new(true));
-    let forward_active = Arc::clone(&active);
-    let forward_cancelled = Arc::clone(&shared.cancelled);
-    let expires_at = shared.token_expires_unix;
-    let forwarder = thread::Builder::new()
-        .name("luvus-uhp-access-terminal".into())
-        .stack_size(256 * 1024)
-        .spawn(move || {
-            while forward_active.load(Ordering::Acquire)
-                && !forward_cancelled.load(Ordering::Acquire)
-                && !unix_expired(expires_at)
-            {
-                match local_reader.read_frame(Duration::from_millis(250)) {
-                    Ok(Some(frame)) => {
-                        if writeln!(remote, "{frame}")
-                            .and_then(|_| remote.flush())
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    Ok(None) => break,
-                    Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
-                    Err(_) => break,
-                }
-            }
-            forward_active.store(false, Ordering::Release);
-        })
-        .context("cannot start terminal output relay")?;
+    let mut forwarder = TerminalForwarder::spawn(
+        local_reader,
+        remote,
+        Arc::clone(&shared.cancelled),
+        shared.token_expires_unix,
+    )?;
 
     let mut input = RemoteFrameReader::new(remote_reader)?;
-    while active.load(Ordering::Acquire)
+    while forwarder.is_active()
         && !shared.cancelled.load(Ordering::Acquire)
         && !unix_expired(shared.token_expires_unix)
     {
@@ -361,15 +490,10 @@ fn stream_terminal(
             Ok(Some(_)) => break,
             Ok(None) => break,
             Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
-            Err(error) => {
-                active.store(false, Ordering::Release);
-                let _ = forwarder.join();
-                return Err(error.into());
-            }
+            Err(error) => return Err(error.into()),
         }
     }
-    active.store(false, Ordering::Release);
-    let _ = forwarder.join();
+    forwarder.stop();
     Ok(())
 }
 
@@ -465,7 +589,7 @@ fn stream_events(
     shared: &Shared,
 ) -> Result<()> {
     let mut reader = LocalFrameReader::new(local)?;
-    let first = reader.read_frame(RESPONSE_TIMEOUT)?.ok_or_else(|| {
+    let first = read_local_frame(&mut reader, RESPONSE_TIMEOUT, shared)?.ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::UnexpectedEof,
             "event stream closed before acknowledgement",
@@ -663,6 +787,32 @@ impl LocalFrameReader {
     }
 }
 
+fn read_local_frame(
+    reader: &mut LocalFrameReader,
+    timeout: Duration,
+    shared: &Shared,
+) -> io::Result<Option<String>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if shared.cancelled.load(Ordering::Acquire) || unix_expired(shared.token_expires_unix) {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "UHP access stopped",
+            ));
+        }
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "local UHP response timed out",
+            ));
+        };
+        match reader.read_frame(remaining.min(CANCELLATION_POLL)) {
+            Err(error) if error.kind() == io::ErrorKind::TimedOut => {}
+            result => return result,
+        }
+    }
+}
+
 fn remote_closed(remote: &TcpStream) -> bool {
     let mut byte = [0_u8; 1];
     match remote.peek(&mut byte) {
@@ -792,12 +942,39 @@ mod tests {
     }
 
     #[test]
+    fn stopping_gateway_drains_a_client_waiting_to_send_its_first_frame() {
+        let pairing = Pairing::new(Duration::from_secs(60)).unwrap();
+        let mut gateway = Gateway::start(
+            PathBuf::from("target/test-state/uhp/no-server.sock"),
+            "luv_tok_stop_test".to_string(),
+            4_000_000_000,
+            pairing,
+            AccessMode::ReadOnly,
+        )
+        .unwrap();
+        let _waiting_client = TcpStream::connect(gateway.address()).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while gateway.shared.active.load(Ordering::Acquire) == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(gateway.shared.active.load(Ordering::Acquire), 1);
+
+        let started = Instant::now();
+        gateway.stop();
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert_eq!(gateway.shared.active.load(Ordering::Acquire), 0);
+        assert!(gateway.accept_thread.is_none());
+        assert!(TcpStream::connect(gateway.address()).is_err());
+    }
+
+    #[test]
     fn gateway_pairs_once_and_denies_remote_mutation_before_local_ipc() {
         let pairing = Pairing::new(Duration::from_secs(60)).unwrap();
         let code = pairing.display_code().to_string();
         let token = "luv_tok_test_only".to_string();
         let mut gateway = Gateway::start(
-            PathBuf::from("target/test-state/web/no-server.sock"),
+            PathBuf::from("target/test-state/uhp/no-server.sock"),
             token.clone(),
             4_000_000_000,
             pairing,
@@ -834,7 +1011,7 @@ mod tests {
         let code = pairing.display_code().to_string();
         let token = "luv_tok_control_test".to_string();
         let mut gateway = Gateway::start(
-            PathBuf::from("target/test-state/web/no-control-server.sock"),
+            PathBuf::from("target/test-state/uhp/no-control-server.sock"),
             token.clone(),
             4_000_000_000,
             pairing,
@@ -875,8 +1052,8 @@ mod tests {
 
     #[test]
     fn terminal_control_stream_relays_frames_and_bounded_actions() {
-        let _env = crate::persist::test_env("web-terminal-stream");
-        let socket_path = crate::persist::ensure_config_dir().join("web-terminal.sock");
+        let _env = crate::persist::test_env("uhp-terminal-stream");
+        let socket_path = crate::persist::ensure_config_dir().join("uhp-terminal.sock");
         let listener = crate::ipc::transport::bind(&socket_path).unwrap();
         let local_server = thread::spawn(move || {
             let mut connection = BufReader::new(listener.accept().unwrap());

--- a/src/uhp/mod.rs
+++ b/src/uhp/mod.rs
@@ -85,7 +85,15 @@ impl AccessSession {
     }
 
     pub(super) fn stop(&mut self) {
-        self.gateway.stop();
+        self.gateway.cancel();
+        self.delegated.revoke();
+        self.gateway.finish_stop();
+    }
+}
+
+impl Drop for AccessSession {
+    fn drop(&mut self) {
+        self.stop();
     }
 }
 
@@ -169,6 +177,7 @@ struct DelegatedToken {
     id: String,
     secret: String,
     expires_at: u64,
+    revoked: bool,
 }
 
 impl DelegatedToken {
@@ -198,14 +207,23 @@ impl DelegatedToken {
             id: id.to_string(),
             secret: secret.to_string(),
             expires_at,
+            revoked: false,
         })
+    }
+
+    fn revoke(&mut self) {
+        if self.revoked {
+            return;
+        }
+        self.revoked = true;
+        let _ = local_request("uhp.token.revoke", json!({"id":self.id}));
+        self.secret.clear();
     }
 }
 
 impl Drop for DelegatedToken {
     fn drop(&mut self) {
-        let _ = local_request("uhp.token.revoke", json!({"id":self.id}));
-        self.secret.clear();
+        self.revoke();
     }
 }
 
@@ -285,7 +303,8 @@ mod shutdown {
 mod shutdown {
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use windows_sys::Win32::Foundation::{BOOL, TRUE};
+    use windows_sys::core::BOOL;
+    use windows_sys::Win32::Foundation::TRUE;
     use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
 
     static REQUESTED: AtomicBool = AtomicBool::new(false);

--- a/src/uhp/mod.rs
+++ b/src/uhp/mod.rs
@@ -1,0 +1,348 @@
+mod gateway;
+mod pairing;
+
+use std::io::Write;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+
+use gateway::Gateway;
+use pairing::Pairing;
+
+const ACCESS_TTL: Duration = Duration::from_secs(30 * 60);
+const CONTROL_TTL: Duration = Duration::from_secs(15 * 60);
+const PAIRING_TTL: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AccessMode {
+    ReadOnly,
+    Control,
+}
+
+impl AccessMode {
+    pub(super) fn ttl(self) -> Duration {
+        match self {
+            Self::ReadOnly => ACCESS_TTL,
+            Self::Control => CONTROL_TTL,
+        }
+    }
+
+    pub(super) fn scopes(self) -> &'static [&'static str] {
+        match self {
+            Self::ReadOnly => &["read"],
+            Self::Control => &["read", "workspace", "agent", "terminal"],
+        }
+    }
+}
+
+pub(super) struct AccessSession {
+    mode: AccessMode,
+    gateway: Gateway,
+    delegated: DelegatedToken,
+    pairing_code: String,
+    pairing_expires_at: u64,
+}
+
+impl AccessSession {
+    pub(super) fn start(mode: AccessMode, context: crate::i18n::cli::Context) -> Result<Self> {
+        probe_server(context)?;
+        let delegated = DelegatedToken::create(mode)
+            .map_err(|_| anyhow!(context.text("Could not authorize UHP access.")))?;
+        let pairing = Pairing::new(PAIRING_TTL)
+            .map_err(|_| anyhow!(context.text("Could not create a secure pairing code.")))?;
+        let pairing_code = pairing.display_code().to_string();
+        let pairing_expires_at = unix_now()?.saturating_add(PAIRING_TTL.as_secs());
+        let gateway = Gateway::start(
+            crate::persist::cli_socket_path(),
+            delegated.secret.clone(),
+            delegated.expires_at,
+            pairing,
+            mode,
+        )
+        .map_err(|_| anyhow!(context.text("Could not start the private UHP access gateway.")))?;
+        Ok(Self {
+            mode,
+            gateway,
+            delegated,
+            pairing_code,
+            pairing_expires_at,
+        })
+    }
+
+    pub(super) fn port(&self) -> u16 {
+        self.gateway.address().port()
+    }
+
+    fn descriptor(&self) -> Value {
+        access_descriptor(
+            self.mode,
+            self.port(),
+            &self.pairing_code,
+            self.pairing_expires_at,
+            self.delegated.expires_at,
+        )
+    }
+
+    pub(super) fn stop(&mut self) {
+        self.gateway.stop();
+    }
+}
+
+/// Start the transport-neutral, authenticated UHP access endpoint. The one
+/// stdout line is deliberately machine-readable so an independent transport
+/// provider can launch this command, forward the loopback endpoint, and pass
+/// the descriptor to any compatible client without knowing Luvus internals.
+pub(crate) fn run_cli(args: &[String], context: crate::i18n::cli::Context) -> Result<i32> {
+    let mode = parse_mode(args, "usage: luvus uhp access [--control]", context)?;
+    let mut access = AccessSession::start(mode, context)?;
+    shutdown::install();
+    println!("{}", serde_json::to_string(&access.descriptor())?);
+    std::io::stdout().flush()?;
+
+    let deadline = std::time::Instant::now() + mode.ttl();
+    while !shutdown::requested() && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    access.stop();
+    Ok(0)
+}
+
+pub(super) fn parse_mode(
+    args: &[String],
+    usage: &'static str,
+    context: crate::i18n::cli::Context,
+) -> Result<AccessMode> {
+    match args {
+        [] => Ok(AccessMode::ReadOnly),
+        [flag] if flag == "--control" => Ok(AccessMode::Control),
+        _ => Err(anyhow!(crate::i18n::cli::help(usage, context.language()))),
+    }
+}
+
+fn unix_now() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_secs())
+}
+
+fn access_descriptor(
+    mode: AccessMode,
+    port: u16,
+    pairing_code: &str,
+    pairing_expires_at: u64,
+    authority_expires_at: u64,
+) -> Value {
+    json!({
+        "$schema":"https://luvus.dev/protocol/uhp/v1/schema/access/descriptor.schema.json",
+        "type":"luvus_uhp_access",
+        "protocol":{
+            "name":crate::api::PROTOCOL_NAME,
+            "major":crate::api::PROTOCOL_MAJOR,
+            "minor":crate::api::PROTOCOL_MINOR,
+        },
+        "access":{"major":1},
+        "endpoint":{
+            "transport":"tcp",
+            "host":"127.0.0.1",
+            "port":port,
+            "framing":"ndjson",
+        },
+        "pairing":{
+            "type":"one_use_code",
+            "code":pairing_code,
+            "expires_at":pairing_expires_at,
+        },
+        "authority":{
+            "mode":match mode {
+                AccessMode::ReadOnly => "read_only",
+                AccessMode::Control => "control",
+            },
+            "scopes":mode.scopes(),
+            "expires_at":authority_expires_at,
+        },
+    })
+}
+
+struct DelegatedToken {
+    id: String,
+    secret: String,
+    expires_at: u64,
+}
+
+impl DelegatedToken {
+    fn create(mode: AccessMode) -> Result<Self> {
+        let response = local_request(
+            "uhp.token.create",
+            json!({"scopes":mode.scopes(),"ttl_s":mode.ttl().as_secs()}),
+        )?;
+        let result = response
+            .get("result")
+            .ok_or_else(|| response_error("cannot create delegated UHP access", &response))?;
+        let id = result
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("invalid delegated-token response"))?;
+        let secret = result
+            .get("token")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("invalid delegated-token response"))?;
+        let expires_at = result
+            .get("expires_at")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| anyhow!("invalid delegated-token response"))?;
+        Ok(Self {
+            id: id.to_string(),
+            secret: secret.to_string(),
+            expires_at,
+        })
+    }
+}
+
+impl Drop for DelegatedToken {
+    fn drop(&mut self) {
+        let _ = local_request("uhp.token.revoke", json!({"id":self.id}));
+        self.secret.clear();
+    }
+}
+
+fn probe_server(context: crate::i18n::cli::Context) -> Result<()> {
+    let response = local_request("ping", Value::Null).map_err(|_| {
+        anyhow!(
+            "{} (socket: {})",
+            context.text("no luvus server running"),
+            crate::persist::cli_socket_path().display()
+        )
+    })?;
+    if response.get("error").is_some() {
+        return Err(response_error(
+            "selected Luvus server did not answer",
+            &response,
+        ));
+    }
+    Ok(())
+}
+
+fn local_request(method: &str, params: Value) -> Result<Value> {
+    let request_id = crate::terminal::backend::random_id().map_err(anyhow::Error::msg)?;
+    let path = crate::persist::cli_socket_path();
+    let mut stream = crate::ipc::transport::connect(&path).with_context(|| {
+        format!(
+            "cannot connect to selected Luvus server ({})",
+            path.display()
+        )
+    })?;
+    writeln!(
+        stream,
+        "{}",
+        json!({"id":request_id,"method":method,"params":params})
+    )?;
+    stream.flush()?;
+    let response =
+        crate::ipc::api::read_response_frame_with_deadline(&mut stream, Duration::from_secs(5))?;
+    let value: Value = serde_json::from_str(&response).context("invalid local UHP response")?;
+    if value.get("id").and_then(Value::as_str) != Some(request_id.as_str()) {
+        return Err(anyhow!("local UHP response id mismatch"));
+    }
+    Ok(value)
+}
+
+fn response_error(context: &'static str, response: &Value) -> anyhow::Error {
+    let code = response
+        .pointer("/error/code")
+        .and_then(Value::as_str)
+        .unwrap_or("unavailable");
+    anyhow!("{context} ({code})")
+}
+
+#[cfg(unix)]
+mod shutdown {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static REQUESTED: AtomicBool = AtomicBool::new(false);
+
+    pub(super) fn requested() -> bool {
+        REQUESTED.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn install() {
+        extern "C" fn on_signal(_signal: libc::c_int) {
+            REQUESTED.store(true, Ordering::Relaxed);
+        }
+        unsafe {
+            let handler = on_signal as extern "C" fn(libc::c_int) as libc::sighandler_t;
+            libc::signal(libc::SIGINT, handler);
+            libc::signal(libc::SIGTERM, handler);
+            libc::signal(libc::SIGHUP, handler);
+        }
+    }
+}
+
+#[cfg(windows)]
+mod shutdown {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use windows_sys::Win32::Foundation::{BOOL, TRUE};
+    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+
+    static REQUESTED: AtomicBool = AtomicBool::new(false);
+
+    unsafe extern "system" fn on_control(_kind: u32) -> BOOL {
+        REQUESTED.store(true, Ordering::Relaxed);
+        TRUE
+    }
+
+    pub(super) fn requested() -> bool {
+        REQUESTED.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn install() {
+        unsafe {
+            SetConsoleCtrlHandler(Some(on_control), TRUE);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expiries_are_bounded() {
+        assert!(ACCESS_TTL <= Duration::from_secs(86_400));
+        assert!(CONTROL_TTL < ACCESS_TTL);
+        assert_eq!(PAIRING_TTL, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn control_authority_is_explicit_and_bounded() {
+        assert_eq!(AccessMode::ReadOnly.scopes(), &["read"]);
+        assert_eq!(
+            AccessMode::Control.scopes(),
+            &["read", "workspace", "agent", "terminal"]
+        );
+    }
+
+    #[test]
+    fn descriptor_is_transport_neutral_and_does_not_disclose_token() {
+        let descriptor = access_descriptor(
+            AccessMode::Control,
+            43123,
+            "ABCD-EFGH-JKLM",
+            1_700_000_300,
+            1_700_000_900,
+        );
+        assert_eq!(descriptor["type"], "luvus_uhp_access");
+        assert_eq!(descriptor["protocol"]["major"], 1);
+        assert_eq!(descriptor["endpoint"]["host"], "127.0.0.1");
+        assert_eq!(descriptor["endpoint"]["transport"], "tcp");
+        assert_eq!(descriptor["endpoint"]["framing"], "ndjson");
+        assert_eq!(descriptor["authority"]["mode"], "control");
+        assert_eq!(descriptor["authority"]["scopes"][3], "terminal");
+        assert!(descriptor.get("token").is_none());
+        assert!(descriptor["authority"].get("token").is_none());
+    }
+}

--- a/src/uhp/pairing.rs
+++ b/src/uhp/pairing.rs
@@ -1,0 +1,113 @@
+use std::time::{Duration, Instant};
+
+const ALPHABET: &[u8; 32] = b"23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+const MAX_ATTEMPTS: u8 = 5;
+
+#[derive(Debug)]
+pub(super) struct Pairing {
+    code: String,
+    expires_at: Instant,
+    attempts: u8,
+    used: bool,
+}
+
+impl Pairing {
+    pub(super) fn new(ttl: Duration) -> Result<Self, String> {
+        let mut entropy = [0_u8; 8];
+        getrandom::fill(&mut entropy)
+            .map_err(|error| format!("operating-system RNG failed: {error}"))?;
+
+        // Twelve base32 symbols carry exactly 60 uniformly random bits. The
+        // alphabet omits visually ambiguous characters for mobile entry.
+        let mut bits = u64::from_le_bytes(entropy);
+        let mut raw = String::with_capacity(12);
+        for _ in 0..12 {
+            raw.push(ALPHABET[(bits & 31) as usize] as char);
+            bits >>= 5;
+        }
+        let code = format!("{}-{}-{}", &raw[..4], &raw[4..8], &raw[8..]);
+        Ok(Self {
+            code,
+            expires_at: Instant::now() + ttl,
+            attempts: 0,
+            used: false,
+        })
+    }
+
+    pub(super) fn display_code(&self) -> &str {
+        &self.code
+    }
+
+    pub(super) fn consume(&mut self, candidate: &str) -> bool {
+        if self.used || self.attempts >= MAX_ATTEMPTS || Instant::now() >= self.expires_at {
+            return false;
+        }
+        self.attempts = self.attempts.saturating_add(1);
+        if constant_time_eq(self.code.as_bytes(), candidate.as_bytes()) {
+            self.used = true;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn constant_time_eq(expected: &[u8], candidate: &[u8]) -> bool {
+    let mut difference = expected.len() ^ candidate.len();
+    let length = expected.len().max(candidate.len());
+    for index in 0..length {
+        let left = expected.get(index).copied().unwrap_or(0);
+        let right = candidate.get(index).copied().unwrap_or(0);
+        difference |= usize::from(left ^ right);
+    }
+    difference == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_has_twelve_unambiguous_base32_symbols() {
+        let pairing = Pairing::new(Duration::from_secs(60)).unwrap();
+        let symbols: String = pairing
+            .display_code()
+            .chars()
+            .filter(|character| *character != '-')
+            .collect();
+        assert_eq!(symbols.len(), 12);
+        assert!(symbols.bytes().all(|byte| ALPHABET.contains(&byte)));
+    }
+
+    #[test]
+    fn pairing_is_one_use() {
+        let mut pairing = Pairing::new(Duration::from_secs(60)).unwrap();
+        let code = pairing.display_code().to_string();
+        assert!(pairing.consume(&code));
+        assert!(!pairing.consume(&code));
+    }
+
+    #[test]
+    fn pairing_exhausts_after_five_failures() {
+        let mut pairing = Pairing::new(Duration::from_secs(60)).unwrap();
+        let code = pairing.display_code().to_string();
+        for _ in 0..MAX_ATTEMPTS {
+            assert!(!pairing.consume("WRONG-CODE"));
+        }
+        assert!(!pairing.consume(&code));
+    }
+
+    #[test]
+    fn expired_pairing_is_rejected() {
+        let mut pairing = Pairing::new(Duration::ZERO).unwrap();
+        let code = pairing.display_code().to_string();
+        assert!(!pairing.consume(&code));
+    }
+
+    #[test]
+    fn constant_time_comparison_checks_length_and_contents() {
+        assert!(constant_time_eq(b"same", b"same"));
+        assert!(!constant_time_eq(b"same", b"samf"));
+        assert!(!constant_time_eq(b"same", b"same-longer"));
+    }
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
             { label: 'Community Themes', slug: 'docs/guides/themes' },
             { label: 'Scripting luvus', slug: 'docs/guides/scripting' },
             { label: 'Automating with UHP', slug: 'docs/guides/uhp' },
+            { label: 'Remote UHP Access', slug: 'docs/guides/uhp-access' },
           ],
         },
         {

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -300,6 +300,13 @@ owner-only Unix socket on macOS and Linux or owner-restricted named pipe on
 Windows. Luvus does not open a public TCP listener. `luvus uhp proxy` is the
 bounded, transport-neutral one-request bridge.
 
+For a persistent third-party transport or client, `luvus uhp access` emits one
+machine-readable descriptor for a scoped loopback gateway and remains in the
+foreground. It does not start or bundle a transport provider. Forward the
+endpoint only through an authenticated encrypted byte stream, pair once, then
+discover live capabilities. `--control` requires the user's explicit
+authorization and remains limited by the gateway allowlist.
+
 ## Remote use
 
 ```sh

--- a/website/src/content/docs/docs/guides/uhp-access.mdx
+++ b/website/src/content/docs/docs/guides/uhp-access.mdx
@@ -26,7 +26,8 @@ The descriptor includes:
 - the exact delegated mode, scopes, and expiry.
 
 It never contains the delegated token or the owner-only Luvus socket or named
-pipe. Validate it against the access descriptor included by `luvus uhp schema`.
+pipe. Validate it against the access descriptor schema emitted by
+`luvus uhp schema`.
 
 ## Provider contract
 

--- a/website/src/content/docs/docs/guides/uhp-access.mdx
+++ b/website/src/content/docs/docs/guides/uhp-access.mdx
@@ -1,0 +1,73 @@
+---
+title: Connecting UHP transports and clients
+description: Plug a secure byte-stream provider or independent client into Luvus without exposing its owner endpoint.
+---
+
+UHP Access is the transport-neutral bridge for remote or embedded clients. It
+lets a provider carry normal UHP 1.0 frames without building any transport into
+Luvus core.
+
+## Start an access endpoint
+
+```sh
+luvus uhp access
+```
+
+The command emits one compact JSON descriptor and stays in the foreground. It
+binds an ephemeral IPv4 loopback port, creates a five-minute one-use pairing
+code, and grants 30 minutes of read-only authority. `--control` must be selected
+explicitly and grants a limited 15-minute control surface.
+
+The descriptor includes:
+
+- UHP and access-contract versions;
+- `127.0.0.1`, the ephemeral TCP port, and NDJSON framing;
+- the one-use pairing code and expiry;
+- the exact delegated mode, scopes, and expiry.
+
+It never contains the delegated token or the owner-only Luvus socket or named
+pipe. Validate it against the access descriptor included by `luvus uhp schema`.
+
+## Provider contract
+
+A provider launches `luvus uhp access`, reads the descriptor line, and forwards
+only its loopback endpoint through an authenticated, confidential,
+integrity-protected ordered byte stream. Preserve half-close, EOF, and
+backpressure. Do not parse or rewrite UHP, persist credentials, publish the
+loopback listener, or silently fall back to plaintext.
+
+The provider and Luvus lifecycles stay separate. If the provider fails, Luvus
+continues normally. If the access command exits or reaches its deadline, its
+gateway closes and token is revoked while panes and agents stay alive. When the
+command is not running, this feature has no listener, thread, transport process,
+timer, or network activity.
+
+## Client contract
+
+Connect to the forwarded port and send this LF-terminated frame first:
+
+```json
+{"type":"pair","code":"ABCD-EFGH-JKLM"}
+```
+
+The paired response returns the delegated token, scopes, and expiry. Open a new
+stream for each ordinary UHP request, include the token in `auth`, and half-close
+the request side after its single frame:
+
+```json
+{"id":"caps","method":"uhp.capabilities","params":{},"auth":"<ephemeral-token>"}
+```
+
+Keep the connection open for `events.subscribe`,
+`terminal.backend.observe`, or `terminal.backend.control`. Discover live
+capabilities after pairing; do not assume methods from a Luvus release number.
+
+## Provider implementations
+
+Luvus does not bundle or select a remote transport. A provider may use SSH, a
+private overlay network, an authenticated tunnel, or another secure ordered
+byte stream. It only needs to launch the access command, consume its descriptor,
+and forward the advertised loopback endpoint without rewriting UHP frames.
+
+Continue with [Automating with UHP](/docs/guides/uhp/) and the
+[UHP method reference](/docs/reference/api/).

--- a/website/src/content/docs/docs/guides/uhp.mdx
+++ b/website/src/content/docs/docs/guides/uhp.mdx
@@ -111,5 +111,10 @@ in-memory, expiring token when a harness needs narrower access:
 Supply the returned secret in `auth`. Use `uhp.token.list` and
 `uhp.token.revoke` to manage it. Never log the secret.
 
+For a provider or client that must work beyond the owner-only local endpoint,
+use `luvus uhp access`. It creates a scoped loopback gateway, emits a versioned
+machine-readable descriptor, and keeps transport outside Luvus core. See
+[Connecting UHP transports and clients](/docs/guides/uhp-access/).
+
 Continue with the [UHP reference](/docs/reference/uhp/) and
 [UHP method reference](/docs/reference/api/).

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -237,6 +237,7 @@ universal harness protocol:
   uhp schema                print the complete installed UHP JSON Schema bundle
   uhp snapshot              print a fenced session snapshot for harness bootstrap
   uhp events                stream sequenced UHP events
+  uhp access [--control]    expose scoped UHP through a private provider endpoint
   uhp proxy                 forward one JSON request from stdin to the selected server
 
 sessions:

--- a/website/src/content/docs/docs/reference/uhp.mdx
+++ b/website/src/content/docs/docs/reference/uhp.mdx
@@ -81,12 +81,16 @@ when their connection or target disappears.
 ## Security
 
 The local endpoint validates same-user ownership and is the default authority
-boundary. UHP never opens a TCP listener. Delegated tokens are memory-only,
-bounded, expiring, and scope restricted.
+boundary. Normal Luvus startup never opens a TCP listener. The explicit,
+foreground `luvus uhp access` command may bind one ephemeral IPv4 loopback
+gateway for a trusted transport provider; it never exposes the owner endpoint.
+Delegated tokens are memory-only, bounded, expiring, and scope restricted.
 
 Terminal and process responses avoid full argument vectors because they can
 contain prompts, credentials, or tokens. Capture, input, messages, and cwd are
 also bounded.
 
-See [Automating with UHP](/docs/guides/uhp/) for a walkthrough and the
+Its machine-readable access descriptor is part of the installed schema bundle.
+See [Connecting UHP transports and clients](/docs/guides/uhp-access/) before
+implementing a provider. See [Automating with UHP](/docs/guides/uhp/) for a walkthrough and the
 [UHP method reference](/docs/reference/api/) for the complete namespaces.

--- a/website/src/content/docs/docs/reference/uhp.mdx
+++ b/website/src/content/docs/docs/reference/uhp.mdx
@@ -84,7 +84,7 @@ The local endpoint validates same-user ownership and is the default authority
 boundary. Normal Luvus startup never opens a TCP listener. The explicit,
 foreground `luvus uhp access` command may bind one ephemeral IPv4 loopback
 gateway for a trusted transport provider; it never exposes the owner endpoint.
-Delegated tokens are memory-only, bounded, expiring, and scope restricted.
+Delegated tokens are memory-only, bounded, expiring, and scope-restricted.
 
 Terminal and process responses avoid full argument vectors because they can
 contain prompts, credentials, or tokens. Capture, input, messages, and cwd are


### PR DESCRIPTION
Add a secure, transport-neutral foreground access boundary so independent clients and tunnel providers can connect to the complete Luvus UHP surface without bundling a browser or network provider.

## What

- Add `luvus uhp access` with an explicit `--control` mode.
- Emit a versioned machine-readable descriptor for an ephemeral IPv4 loopback endpoint.
- Require one-use, expiring pairing before returning a scoped in-memory UHP token.
- Keep read-only and limited-control allowlists separate, including bounded terminal observe/control streams.
- Enforce connection, frame, request-rate, timeout, identity, and response-ID bounds at the gateway.
- Revoke delegated authority and close the gateway when the foreground command exits while leaving the Luvus server and panes alive.
- Publish the access descriptor in the installed UHP schema bundle and document the provider/client contract.
- Keep CLI help, localization, bundled agent guidance, and website documentation synchronized.
- Place the access runtime under `src/uhp/`; existing contracts and dispatch remain under `src/api/`.

This PR intentionally contains no Tailcat launcher, WASM runtime, browser client, public listener, provider dependency, or normal-startup background work. The separate `experiment/uhp-tailcat-web` branch preserves that prototype for possible future development.

## Why

The owner-only socket or named pipe is the correct local security boundary, but independent remote transports need a safe bootstrap mechanism. Embedding one provider into Luvus would couple UHP to its lifecycle and dependencies. This access boundary lets a provider forward a scoped loopback stream while UHP remains the single automation protocol.

## Verification

- [x] `cargo test --locked` — 1,167 unit tests plus CLI, named-session, and theme integration tests passed
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --locked`
- [x] Website `npm run build`
- [x] Package manifest inspection confirms `src/uhp/` and access schemas are included with no `src/web/` or `web/` artifacts
- [x] Isolated live test verified descriptor emission, one-use pairing, authenticated capability discovery, read-only mutation denial, shutdown isolation, and no provider child process

## Notes

The live gateway test was performed on macOS in an isolated temporary Luvus home and named session. Cross-platform behavior remains covered by the repository CI matrix; no untested OS is claimed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `luvus uhp access` for temporary, scoped UHP access through a private loopback endpoint.
  - Added one-time pairing, expiring tokens, read-only access, and optional limited control mode.
  - Added machine-readable access descriptors and schema support.
  - Added Windows console shutdown handling.

- **Security**
  - Added authenticated encrypted transport requirements, pairing limits, rate limits, connection limits, and bounded access windows.

- **Documentation**
  - Added UHP Access guides, command references, provider requirements, and pairing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->