### PR TITLE
feat(uhp): publish general event catalog

### DIFF
--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -16,8 +16,9 @@ luvus uhp snapshot
 
 Capabilities report the protocol version, method contracts, access mode,
 required scope, idempotence, atomic methods, limits, event sequence, terminal
-features, and server identity rules. The schema defines exact request and
-response fields. Do not infer a method from a newer website or binary.
+features, and server identity rules. The schema defines exact request, response,
+and general event payload fields. Do not infer a method from a newer website or
+binary.
 
 `luvus uhp proxy` accepts one newline-delimited request from stdin and emits one
 response. A request has `id`, `method`, and `params`; add `auth` only for an

--- a/protocol/uhp/v1/README.md
+++ b/protocol/uhp/v1/README.md
@@ -5,6 +5,8 @@ This package is the source-controlled Universal Harness Protocol 1.0 contract.
 - `schema/request.schema.json` publishes every callable method.
 - `schema/response.schema.json` defines success and error envelopes.
 - `schema/event.schema.json` defines sequenced event frames.
+- `schema/event-catalog.schema.json` maps general event names to their payload
+  field schemas without rejecting future additive event names.
 - `schema/terminal/` contains strict terminal method and stream components.
 - `schema/access/descriptor.schema.json` defines transport-neutral remote
   bootstrap metadata; `access/README.md` defines provider and pairing behavior.

--- a/protocol/uhp/v1/schema/event-catalog.schema.json
+++ b/protocol/uhp/v1/schema/event-catalog.schema.json
@@ -260,7 +260,7 @@
         "agent": { "type": "string" },
         "cwd": { "type": "string" },
         "project": { "type": "string" },
-        "branch": { "type": "string" },
+        "branch": { "type": ["string", "null"] },
         "authority": { "type": ["string", "null"] },
         "state_source": { "type": ["string", "null"] }
       }
@@ -322,9 +322,21 @@
         "notes": { "type": "array", "items": { "type": "string" } },
         "worktree": { "type": ["string", "null"] },
         "branch": { "type": ["string", "null"] },
+        "mode": { "enum": ["worktree", "workspace"] },
+        "workspace_worker": { "$ref": "#/$defs/workspace_worker" },
         "context": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
         "created": { "type": "integer", "minimum": 0 },
         "updated": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "workspace_worker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace_id", "tab_id", "root"],
+      "properties": {
+        "workspace_id": { "type": "string" },
+        "tab_id": { "type": "string" },
+        "root": { "type": "string" }
       }
     },
     "task_released": {
@@ -336,12 +348,16 @@
     "task_started": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "pane", "worktree", "branch"],
+      "required": ["id", "pane", "mode", "workspace_id", "tab_id", "cwd", "worktree", "branch"],
       "properties": {
         "id": { "type": "string" },
         "pane": { "type": "string" },
-        "worktree": { "type": "string" },
-        "branch": { "type": "string" }
+        "mode": { "enum": ["worktree", "workspace"] },
+        "workspace_id": { "type": "string" },
+        "tab_id": { "type": "string" },
+        "cwd": { "type": "string" },
+        "worktree": { "type": ["string", "null"] },
+        "branch": { "type": ["string", "null"] }
       }
     },
     "task_needs_compaction": {

--- a/protocol/uhp/v1/schema/event-catalog.schema.json
+++ b/protocol/uhp/v1/schema/event-catalog.schema.json
@@ -1,0 +1,454 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://luvus.dev/protocol/uhp/v1/event-catalog.schema.json",
+  "title": "Luvus Universal Harness Protocol general event payload catalog",
+  "description": "Payload schemas for events currently emitted by the general UHP event stream. The event envelope remains forward-compatible with future names.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "agent.authority_released",
+    "agent.authority_reported",
+    "agent.hook",
+    "config.changed",
+    "events.resync_required",
+    "layout.applied",
+    "layout.ratio_changed",
+    "lease.acquired",
+    "lease.released",
+    "pane.agent_status_changed",
+    "pane.closed",
+    "pane.created",
+    "pane.focused",
+    "pane.forked",
+    "pane.moved",
+    "pane.renamed",
+    "pane.resized",
+    "pane.swapped",
+    "pane.zoomed",
+    "server.agent_manifests_reloaded",
+    "tab.closed",
+    "tab.created",
+    "tab.moved",
+    "task.added",
+    "task.claimed",
+    "task.deleted",
+    "task.done",
+    "task.gate_failed",
+    "task.gate_passed",
+    "task.gate_running",
+    "task.merge_conflict",
+    "task.merge_failed",
+    "task.merge_started",
+    "task.merged",
+    "task.needs_compaction",
+    "task.ready",
+    "task.released",
+    "task.started",
+    "task.updated",
+    "terminal.closed",
+    "terminal.created",
+    "terminal.exited",
+    "terminal.metadata_changed",
+    "terminal.moved",
+    "terminal.output_ready",
+    "workspace.block_moved",
+    "workspace.closed",
+    "workspace.created",
+    "workspace.metadata_reported",
+    "workspace.moved"
+  ],
+  "properties": {
+    "agent.authority_released": { "$ref": "#/$defs/authority_released" },
+    "agent.authority_reported": { "$ref": "#/$defs/authority_reported" },
+    "agent.hook": { "$ref": "#/$defs/agent_hook" },
+    "config.changed": { "$ref": "#/$defs/empty" },
+    "events.resync_required": { "$ref": "#/$defs/resync_required" },
+    "layout.applied": { "$ref": "#/$defs/layout_applied" },
+    "layout.ratio_changed": { "$ref": "#/$defs/layout_ratio_changed" },
+    "lease.acquired": { "$ref": "#/$defs/lease" },
+    "lease.released": { "$ref": "#/$defs/lease_released" },
+    "pane.agent_status_changed": { "$ref": "#/$defs/agent_status" },
+    "pane.closed": { "$ref": "#/$defs/pane_only" },
+    "pane.created": { "$ref": "#/$defs/pane_created" },
+    "pane.focused": { "$ref": "#/$defs/pane_only" },
+    "pane.forked": { "$ref": "#/$defs/pane_forked" },
+    "pane.moved": { "$ref": "#/$defs/pane_moved" },
+    "pane.renamed": { "$ref": "#/$defs/pane_renamed" },
+    "pane.resized": { "$ref": "#/$defs/pane_resized" },
+    "pane.swapped": { "$ref": "#/$defs/pane_swapped" },
+    "pane.zoomed": { "$ref": "#/$defs/pane_zoomed" },
+    "server.agent_manifests_reloaded": { "$ref": "#/$defs/manifests_reloaded" },
+    "tab.closed": { "$ref": "#/$defs/tab_only" },
+    "tab.created": { "$ref": "#/$defs/tab_only" },
+    "tab.moved": { "$ref": "#/$defs/tab_moved" },
+    "task.added": { "$ref": "#/$defs/task" },
+    "task.claimed": { "$ref": "#/$defs/task" },
+    "task.deleted": { "$ref": "#/$defs/id_only" },
+    "task.done": { "$ref": "#/$defs/task" },
+    "task.gate_failed": { "$ref": "#/$defs/task_gate_failed" },
+    "task.gate_passed": { "$ref": "#/$defs/id_only" },
+    "task.gate_running": { "$ref": "#/$defs/task_gate_running" },
+    "task.merge_conflict": { "$ref": "#/$defs/task_merge_conflict" },
+    "task.merge_failed": { "$ref": "#/$defs/task_merge_failed" },
+    "task.merge_started": { "$ref": "#/$defs/task_merge_started" },
+    "task.merged": { "$ref": "#/$defs/task_merged" },
+    "task.needs_compaction": { "$ref": "#/$defs/task_needs_compaction" },
+    "task.ready": { "$ref": "#/$defs/id_only" },
+    "task.released": { "$ref": "#/$defs/task_released" },
+    "task.started": { "$ref": "#/$defs/task_started" },
+    "task.updated": { "$ref": "#/$defs/task" },
+    "terminal.closed": { "$ref": "https://luvus.dev/protocol/uhp/v1/schema/terminal/event.schema.json#/oneOf/1/properties/data" },
+    "terminal.created": { "$ref": "https://luvus.dev/protocol/uhp/v1/schema/terminal/event.schema.json#/oneOf/1/properties/data" },
+    "terminal.exited": { "$ref": "https://luvus.dev/protocol/uhp/v1/schema/terminal/event.schema.json#/oneOf/1/properties/data" },
+    "terminal.metadata_changed": { "$ref": "https://luvus.dev/protocol/uhp/v1/schema/terminal/event.schema.json#/oneOf/1/properties/data" },
+    "terminal.moved": { "$ref": "https://luvus.dev/protocol/uhp/v1/schema/terminal/event.schema.json#/oneOf/1/properties/data" },
+    "terminal.output_ready": { "$ref": "https://luvus.dev/protocol/uhp/v1/schema/terminal/event.schema.json#/oneOf/1/properties/data" },
+    "workspace.block_moved": { "$ref": "#/$defs/workspace_block_moved" },
+    "workspace.closed": { "$ref": "#/$defs/workspace_only" },
+    "workspace.created": { "$ref": "#/$defs/workspace_only" },
+    "workspace.metadata_reported": { "$ref": "#/$defs/workspace_only" },
+    "workspace.moved": { "$ref": "#/$defs/workspace_moved" }
+  },
+  "$defs": {
+    "empty": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "workspace_only": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace"],
+      "properties": { "workspace": { "type": "string" } }
+    },
+    "workspace_moved": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace", "to"],
+      "properties": {
+        "workspace": { "type": "string" },
+        "to": { "type": "string" }
+      }
+    },
+    "workspace_block_moved": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspaces", "positions"],
+      "properties": {
+        "workspaces": { "type": "array", "items": { "type": "integer", "minimum": 0 } },
+        "positions": { "type": "array", "items": { "type": "integer", "minimum": 0 } }
+      }
+    },
+    "tab_only": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tab"],
+      "properties": { "tab": { "type": "string" } }
+    },
+    "tab_moved": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace", "from", "to", "active"],
+      "properties": {
+        "workspace": { "type": "string" },
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "active": { "type": "string" },
+        "mode": { "const": "swap" }
+      }
+    },
+    "pane_only": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane"],
+      "properties": { "pane": { "type": "string" } }
+    },
+    "pane_created": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane"],
+      "properties": {
+        "pane": { "type": "string" },
+        "module": { "type": "string" },
+        "terminal_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" }
+      }
+    },
+    "pane_forked": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to", "agent", "workspace", "tab"],
+      "properties": {
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "agent": { "type": "string" },
+        "workspace": { "type": "string" },
+        "tab": { "type": "string" }
+      }
+    },
+    "pane_moved": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "workspace", "tab"],
+      "properties": {
+        "pane": { "type": "string" },
+        "workspace": { "type": "string" },
+        "tab": { "type": "string" }
+      }
+    },
+    "pane_renamed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "name"],
+      "properties": {
+        "pane": { "type": "string" },
+        "name": { "type": ["string", "null"] }
+      }
+    },
+    "pane_resized": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "cells"],
+      "properties": {
+        "pane": { "type": "string" },
+        "cells": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "pane_swapped": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "with"],
+      "properties": {
+        "pane": { "type": "string" },
+        "with": { "type": "string" }
+      }
+    },
+    "pane_zoomed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "enabled"],
+      "properties": {
+        "pane": { "type": "string" },
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "layout_applied": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace", "tab"],
+      "properties": {
+        "workspace": { "type": "string" },
+        "tab": { "type": "string" }
+      }
+    },
+    "layout_ratio_changed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace", "tab", "path", "ratio"],
+      "properties": {
+        "workspace": { "type": "string" },
+        "tab": { "type": "string" },
+        "path": { "type": "array", "items": { "enum": ["a", "b"] } },
+        "ratio": { "type": "number" }
+      }
+    },
+    "agent_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "status", "agent", "cwd", "project", "branch", "authority"],
+      "properties": {
+        "pane": { "type": "string" },
+        "status": { "enum": ["blocked", "working", "done", "idle", "unknown"] },
+        "agent": { "type": "string" },
+        "cwd": { "type": "string" },
+        "project": { "type": "string" },
+        "branch": { "type": "string" },
+        "authority": { "type": ["string", "null"] },
+        "state_source": { "type": ["string", "null"] }
+      }
+    },
+    "agent_hook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "agent", "kind", "message", "tool"],
+      "properties": {
+        "pane": { "type": "string" },
+        "agent": { "type": "string" },
+        "kind": { "type": "string" },
+        "message": { "type": "string" },
+        "tool": { "type": "string" }
+      }
+    },
+    "authority_reported": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "source", "agent", "status", "sequence", "ttl_s"],
+      "properties": {
+        "pane": { "type": "string" },
+        "source": { "type": "string" },
+        "agent": { "type": "string" },
+        "status": { "enum": ["blocked", "working", "done", "idle", "unknown"] },
+        "sequence": { "type": "integer", "minimum": 0 },
+        "ttl_s": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "authority_released": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pane", "source", "reason"],
+      "properties": {
+        "pane": { "type": "string" },
+        "source": { "type": "string" },
+        "reason": { "enum": ["released", "expired"] }
+      }
+    },
+    "id_only": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": { "id": { "type": "string" } }
+    },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "status", "assignee", "deps", "paths", "gate", "outputs", "notes", "worktree", "branch", "context", "created", "updated"],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "status": { "enum": ["queued", "claimed", "running", "blocked", "review", "done", "merging", "merged", "failed"] },
+        "assignee": { "type": ["integer", "null"], "minimum": 1 },
+        "deps": { "type": "array", "items": { "type": "string" } },
+        "paths": { "type": "array", "items": { "type": "string" } },
+        "gate": { "type": ["string", "null"] },
+        "outputs": { "type": "array", "items": { "type": "string" } },
+        "notes": { "type": "array", "items": { "type": "string" } },
+        "worktree": { "type": ["string", "null"] },
+        "branch": { "type": ["string", "null"] },
+        "context": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "created": { "type": "integer", "minimum": 0 },
+        "updated": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "task_released": {
+      "oneOf": [
+        { "$ref": "#/$defs/task" },
+        { "$ref": "#/$defs/id_only" }
+      ]
+    },
+    "task_started": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "pane", "worktree", "branch"],
+      "properties": {
+        "id": { "type": "string" },
+        "pane": { "type": "string" },
+        "worktree": { "type": "string" },
+        "branch": { "type": "string" }
+      }
+    },
+    "task_needs_compaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "context"],
+      "properties": {
+        "id": { "type": "string" },
+        "context": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "task_merge_started": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "branch", "into"],
+      "properties": {
+        "id": { "type": "string" },
+        "branch": { "type": "string" },
+        "into": { "type": "string" }
+      }
+    },
+    "task_merged": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "branch", "into", "commit"],
+      "properties": {
+        "id": { "type": "string" },
+        "branch": { "type": "string" },
+        "into": { "type": "string" },
+        "commit": { "type": "string" }
+      }
+    },
+    "task_merge_conflict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "branch", "files"],
+      "properties": {
+        "id": { "type": "string" },
+        "branch": { "type": "string" },
+        "files": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "task_merge_failed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "branch", "message"],
+      "properties": {
+        "id": { "type": "string" },
+        "branch": { "type": "string" },
+        "message": { "type": "string" }
+      }
+    },
+    "task_gate_running": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "gate"],
+      "properties": {
+        "id": { "type": "string" },
+        "gate": { "type": "string" }
+      }
+    },
+    "task_gate_failed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "code"],
+      "properties": {
+        "id": { "type": "string" },
+        "code": { "type": ["integer", "null"] }
+      }
+    },
+    "lease": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "pane", "task", "paths", "acquired"],
+      "properties": {
+        "id": { "type": "string" },
+        "pane": { "type": "integer", "minimum": 1 },
+        "task": { "type": "string" },
+        "paths": { "type": "array", "items": { "type": "string" } },
+        "acquired": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "lease_released": {
+      "oneOf": [
+        { "$ref": "#/$defs/id_only" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["pane", "leases"],
+          "properties": {
+            "pane": { "type": "string" },
+            "leases": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+      ]
+    },
+    "manifests_reloaded": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rules"],
+      "properties": { "rules": { "type": "integer", "minimum": 0 } }
+    },
+    "resync_required": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": { "reason": { "const": "subscriber_overflow" } }
+    }
+  }
+}

--- a/protocol/uhp/v1/terminal/schema/event.schema.json
+++ b/protocol/uhp/v1/terminal/schema/event.schema.json
@@ -36,6 +36,7 @@
         "event":{"enum":["terminal.created","terminal.moved","terminal.metadata_changed","terminal.output_ready","terminal.exited","terminal.closed"]},
         "sequence":{"type":"integer","minimum":1},
         "data":{
+          "type":"object",
           "properties":{
             "server_generation":{"type":"string","pattern":"^[0-9a-f]{32}$"},
             "terminal_id":{"type":"string","pattern":"^[0-9a-f]{32}$"},

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -16,8 +16,9 @@ luvus uhp snapshot
 
 Capabilities report the protocol version, method contracts, access mode,
 required scope, idempotence, atomic methods, limits, event sequence, terminal
-features, and server identity rules. The schema defines exact request and
-response fields. Do not infer a method from a newer website or binary.
+features, and server identity rules. The schema defines exact request, response,
+and general event payload fields. Do not infer a method from a newer website or
+binary.
 
 `luvus uhp proxy` accepts one newline-delimited request from stdin and emits one
 response. A request has `id`, `method`, and `params`; add `auth` only for an

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -248,6 +248,92 @@ mod tests {
         assert_eq!(terminal_data["type"], "object");
     }
 
+    /// The catalog mirrors shared-workspace task bindings and started payloads.
+    #[test]
+    fn general_event_catalog_tracks_task_worker_payloads() {
+        let bundle = schema_bundle();
+        let definitions = &bundle["event_catalog"]["$defs"];
+
+        assert_eq!(
+            definitions["agent_status"]["properties"]["branch"]["type"],
+            json!(["string", "null"])
+        );
+
+        let task = &definitions["task"];
+        let task_required: std::collections::BTreeSet<_> = task["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        assert!(!task_required.contains("mode"));
+        assert!(!task_required.contains("workspace_worker"));
+        assert_eq!(
+            task["properties"]["mode"]["enum"],
+            json!(["worktree", "workspace"])
+        );
+        assert_eq!(
+            task["properties"]["workspace_worker"]["$ref"],
+            "#/$defs/workspace_worker"
+        );
+
+        let workspace_worker = &definitions["workspace_worker"];
+        let workspace_worker_required: std::collections::BTreeSet<_> = workspace_worker["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            workspace_worker_required,
+            ["root", "tab_id", "workspace_id"].into_iter().collect()
+        );
+        assert_eq!(workspace_worker["additionalProperties"], false);
+        assert_eq!(workspace_worker["properties"]["root"]["type"], "string");
+        assert_eq!(workspace_worker["properties"]["tab_id"]["type"], "string");
+        assert_eq!(
+            workspace_worker["properties"]["workspace_id"]["type"],
+            "string"
+        );
+
+        let task_started = &definitions["task_started"];
+        let task_started_required: std::collections::BTreeSet<_> = task_started["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            task_started_required,
+            [
+                "branch",
+                "cwd",
+                "id",
+                "mode",
+                "pane",
+                "tab_id",
+                "workspace_id",
+                "worktree",
+            ]
+            .into_iter()
+            .collect()
+        );
+        assert_eq!(task_started["additionalProperties"], false);
+        assert_eq!(
+            task_started["properties"]["mode"]["enum"],
+            json!(["worktree", "workspace"])
+        );
+        for field in ["workspace_id", "tab_id", "cwd"] {
+            assert_eq!(task_started["properties"][field]["type"], "string");
+        }
+        for field in ["worktree", "branch"] {
+            assert_eq!(
+                task_started["properties"][field]["type"],
+                json!(["string", "null"])
+            );
+        }
+    }
+
     #[test]
     fn published_fixture_manifest_tracks_version_and_line_counts() {
         let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("protocol/uhp/v1");

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -13,6 +13,9 @@ pub fn schema_bundle() -> Value {
     let event = schema(include_str!(
         "../../protocol/uhp/v1/schema/event.schema.json"
     ));
+    let event_catalog = schema(include_str!(
+        "../../protocol/uhp/v1/schema/event-catalog.schema.json"
+    ));
     let access_descriptor = schema(include_str!(
         "../../protocol/uhp/v1/schema/access/descriptor.schema.json"
     ));
@@ -34,6 +37,10 @@ pub fn schema_bundle() -> Value {
         event.clone(),
     );
     documents.insert(
+        "https://luvus.dev/protocol/uhp/v1/event-catalog.schema.json".into(),
+        event_catalog.clone(),
+    );
+    documents.insert(
         "https://luvus.dev/protocol/uhp/v1/schema/access/descriptor.schema.json".into(),
         access_descriptor.clone(),
     );
@@ -46,6 +53,7 @@ pub fn schema_bundle() -> Value {
         "request":request,
         "response":response,
         "event":event,
+        "event_catalog":event_catalog,
         "access":{"descriptor":access_descriptor},
         "terminal":terminal,
         "documents":documents,
@@ -95,6 +103,149 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn schema_bundle_publishes_the_general_event_catalog() {
+        let bundle = schema_bundle();
+        let catalog = bundle["event_catalog"]["properties"].as_object().unwrap();
+        let actual: std::collections::BTreeSet<_> = catalog.keys().map(String::as_str).collect();
+        let declared: std::collections::BTreeSet<_> = bundle["event_catalog"]["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        let expected: std::collections::BTreeSet<_> = [
+            "agent.authority_released",
+            "agent.authority_reported",
+            "agent.hook",
+            "config.changed",
+            "events.resync_required",
+            "layout.applied",
+            "layout.ratio_changed",
+            "lease.acquired",
+            "lease.released",
+            "pane.agent_status_changed",
+            "pane.closed",
+            "pane.created",
+            "pane.focused",
+            "pane.forked",
+            "pane.moved",
+            "pane.renamed",
+            "pane.resized",
+            "pane.swapped",
+            "pane.zoomed",
+            "server.agent_manifests_reloaded",
+            "tab.closed",
+            "tab.created",
+            "tab.moved",
+            "task.added",
+            "task.claimed",
+            "task.deleted",
+            "task.done",
+            "task.gate_failed",
+            "task.gate_passed",
+            "task.gate_running",
+            "task.merge_conflict",
+            "task.merge_failed",
+            "task.merge_started",
+            "task.merged",
+            "task.needs_compaction",
+            "task.ready",
+            "task.released",
+            "task.started",
+            "task.updated",
+            "terminal.closed",
+            "terminal.created",
+            "terminal.exited",
+            "terminal.metadata_changed",
+            "terminal.moved",
+            "terminal.output_ready",
+            "workspace.block_moved",
+            "workspace.closed",
+            "workspace.created",
+            "workspace.metadata_reported",
+            "workspace.moved",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(actual, expected);
+        assert_eq!(declared, expected);
+
+        let agent_status = &bundle["event_catalog"]["$defs"]["agent_status"];
+        let required: std::collections::BTreeSet<_> = agent_status["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            required,
+            [
+                "agent",
+                "authority",
+                "branch",
+                "cwd",
+                "pane",
+                "project",
+                "status",
+            ]
+            .into_iter()
+            .collect()
+        );
+        assert_eq!(agent_status["additionalProperties"], false);
+        assert_eq!(
+            catalog["pane.agent_status_changed"]["$ref"],
+            "#/$defs/agent_status"
+        );
+
+        fn assert_refs_resolve(root: &Value, documents: &Value, value: &Value) {
+            if let Some(reference) = value.get("$ref").and_then(Value::as_str) {
+                let (document, pointer) = reference.split_once('#').unwrap_or((reference, ""));
+                let target = if document.is_empty() {
+                    root
+                } else {
+                    documents
+                        .get(document)
+                        .unwrap_or_else(|| panic!("missing event catalog document {document}"))
+                };
+                assert!(
+                    target.pointer(pointer).is_some(),
+                    "missing event catalog reference {reference}"
+                );
+            }
+            match value {
+                Value::Array(values) => {
+                    for value in values {
+                        assert_refs_resolve(root, documents, value);
+                    }
+                }
+                Value::Object(values) => {
+                    for value in values.values() {
+                        assert_refs_resolve(root, documents, value);
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert_refs_resolve(
+            &bundle["event_catalog"],
+            &bundle["documents"],
+            &bundle["event_catalog"],
+        );
+
+        for (id, document) in bundle["documents"].as_object().unwrap() {
+            if let Some(declared_id) = document.get("$id").and_then(Value::as_str) {
+                assert_eq!(declared_id, id, "schema document key must match its $id");
+            }
+        }
+
+        let terminal_ref = catalog["terminal.created"]["$ref"].as_str().unwrap();
+        let (document, pointer) = terminal_ref.split_once('#').unwrap();
+        assert!(bundle["documents"].get(document).is_some());
+        let terminal_data = bundle["documents"][document].pointer(pointer).unwrap();
+        assert_eq!(terminal_data["type"], "object");
     }
 
     #[test]

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -29,6 +29,9 @@ luvus uhp schema
 luvus uhp snapshot
 ```
 
+The installed schema's `event_catalog.properties` maps general event names to
+their payload field schemas.
+
 The website documents the current release. A development build or older server
 can differ. Report the version and follow its live help for exact behavior.
 

--- a/website/src/content/docs/docs/guides/uhp.mdx
+++ b/website/src/content/docs/docs/guides/uhp.mdx
@@ -22,7 +22,9 @@ luvus uhp snapshot
 
 UHP is always available to the local owner. Capability discovery returns
 `luvus-uhp` version `1.0`, the complete method registry, access contracts,
-limits, event sequence, identity rules, and terminal capabilities.
+limits, event sequence, identity rules, and terminal capabilities. Schema
+discovery includes `event_catalog.properties`, which maps general event names to
+their payload field schemas.
 
 ## Send one request
 

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -751,19 +751,19 @@ growing server memory. The acknowledgment declares
 before EOF. `luvus events` is exactly this.
 
 ```json
-{"event":"pane.agent_status_changed","sequence":41,"data":{"pane":"4","status":"blocked","agent":"claude"}}
-{"event":"task.gate_passed","sequence":42,"data":{"task":"t1"}}
-{"event":"lease.acquired","sequence":43,"data":{"lease":"L2","task":"t3"}}
+{"event":"pane.agent_status_changed","sequence":41,"data":{"pane":"4","status":"blocked","agent":"claude","cwd":"/work/app","project":"app","branch":"main","authority":"process_tree","state_source":"manifest_rule"}}
+{"event":"task.gate_passed","sequence":42,"data":{"id":"t1"}}
+{"event":"lease.acquired","sequence":43,"data":{"id":"L2","pane":4,"task":"t3","paths":["src/**"],"acquired":1788146509}}
 ```
 
-Event names: `pane.created` · `pane.closed` · `pane.forked` · `pane.moved` · `pane.agent_status_changed` ·
-`agent.hook` · `workspace.created` · `workspace.closed` (a module hook may
-still spell these `node.created` / `node.closed`) · `tab.created` · `tab.closed` · `tab.moved`
-· `task.added` · `task.claimed` · `task.started` · `task.ready` ·
-`task.gate_running` · `task.gate_passed` · `task.gate_failed` ·
-`task.needs_compaction` · `task.done` · `task.merge_started` · `task.merged` ·
-`task.merge_conflict` · `task.merge_failed` · `task.released` · `lease.acquired` ·
-`lease.released`.
+`luvus uhp schema` exposes `event_catalog.properties`: every key is a general
+stream event name and its value is the JSON Schema for that event's `data`
+object. The catalog includes application and terminal lifecycle events plus the
+overflow resync event. The generic event envelope remains forward-compatible
+with future additive names. Register the returned `documents` by `$id` and
+resolve an entry from the catalog document, for example
+`https://luvus.dev/protocol/uhp/v1/event-catalog.schema.json#/properties/pane.agent_status_changed`;
+do not detach a fragment that contains a local `$ref` from its root document.
 
 `terminal.backend.events.subscribe` uses the same stream framing but filters to
 `terminal.*` events. Its acknowledgment includes the current sequence and queue

--- a/website/src/content/docs/docs/reference/uhp.mdx
+++ b/website/src/content/docs/docs/reference/uhp.mdx
@@ -35,6 +35,9 @@ luvus uhp events
 version, methods and contracts, server and event identity, bounded limits,
 agent authority sources, authorization scopes, and atomic operations.
 Consumers must use discovery rather than infer support from the Luvus release.
+The installed schema's `event_catalog.properties` maps every current general
+stream event name to the JSON Schema for its `data` payload. Register the
+bundle's `documents` by `$id` before resolving catalog references.
 
 ## Framing
 


### PR DESCRIPTION
The UHP schema now publishes the general event names and their payload field shapes so clients can discover the event contract without reverse engineering the stream.

## What changed

- add an embedded event_catalog schema document covering 50 general stream events, including application events, events.resync_required, and the terminal lifecycle events
- describe payload fields for agent, pane, tab, workspace, task, lease, layout, config, and server events
- reuse the existing terminal lifecycle payload schemas through canonical references
- keep the generic event envelope open so future additive event names remain forward compatible
- validate the exact catalog, document IDs, reference resolution, and pane.agent_status_changed fields in tests
- document schema-driven event discovery and correct stale event examples in the website and bundled skill reference

## Why

For a mobile-client MVP, we observed against a live 0.13.x server with a Claude Code pane that pane.agent_status_changed was only discoverable empirically. The schema described event as an arbitrary string and data as an arbitrary object, leaving delegated clients without a machine-readable application event contract.

Publishing a separate catalog is additive and lets clients generate or validate known payloads while continuing to tolerate newer server events.

## Verification

- cargo test --locked: 1,213 passed, 0 failed
- cargo test --locked api::schema::tests -- --nocapture: 4 passed, 0 failed
- terminal external-reference test: 1 passed, 0 failed
- cargo clippy --all-targets -- -D warnings: passed
- cargo fmt --all -- --check: passed
- cargo build --release --locked: passed
- npm run build in website: passed, 46 pages built
- cargo run --quiet -- uhp schema plus jq catalog checks: passed
- both modified JSON schema documents parse successfully

## Notes

The catalog is exposed as event_catalog in the schema bundle and registered in documents under its canonical $id. Consumers should register bundled documents by $id before resolving external references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive event catalog describing payload fields for general event-stream events.
  * Exposed the catalog through schema discovery and capability information.
  * Added strict validation for event names, payload fields, types, and supported value combinations.
  * Expanded event examples and task-start documentation with workspace-mode details and richer agent, task, and lease data.

* **Bug Fixes**
  * Improved terminal event schema validation by explicitly requiring object data.

* **Documentation**
  * Updated UHP guidance and references to explain event catalog discovery and schema resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->