### PR TITLE
feat(modules): add telegram-notify example module (card t1)

### DIFF
--- a/examples/modules/README.md
+++ b/examples/modules/README.md
@@ -1,6 +1,6 @@
 # Example modules
 
-Five complete, working luvus modules across three languages, each covering a
+Six complete, working luvus modules across three languages, each covering a
 different part of the extension surface. They are meant to be **copied and
 edited**, not installed as-is.
 
@@ -11,6 +11,7 @@ edited**, not installed as-is.
 | [`scratch-pane`](scratch-pane) | Node | A **pane** entrypoint, `pane` right-click actions, reading the **selection**, **renaming a tab**, the state dir |
 | [`file-tree`](file-tree) | Bash | A **collapsible file tree** dock (per-row `toggle`/`open` actions, on-disk expand state), opening a file into a split **pane** via `pane split` + `pane run` — a no-core-edits prototype of docs/38 |
 | [`ci-bar`](ci-bar) | Bash | A multi-segment **Luvus Bar** widget, compact content, a clickable action, startup restoration, and a transient notification |
+| [`telegram-notify`](telegram-notify) | Bash | An **event hook** on agent status that sends a **Telegram** message (`blocked`/`done`/`both`), a **secret** setting, an `agent` right-click test-send action, redacted failure logging via `luvus module log` |
 
 Nothing here needs a build step or a dependency beyond the language runtime
 itself (`sh`, `python3`, `node`).

--- a/examples/modules/telegram-notify/README.md
+++ b/examples/modules/telegram-notify/README.md
@@ -1,0 +1,74 @@
+# Telegram Notify
+
+Get a Telegram message when one of your agents needs you (`blocked`) or
+finishes (`done`), plus a right-click **Send a test message** action on any
+live agent.
+
+Pure `sh` + `curl` (macOS / Linux) -- no dependency beyond the shell. The
+whole module is `luvus-module.toml` and `notify.sh`.
+
+## Setup
+
+1. Create a bot with [@BotFather](https://t.me/BotFather) (`/newbot`) and
+   copy the token it gives you.
+2. Find your chat id: message your new bot once, then open
+   `https://api.telegram.org/bot<YOUR-TOKEN>/getUpdates` in a browser and
+   read the `"chat":{"id":...}` value from the response. (For a group chat,
+   add the bot to the group and use the group's negative id.)
+3. Link the module and fill in the settings:
+
+   ```sh
+   luvus module link ./examples/modules/telegram-notify
+   ```
+
+   **Settings -> Modules -> Telegram Notify**:
+
+   | Setting | Meaning |
+   |---|---|
+   | Bot token | The BotFather token (stored as a secret; masked in Settings) |
+   | Chat ID | Where messages are delivered |
+   | Notify on | `blocked` (default), `done`, or `both` -- which agent status changes send a message |
+
+4. Right-click a live agent -> **Send a test message** to confirm the wiring.
+   The test action ignores the *Notify on* filter and always sends.
+
+## Behavior
+
+- One plain `sendMessage` per status change. No retries, no queueing, no
+  toasts -- the Telegram message is the notification.
+- The event message reads `<agent> is <status> in <workspace>`, where
+  `<workspace>` is the changed pane's workspace (from the event payload),
+  not whichever workspace has focus.
+- If the message text contains quotes or backslashes (agent names can), the
+  JSON body escapes them, so odd names do not break the request.
+
+## If nothing arrives
+
+Failures -- missing settings, network errors, non-2xx Telegram responses --
+are recorded as a single redacted line in `luvus module log`. Check it with:
+
+```sh
+luvus module log
+```
+
+The bot token and the request URL (which embeds it) are never written to the
+log under any outcome. A `curl exit` line means the request never completed;
+an `HTTP <code>` line means Telegram answered and rejected it (401 = wrong
+token, 400 = usually a wrong chat id).
+
+## Live smoke test (operator)
+
+The success path needs real credentials, so it is run by hand:
+
+1. Start a dev instance in an isolated home -- never your production server:
+
+   ```sh
+   env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION LUVUS_HOME="$HOME/.luvus-dev" luvus
+   ```
+
+2. In that instance: `luvus module link ./examples/modules/telegram-notify`,
+   then enter the real bot token and chat id in Settings -> Modules.
+3. Start any agent in a pane and let it go `blocked` or `done` -- a Telegram
+   message should arrive. Right-click the agent -> **Send a test message**
+   for a second one, regardless of its current status.
+4. If either message is missing, `luvus module log` carries the reason.

--- a/examples/modules/telegram-notify/README.md
+++ b/examples/modules/telegram-notify/README.md
@@ -66,8 +66,16 @@ The success path needs real credentials, so it is run by hand:
    env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION LUVUS_HOME="$HOME/.luvus-dev" luvus
    ```
 
-2. In that instance: `luvus module link ./examples/modules/telegram-notify`,
-   then enter the real bot token and chat id in Settings -> Modules.
+2. Link the module into that same isolated home. Keep the env prefix -- a
+   bare `luvus module link` reaches your selected server, which may be
+   production:
+
+   ```sh
+   env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION LUVUS_HOME="$HOME/.luvus-dev" \
+       luvus module link ./examples/modules/telegram-notify
+   ```
+
+   Then enter the real bot token and chat id in Settings -> Modules.
 3. Start any agent in a pane and let it go `blocked` or `done` -- a Telegram
    message should arrive. Right-click the agent -> **Send a test message**
    for a second one, regardless of its current status.

--- a/examples/modules/telegram-notify/luvus-module.toml
+++ b/examples/modules/telegram-notify/luvus-module.toml
@@ -1,0 +1,41 @@
+id = "example.telegram-notify"
+name = "Telegram Notify"
+version = "0.1.0"
+min_luvus_version = "0.8.3"
+description = "Send a Telegram message when an agent needs you or finishes. Right-click an agent to send a test message."
+platforms = ["macos", "linux"]
+
+# Fires every time a pane's agent state changes. notify.sh reads the payload
+# (LUVUS_MODULE_EVENT_JSON) so the message names the pane that actually
+# changed, not the one in focus.
+[[events]]
+on = "pane.agent_status_changed"
+command = ["sh", "notify.sh"]
+
+# Adds a row to the right-click menu on a live agent in the AGENTS sidebar.
+# Bypasses the notify-on filter entirely -- it always sends.
+[[actions]]
+id = "send-test"
+title = "Send a test message"
+contexts = ["agent"]
+command = ["sh", "notify.sh", "--test"]
+
+# Created via @BotFather; luvus masks secret settings in Settings -> Modules.
+[[settings]]
+key = "bot_token"
+title = "Bot token"
+type = "string"
+secret = true
+
+# The chat to deliver to: a user id, or a negative id for a group chat.
+[[settings]]
+key = "chat_id"
+title = "Chat ID"
+type = "string"
+
+[[settings]]
+key = "notify_on"
+title = "Notify on"
+type = "enum"
+options = ["blocked", "done", "both"]
+default = "blocked"

--- a/examples/modules/telegram-notify/notify.sh
+++ b/examples/modules/telegram-notify/notify.sh
@@ -48,7 +48,10 @@ send() {
       --data-binary "$body" -K - 2>/dev/null)
   curl_rc=$?
   if [ "$curl_rc" -ne 0 ]; then
-    printf 'telegram-notify: send failed (curl exit %s)\n' "$curl_rc" >&2
+    case "$curl_rc" in
+      3) printf 'telegram-notify: send failed (curl exit 3 -- malformed URL; check that bot_token has no stray characters)\n' >&2 ;;
+      *) printf 'telegram-notify: send failed (curl exit %s)\n' "$curl_rc" >&2 ;;
+    esac
     return 1
   fi
   case "$http_code" in
@@ -60,8 +63,13 @@ send() {
   esac
 }
 
-bot_token="${LUVUS_SETTING_BOT_TOKEN:-}"
-chat_id="${LUVUS_SETTING_CHAT_ID:-}"
+# Settings text inputs routinely pick up stray spaces or a trailing newline
+# on paste; a space inside the API URL makes curl reject the whole request
+# (exit 3). Trim surrounding whitespace and embedded newlines before use.
+trim() { printf '%s' "$1" | tr -d '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'; }
+
+bot_token=$(trim "${LUVUS_SETTING_BOT_TOKEN:-}")
+chat_id=$(trim "${LUVUS_SETTING_CHAT_ID:-}")
 notify_on="${LUVUS_SETTING_NOTIFY_ON:-blocked}"
 api_url="https://api.telegram.org/bot${bot_token}/sendMessage"
 test_only=false
@@ -120,6 +128,12 @@ if [ -z "$bot_token" ]; then
   printf 'telegram-notify: bot_token is not set -- add it in Settings > Modules\n' >&2
   exit 1
 fi
+case "$bot_token" in
+  *[[:space:]]*|*\"*|*\'*)
+    printf 'telegram-notify: bot_token still contains a space or quote -- paste the BotFather token again without extra characters\n' >&2
+    exit 1
+    ;;
+esac
 if [ -z "$chat_id" ]; then
   printf 'telegram-notify: chat_id is not set -- add it in Settings > Modules\n' >&2
   exit 1

--- a/examples/modules/telegram-notify/notify.sh
+++ b/examples/modules/telegram-notify/notify.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Telegram Notify -- sends a Telegram message when a pane's agent status
+# changes, with a right-click "Send a test message" action.
+#
+# luvus runs this as a plain subprocess; everything arrives in the environment:
+#   LUVUS_SETTING_BOT_TOKEN / LUVUS_SETTING_CHAT_ID / LUVUS_SETTING_NOTIFY_ON
+#   LUVUS_MODULE_EVENT_JSON   event payload (agent/status/pane/project/cwd)
+#   LUVUS_PANE_AGENT / LUVUS_PANE_STATUS / LUVUS_PANE_ID   flat fallbacks
+#   LUVUS_WORKSPACE_CWD       the FOCUSED workspace -- fallback only, because
+#                             the event payload describes the pane that changed
+#
+# stderr lands in `luvus module log`, which is the module's only failure
+# channel (no toasts, no retries). The bot token never appears in argv (the
+# request URL is handed to curl through its stdin config) and never in a log
+# line: curl's stderr is discarded wholesale because --show-error would print
+# the token-bearing URL on transport errors.
+#
+# POSIX sh + curl only; no other interpreter or tool is needed.
+
+# Escape the two characters that matter inside a JSON string (house pattern,
+# file-tree/lib.sh). Command substitution eats the trailing newline, which is
+# exactly what we want here.
+json_esc() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+# First "key": "value" string field of a luvus-produced JSON payload, via
+# bounded sed. Empty output means the key is absent or its value is an empty
+# string; callers treat both as "missing" and fall back.
+json_field() {
+  printf '%s' "$2" |
+    sed -n 's/.*"'"$1"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+    sed -n '1p'
+}
+
+# Basename of a non-empty path; empty otherwise.
+path_tail() {
+  [ -n "$1" ] || return 0
+  basename "$1"
+}
+
+# Send one message ($1) to the configured chat. One attempt, no retry.
+# Failure reporting uses only the curl exit code or the HTTP status -- never
+# curl's own output, which embeds the token.
+send() {
+  body="{\"chat_id\":\"$(json_esc "$chat_id")\",\"text\":\"$(json_esc "$1")\"}"
+  http_code=$(printf 'url = "%s"\n' "$api_url" |
+    curl -sS --max-time 10 -o /dev/null -w '%{http_code}' \
+      -H 'Content-Type: application/json' \
+      --data-binary "$body" -K - 2>/dev/null)
+  curl_rc=$?
+  if [ "$curl_rc" -ne 0 ]; then
+    printf 'telegram-notify: send failed (curl exit %s)\n' "$curl_rc" >&2
+    return 1
+  fi
+  case "$http_code" in
+    2*) return 0 ;;
+    *)
+      printf 'telegram-notify: send failed (HTTP %s)\n' "$http_code" >&2
+      return 1
+      ;;
+  esac
+}
+
+bot_token="${LUVUS_SETTING_BOT_TOKEN:-}"
+chat_id="${LUVUS_SETTING_CHAT_ID:-}"
+notify_on="${LUVUS_SETTING_NOTIFY_ON:-blocked}"
+api_url="https://api.telegram.org/bot${bot_token}/sendMessage"
+test_only=false
+[ "${1:-}" = "--test" ] && test_only=true
+
+# --- event identity ------------------------------------------------------
+# Prefer the event payload -- it describes the pane that actually changed --
+# over the flat vars, which can describe the pane in focus. Absent payload,
+# unparseable JSON, or empty fields fall back to the flat vars / focused
+# workspace (luvus builds payload fields with unwrap_or_default(), so a
+# present-but-empty value is possible).
+payload="${LUVUS_MODULE_EVENT_JSON:-}"
+agent=""
+status=""
+pane=""
+project=""
+cwd=""
+if [ -n "$payload" ]; then
+  agent=$(json_field agent "$payload")
+  status=$(json_field status "$payload")
+  pane=$(json_field pane "$payload")
+  project=$(json_field project "$payload")
+  cwd=$(json_field cwd "$payload")
+fi
+[ -n "$agent" ] || agent="${LUVUS_PANE_AGENT:-agent}"
+[ -n "$status" ] || status="${LUVUS_PANE_STATUS:-unknown}"
+[ -n "$pane" ] || pane="${LUVUS_PANE_ID:-?}"
+
+# Workspace token: the changed pane's project name, then its cwd, and only
+# then the focused workspace's cwd. Never empty -- the message must be able
+# to name where it happened even with everything unset.
+workspace="$project"
+[ -n "$workspace" ] || workspace=$(path_tail "$cwd")
+[ -n "$workspace" ] || workspace=$(path_tail "${LUVUS_WORKSPACE_CWD:-}")
+[ -n "$workspace" ] || workspace="luvus"
+
+# --- what to send --------------------------------------------------------
+if [ "$test_only" = true ]; then
+  message="luvus telegram-notify: test message (pane ${pane} in ${workspace})"
+else
+  # Fail-closed gating: only the selected statuses notify. An unexpected
+  # notify_on value stays silent rather than notifying on everything.
+  case "$notify_on" in
+    both)
+      [ "$status" = blocked ] || [ "$status" = done ] || exit 0
+      ;;
+    blocked) [ "$status" = blocked ] || exit 0 ;;
+    done)    [ "$status" = done ]    || exit 0 ;;
+    *) exit 0 ;;
+  esac
+  message="${agent} is ${status} in ${workspace}"
+fi
+
+# --- settings guard (checked only once a send is actually attempted) ------
+if [ -z "$bot_token" ]; then
+  printf 'telegram-notify: bot_token is not set -- add it in Settings > Modules\n' >&2
+  exit 1
+fi
+if [ -z "$chat_id" ]; then
+  printf 'telegram-notify: chat_id is not set -- add it in Settings > Modules\n' >&2
+  exit 1
+fi
+
+send "$message"


### PR DESCRIPTION
A new example module that sends a Telegram message when one of your agents goes `blocked` or finishes (`done`), plus a right-click **Send a test message** action on any live agent.

## What

- `examples/modules/telegram-notify/`: `luvus-module.toml` (bot token as a secret, chat id, `notify_on` = blocked/done/both) + `notify.sh` (POSIX sh + curl, `--max-time 10`, fail-closed status gating, no retries)
- One plain `sendMessage` per status change; failures land in `luvus module log` only — the bot token never appears in argv or in any log line (the request URL is handed to curl via its stdin config)
- README with BotFather setup, an isolated-home live smoke test procedure (env-isolation prefix included so the smoke never touches a production server), and a troubleshooting section
- Index row in `examples/modules/README.md`

## Why

Agents occasionally need you when you are not at the desk (`blocked`) and you want to know when they finish. This gives a mobile notification path with zero dependencies beyond the shell.

## Verification

- [x] `sh -n notify.sh` on macOS `/bin/sh` and Alpine busybox `sh` (container)
- [x] ACs verified by direct invocation: gating, payload/fallback extraction, 401 on dummy token over real network, secret hygiene grep, argv/stdin evidence
- [x] Manual live smoke in an isolated dev home: real credentials, status-change and test-action messages delivered (operator-confirmed)
- [ ] `cargo test --locked` / clippy / fmt — no Rust changes in this PR; CI covers them

## Notes

- The live smoke surfaced one real-world robustness gap, fixed in this PR (32f4080): a pasted token with a stray space makes the assembled API URL malformed (`curl exit 3`) — settings are now trimmed, a mid-value space fails early with a clear message, and the curl exit-3 log line gained a hint.
- Module declares `platforms = ["macos", "linux"]`; no `src/` behavior changed.
- Optional follow-ups recorded in review: control-char escaping in `json_field` (F1), chat id/message visibility in curl argv up to the 10s timeout (F2).

🗿 MoAI