### PR TITLE
fix(detect): parse padded ps process columns

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -552,6 +552,21 @@ fn proc_fs_table() -> Option<PsTable> {
 /// The process table from one `ps` invocation — the portable fallback and the
 /// path macOS/BSD always take. See [`ps_table`] for why Linux prefers `/proc`.
 #[cfg(unix)]
+fn parse_ps_command_line(line: &str) -> Option<(u32, u32, &str)> {
+    let line = line.trim_start();
+    let pid_end = line.find(char::is_whitespace)?;
+    let (pid, rest) = line.split_at(pid_end);
+    let rest = rest.trim_start();
+    let ppid_end = rest.find(char::is_whitespace)?;
+    let (ppid, command) = rest.split_at(ppid_end);
+    let command = command.trim_start();
+    if command.is_empty() {
+        return None;
+    }
+    Some((pid.parse().ok()?, ppid.parse().ok()?, command))
+}
+
+#[cfg(unix)]
 fn ps_command_table() -> Option<PsTable> {
     use std::collections::HashMap;
     let out = match std::process::Command::new("ps")
@@ -565,23 +580,10 @@ fn ps_command_table() -> Option<PsTable> {
     let mut cmd: HashMap<u32, String> = HashMap::new();
     let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
     for line in text.lines() {
-        let mut it = line.split_whitespace();
-        let (Some(pid), Some(ppid)) = (it.next(), it.next()) else {
+        let Some((pid, ppid, command)) = parse_ps_command_line(line) else {
             continue;
         };
-        let (Ok(pid), Ok(ppid)) = (pid.parse::<u32>(), ppid.parse::<u32>()) else {
-            continue;
-        };
-        // Everything after the two numeric columns is the command, spaces intact.
-        let rest = line
-            .splitn(3, |c: char| c.is_whitespace())
-            .nth(2)
-            .unwrap_or("")
-            .trim_start();
-        if rest.is_empty() {
-            continue;
-        }
-        cmd.insert(pid, rest.to_string());
+        cmd.insert(pid, command.to_string());
         children.entry(ppid).or_default().push(pid);
     }
     Some((cmd, children))
@@ -1003,6 +1005,23 @@ mod tests {
         );
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ps_command_line_handles_padded_numeric_columns() {
+        assert_eq!(
+            super::parse_ps_command_line(" 5555 91833 /bin/zsh"),
+            Some((5555, 91833, "/bin/zsh"))
+        );
+        assert_eq!(
+            super::parse_ps_command_line(" 6647  5555 opencode2 --model  gpt"),
+            Some((6647, 5555, "opencode2 --model  gpt"))
+        );
+        assert_eq!(
+            super::parse_ps_command_line("15818 91833 /bin/zsh"),
+            Some((15818, 91833, "/bin/zsh"))
+        );
     }
 
     #[cfg(any(unix, windows))]


### PR DESCRIPTION
Preserve agent process identities when `ps` pads PID and PPID columns.

## What

- Parse PID and PPID after removing fixed-width alignment padding.
- Preserve the complete command field, including internal argument spacing.
- Add regression coverage for padded four-digit and unpadded five-digit process IDs.

## Why

On macOS/BSD, leading or repeated spaces in `ps -Ao pid=,ppid=,args=` could shift a numeric column into the command field. Recognized agents were then classified as their shell and omitted from the Agents dock.

Fixes #219.

## Verification

- [x] `cargo test ps_command_line_handles_padded_numeric_columns -- --nocapture`
- [x] `cargo test process_tree_finds_this_process_and_its_children -- --nocapture`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --locked`
- [ ] `cargo test --locked` — 1227 passed and 4 unrelated tests failed; the same 4 failures reproduce on unmodified `origin/main` in this worktree (1226 passed).

## Notes

Validated on macOS arm64. Linux normally uses `/proc`; Windows uses its separate process snapshot implementation. The production server was not restarted during verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process command parsing when numeric columns contain leading or padded whitespace.
  * Preserved spacing within command text for more accurate process information.

* **Tests**
  * Added coverage for process entries with padded numeric columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->