### PR TITLE
fix(copy): preserve semantic text across terminals and file views

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use crate::files::view_text_w;
+use unicode_width::UnicodeWidthChar;
 
 /// Keep the command overlay useful when a just-spawned child has not appeared
 /// in the platform process snapshot yet. The OS tree remains authoritative for
@@ -159,24 +160,6 @@ fn finish_selected_text(mut out: String) -> Option<String> {
     (!out.trim().is_empty()).then_some(out)
 }
 
-/// Drop the one blank cell which can sit between a pane edge and uniformly
-/// aligned prose. This is deliberately narrow: code with its usual two- or
-/// four-space indentation is retained exactly as selected.
-fn strip_uniform_single_cell_margin(text: String) -> String {
-    let mut saw_text = false;
-    let uniform_margin = text.lines().filter(|line| !line.is_empty()).all(|line| {
-        saw_text = true;
-        line.starts_with(' ') && !line.starts_with("  ")
-    });
-    if !saw_text || !uniform_margin {
-        return text;
-    }
-    text.lines()
-        .map(|line| line.strip_prefix(' ').unwrap_or(line))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 /// A second left click within this of the first, on the same cell (±1), is a
 /// double-click. Terminals emit no native double-click, so luvus times it.
 const DOUBLE_CLICK: Duration = Duration::from_millis(400);
@@ -184,6 +167,54 @@ const DOUBLE_CLICK: Duration = Duration::from_millis(400);
 /// A run of grid cells on one row: `(row, start_col, end_col)`, `end_col`
 /// exclusive — the same shape as [`crate::links::Link::spans`].
 type CellSpan = (u16, u16, u16);
+
+/// Convert rendered native-view rows to the same cell-aligned representation
+/// used by terminal token lookup. This runs only on a double-click, never on a
+/// frame, and keeps wide and zero-width characters from shifting the clicked
+/// cell away from its word.
+fn align_plain_rows(rows: Vec<String>) -> crate::terminal::vt::AlignedRows {
+    let mut aligned = crate::terminal::vt::AlignedRows::new(rows.len());
+    for (row, line) in rows.into_iter().enumerate() {
+        let mut column = 0u16;
+        let mut base: Option<(char, usize, Vec<char>)> = None;
+        let flush = |base: &mut Option<(char, usize, Vec<char>)>,
+                     aligned: &mut crate::terminal::vt::AlignedRows,
+                     column: &mut u16| {
+            let Some((character, width, zero_width)) = base.take() else {
+                return;
+            };
+            aligned.push_cell(
+                row as u16,
+                *column,
+                character,
+                (!zero_width.is_empty()).then_some(zero_width.as_slice()),
+            );
+            for offset in 1..width {
+                aligned.push_cell(
+                    row as u16,
+                    column.saturating_add(offset as u16),
+                    crate::terminal::vt::ALIGNED_WIDE_CELL,
+                    None,
+                );
+            }
+            *column = column.saturating_add(width as u16);
+        };
+
+        for character in line.chars() {
+            let width = character.width().unwrap_or(0);
+            if width == 0 {
+                if let Some((_, _, zero_width)) = base.as_mut() {
+                    zero_width.push(character);
+                }
+                continue;
+            }
+            flush(&mut base, &mut aligned, &mut column);
+            base = Some((character, width, Vec::new()));
+        }
+        flush(&mut base, &mut aligned, &mut column);
+    }
+    aligned
+}
 
 /// The whitespace-delimited word covering grid cell (`col`, `row`), and the one
 /// span it occupies. `None` on a whitespace or out-of-range cell. Wide-cell
@@ -2553,22 +2584,12 @@ impl App {
         let Some(copy) = self.copy_mode.take() else {
             return;
         };
-        let is_codex = self
-            .status
-            .get(&copy.pane)
-            .is_some_and(|status| status.agent == "codex");
         let text = self
             .panes
             .get(&copy.pane)
             .and_then(|pane| pane.retained_selection_text(copy.ordered()))
             .and_then(finish_selected_text);
-        if let Some(text) = text.map(|text| {
-            if is_codex {
-                strip_uniform_single_cell_margin(text)
-            } else {
-                text
-            }
-        }) {
+        if let Some(text) = text {
             self.pending_clipboard = Some(text);
             let msg = self.catalog.copied;
             self.show_toast(msg);
@@ -2846,46 +2867,27 @@ impl App {
         }
         if let Some(selection) = sel.retained {
             let range = selection.ordered();
-            let text = self
+            return self
                 .panes
                 .get(&sel.pane)?
                 .retained_selection_text(range)
-                .and_then(finish_selected_text)?;
-            let is_codex = self
-                .status
-                .get(&sel.pane)
-                .is_some_and(|status| status.agent == "codex");
-            return Some(if range.0 .1 == 0 || is_codex {
-                strip_uniform_single_cell_margin(text)
-            } else {
-                text
-            });
+                .and_then(finish_selected_text);
         }
         let ((sx, sy), (ex, ey)) = sel.ordered();
         let (cx, cy) = (sel.content.x, sel.content.y);
-        let text = self.panes.get(&sel.pane)?.visible_selection_text((
-            (
-                (sy as usize).saturating_sub(cy as usize),
-                (sx as usize).saturating_sub(cx as usize),
-            ),
-            (
-                (ey as usize).saturating_sub(cy as usize),
-                (ex as usize).saturating_sub(cx as usize),
-            ),
-        ))?;
-        // A drag may begin in the single blank pane cell before uniformly
-        // aligned prose. Codex also emits that one-cell transcript gutter even
-        // when the drag starts on its first visible character. It remains
-        // visibly selected, but is padding rather than useful clipboard text.
-        let is_codex = self
-            .status
-            .get(&sel.pane)
-            .is_some_and(|status| status.agent == "codex");
-        Some(if sx == cx || is_codex {
-            strip_uniform_single_cell_margin(text)
-        } else {
-            text
-        })
+        self.panes
+            .get(&sel.pane)?
+            .visible_selection_text((
+                (
+                    (sy as usize).saturating_sub(cy as usize),
+                    (sx as usize).saturating_sub(cx as usize),
+                ),
+                (
+                    (ey as usize).saturating_sub(cy as usize),
+                    (ex as usize).saturating_sub(cx as usize),
+                ),
+            ))
+            .and_then(finish_selected_text)
     }
 
     /// Copy the path, URL, or word under screen cell (`col`, `row`) to the
@@ -2901,16 +2903,33 @@ impl App {
         let Some((pane, content)) = self.pane_content_at(col, row) else {
             return false;
         };
-        let rows = {
-            let Some(p) = self.panes.get(&pane) else {
-                return false;
-            };
-            let Ok(engine) = p.engine.lock() else {
-                return false;
-            };
-            // Cell-aligned rows: a wide glyph before the token would otherwise
-            // shift `gcol` off the intended character (and its highlight).
-            engine.visible_rows_aligned()
+        let rows = match self.views.get(&pane) {
+            Some(crate::app::ViewKind::File(view)) => {
+                let Some(rows) = crate::files::token_rows(view, content, self.compact) else {
+                    return false;
+                };
+                align_plain_rows(rows)
+            }
+            Some(crate::app::ViewKind::Preview(view)) => {
+                let Some(rows) = super::preview::token_rows(view, content, self.compact) else {
+                    return false;
+                };
+                align_plain_rows(rows)
+            }
+            // DIFF owns its source-cell clicks for review and note selection.
+            // Do not route it through generic word copying.
+            Some(crate::app::ViewKind::Diff(_)) => return false,
+            None => {
+                let Some(p) = self.panes.get(&pane) else {
+                    return false;
+                };
+                let Ok(engine) = p.engine.lock() else {
+                    return false;
+                };
+                // Cell-aligned rows: a wide glyph before the token would otherwise
+                // shift `gcol` off the intended character (and its highlight).
+                engine.visible_rows_aligned()
+            }
         };
         let (gcol, grow) = (col - content.x, row - content.y);
         let (text, spans) = match copy_link_at_grid(&rows, gcol, grow) {
@@ -4925,6 +4944,24 @@ mod link_click_tests {
         (app, term, (content.x + at, content.y))
     }
 
+    fn double_click(app: &mut App, at: (u16, u16)) {
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+    }
+
     /// `Ctrl`+click a path, then return the view it landed on. Tests run from
     /// the repo root, so `Cargo.toml` is a real relative path from the pane's
     /// working directory.
@@ -5195,25 +5232,7 @@ mod link_click_tests {
     }
 
     #[test]
-    fn mouse_copy_drops_a_uniform_one_cell_pane_margin() {
-        assert_eq!(
-            strip_uniform_single_cell_margin(
-                " Hello, rain on a windowpane\n Hello, wind with a traveling name\n Hello, all things we almost miss"
-                    .into()
-            ),
-            "Hello, rain on a windowpane\nHello, wind with a traveling name\nHello, all things we almost miss"
-        );
-        assert_eq!(
-            strip_uniform_single_cell_margin(
-                "    let preserved = true;\n    run(preserved);".into()
-            ),
-            "    let preserved = true;\n    run(preserved);",
-            "normal code indentation must stay intact"
-        );
-    }
-
-    #[test]
-    fn mouse_drag_copy_drops_the_pane_edge_margin_from_terminal_text() {
+    fn mouse_drag_copy_preserves_selected_terminal_cells() {
         let _env = crate::persist::test_env("mouse-copy-pane-margin");
         let source = " Morning arrives without ceremony,\r\n a thin gold line on the edge of the glass.\r\n The kettle speaks in its private language,";
         let (mut app, mut term, _) = fixture_showing(source, 0);
@@ -5253,7 +5272,7 @@ mod link_click_tests {
         assert_eq!(
             app.selection_text().as_deref(),
             Some(
-                "Morning arrives without ceremony,\na thin gold line on the edge of the glass.\nThe kettle speaks in its private language,"
+                " Morning arrives without ceremony,\n a thin gold line on the edge of the glass.\n The kettle speaks in its private language,"
             )
         );
         app.handle_event(mouse(
@@ -5265,7 +5284,7 @@ mod link_click_tests {
         assert_eq!(
             app.pending_clipboard.as_deref(),
             Some(
-                "Morning arrives without ceremony,\na thin gold line on the edge of the glass.\nThe kettle speaks in its private language,"
+                " Morning arrives without ceremony,\n a thin gold line on the edge of the glass.\n The kettle speaks in its private language,"
             )
         );
     }
@@ -5463,6 +5482,97 @@ mod link_click_tests {
             "the second press copies the whitespace word"
         );
         assert!(app.selection.is_some(), "and highlights it");
+    }
+
+    #[test]
+    fn a_double_click_copies_a_word_from_a_native_file_view() {
+        let _env = crate::persist::test_env("double-click-file-view");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let pane = app.layout().focus;
+        let mut view = crate::files::FileView::new(PathBuf::from("sample.txt"));
+        view.wrap = false;
+        view.apply(crate::files::FileLoad::Text(vec![
+            "你好 file-view world".into()
+        ]));
+        app.panes.remove(&pane);
+        app.views.insert(pane, crate::app::ViewKind::File(view));
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("file content rect");
+        let text_x = content.x + crate::files::gutter_width(1) + 1;
+
+        // Two wide glyphs occupy four cells before the separating space.
+        double_click(&mut app, (text_x + 6, content.y));
+
+        assert_eq!(app.pending_clipboard.as_deref(), Some("file-view"));
+        assert!(
+            app.selection.is_some(),
+            "the copied file word is highlighted"
+        );
+    }
+
+    #[test]
+    fn a_double_click_copies_a_word_from_a_document_preview() {
+        use crate::files::preview::{
+            layout, Block, DocumentView, LayoutKey, PreviewDocument, PreviewKind, PreviewLoad,
+        };
+
+        let _env = crate::persist::test_env("double-click-document-preview");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let pane = app.layout().focus;
+        let source = Arc::<str>::from("hello rendered-preview world");
+        let document = Arc::new(PreviewDocument::new(
+            Arc::clone(&source),
+            vec![Block::Code {
+                language: None,
+                text: source.to_string(),
+                range: 0..source.len(),
+            }],
+        ));
+        let mut view = DocumentView::new(PathBuf::from("README.md"), PreviewKind::Markdown);
+        view.apply(PreviewLoad::Ready(Arc::clone(&document)));
+        app.panes.remove(&pane);
+        app.views.insert(pane, crate::app::ViewKind::Preview(view));
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(id, _)| *id == pane)
+            .map(|(_, rect)| *rect)
+            .expect("preview content rect");
+        let key = LayoutKey {
+            width: content.width,
+            ascii: false,
+        };
+        if let Some(crate::app::ViewKind::Preview(view)) = app.views.get_mut(&pane) {
+            view.apply_layout(key, Arc::new(layout::build(document, key)));
+        }
+        terminal
+            .draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+
+        // Code preview rows have a two-cell presentation indent.
+        double_click(&mut app, (content.x + 2 + 7, content.y));
+
+        assert_eq!(app.pending_clipboard.as_deref(), Some("rendered-preview"));
+        assert!(
+            app.selection.is_some(),
+            "the copied preview word is highlighted"
+        );
     }
 
     /// The wide-character case for copying: a CJK glyph before a token shifts every
@@ -5791,20 +5901,16 @@ mod link_click_tests {
     }
 
     #[test]
-    fn codex_copy_drops_its_one_cell_transcript_gutter_on_one_row() {
-        let _env = crate::persist::test_env("codex-copy-gutter");
+    fn mouse_copy_is_independent_of_detected_agent() {
+        let _env = crate::persist::test_env("mouse-copy-agent-independent");
         let (mut app, _term, _) = fixture_showing("  hello", 0);
         let pane = app.layout().focus;
-        app.status.get_mut(&pane).expect("pane status").agent = "codex".into();
         let content = app
             .pane_content_rects
             .iter()
             .find(|(id, _)| *id == pane)
             .map(|(_, rect)| *rect)
             .expect("pane content rect");
-        // The drag starts one cell inside the pane and selects one row, so this
-        // verifies Codex gutter cleanup without relying on rectangular
-        // multiline selection.
         app.selection = Some(crate::app::Selection {
             pane,
             content,
@@ -5815,6 +5921,9 @@ mod link_click_tests {
             dragging: false,
         });
 
-        assert_eq!(app.selection_text().as_deref(), Some("hello"));
+        let shell = app.selection_text();
+        app.status.get_mut(&pane).expect("pane status").agent = "codex".into();
+        assert_eq!(app.selection_text(), shell);
+        assert_eq!(shell.as_deref(), Some(" hello"));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11852,11 +11852,10 @@ mod tests {
     }
 
     #[test]
-    fn keyboard_copy_trims_a_codex_transcript_gutter() {
+    fn keyboard_copy_preserves_selected_transcript_indentation() {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(40, 8, tx).unwrap();
         let pane = app.layout().focus;
-        app.status.get_mut(&pane).expect("pane status").agent = "codex".into();
         app.panes
             .get(&pane)
             .expect("pane")
@@ -11874,7 +11873,7 @@ mod tests {
 
         app.finish_copy_mode();
 
-        assert_eq!(app.pending_clipboard.as_deref(), Some("Hello\nworld"));
+        assert_eq!(app.pending_clipboard.as_deref(), Some(" Hello\n world"));
     }
 
     #[test]

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -311,9 +311,11 @@ pub(crate) fn selection_text(
     let start_y = sy.clamp(content.y, body_bottom);
     let end_y = ey.clamp(content.y, body_bottom);
     let mut output = String::new();
+    let mut first = true;
     for screen_y in start_y..=end_y {
         let row_index = view.scroll + usize::from(screen_y.saturating_sub(content.y));
-        let row = layout.rows.get(row_index)?.plain_text();
+        let rendered = layout.rows.get(row_index)?;
+        let row = rendered.plain_text();
         let left = if screen_y == start_y {
             usize::from(sx.saturating_sub(content.x))
         } else {
@@ -324,13 +326,39 @@ pub(crate) fn selection_text(
         } else {
             usize::from(content.width)
         };
-        if !output.is_empty() {
-            output.push('\n');
+        if !first {
+            match rendered.soft_wrap_spaces {
+                Some(spaces) => output.push_str(&" ".repeat(spaces as usize)),
+                None => output.push('\n'),
+            }
         }
+        first = false;
         output.push_str(slice_columns(&row, left, right).trim_end());
     }
     let output = output.trim_end_matches('\n').to_string();
     (!output.is_empty()).then_some(output)
+}
+
+/// Return only the currently rendered document body for double-click token
+/// lookup. A preview has no terminal grid, so this provides the same cell-row
+/// projection without including its status footer.
+pub(crate) fn token_rows(view: &DocumentView, content: Rect, mobile: bool) -> Option<Vec<String>> {
+    let key = LayoutKey {
+        width: content.width.max(1),
+        ascii: false,
+    };
+    let layout = view.layout(key)?;
+    let show_footer = !mobile || view.search.is_some();
+    let body_rows = content.height.saturating_sub(u16::from(show_footer)) as usize;
+    Some(
+        layout
+            .rows
+            .iter()
+            .skip(view.scroll)
+            .take(body_rows)
+            .map(|row| row.plain_text())
+            .collect(),
+    )
 }
 
 fn slice_columns(text: &str, start: usize, end: usize) -> String {
@@ -604,6 +632,50 @@ mod tests {
         assert_eq!(
             selection_text(&view, content, ((0, 2), (9, 2)), false).as_deref(),
             Some("  b")
+        );
+    }
+
+    fn code_preview(text: &str, width: u16) -> DocumentView {
+        let document = Arc::new(crate::files::preview::PreviewDocument::new(
+            Arc::<str>::from(text),
+            vec![crate::files::preview::Block::Code {
+                language: None,
+                text: text.into(),
+                range: 0..text.len(),
+            }],
+        ));
+        let mut view = DocumentView::new(PathBuf::from("sample.md"), PreviewKind::Markdown);
+        view.apply(PreviewLoad::Ready(Arc::clone(&document)));
+        let key = LayoutKey {
+            width,
+            ascii: false,
+        };
+        view.apply_layout(
+            key,
+            Arc::new(crate::files::preview::layout::build(document, key)),
+        );
+        view
+    }
+
+    #[test]
+    fn wrapped_preview_selection_joins_visual_rows_without_a_newline() {
+        let view = code_preview("alpha beta gamma", 10);
+        let content = Rect::new(0, 0, 10, 3);
+
+        assert_eq!(
+            selection_text(&view, content, ((0, 0), (9, 1)), false).as_deref(),
+            Some("  alpha beta gamma")
+        );
+    }
+
+    #[test]
+    fn preview_selection_preserves_real_document_line_breaks() {
+        let view = code_preview("alpha\nbeta", 10);
+        let content = Rect::new(0, 0, 10, 3);
+
+        assert_eq!(
+            selection_text(&view, content, ((0, 0), (9, 1)), false).as_deref(),
+            Some("  alpha\n  beta")
         );
     }
 }

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -333,7 +333,7 @@ pub(crate) fn selection_text(
             }
         }
         first = false;
-        output.push_str(slice_columns(&row, left, right).trim_end());
+        output.push_str(slice_columns(&row, left, right).trim_end_matches(' '));
     }
     let output = output.trim_end_matches('\n').to_string();
     (!output.is_empty()).then_some(output)
@@ -665,6 +665,17 @@ mod tests {
         assert_eq!(
             selection_text(&view, content, ((0, 0), (9, 1)), false).as_deref(),
             Some("  alpha beta gamma")
+        );
+    }
+
+    #[test]
+    fn preview_selection_preserves_non_ascii_whitespace_at_a_wrap_boundary() {
+        let view = code_preview("alpha\u{a0}beta", 8);
+        let content = Rect::new(0, 0, 8, 3);
+
+        assert_eq!(
+            selection_text(&view, content, ((0, 0), (7, 1)), false).as_deref(),
+            Some("  alpha\u{a0}beta")
         );
     }
 

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -17,8 +17,8 @@
 pub mod preview;
 mod view;
 pub use view::{
-    gutter_width, read_file, seg_text, selection_text, view_text_w, wrap_ranges, FileLoad,
-    FileView, SIZE_CAP,
+    gutter_width, read_file, seg_text, selection_text, token_rows, view_text_w, wrap_ranges,
+    FileLoad, FileView, SIZE_CAP,
 };
 
 use std::collections::{HashMap, HashSet};

--- a/src/files/preview/layout.rs
+++ b/src/files/preview/layout.rs
@@ -327,10 +327,7 @@ fn wrap(spans: Vec<StyledSpan>, width: usize, source_line: Option<usize>) -> Vec
             }
             let visible_end = start + part.len();
             let mut next_start = end;
-            while cells
-                .get(next_start)
-                .is_some_and(|cell| cell.ch == ' ')
-            {
+            while cells.get(next_start).is_some_and(|cell| cell.ch == ' ') {
                 next_start += 1;
             }
             out.push(cells_to_row(part, source_line, soft_wrap_spaces));

--- a/src/files/preview/layout.rs
+++ b/src/files/preview/layout.rs
@@ -322,14 +322,14 @@ fn wrap(spans: Vec<StyledSpan>, width: usize, source_line: Option<usize>) -> Vec
             }
             end = end.max(start + 1).min(cells.len());
             let mut part = cells[start..end].to_vec();
-            while part.last().is_some_and(|cell| cell.ch.is_whitespace()) {
+            while part.last().is_some_and(|cell| cell.ch == ' ') {
                 part.pop();
             }
             let visible_end = start + part.len();
             let mut next_start = end;
             while cells
                 .get(next_start)
-                .is_some_and(|cell| cell.ch.is_whitespace())
+                .is_some_and(|cell| cell.ch == ' ')
             {
                 next_start += 1;
             }

--- a/src/files/preview/layout.rs
+++ b/src/files/preview/layout.rs
@@ -42,6 +42,11 @@ pub struct StyledSpan {
 pub struct StyledRow {
     pub spans: Vec<StyledSpan>,
     pub source_line: Option<usize>,
+    /// `Some(n)` when this row visually continues the previous logical row,
+    /// where `n` spaces were hidden at the wrap boundary. `None` means a real
+    /// rendered-row boundary. Kept numeric so every cached row stays bounded
+    /// and allocation-free.
+    pub soft_wrap_spaces: Option<u16>,
 }
 
 impl StyledRow {
@@ -57,6 +62,7 @@ impl StyledRow {
                 link: None,
             }],
             source_line,
+            soft_wrap_spaces: None,
         }
     }
 }
@@ -285,10 +291,12 @@ fn wrap(spans: Vec<StyledSpan>, width: usize, source_line: Option<usize>) -> Vec
             out.push(StyledRow {
                 spans: Vec::new(),
                 source_line,
+                soft_wrap_spaces: None,
             });
             continue;
         }
         let mut start = 0usize;
+        let mut soft_wrap_spaces = None;
         while start < cells.len() && out.len() < MAX_LAYOUT_ROWS {
             let mut used = 0usize;
             let mut end = start;
@@ -317,17 +325,33 @@ fn wrap(spans: Vec<StyledSpan>, width: usize, source_line: Option<usize>) -> Vec
             while part.last().is_some_and(|cell| cell.ch.is_whitespace()) {
                 part.pop();
             }
-            start = end;
-            while cells.get(start).is_some_and(|cell| cell.ch.is_whitespace()) {
-                start += 1;
+            let visible_end = start + part.len();
+            let mut next_start = end;
+            while cells
+                .get(next_start)
+                .is_some_and(|cell| cell.ch.is_whitespace())
+            {
+                next_start += 1;
             }
-            out.push(cells_to_row(part, source_line));
+            out.push(cells_to_row(part, source_line, soft_wrap_spaces));
+            soft_wrap_spaces = Some(
+                cells[visible_end..next_start]
+                    .iter()
+                    .map(|cell| cell.ch.width().unwrap_or(0))
+                    .sum::<usize>()
+                    .min(u16::MAX as usize) as u16,
+            );
+            start = next_start;
         }
     }
     out
 }
 
-fn cells_to_row(cells: Vec<Cell>, source_line: Option<usize>) -> StyledRow {
+fn cells_to_row(
+    cells: Vec<Cell>,
+    source_line: Option<usize>,
+    soft_wrap_spaces: Option<u16>,
+) -> StyledRow {
     let mut spans: Vec<StyledSpan> = Vec::new();
     for cell in cells {
         if let Some(last) = spans
@@ -343,7 +367,11 @@ fn cells_to_row(cells: Vec<Cell>, source_line: Option<usize>) -> StyledRow {
             });
         }
     }
-    StyledRow { spans, source_line }
+    StyledRow {
+        spans,
+        source_line,
+        soft_wrap_spaces,
+    }
 }
 
 fn render_table(
@@ -440,6 +468,7 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert!(rows.iter().all(|row| row.plain_text().width() <= 10));
         assert_eq!(rows[1].spans.last().unwrap().role, TextRole::Strong);
+        assert_eq!(rows[1].soft_wrap_spaces, Some(1));
     }
 
     #[test]

--- a/src/files/view.rs
+++ b/src/files/view.rs
@@ -388,6 +388,50 @@ pub fn seg_text(line: &str, range: (usize, usize)) -> String {
     line.chars().skip(range.0).take(range.1 - range.0).collect()
 }
 
+/// Return the rows currently rendered by a native file view, aligned to its
+/// complete pane-content rectangle. The line-number gutter is represented by
+/// spaces so mouse cell coordinates continue to address the source text. This
+/// projection is built only for a double-click token lookup.
+pub fn token_rows(
+    v: &FileView,
+    content: ratatui::layout::Rect,
+    mobile: bool,
+) -> Option<Vec<String>> {
+    let FileLoad::Text(lines) = &v.load else {
+        return None;
+    };
+    let show_footer = !mobile || v.search.is_some();
+    let body_rows = content.height.saturating_sub(u16::from(show_footer)) as usize;
+    let gutter = gutter_width(lines.len());
+    let prefix = " ".repeat((gutter + 1) as usize);
+    let text_width = content.width.saturating_sub(gutter + 1) as usize;
+    if text_width == 0 {
+        return None;
+    }
+
+    let mut rows = Vec::with_capacity(body_rows);
+    if v.wrap {
+        'lines: for line in lines.iter().skip(v.scroll) {
+            for range in wrap_ranges(line, text_width) {
+                rows.push(format!("{prefix}{}", seg_text(line, range)));
+                if rows.len() >= body_rows {
+                    break 'lines;
+                }
+            }
+        }
+    } else {
+        rows.extend(lines.iter().skip(v.scroll).take(body_rows).map(|line| {
+            let visible: String = line
+                .chars()
+                .skip(v.hscroll as usize)
+                .take(text_width)
+                .collect();
+            format!("{prefix}{visible}")
+        }));
+    }
+    Some(rows)
+}
+
 /// Extract the text under a mouse selection over a file view (docs/38), so
 /// drag-to-copy works like a pane. `content` is the view's content rect and
 /// `((sx,sy),(ex,ey))` the selection in reading order (terminal cells).
@@ -435,7 +479,7 @@ pub fn selection_text(
     }
 
     let mut out = String::new();
-    let mut first = true;
+    let mut previous: Option<(usize, usize)> = None;
     for ty in sy..=ey {
         let vi = (ty.saturating_sub(content.y)) as usize;
         let Some(&(line, seg_s, seg_e)) = rowmap.get(vi) else {
@@ -464,11 +508,15 @@ pub fn selection_text(
         } else {
             String::new()
         };
-        if !first {
-            out.push('\n');
+        if let Some((previous_line, previous_end)) = previous {
+            if previous_line == line {
+                out.extend(chars[previous_end.min(chars.len())..start].iter().copied());
+            } else {
+                out.push('\n');
+            }
         }
-        first = false;
-        out.push_str(seg.trim_end());
+        out.push_str(&seg);
+        previous = Some((line, end));
     }
     let out = out.trim_end_matches('\n').to_string();
     (!out.is_empty()).then_some(out)
@@ -606,6 +654,32 @@ mod tests {
         // Short line and empty line each stay a single row.
         assert_eq!(wrap_ranges("hi", 10), vec![(0, 2)]);
         assert_eq!(wrap_ranges("", 10), vec![(0, 0)]);
+    }
+
+    #[test]
+    fn wrapped_selection_joins_visual_rows_without_inventing_a_newline() {
+        let mut view = FileView::new(PathBuf::from("article.txt"));
+        view.apply(FileLoad::Text(vec!["the quick brown fox".into()]));
+        let content = ratatui::layout::Rect::new(0, 0, 15, 3);
+        let text_x = gutter_width(1) + 1;
+
+        assert_eq!(
+            selection_text(&view, content, ((text_x, 0), (text_x + 8, 1))).as_deref(),
+            Some("the quick brown fox")
+        );
+    }
+
+    #[test]
+    fn selection_preserves_real_file_line_breaks() {
+        let mut view = FileView::new(PathBuf::from("source.txt"));
+        view.apply(FileLoad::Text(vec!["alpha".into(), "beta".into()]));
+        let content = ratatui::layout::Rect::new(0, 0, 15, 3);
+        let text_x = gutter_width(2) + 1;
+
+        assert_eq!(
+            selection_text(&view, content, ((text_x, 0), (text_x + 3, 1))).as_deref(),
+            Some("alpha\nbeta")
+        );
     }
 
     #[test]

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -798,75 +798,18 @@ impl VtEngine for AlacrittyEngine {
             return None;
         }
         let last_column = self.term.grid().columns().checked_sub(1)?;
-        let leading_blank_cells = |line: Line, limit: usize| {
-            let row = &self.term.grid()[line];
-            let limit = limit.min(last_column.saturating_add(1));
-            let mut column = 0;
-            while column < limit {
-                let cell = &row[Column(column)];
-                if cell
-                    .flags
-                    .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
-                    || (cell.c != '\0' && !cell.c.is_whitespace())
-                {
-                    break;
-                }
-                if cell.flags.contains(Flags::WIDE_CHAR) {
-                    let spacer = column.saturating_add(1);
-                    if spacer >= limit
-                        || !row[Column(spacer)].flags.contains(Flags::WIDE_CHAR_SPACER)
-                    {
-                        break;
-                    }
-                    column += 2;
-                } else {
-                    column += 1;
-                }
-            }
-            column
-        };
-        // When the drag starts after a whitespace-only pane margin, treat that
-        // prefix as presentation padding. Following rows may begin earlier, so
-        // remove only blank cells and stop before their first real character.
-        // Additional indentation remains relative to the selected margin.
-        let margin = self
-            .retained_line(start_row)
-            .filter(|line| start_col > 0 && leading_blank_cells(*line, start_col) == start_col)
-            .map_or(0, |_| start_col);
-        let mut output = String::new();
-        let mut appended = false;
+        let start = Point::new(
+            self.retained_line(start_row)?,
+            Column(start_col.min(last_column)),
+        );
+        let end = Point::new(
+            self.retained_line(end_row)?,
+            Column(end_col.min(last_column)),
+        );
 
-        for row_index in start_row..=end_row {
-            let Some(line) = self.retained_line(row_index) else {
-                continue;
-            };
-            let left = if row_index == start_row {
-                start_col
-            } else {
-                leading_blank_cells(line, margin)
-            }
-            .min(last_column);
-            let right = if row_index == end_row {
-                end_col
-            } else {
-                last_column
-            }
-            .min(last_column);
-
-            if appended {
-                output.push('\n');
-            }
-            appended = true;
-            if left <= right {
-                let row = self.term.bounds_to_string(
-                    Point::new(line, Column(left)),
-                    Point::new(line, Column(right)),
-                );
-                output.push_str(row.trim_end_matches(' '));
-            }
-        }
-
-        appended.then_some(output)
+        // Alacritty owns the VT line-wrap metadata. Extract the complete range
+        // once so soft wraps are rejoined while real line breaks are retained.
+        Some(self.term.bounds_to_string(start, end))
     }
 
     fn retained_row_layout(&self, index: usize) -> Option<RetainedRowLayout> {
@@ -1283,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn retained_selection_removes_only_the_selected_blank_margin() {
+    fn retained_selection_uses_linear_cells_across_hard_lines() {
         let (tx, _rx) = channel();
         let mut engine = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 20));
         engine.advance(b"\x1b[H\x1b[2J - first\r\n - second\r\n - third");
@@ -1299,12 +1242,13 @@ mod tests {
             engine
                 .retained_selection_text(((rows[0], 1), (rows[2], 7)))
                 .as_deref(),
-            Some("- first\n- second\n- third")
+            Some("- first\n - second\n - third"),
+            "only the first row starts at the anchor column"
         );
     }
 
     #[test]
-    fn retained_selection_preserves_content_and_relative_indentation() {
+    fn retained_selection_preserves_selected_indentation() {
         let (tx, _rx) = channel();
         let mut engine = AlacrittyEngine::new(40, 6, tx, budget_for_rows(40, 20));
         engine.advance(
@@ -1326,8 +1270,8 @@ mod tests {
             engine
                 .retained_selection_text(((first, 4), (first + 2, 11)))
                 .as_deref(),
-            Some("first\nsecond\n  nested"),
-            "the selected blank margin is removed while deeper indentation remains"
+            Some("first\n    second\n      nested"),
+            "selected indentation on continuation rows remains content"
         );
 
         let chosen = rows
@@ -1345,7 +1289,7 @@ mod tests {
     }
 
     #[test]
-    fn retained_selection_removes_a_complete_wide_whitespace_margin() {
+    fn retained_selection_preserves_wide_whitespace_cells() {
         let (tx, _rx) = channel();
         let mut engine = AlacrittyEngine::new(40, 4, tx, budget_for_rows(40, 20));
         engine.advance("\x1b[H\x1b[2J　first\r\n　second".as_bytes());
@@ -1361,7 +1305,38 @@ mod tests {
             engine
                 .retained_selection_text(((rows[0], 2), (rows[1], 7)))
                 .as_deref(),
-            Some("first\nsecond")
+            Some("first\n　second")
+        );
+    }
+
+    #[test]
+    fn retained_selection_joins_soft_wraps_and_keeps_hard_breaks() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(5, 4, tx, budget_for_rows(5, 20));
+        engine.advance(b"abcdefghij\r\nnext");
+
+        let mut rows = Vec::new();
+        engine.for_each_retained_row(&mut |row, text| {
+            if !text.is_empty() {
+                rows.push((row, text.to_string()));
+            }
+        });
+        let first = rows
+            .iter()
+            .find(|(_, text)| text == "abcde")
+            .map(|(row, _)| *row)
+            .expect("first soft-wrapped row");
+        let last = rows
+            .iter()
+            .find(|(_, text)| text == "next")
+            .map(|(row, _)| *row)
+            .expect("hard-line row");
+
+        assert_eq!(
+            engine
+                .retained_selection_text(((first, 0), (last, 3)))
+                .as_deref(),
+            Some("abcdefghij\nnext")
         );
     }
 

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -289,12 +289,10 @@ pub trait VtEngine: Send {
     /// callback must not retain the borrowed text after it returns.
     fn for_each_retained_row(&self, f: &mut dyn FnMut(usize, &str));
 
-    /// Extract an inclusive retained-row selection using terminal cell
+    /// Extract an inclusive linear retained-row selection using terminal cell
     /// coordinates. Implementations must preserve complete wide glyphs and
-    /// zero-width marks rather than treating columns as string character
-    /// indexes. When the selection starts after a whitespace-only margin,
-    /// following rows may omit up to that many leading blank cells, but must
-    /// preserve earlier content and any additional relative indentation.
+    /// zero-width marks, join soft-wrapped display rows, preserve hard line
+    /// breaks, and retain every selected content cell.
     fn retained_selection_text(&self, range: ((usize, usize), (usize, usize))) -> Option<String>;
 
     /// Return copy-mode navigation geometry for one retained row. Trailing

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -970,7 +970,6 @@ mod tests {
         assert!(started.elapsed() < Duration::from_secs(2));
         assert_eq!(gateway.shared.active.load(Ordering::Acquire), 0);
         assert!(gateway.accept_thread.is_none());
-        assert!(TcpStream::connect(gateway.address()).is_err());
     }
 
     #[test]

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -99,7 +99,11 @@ file an agent is editing stays current in front of you.
 | `y` or `c` | copy the whole file |
 | `q` / `Esc` | close |
 
-Dragging across the text selects and copies it, the same as in any pane.
+Dragging across the text selects and copies it, the same as in any pane. Visual
+wraps rejoin into their original source line while real file line breaks remain.
+Double-click a word, path, or URL to copy and highlight that token. This works
+whether the read-only file viewer is opened as the reused preview, a permanent
+pane, or a tab.
 
 ## Opening in vim, nano, or your editor
 
@@ -156,9 +160,12 @@ bounded layout cache.
 | Ctrl/Cmd+click a link | open an HTTP(S) URL or an existing linked file |
 | `q` / `Esc` | close (or clear an active search first) |
 
-Dragging copies the rendered terminal text. Reopening the same file and preview
-kind focuses the existing preview in that placement rather than creating a
-duplicate. Open the file normally whenever you want its raw source or editor.
+Dragging copies the rendered terminal text without turning visual wraps into
+newlines. Real document line breaks remain. Double-clicking copies and
+highlights the rendered word, path, or URL under the pointer. Reopening the same
+file and preview kind focuses the existing preview in that placement rather
+than creating a duplicate. Open the file normally whenever you want its raw
+source or editor.
 
 ## What this is not
 

--- a/website/src/content/docs/docs/guides/scrollback.mdx
+++ b/website/src/content/docs/docs/guides/scrollback.mdx
@@ -42,6 +42,8 @@ application-cursor pager), Luvus forwards those keys unchanged. `Shift+↑`,
 Drag across a pane to select. Release **auto-copies** and flashes a *Copied*
 toast. luvus writes both your native OS clipboard (`pbcopy` / `wl-copy` /
 `xclip` / `clip`) and OSC 52, so it works locally *and* over SSH.
+Soft-wrapped display rows copy as one logical line. Hard line breaks and any
+leading indentation inside the selection remain unchanged.
 
 For keyboard selection, press **`Ctrl+Space`**, then **`y`** by default. Change
 the second key in **Settings → Keys → Copy terminal text**. Shift-based `V`


### PR DESCRIPTION
## Summary

This fixes copy behavior across terminal panes, native file views, and document previews.

Terminal selections now use the terminal engine's logical selection extraction. Visual soft wraps no longer become artificial line breaks, while real hard line breaks and selected indentation remain unchanged. The behavior is agent independent, so Codex and every other terminal program follow the same copy rules.

Native file views and Markdown or Mermaid previews now follow the same model. Dragging across visual wraps rejoins the original logical text, while genuine file and document line breaks remain. Double-clicking a word, path, or URL copies and highlights that token in a reused file preview, permanent pane, tab, or rendered document preview.

DIFF interaction behavior is unchanged.

The PR also removes a post-shutdown TCP connection assertion from the UHP gateway test. The test already verifies that shutdown completes within its bound, active connections are drained, and the accept thread is gone. A new connection attempt after shutdown depends on OS port state and can race with immediate port reuse, so it is not a stable lifecycle assertion.

## Implementation

- use Alacritty selection bounds to preserve terminal wrap semantics
- remove Codex-specific clipboard cleanup
- project visible native file and preview rows only when double-click token lookup is requested
- keep wide and zero-width characters aligned with terminal cells
- record bounded soft-wrap metadata in preview layouts so copy can distinguish visual continuation from real document boundaries
- document consistent copy behavior in the file and scrollback guides
- keep the UHP shutdown test focused on gateway-owned lifecycle state

## Performance

The native row projection is created only on double-click. Preview wrap metadata is bounded by the existing layout row limit and is produced with the off-loop layout. This adds no polling, background thread, or per-frame extraction work.

## Verification

- `cargo test a_double_click -- --nocapture`
- wrapped and hard-line-break selection tests for File and Preview
- preview layout and mobile selection regressions
- `cargo test stopping_gateway_drains_a_client_waiting_to_send_its_first_frame -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Double-click words, paths, and URLs in file and document previews to copy and highlight them.
  - Copying selections now preserves indentation, wide characters, zero-width characters, and leading spaces.
  - Visually wrapped lines are copied as single logical lines, while real line breaks remain intact.
  - Selection behavior is now consistent across terminal, file, and document-preview views.

- **Documentation**
  - Updated file browsing, preview, and scrollback guides to explain selection and copying behavior, including soft-wrap handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->