### PR TITLE
fix(workspace): preserve explicit closures on reattach

### DIFF
--- a/src/app/cwd.rs
+++ b/src/app/cwd.rs
@@ -299,7 +299,7 @@ impl App {
         self.workspaces[dest].tabs.push(tab);
         let new_tab = self.workspaces[dest].tabs.len() - 1;
         if self.workspaces[src].tabs.is_empty() && self.workspaces.len() > 1 {
-            self.close_workspace(src);
+            self.close_workspace_after_rehome(src);
         }
         let dest = self
             .workspaces
@@ -739,6 +739,10 @@ mod tests {
                 .iter()
                 .all(|ws| !crate::platform::same_path(&ws.cwd, &home)),
             "empty source workspace closed"
+        );
+        assert!(
+            !app.automatic_workspace_open_is_suppressed(&home),
+            "automatic CWD rehoming is not an explicit workspace removal"
         );
         let files = files_rx
             .recv_timeout(Duration::from_secs(1))

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1774,10 +1774,12 @@ impl App {
                     .position(|w| crate::platform::same_path(&w.cwd, &path))
                 {
                     Some(i) => {
+                        self.forget_closed_workspace_path(&path);
                         if focus {
                             self.active_ws = i;
                         }
                     }
+                    None if !focus && self.automatic_workspace_open_is_suppressed(&path) => {}
                     // Report a failed open instead of answering with the
                     // *previously* active node, which read as success and left
                     // the caller (and the user) looking at the wrong folder.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -908,6 +908,7 @@ pub struct WsRename {
 /// Cap a custom workspace name (same reasoning as [`TAB_NAME_MAX`]). Shared
 /// with the CLI so local validation and the socket mutation agree.
 pub(crate) const WS_NAME_MAX: usize = 40;
+const MAX_CLOSED_WORKSPACE_PATHS: usize = 128;
 
 /// Why workspace metadata could not be changed.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -1527,6 +1528,9 @@ pub struct App {
     pub editors: Vec<(String, String)>,
     pub workspaces: Vec<Workspace>,
     pub active_ws: usize,
+    /// Bounded per-session roots the user explicitly removed. The launch-CWD
+    /// attach path consults this before automatically creating a workspace.
+    pub(crate) closed_workspace_paths: Vec<PathBuf>,
     pub theme: Theme,
     /// Appearance reported to programs running inside panes.
     pane_appearance: crate::terminal::appearance::PaneAppearance,
@@ -2129,6 +2133,7 @@ impl App {
                 active_tab: 0,
             }],
             active_ws: 0,
+            closed_workspace_paths: Vec::new(),
             theme,
             pane_appearance,
             probed_appearance: None,
@@ -2696,6 +2701,11 @@ impl App {
             return None;
         }
         let active_ws = snap.active_ws.min(workspaces.len() - 1);
+        let closed_workspace_paths = snap
+            .closed_workspace_paths
+            .into_iter()
+            .take(MAX_CLOSED_WORKSPACE_PATHS)
+            .collect();
         let backend_server_generation = crate::terminal::backend::random_id().ok()?;
         let backend_terminal_index = panes
             .iter()
@@ -2728,6 +2738,7 @@ impl App {
             editors: crate::platform::editor_choices(),
             workspaces,
             active_ws,
+            closed_workspace_paths,
             theme,
             pane_appearance,
             probed_appearance: None,
@@ -3742,6 +3753,7 @@ impl App {
             self.show_toast(format!("couldn't open {} — shell failed to start", name));
             return false;
         };
+        self.forget_closed_workspace_path(&cwd);
         self.workspaces.push(Workspace {
             id: crate::ids::public_id("workspace"),
             name,
@@ -3765,6 +3777,32 @@ impl App {
             &[crate::logging::Field::WorkspaceIndex(ws as u64)],
         );
         true
+    }
+
+    fn automatic_workspace_open_is_suppressed(&self, path: &std::path::Path) -> bool {
+        self.closed_workspace_paths
+            .iter()
+            .any(|closed| crate::platform::same_path(closed, path))
+    }
+
+    fn remember_closed_workspace_path(&mut self, path: PathBuf) {
+        self.closed_workspace_paths
+            .retain(|closed| !crate::platform::same_path(closed, &path));
+        if self.closed_workspace_paths.len() >= MAX_CLOSED_WORKSPACE_PATHS {
+            self.closed_workspace_paths.remove(0);
+        }
+        self.closed_workspace_paths.push(path);
+        self.session_dirty = true;
+        self.persist_session_now = true;
+    }
+
+    fn forget_closed_workspace_path(&mut self, path: &std::path::Path) {
+        let before = self.closed_workspace_paths.len();
+        self.closed_workspace_paths
+            .retain(|closed| !crate::platform::same_path(closed, path));
+        if self.closed_workspace_paths.len() != before {
+            self.session_dirty = true;
+        }
     }
 
     /// Restore the workspace hierarchy when an exceptional empty state reaches
@@ -5686,8 +5724,8 @@ impl App {
         let mut removed = false;
         if self.active_ws < self.workspaces.len() {
             let closed_workspace_id = self.workspaces[self.active_ws].id.clone();
+            let closed_root = self.workspaces[self.active_ws].cwd.clone();
             if self.workspaces.len() > 1 {
-                let closed_root = self.workspaces[self.active_ws].cwd.clone();
                 self.fail_pending_files_api_for_root(
                     &closed_root,
                     "workspace closed while FILES was loading",
@@ -5699,6 +5737,7 @@ impl App {
             }
             self.clear_workspace_transients(&closed_workspace_id);
             self.workspaces.remove(self.active_ws);
+            self.remember_closed_workspace_path(closed_root);
             removed = true;
         }
         if removed {
@@ -5729,12 +5768,22 @@ impl App {
 
     /// Close a workspace and all of its panes.
     fn close_workspace(&mut self, index: usize) {
+        self.close_workspace_with_suppression(index, true);
+    }
+
+    /// CWD rehoming may empty a workspace as an implementation detail. That is
+    /// not a user removal, so launching from its root later may open it again.
+    fn close_workspace_after_rehome(&mut self, index: usize) {
+        self.close_workspace_with_suppression(index, false);
+    }
+
+    fn close_workspace_with_suppression(&mut self, index: usize, suppress_reopen: bool) {
         if index >= self.workspaces.len() {
             return;
         }
         let closed_workspace_id = self.workspaces[index].id.clone();
+        let closed_root = self.workspaces[index].cwd.clone();
         if self.workspaces.len() > 1 {
-            let closed_root = self.workspaces[index].cwd.clone();
             self.fail_pending_files_api_for_root(
                 &closed_root,
                 "workspace closed while FILES was loading",
@@ -5756,6 +5805,9 @@ impl App {
         self.clear_workspace_transients(&closed_workspace_id);
         self.workspaces.remove(index);
         self.session_dirty = true;
+        if suppress_reopen {
+            self.remember_closed_workspace_path(closed_root);
+        }
         self.emit_event(
             "workspace.closed",
             serde_json::json!({"workspace": index.to_string()}),
@@ -9507,6 +9559,68 @@ mod tests {
         // An explicit open (focus:true) still focuses the folder.
         open(&mut app, &first, true);
         assert_eq!(app.ws().cwd, first, "explicit open still focuses");
+    }
+
+    #[test]
+    fn attach_open_does_not_restore_an_explicitly_closed_workspace() {
+        let _env = crate::persist::test_env("closed-launch-workspace");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let launch_cwd = app.ws().cwd.clone();
+        let other = std::env::temp_dir().join(format!(
+            "luvus-closed-launch-workspace-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&other).unwrap();
+        assert!(app.create_workspace_at(other.clone()));
+
+        app.close_workspace(0);
+        assert_eq!(app.workspaces.len(), 1);
+        assert!(app.automatic_workspace_open_is_suppressed(&launch_cwd));
+        assert!(
+            app.persist_session_now,
+            "an explicit removal is persisted without a debounce race"
+        );
+
+        let snapshot = crate::persist::snapshot(&app);
+        drop(app);
+        let (tx2, _rx2) = std::sync::mpsc::channel();
+        let mut restored = App::from_snapshot(snapshot, tx2).expect("remaining workspace restores");
+
+        let open = |app: &mut App, focus: bool| {
+            let (reply, _r) = mpsc::channel();
+            app.handle_api(&ApiRequest {
+                id: "1".into(),
+                method: "workspace.open".into(),
+                params: json!({
+                    "path": launch_cwd.display().to_string(),
+                    "focus": focus,
+                }),
+                reply,
+            });
+        };
+
+        open(&mut restored, false);
+        assert_eq!(
+            restored.workspaces.len(),
+            1,
+            "automatic attach does not resurrect the removed launch folder"
+        );
+        assert!(restored
+            .workspaces
+            .iter()
+            .all(|workspace| !crate::platform::same_path(&workspace.cwd, &launch_cwd)));
+
+        open(&mut restored, true);
+        assert_eq!(restored.workspaces.len(), 2);
+        assert!(crate::platform::same_path(&restored.ws().cwd, &launch_cwd));
+        assert!(
+            !restored.automatic_workspace_open_is_suppressed(&launch_cwd),
+            "an explicit reopen clears the remembered removal"
+        );
+
+        drop(restored);
+        let _ = std::fs::remove_dir_all(other);
     }
 
     #[test]

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -20,6 +20,10 @@ pub struct SessionSnapshot {
     pub version: u32,
     pub active_ws: usize,
     pub workspaces: Vec<WsSnap>,
+    /// Workspace roots the user explicitly closed. Automatic attach-time CWD
+    /// opening must not resurrect them; an explicit open removes the entry.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub closed_workspace_paths: Vec<PathBuf>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -775,6 +779,7 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
         version: SNAPSHOT_VERSION,
         active_ws: app.active_ws,
         workspaces,
+        closed_workspace_paths: app.closed_workspace_paths.clone(),
     }
 }
 
@@ -852,6 +857,17 @@ pub fn load() -> Option<SessionSnapshot> {
 #[cfg(test)]
 mod diff_snap_schema_tests {
     use super::*;
+
+    #[test]
+    fn older_sessions_default_to_no_closed_workspace_paths() {
+        let snapshot: SessionSnapshot = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "active_ws": 0,
+            "workspaces": [],
+        }))
+        .unwrap();
+        assert!(snapshot.closed_workspace_paths.is_empty());
+    }
 
     #[test]
     fn diff_snapshot_display_state_defaults_without_dropping_the_session() {


### PR DESCRIPTION
Explicitly removed launch folders now stay removed when Luvus attaches again.

## What

- persist a bounded, per-session list of workspace roots explicitly closed by the user
- suppress only the automatic attach-time reopen for those roots
- clear the suppression when the user explicitly opens the folder again
- keep automatic CWD rehoming from being treated as an explicit workspace removal
- preserve compatibility with existing session snapshots through a defaulted optional field

## Why

Starting Luvus from a folder automatically opens that folder as a workspace. Previously, this attach-time behavior ran on every launch without remembering that the user had later removed the workspace. As a result, the removed launch folder returned after closing and reopening the client.

## Verification

- [ ] `cargo test --locked`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] focused workspace, persistence, and CWD-rehome regression tests
- [x] isolated manual attach/detach lifecycle using a temporary `LUVUS_HOME` and named session

Focused tests covered:

- explicitly closed launch folders remain absent after snapshot restore and automatic attach
- explicit reopen still restores the folder
- existing workspace focus behavior remains unchanged
- closing the final workspace still creates a neutral home terminal
- automatic CWD rehoming does not suppress future workspace opens
- older session snapshots default safely without the new field

## Notes

The live lifecycle was validated locally on macOS. Linux and Windows behavior is covered by platform-neutral logic but was not manually exercised in this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly closed workspaces no longer automatically reopen during session restoration or launch-directory attachment.
  * Explicitly reopening a workspace still works as expected.
  * Prevented errors when automatic workspace opening is suppressed.
  * Improved tab rehoming so empty source workspaces close cleanly without affecting future automatic workspace opening.
* **Session Management**
  * Workspace closure preferences are preserved across sessions, including compatibility with older session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->