### PR TITLE
fix: attach cross-workspace pane splits

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1412,8 +1412,11 @@ impl App {
                         "could not create a terminal in the home directory".to_string(),
                     ));
                 }
-                let base = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
-                self.layout_mut().focus = base;
+                let base = if p.get("pane").is_some() {
+                    self.resolve_pane(p).ok_or_else(not_found)?
+                } else {
+                    self.layout().focus
+                };
                 let dir = p
                     .get("direction")
                     .and_then(|v| v.as_str())
@@ -1423,13 +1426,8 @@ impl App {
                 } else {
                     Axis::Col
                 };
-                self.split(axis);
-                let new = self.layout().focus;
-                // `focus: false` keeps the caller's focus where it was (background
-                // split), instead of moving it to the new pane.
-                if p.get("focus").and_then(|v| v.as_bool()) == Some(false) {
-                    self.layout_mut().focus = base;
-                }
+                let focus = p.get("focus").and_then(|v| v.as_bool()) != Some(false);
+                let new = self.split_pane(base, axis, focus).ok_or_else(not_found)?;
                 Ok(json!({"type":"pane","pane": new.0.to_string()}))
             }
             "pane.move" => {
@@ -7025,6 +7023,108 @@ command = ["true"]
         // Default split still moves focus to the new pane.
         let out2 = app.dispatch("pane.split", &json!({})).unwrap();
         assert_eq!(app.layout().focus.0.to_string(), out2["pane"]);
+    }
+
+    #[test]
+    fn pane_split_targets_foreign_workspace_without_detaching() {
+        let _env = crate::persist::test_env("pane-split-foreign-workspace");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let caller_ws = app.active_ws;
+        let caller_tab = app.workspaces[caller_ws].active_tab;
+        let caller_pane = app.layout().focus;
+
+        let target_root = crate::persist::config_dir().join("target-workspace");
+        let target_cwd = target_root.join("nested-pane-cwd");
+        std::fs::create_dir_all(&target_cwd).unwrap();
+        assert!(app.create_workspace_at(target_root.clone()));
+        let target_ws = app.active_ws;
+        let target_tab = app.workspaces[target_ws].active_tab;
+        let target_pane = app.layout().focus;
+        app.panes.get_mut(&target_pane).unwrap().cwd = target_cwd.clone();
+
+        app.active_ws = caller_ws;
+        app.workspaces[caller_ws].active_tab = caller_tab;
+        app.workspaces[caller_ws].tabs[caller_tab].layout.focus = caller_pane;
+        app.zoomed = true;
+
+        let out = app
+            .dispatch(
+                "pane.split",
+                &json!({"pane": target_pane.0.to_string(), "focus": false}),
+            )
+            .unwrap();
+        let new_pane = PaneId(out["pane"].as_str().unwrap().parse().unwrap());
+
+        assert_eq!(
+            app.active_ws, caller_ws,
+            "the caller's workspace stays active"
+        );
+        assert_eq!(app.workspaces[caller_ws].active_tab, caller_tab);
+        assert_eq!(app.layout().focus, caller_pane, "the caller keeps focus");
+        assert!(app.zoomed, "a background split preserves caller zoom");
+        assert_eq!(app.pane_location(new_pane), Some((target_ws, target_tab)));
+        assert_eq!(
+            app.workspaces[target_ws].tabs[target_tab].layout.focus, target_pane,
+            "the inactive target tab's focus is restored"
+        );
+        assert_eq!(
+            app.panes.get(&new_pane).map(|pane| &pane.cwd),
+            Some(&target_cwd),
+            "a split inherits the target pane's live cwd"
+        );
+        let occurrences = app
+            .workspaces
+            .iter()
+            .flat_map(|workspace| &workspace.tabs)
+            .flat_map(|tab| tab.layout.leaves())
+            .filter(|pane| *pane == new_pane)
+            .count();
+        assert_eq!(occurrences, 1, "every spawned pane has one layout owner");
+
+        app.status.get_mut(&new_pane).unwrap().agent = "claude".into();
+        let agents = app.dispatch("agent.list", &json!({})).unwrap();
+        let new_pane_text = new_pane.0.to_string();
+        let row = agents["agents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["pane"].as_str() == Some(new_pane_text.as_str()))
+            .expect("the attached pane is visible to agent.list");
+        assert_eq!(row["workspace"], target_ws.to_string());
+        assert_eq!(row["tab"], (target_tab + 1).to_string());
+
+        app.config.layout.new_pane_to_workspace_root = true;
+        let root_out = app
+            .dispatch(
+                "pane.split",
+                &json!({"pane": target_pane.0.to_string(), "focus": false}),
+            )
+            .unwrap();
+        let root_pane = PaneId(root_out["pane"].as_str().unwrap().parse().unwrap());
+        assert_eq!(app.pane_location(root_pane), Some((target_ws, target_tab)));
+        assert_eq!(
+            app.panes.get(&root_pane).map(|pane| &pane.cwd),
+            Some(&target_root),
+            "root-first mode uses the target workspace root, not the caller's"
+        );
+
+        app.config.layout.new_pane_to_workspace_root = false;
+        app.zoomed = true;
+        app.scroll_pane = Some(caller_pane);
+        let focused_out = app
+            .dispatch("pane.split", &json!({"pane": target_pane.0.to_string()}))
+            .unwrap();
+        let focused_pane = PaneId(focused_out["pane"].as_str().unwrap().parse().unwrap());
+        assert_eq!(app.active_ws, target_ws);
+        assert_eq!(app.workspaces[target_ws].active_tab, target_tab);
+        assert_eq!(app.layout().focus, focused_pane);
+        assert_eq!(
+            app.pane_location(focused_pane),
+            Some((target_ws, target_tab))
+        );
+        assert!(!app.zoomed, "a focused split exits zoom");
+        assert_eq!(app.scroll_pane, None, "the new pane starts at live output");
     }
 
     #[test]

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -7228,6 +7228,57 @@ command = ["true"]
         assert!(!app.status.contains_key(&dead_pane));
     }
 
+    /// Closing an inactive workspace through pane teardown publishes one removal.
+    #[test]
+    fn closing_last_inactive_workspace_pane_emits_one_workspace_closed_event() {
+        let _env = crate::persist::test_env("close-last-inactive-workspace-pane");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let caller_ws = app.active_ws;
+        let caller_tab = app.workspaces[caller_ws].active_tab;
+        let caller_pane = app.layout().focus;
+
+        let target_root = crate::persist::config_dir().join("close-event-target-workspace");
+        std::fs::create_dir_all(&target_root).unwrap();
+        assert!(app.create_workspace_at(target_root));
+        let target_ws = app.active_ws;
+        let target_workspace_id = app.workspaces[target_ws].id.clone();
+        let target_pane = app.layout().focus;
+
+        app.active_ws = caller_ws;
+        app.workspaces[caller_ws].active_tab = caller_tab;
+        app.workspaces[caller_ws].tabs[caller_tab].layout.focus = caller_pane;
+        app.zoomed = true;
+        let event_floor = crate::ipc::api::current_sequence(&app.events);
+
+        app.handle_event(AppEvent::PtyExit(target_pane));
+
+        assert_eq!(app.workspaces.len(), 1);
+        assert!(
+            app.workspaces
+                .iter()
+                .all(|workspace| workspace.id != target_workspace_id),
+            "the inactive workspace is removed"
+        );
+        assert_eq!(app.active_ws, caller_ws);
+        assert_eq!(app.workspaces[caller_ws].active_tab, caller_tab);
+        assert_eq!(app.layout().focus, caller_pane);
+        assert!(app.zoomed, "the caller's zoom state is preserved");
+        assert!(!app.panes.contains_key(&target_pane));
+        assert!(!app.status.contains_key(&target_pane));
+
+        let events = crate::ipc::api::replayed_events_after(&app.events, event_floor);
+        let workspace_closed: Vec<_> = events
+            .iter()
+            .filter(|event| event["event"] == "workspace.closed")
+            .collect();
+        assert_eq!(workspace_closed.len(), 1);
+        assert_eq!(
+            workspace_closed[0]["data"],
+            json!({"workspace": target_ws.to_string()})
+        );
+    }
+
     #[test]
     fn workspace_organization_api_renames_pins_lists_and_validates() {
         let _env = crate::persist::test_env("workspace-organization-api");

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1215,6 +1215,7 @@ impl App {
         }
     }
 
+    /// Validate and execute one bounded local API method against server-owned state.
     pub(crate) fn dispatch(&mut self, method: &str, p: &Value) -> Result<Value, (String, String)> {
         match method {
             "ping" => Ok(json!({
@@ -1412,10 +1413,9 @@ impl App {
                         "could not create a terminal in the home directory".to_string(),
                     ));
                 }
-                let base = if p.get("pane").is_some() {
-                    self.resolve_pane(p).ok_or_else(not_found)?
-                } else {
-                    self.layout().focus
+                let base = match p.get("pane") {
+                    None | Some(Value::Null) => self.layout().focus,
+                    Some(_) => self.resolve_pane(p).ok_or_else(not_found)?,
                 };
                 let dir = p
                     .get("direction")
@@ -1428,7 +1428,13 @@ impl App {
                 };
                 let focus = p.get("focus").and_then(|v| v.as_bool()) != Some(false);
                 let new = self.split_pane(base, axis, focus).ok_or_else(not_found)?;
-                Ok(json!({"type":"pane","pane": new.0.to_string()}))
+                let (workspace, tab) = self.pane_location(new).ok_or_else(not_found)?;
+                Ok(json!({
+                    "type":"pane",
+                    "pane": new.0.to_string(),
+                    "workspace": workspace.to_string(),
+                    "tab": (tab + 1).to_string(),
+                }))
             }
             "pane.move" => {
                 let id = self.resolve_pane(p).ok_or_else(not_found)?;
@@ -7007,6 +7013,26 @@ command = ["true"]
         assert_eq!(app.agent_name_for(pane), Some("harness-shell"));
     }
 
+    /// An explicit null pane has the same focused-pane semantics as omission.
+    #[test]
+    fn pane_split_null_pane_targets_the_focused_layout_pane() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let base = app.layout().focus;
+
+        let out = app
+            .dispatch("pane.split", &json!({"pane": null, "focus": false}))
+            .expect("an explicit null pane falls back to layout focus");
+        let split = PaneId(out["pane"].as_str().unwrap().parse().unwrap());
+
+        assert_ne!(split, base);
+        assert_eq!(out["workspace"], "0");
+        assert_eq!(out["tab"], "1");
+        assert_eq!(app.pane_location(split), Some((0, 0)));
+        assert_eq!(app.layout().focus, base);
+    }
+
+    /// Background and default splits preserve their established focus behavior.
     #[test]
     fn pane_split_no_focus_keeps_the_caller_focused() {
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -7025,6 +7051,7 @@ command = ["true"]
         assert_eq!(app.layout().focus.0.to_string(), out2["pane"]);
     }
 
+    /// Cross-workspace splits attach once and report their owning workspace and tab.
     #[test]
     fn pane_split_targets_foreign_workspace_without_detaching() {
         let _env = crate::persist::test_env("pane-split-foreign-workspace");
@@ -7056,6 +7083,8 @@ command = ["true"]
             .unwrap();
         let new_pane = PaneId(out["pane"].as_str().unwrap().parse().unwrap());
 
+        assert_eq!(out["workspace"], target_ws.to_string());
+        assert_eq!(out["tab"], (target_tab + 1).to_string());
         assert_eq!(
             app.active_ws, caller_ws,
             "the caller's workspace stays active"

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -7156,6 +7156,78 @@ command = ["true"]
         assert_eq!(app.scroll_pane, None, "the new pane starts at live output");
     }
 
+    /// A failed background split is removed from its inactive owning layout.
+    #[test]
+    fn pane_split_failed_spawn_cleans_inactive_workspace_without_changing_caller() {
+        let _env = crate::persist::test_env("pane-split-failed-inactive-workspace");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let caller_ws = app.active_ws;
+        let caller_tab = app.workspaces[caller_ws].active_tab;
+        let caller_pane = app.layout().focus;
+
+        let target_root = crate::persist::config_dir().join("failed-target-workspace");
+        std::fs::create_dir_all(&target_root).unwrap();
+        assert!(app.create_workspace_at(target_root));
+        let target_ws = app.active_ws;
+        let target_tab = app.workspaces[target_ws].active_tab;
+        let target_pane = app.layout().focus;
+
+        app.active_ws = caller_ws;
+        app.workspaces[caller_ws].active_tab = caller_tab;
+        app.workspaces[caller_ws].tabs[caller_tab].layout.focus = caller_pane;
+        app.zoomed = true;
+        app.config.shell = "luvus-not-a-real-shell-deferred-split".to_string();
+
+        let out = app
+            .dispatch(
+                "pane.split",
+                &json!({"pane": target_pane.0.to_string(), "focus": false}),
+            )
+            .unwrap();
+        let dead_pane = PaneId(out["pane"].as_str().unwrap().parse().unwrap());
+        assert_eq!(app.pane_location(dead_pane), Some((target_ws, target_tab)));
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(!remaining.is_zero(), "the deferred spawn did not fail");
+            match rx.recv_timeout(remaining) {
+                Ok(AppEvent::PtyExit(id)) if id == dead_pane => {
+                    app.handle_event(AppEvent::PtyExit(id));
+                    break;
+                }
+                Ok(AppEvent::PtyReady { id, .. }) if id == dead_pane => {
+                    panic!("the deliberately invalid shell unexpectedly spawned")
+                }
+                Ok(_) => {}
+                Err(error) => panic!("the deferred spawn did not fail: {error}"),
+            }
+        }
+
+        assert!(
+            !app.workspaces[target_ws].tabs[target_tab]
+                .layout
+                .contains(dead_pane),
+            "the owning inactive layout drops the dead leaf"
+        );
+        assert_eq!(
+            app.workspaces[target_ws].tabs[target_tab].layout.leaves(),
+            vec![target_pane]
+        );
+        assert_eq!(
+            app.workspaces[target_ws].tabs[target_tab].layout.focus,
+            target_pane
+        );
+        assert_eq!(app.pane_location(dead_pane), None);
+        assert_eq!(app.active_ws, caller_ws);
+        assert_eq!(app.workspaces[caller_ws].active_tab, caller_tab);
+        assert_eq!(app.layout().focus, caller_pane);
+        assert!(app.zoomed, "the caller's zoom state is preserved");
+        assert!(!app.panes.contains_key(&dead_pane));
+        assert!(!app.status.contains_key(&dead_pane));
+    }
+
     #[test]
     fn workspace_organization_api_renames_pins_lists_and_validates() {
         let _env = crate::persist::test_env("workspace-organization-api");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5818,6 +5818,10 @@ impl App {
             removed = true;
         }
         if removed {
+            self.emit_event(
+                "workspace.closed",
+                serde_json::json!({"workspace": workspace_index.to_string()}),
+            );
             crate::logging::event(
                 crate::logging::EventKind::WorkspaceClose,
                 &[crate::logging::Field::WorkspaceIndex(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3560,9 +3560,43 @@ impl App {
         }
     }
 
+    /// Split the focused pane and follow the newly attached sibling.
     fn split(&mut self, axis: Axis) {
         let pane = self.layout().focus;
         let _ = self.split_pane(pane, axis, true);
+    }
+
+    /// Spawn and attach a sibling beside `target`, preserving inactive view state
+    /// when the caller requests a background operation.
+    fn spawn_and_attach_new_pane(
+        &mut self,
+        workspace: usize,
+        tab: usize,
+        target: PaneId,
+        axis: Axis,
+        focus: bool,
+        spawn: impl FnOnce(&mut Self) -> Option<PaneId>,
+    ) -> Option<PaneId> {
+        let previous_zoom = self.zoomed;
+        let previous_target_focus = self.workspaces[workspace].tabs[tab].layout.focus;
+        let new_id = spawn(self)?;
+        {
+            let layout = &mut self.workspaces[workspace].tabs[tab].layout;
+            layout.focus = target;
+            layout.split_focused(axis, new_id);
+            if !focus {
+                layout.focus = previous_target_focus;
+            }
+        }
+        if focus {
+            self.active_ws = workspace;
+            self.workspaces[workspace].active_tab = tab;
+            self.scroll_pane = None;
+            self.zoomed = false;
+        } else {
+            self.zoomed = previous_zoom;
+        }
+        Some(new_id)
     }
 
     /// Split beside a pane in the workspace and tab that actually own it.
@@ -3576,26 +3610,9 @@ impl App {
         // worker retries the fallbacks instead of spawning in a dead directory.
         let cwds = self.spawn_cwds_for(wsi, pane);
         let (cwd, fallback_cwds) = cwds.split_first()?;
-        let previous_zoom = self.zoomed;
-        let previous_target_focus = self.workspaces[wsi].tabs[ti].layout.focus;
-        let id = self.spawn_into_deferred(cwd.clone(), fallback_cwds)?;
-        {
-            let layout = &mut self.workspaces[wsi].tabs[ti].layout;
-            layout.focus = pane;
-            layout.split_focused(axis, id);
-            if !focus {
-                layout.focus = previous_target_focus;
-            }
-        }
-        if focus {
-            self.active_ws = wsi;
-            self.workspaces[wsi].active_tab = ti;
-            self.scroll_pane = None;
-            self.zoomed = false;
-        } else {
-            self.zoomed = previous_zoom;
-        }
-        Some(id)
+        self.spawn_and_attach_new_pane(wsi, ti, pane, axis, focus, |app| {
+            app.spawn_into_deferred(cwd.clone(), fallback_cwds)
+        })
     }
 
     /// Fork `pane`'s agent session into a new sibling on its right, preserving
@@ -3647,30 +3664,11 @@ impl App {
         let fork =
             crate::agent::fork_command(&agent, &sid).ok_or(AgentForkError::UnsupportedAgent)?;
 
-        // `spawn_resume_pane` changes the global zoom flag. Capture the complete
-        // view state needed by --no-focus before spawning, then restore it after
-        // inserting the new leaf into the source tab.
-        let previous_zoom = self.zoomed;
-        let previous_source_focus = self.workspaces[wsi].tabs[ti].layout.focus;
         let new_id = self
-            .spawn_resume_pane(cwd, &fork)
+            .spawn_and_attach_new_pane(wsi, ti, pane, Axis::Col, focus, |app| {
+                app.spawn_resume_pane(cwd, &fork)
+            })
             .ok_or(AgentForkError::SpawnFailed)?;
-        {
-            let layout = &mut self.workspaces[wsi].tabs[ti].layout;
-            layout.focus = pane;
-            layout.split_focused(Axis::Col, new_id);
-            if !focus {
-                layout.focus = previous_source_focus;
-            }
-        }
-        if focus {
-            self.active_ws = wsi;
-            self.workspaces[wsi].active_tab = ti;
-            self.scroll_pane = None;
-            self.zoomed = false;
-        } else {
-            self.zoomed = previous_zoom;
-        }
         // Label the new pane as the same agent right away (detection will confirm
         // it, and pick up the fork's fresh session id, on the next tick).
         if let Some(nst) = self.status.get_mut(&new_id) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3373,12 +3373,24 @@ impl App {
     /// the synchronous spawn path's own fallback. Shared by `new_tab` and `split`
     /// so the two stay aligned.
     fn spawn_cwds(&self) -> Vec<PathBuf> {
+        self.spawn_cwds_for(self.active_ws, self.layout().focus)
+    }
+
+    /// Resolve the spawn directory chain for a specific pane and its workspace.
+    /// Socket callers may target an inactive pane, so this cannot rely on the
+    /// active workspace or tab.
+    fn spawn_cwds_for(&self, workspace: usize, pane: PaneId) -> Vec<PathBuf> {
         let home = crate::platform::home_dir().unwrap_or_default();
-        let root = self.ws().cwd.clone();
+        let root = self.workspaces[workspace].cwd.clone();
         let ordered = if self.config.layout.new_pane_to_workspace_root {
             vec![root, home.clone()]
         } else {
-            vec![self.focused_cwd(), root, home.clone()]
+            let pane_cwd = self
+                .panes
+                .get(&pane)
+                .map(|pane| pane.cwd.clone())
+                .unwrap_or_else(|| root.clone());
+            vec![pane_cwd, root, home.clone()]
         };
         let mut chain: Vec<PathBuf> = Vec::new();
         for candidate in ordered {
@@ -3549,18 +3561,41 @@ impl App {
     }
 
     fn split(&mut self, axis: Axis) {
-        // Resolve the candidate chain up front (focused pane → workspace root →
-        // $HOME, existing only) and hand the primary plus its fallbacks to the
-        // deferred worker. If the primary is deleted in the race window before
-        // the fork, the worker retries the fallbacks instead of spawning a dead
-        // pane; the chain is never empty, so the `else` here is unreachable.
-        let cwds = self.spawn_cwds();
-        let Some((cwd, fallback_cwds)) = cwds.split_first() else {
-            return;
-        };
-        if let Some(id) = self.spawn_into_deferred(cwd.clone(), fallback_cwds) {
-            self.layout_mut().split_focused(axis, id);
+        let pane = self.layout().focus;
+        let _ = self.split_pane(pane, axis, true);
+    }
+
+    /// Split beside a pane in the workspace and tab that actually own it.
+    /// With focus disabled, the current view and the target tab's prior focus are
+    /// preserved even when the target belongs to another workspace.
+    fn split_pane(&mut self, pane: PaneId, axis: Axis, focus: bool) -> Option<PaneId> {
+        let (wsi, ti) = self.pane_location(pane)?;
+        // Resolve the candidate chain up front (target pane → target workspace
+        // root → $HOME, existing only) and hand the primary plus its fallbacks to
+        // the deferred worker. If the primary vanishes before the fork, the
+        // worker retries the fallbacks instead of spawning in a dead directory.
+        let cwds = self.spawn_cwds_for(wsi, pane);
+        let (cwd, fallback_cwds) = cwds.split_first()?;
+        let previous_zoom = self.zoomed;
+        let previous_target_focus = self.workspaces[wsi].tabs[ti].layout.focus;
+        let id = self.spawn_into_deferred(cwd.clone(), fallback_cwds)?;
+        {
+            let layout = &mut self.workspaces[wsi].tabs[ti].layout;
+            layout.focus = pane;
+            layout.split_focused(axis, id);
+            if !focus {
+                layout.focus = previous_target_focus;
+            }
         }
+        if focus {
+            self.active_ws = wsi;
+            self.workspaces[wsi].active_tab = ti;
+            self.scroll_pane = None;
+            self.zoomed = false;
+        } else {
+            self.zoomed = previous_zoom;
+        }
+        Some(id)
     }
 
     /// Fork `pane`'s agent session into a new sibling on its right, preserving

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5737,13 +5737,38 @@ impl App {
     }
 
     fn close_pane(&mut self, id: PaneId) {
+        let owner = self.pane_location(id);
         self.drop_leaf_runtime(id);
         self.release_leaf_ownership(id);
         self.session_dirty = true;
-        if self.layout_mut().remove(id) {
-            self.close_active_tab();
+        if let Some((workspace, tab)) = owner {
+            let tab_is_empty = self.workspaces[workspace].tabs[tab].layout.remove(id);
+            if tab_is_empty {
+                self.close_empty_tab(workspace, tab);
+            }
         }
         self.emit_event("pane.closed", serde_json::json!({"pane": id.0.to_string()}));
+    }
+
+    /// Remove an empty tab by location without changing a surviving caller's view.
+    fn close_empty_tab(&mut self, workspace_index: usize, tab_index: usize) {
+        let caller_focus = self.layout().focus;
+        let owner_focus = self.workspaces[workspace_index].tabs
+            [self.workspaces[workspace_index].active_tab]
+            .layout
+            .focus;
+
+        self.active_ws = workspace_index;
+        self.workspaces[workspace_index].active_tab = tab_index;
+        self.close_active_tab();
+
+        if let Some((workspace, tab)) = self.pane_location(owner_focus) {
+            self.workspaces[workspace].active_tab = tab;
+        }
+        if let Some((workspace, tab)) = self.pane_location(caller_focus) {
+            self.active_ws = workspace;
+            self.workspaces[workspace].active_tab = tab;
+        }
     }
 
     fn close_active_tab(&mut self) {

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -1000,6 +1000,19 @@ pub fn current_sequence(bus: &EventBus) -> u64 {
     bus.0.lock().map(|state| state.sequence).unwrap_or(0)
 }
 
+#[cfg(test)]
+pub(crate) fn replayed_events_after(bus: &EventBus, sequence: u64) -> Vec<Value> {
+    let Ok(state) = bus.0.lock() else {
+        return Vec::new();
+    };
+    state
+        .replay
+        .iter()
+        .filter(|(event_sequence, _)| *event_sequence > sequence)
+        .filter_map(|(_, line)| serde_json::from_str(line).ok())
+        .collect()
+}
+
 /// Publish one structured event without blocking the app loop.
 pub fn publish_event(bus: &EventBus, event: &str, data: Value) -> u64 {
     let Ok(mut state) = bus.0.lock() else {

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -266,3 +266,9 @@ server:
 (o_o)   https://luvus.dev/agent-readme.md
 /|_|\
 ```
+
+When `pane split <id>` targets a pane outside the current view, the new pane is
+inserted beside that target in the same workspace and tab. It starts in the
+target pane's live working directory; with
+`layout.new_pane_to_workspace_root = true`, it starts at the target workspace
+root instead. `--no-focus` preserves the caller's current view.


### PR DESCRIPTION
Fixes #215.

## Problem

An explicit `pane split <id>` can target a pane in an inactive workspace, but the old path always mutates the active workspace/tab layout. The pane runtime is created successfully while layout insertion silently misses its foreign target, leaving a functional process that is absent from every layout tree.

This was observed against a live Luvus 0.13.2 server: `pane status` could read the new pane, while `agent list` omitted it and `pane move` returned `not_found`. An isolated two-workspace server reproduced the pane as detached immediately after creation, before any later layout action.

## Root cause

`pane.split` resolved the requested pane globally, assigned that foreign id as the active layout's focus, and then called the active-layout-only split path. `TileLayout::split_focused` does not surface the failed lookup, while deferred spawning has already inserted the new runtime into the flat pane and status registries. This splits the two lookup worlds: process/status APIs find the flat runtime, but layout-scoped APIs cannot find an owning workspace/tab.

## Fix

- Resolve the target pane's owning workspace and tab before spawning.
- Insert the new leaf beside the target in that exact layout.
- Preserve the caller's workspace, tab, focus, and zoom for `--no-focus`.
- For a focused split, switch to the target workspace/tab and focus the new pane.
- Resolve cwd relative to the target: target pane live cwd by default, or the target workspace root when `layout.new_pane_to_workspace_root = true`.
- Document the cross-workspace and cwd behavior in the CLI reference.

The scope stays on pane creation; no registry or layout representation changes are needed.

## Tests

- `cargo test --locked pane_split_targets_foreign_workspace_without_detaching -- --nocapture` — 1 passed.
- `cargo test --locked` — 1,225 passed; 0 failed.
- `cargo clippy --locked --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `cargo build --release --locked` — passed.
- Upstream-main red control: the foreign-workspace `--no-focus` regression failed because caller focus changed from pane 1 to pane 2; the fix passes.
- Isolated live server: the new pane appeared immediately in the target workspace snapshot, was visible through `agent list`, preserved the caller view under `--no-focus`, and could be moved to a new tab successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Split panes in inactive workspaces without leaving the current view.
  - Targeted splits open beside the specified pane in the same workspace and tab.
  - New panes inherit the target pane’s working directory or workspace root.
  - Background splits preserve focus, active view, and zoom state.
  - Close panes in inactive workspaces while preserving the current view.
  - Closing the final pane removes its empty tab or workspace and emits a workspace-closed event.

- **Documentation**
  - Documented targeted split behavior and focus preservation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->