### PR TITLE
fix(input): forward Ctrl+/ to nested TUIs

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2585,7 +2585,8 @@ impl App {
                     // forwarded, so typing to the agent resumes with no lost key.
                     pane.scroll_to_bottom();
                     exit = true;
-                    if let Some(bytes) = encode_key(&key, newline, pane.application_cursor()) {
+                    let (app_cursor, disambiguate) = pane.key_encoding_modes();
+                    if let Some(bytes) = encode_key(&key, newline, app_cursor, disambiguate) {
                         pane.send(&bytes);
                     }
                 }
@@ -3507,11 +3508,12 @@ impl App {
                 if self.prefix.matches(&key) {
                     let prefix = self.prefix.key_event();
                     let newline = self.config.shift_enter_bytes().to_vec();
-                    let app_cursor = self.focused().is_some_and(|p| p.application_cursor());
-                    if let (Some(p), Some(bytes)) =
-                        (self.focused(), encode_key(&prefix, &newline, app_cursor))
-                    {
-                        p.send(&bytes);
+                    if let Some(pane) = self.focused() {
+                        let (app_cursor, disambiguate) = pane.key_encoding_modes();
+                        if let Some(bytes) = encode_key(&prefix, &newline, app_cursor, disambiguate)
+                        {
+                            pane.send(&bytes);
+                        }
                     }
                     return true; // left prefix mode → the status bar updates
                 }
@@ -3598,8 +3600,11 @@ impl App {
                 let newline = self.config.shift_enter_bytes();
                 // Cursor keys follow the pane's DECCKM state: a `less` that
                 // turned application cursor mode on only recognizes SS3 codes.
-                let app_cursor = self.focused().is_some_and(|p| p.application_cursor());
-                if let Some(bytes) = encode_key(&key, newline, app_cursor) {
+                let (app_cursor, disambiguate) = self
+                    .focused()
+                    .map(|pane| pane.key_encoding_modes())
+                    .unwrap_or((false, false));
+                if let Some(bytes) = encode_key(&key, newline, app_cursor, disambiguate) {
                     if let Some(p) = self.focused() {
                         // Typing snaps the view back to the live bottom, so you
                         // always see what you type (like every terminal).
@@ -3719,7 +3724,12 @@ fn mouse_wheel_seq(up: bool, col: u16, row: u16, sgr: bool) -> Vec<u8> {
 /// (`ESC O <letter>`) when the app enabled application cursor mode, exactly as a
 /// real terminal would send them — some apps (`less`) only recognize the SS3
 /// form once they've turned the mode on.
-fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8>> {
+fn encode_key(
+    key: &KeyEvent,
+    newline: &[u8],
+    app_cursor: bool,
+    disambiguate: bool,
+) -> Option<Vec<u8>> {
     // AltGr arrives as Ctrl+Alt on Windows (`keys::is_ctrl_chord`) and types a
     // character — it is neither a Ctrl chord nor an `ESC`-prefixed Alt key.
     let ctrl = super::keys::is_ctrl_chord(key.modifiers);
@@ -3733,6 +3743,21 @@ fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8
     let bytes: Vec<u8> = match key.code {
         KeyCode::Char(c) => {
             if ctrl {
+                if disambiguate {
+                    let codepoint = match c {
+                        // Crossterm represents a legacy 0x1f input byte as
+                        // Ctrl+7. The originating terminal could not
+                        // distinguish it from Ctrl+/, so prefer the user-facing
+                        // slash binding when the nested application requests
+                        // an unambiguous key sequence.
+                        '/' | '7' => Some('/'),
+                        '_' => Some('_'),
+                        _ => None,
+                    };
+                    if let Some(codepoint) = codepoint {
+                        return Some(csi_u_char(codepoint, key.modifiers));
+                    }
+                }
                 let b = match c.to_ascii_lowercase() {
                     'a'..='z' => (c.to_ascii_uppercase() as u8) & 0x1f,
                     ' ' | '@' => 0,
@@ -3740,7 +3765,10 @@ fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8
                     '\\' => 0x1c,
                     ']' => 0x1d,
                     '^' => 0x1e,
-                    '_' => 0x1f,
+                    // Ctrl+/ is the user-facing chord for the US control byte.
+                    // Legacy terminal input arrives through crossterm as
+                    // Ctrl+7, while enhanced keyboard protocols preserve `/`.
+                    '_' | '/' | '7' => 0x1f,
                     _ => return None,
                 };
                 if alt {
@@ -3816,6 +3844,15 @@ fn encode_key(key: &KeyEvent, newline: &[u8], app_cursor: bool) -> Option<Vec<u8
 
 fn csi(final_byte: u8) -> Vec<u8> {
     vec![0x1b, b'[', final_byte]
+}
+
+fn csi_u_char(character: char, modifiers: KeyModifiers) -> Vec<u8> {
+    format!(
+        "\x1b[{};{}u",
+        character as u32,
+        key_modifier_param(modifiers)
+    )
+    .into_bytes()
 }
 
 /// Encode a cursor key (arrows / Home / End). In application cursor mode
@@ -4197,7 +4234,8 @@ mod tests {
     fn shift_enter_sends_a_newline_not_a_submit() {
         // The default newline sequence is `ESC CR`.
         let nl = b"\x1b\r";
-        let enter = |m: KeyModifiers| encode_key(&KeyEvent::new(KeyCode::Enter, m), nl, false);
+        let enter =
+            |m: KeyModifiers| encode_key(&KeyEvent::new(KeyCode::Enter, m), nl, false, false);
         assert_eq!(
             enter(KeyModifiers::NONE),
             Some(b"\r".to_vec()),
@@ -4218,6 +4256,7 @@ mod tests {
             encode_key(
                 &KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
                 nl,
+                false,
                 false
             ),
             Some(b"\r".to_vec())
@@ -4232,8 +4271,9 @@ mod tests {
     fn altgr_types_its_character_instead_of_a_control_byte() {
         let nl = b"\x1b\r";
         let altgr = KeyModifiers::CONTROL | KeyModifiers::ALT;
-        let enc =
-            |c: char, m: KeyModifiers| encode_key(&KeyEvent::new(KeyCode::Char(c), m), nl, false);
+        let enc = |c: char, m: KeyModifiers| {
+            encode_key(&KeyEvent::new(KeyCode::Char(c), m), nl, false, false)
+        };
         if cfg!(windows) {
             for c in ['\\', '@', '#', '[', ']', '{', '}', '|', '~', '€'] {
                 assert_eq!(
@@ -4260,7 +4300,7 @@ mod tests {
         // The exception is for characters only: every other key keeps both
         // modifiers, so Ctrl+Alt+Enter is still a modified Enter.
         assert_eq!(
-            encode_key(&KeyEvent::new(KeyCode::Enter, altgr), nl, false),
+            encode_key(&KeyEvent::new(KeyCode::Enter, altgr), nl, false, false),
             Some(nl.to_vec()),
             "Ctrl+Alt+Enter still sends the configured newline"
         );
@@ -4271,14 +4311,20 @@ mod tests {
     #[test]
     fn shift_enter_sequence_is_configurable() {
         let shift = KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT);
-        assert_eq!(encode_key(&shift, b"\n", false), Some(b"\n".to_vec()));
         assert_eq!(
-            encode_key(&shift, b"\x1b[13;2u", false),
+            encode_key(&shift, b"\n", false, false),
+            Some(b"\n".to_vec())
+        );
+        assert_eq!(
+            encode_key(&shift, b"\x1b[13;2u", false, false),
             Some(b"\x1b[13;2u".to_vec())
         );
         // Plain Enter ignores the newline sequence and always submits.
         let plain = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        assert_eq!(encode_key(&plain, b"\n", false), Some(b"\r".to_vec()));
+        assert_eq!(
+            encode_key(&plain, b"\n", false, false),
+            Some(b"\r".to_vec())
+        );
     }
 
     #[test]
@@ -4287,6 +4333,7 @@ mod tests {
             encode_key(
                 &KeyEvent::new(KeyCode::Char('a'), modifiers),
                 b"\x1b\r",
+                false,
                 false,
             )
         };
@@ -4299,8 +4346,37 @@ mod tests {
     }
 
     #[test]
+    fn control_slash_reaches_nested_tuis_across_terminal_encodings() {
+        let encode = |character, disambiguate| {
+            encode_key(
+                &KeyEvent::new(KeyCode::Char(character), KeyModifiers::CONTROL),
+                b"\x1b\r",
+                false,
+                disambiguate,
+            )
+        };
+
+        assert_eq!(encode('/', false), Some(vec![0x1f]));
+        assert_eq!(
+            encode('7', false),
+            Some(vec![0x1f]),
+            "crossterm decodes the legacy 0x1f byte as Ctrl+7"
+        );
+        assert_eq!(encode('_', false), Some(vec![0x1f]));
+
+        assert_eq!(encode('/', true), Some(b"\x1b[47;5u".to_vec()));
+        assert_eq!(
+            encode('7', true),
+            Some(b"\x1b[47;5u".to_vec()),
+            "a legacy Ctrl+/ alias regains slash identity for a nested CSI-u client"
+        );
+        assert_eq!(encode('_', true), Some(b"\x1b[95;5u".to_vec()));
+    }
+
+    #[test]
     fn navigation_keys_preserve_modifiers_for_nested_prompt_editors() {
-        let key = |code, modifiers| encode_key(&KeyEvent::new(code, modifiers), b"\x1b\r", false);
+        let key =
+            |code, modifiers| encode_key(&KeyEvent::new(code, modifiers), b"\x1b\r", false, false);
 
         // The existing unmodified sequences stay byte-for-byte compatible.
         assert_eq!(
@@ -4348,7 +4424,8 @@ mod tests {
         // When the pane enabled DECCKM (`ESC[?1h`), unmodified cursor keys go out
         // as SS3 (`ESC O <letter>`) — the bytes a real terminal sends once the
         // app turned the mode on. `less` is strict about this and ignores CSI.
-        let app = |code, modifiers| encode_key(&KeyEvent::new(code, modifiers), b"\x1b\r", true);
+        let app =
+            |code, modifiers| encode_key(&KeyEvent::new(code, modifiers), b"\x1b\r", true, false);
         assert_eq!(
             app(KeyCode::Up, KeyModifiers::NONE),
             Some(b"\x1bOA".to_vec())
@@ -4387,7 +4464,8 @@ mod tests {
 
     #[test]
     fn tilde_navigation_keys_preserve_modifiers() {
-        let key = |code, modifiers| encode_key(&KeyEvent::new(code, modifiers), b"\x1b\r", false);
+        let key =
+            |code, modifiers| encode_key(&KeyEvent::new(code, modifiers), b"\x1b\r", false, false);
         assert_eq!(
             key(KeyCode::Delete, KeyModifiers::NONE),
             Some(b"\x1b[3~".to_vec())
@@ -4404,8 +4482,14 @@ mod tests {
 
     #[test]
     fn function_keys_encode_to_tilde_codes() {
-        let key =
-            |n, modifiers| encode_key(&KeyEvent::new(KeyCode::F(n), modifiers), b"\x1b\r", false);
+        let key = |n, modifiers| {
+            encode_key(
+                &KeyEvent::new(KeyCode::F(n), modifiers),
+                b"\x1b\r",
+                false,
+                false,
+            )
+        };
         // F1–F4 and F5–F12 carry the standard xterm CSI-tilde codes.
         assert_eq!(key(1, KeyModifiers::NONE), Some(b"\x1b[11~".to_vec()));
         assert_eq!(key(4, KeyModifiers::NONE), Some(b"\x1b[14~".to_vec()));

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -1030,6 +1030,14 @@ impl Pane {
             .unwrap_or(false)
     }
 
+    /// Input modes read together under one engine lock.
+    pub fn key_encoding_modes(&self) -> (bool, bool) {
+        self.engine
+            .lock()
+            .map(|e| (e.application_cursor(), e.disambiguate_escape_codes()))
+            .unwrap_or((false, false))
+    }
+
     /// `(mouse_report, sgr)` — whether the child tracks the mouse, and whether
     /// it wants SGR-encoded reports. Read together under one lock.
     /// The app's mouse-tracking state, read under **one** engine lock — callers

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -140,6 +140,7 @@ impl AlacrittyEngine {
         // estimate until an engine provides native byte accounting.
         let config = Config {
             scrolling_history: history_rows_for_budget(history_budget_bytes, cols),
+            kitty_keyboard: true,
             ..Config::default()
         };
         let term = Term::new(config, &dims, proxy);
@@ -160,6 +161,7 @@ impl AlacrittyEngine {
                 self.history_budget_bytes,
                 self.term.grid().columns() as u16,
             ),
+            kitty_keyboard: true,
             ..Config::default()
         });
     }
@@ -875,6 +877,10 @@ impl VtEngine for AlacrittyEngine {
 
     fn application_cursor(&self) -> bool {
         self.term.mode().contains(TermMode::APP_CURSOR)
+    }
+
+    fn disambiguate_escape_codes(&self) -> bool {
+        self.term.mode().contains(TermMode::DISAMBIGUATE_ESC_CODES)
     }
 
     fn mouse_drag(&self) -> bool {
@@ -1598,6 +1604,25 @@ mod tests {
         assert!(!e.alternate_scroll());
         e.advance(b"\x1b[?1007h");
         assert!(e.alternate_scroll());
+    }
+
+    #[test]
+    fn nested_keyboard_disambiguation_is_tracked_across_config_updates() {
+        let (tx, _rx) = channel();
+        let mut e = AlacrittyEngine::new(20, 5, tx, budget_for_rows(20, 2_000));
+        assert!(!e.disambiguate_escape_codes());
+
+        e.advance(b"\x1b[>1u");
+        assert!(e.disambiguate_escape_codes());
+
+        e.set_history_budget(budget_for_rows(20, 1_000));
+        assert!(
+            e.disambiguate_escape_codes(),
+            "changing scrollback settings must not disable the child keyboard protocol"
+        );
+
+        e.advance(b"\x1b[<u");
+        assert!(!e.disambiguate_escape_codes());
     }
 
     #[test]

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -324,6 +324,11 @@ pub trait VtEngine: Send {
     /// and mouse modes, this lets the input layer leave pager keys alone.
     fn application_cursor(&self) -> bool;
 
+    /// Whether the child requested unambiguous CSI-u encoding for control keys.
+    /// Input encoding must honor this for chords whose legacy byte loses the
+    /// original key identity, such as Ctrl+/ versus Ctrl+7.
+    fn disambiguate_escape_codes(&self) -> bool;
+
     /// Whether the child also requested **drag/motion tracking** (1002/1003) —
     /// press-and-move events are forwarded only then, so a click-only (1000)
     /// app isn't spammed with motion it never asked for.


### PR DESCRIPTION
## Summary

- enable the vendored terminal engine to track nested Kitty keyboard modes
- forward Ctrl+/ as CSI 47;5u when the focused TUI requests disambiguated input
- preserve the standard 0x1F byte for ordinary shells and accept Crossterm legacy Ctrl+7 input
- retain keyboard mode state when scrollback settings change

## Why

The first encoder-only fix correctly delivered 0x1F to the pane, confirmed with an od probe, but that legacy byte loses the original slash identity. Codex enables the nested Kitty keyboard protocol and needs the disambiguated sequence to recognize its Ctrl+/ binding. Luvus previously disabled that protocol in its terminal engine, so the nested request was ignored.

The client transport and SSH bridge already preserve key events and require no wire-protocol change.

## Verification

- cargo fmt --all --check
- focused legacy and CSI-u Ctrl+/ encoding test
- focused nested keyboard-mode lifecycle test
- cargo clippy --all-targets -- -D warnings
- cargo test --locked
- cargo build --release --locked
- live Ghostty and Codex /keymap debug: detected ctrl + / and resolved global.toggle_side_conversation

All 1,274 locked tests pass locally. The manual od probe produced 1f 0a, proving the original key reached the pane; after mode-aware encoding was added, Codex recognized Ctrl+/ and its side-conversation action end to end.

Fixes #226