### PR TITLE
fix(input): disambiguate Ctrl+Shift+<letter> for nested TUIs

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3752,6 +3752,20 @@ fn encode_key(
                         // an unambiguous key sequence.
                         '/' | '7' => Some('/'),
                         '_' => Some('_'),
+                        // A Ctrl chord on a letter is folded through
+                        // `to_ascii_uppercase() & 0x1f` below, which is caseless:
+                        // Ctrl+Shift+P and Ctrl+P both become 0x10, so an agent
+                        // binding Ctrl+Shift+<letter> silently gets the
+                        // unshifted action. Report the *unshifted* codepoint and
+                        // let `key_modifier_param` carry Shift, as the protocol
+                        // requires — Ctrl+Shift+P is `CSI 112;6u`, never
+                        // `CSI 80;...`, since the shifted codepoint would
+                        // reintroduce the very ambiguity being resolved.
+                        //
+                        // Only diverted when Shift is present: plain Ctrl+P is
+                        // already unambiguous as 0x10, and the disambiguate
+                        // level leaves such keys in their legacy form.
+                        'a'..='z' | 'A'..='Z' if shift => Some(c.to_ascii_lowercase()),
                         _ => None,
                     };
                     if let Some(codepoint) = codepoint {
@@ -4371,6 +4385,44 @@ mod tests {
             "a legacy Ctrl+/ alias regains slash identity for a nested CSI-u client"
         );
         assert_eq!(encode('_', true), Some(b"\x1b[95;5u".to_vec()));
+    }
+
+    /// `Ctrl+Shift+<letter>` must survive the trip to a nested TUI. The legacy
+    /// fold `to_ascii_uppercase() & 0x1f` is caseless, so it maps Ctrl+Shift+P
+    /// and Ctrl+P onto the same 0x10 and an agent binding the shifted chord
+    /// silently gets the unshifted action instead.
+    #[test]
+    fn control_shift_letters_reach_nested_tuis_distinctly() {
+        let encode = |character, modifiers, disambiguate| {
+            encode_key(
+                &KeyEvent::new(KeyCode::Char(character), modifiers),
+                b"\x1b\r",
+                false,
+                disambiguate,
+            )
+        };
+        let ctrl = KeyModifiers::CONTROL;
+        let ctrl_shift = KeyModifiers::CONTROL | KeyModifiers::SHIFT;
+
+        // Legacy encoding cannot separate them; this is the collapse itself.
+        assert_eq!(encode('p', ctrl, false), Some(vec![0x10]));
+        assert_eq!(encode('p', ctrl_shift, false), Some(vec![0x10]));
+
+        // A CSI-u client gets distinct sequences. The codepoint stays lowercase
+        // `p` (112) and Shift rides in the modifier param: 5 = ctrl, 6 = ctrl+shift.
+        assert_eq!(encode('p', ctrl, true), Some(vec![0x10]));
+        assert_eq!(encode('p', ctrl_shift, true), Some(b"\x1b[112;6u".to_vec()));
+        assert_ne!(encode('p', ctrl, true), encode('p', ctrl_shift, true));
+
+        // Crossterm may report the shifted press as uppercase; it must still
+        // report 112, never 80, or the ambiguity returns.
+        assert_eq!(encode('P', ctrl_shift, true), Some(b"\x1b[112;6u".to_vec()));
+
+        // Unshifted Ctrl chords keep their legacy bytes, and plain typing and
+        // Shift-only capitals are untouched by the protocol.
+        assert_eq!(encode('a', ctrl, true), Some(vec![0x01]));
+        assert_eq!(encode('A', KeyModifiers::SHIFT, true), Some(b"A".to_vec()));
+        assert_eq!(encode('a', KeyModifiers::NONE, true), Some(b"a".to_vec()));
     }
 
     #[test]


### PR DESCRIPTION
`Ctrl+Shift+<letter>` now reaches a nested TUI as a distinct chord instead of arriving as plain `Ctrl+<letter>`.

Builds directly on #227 — please take that first. This is a follow-up to it, not a parallel implementation.

## What

- Extends the existing `if disambiguate` `match` in `encode_key` to cover shifted ASCII letters, reusing `csi_u_char` and `key_modifier_param` as-is. No new helpers, no signature changes, no other files touched.
- Reports the **unshifted** codepoint and lets `key_modifier_param` carry Shift, as the protocol requires: `Ctrl+Shift+P` is `CSI 112;6u`, never `CSI 80;...`. Reporting the shifted codepoint would reintroduce the ambiguity being resolved. Crossterm may deliver the press as uppercase `P`, so the arm accepts both cases and lowercases.

Deliberately narrow — diverted **only** when Shift is present:

- Plain `Ctrl+P` stays `0x10`. It is already unambiguous, and the disambiguate level leaves such keys in their legacy form.
- Unmodified typing and `Shift`-only capitals are untouched.
- A pane that never negotiates the protocol sees byte-identical output to today.

## Why

The legacy Ctrl fold is caseless. `(c.to_ascii_uppercase() as u8) & 0x1f` maps both `Ctrl+Shift+P` and `Ctrl+P` onto `0x10`, so Shift has nowhere to go and a pane app cannot tell the two apart.

Agents that bind `Ctrl+Shift+<letter>` therefore get the unshifted action, with nothing to explain why. Pi and OMP both put model cycling on `Ctrl+Shift+P` by default; inside a Luvus pane it silently ran whatever the editor had on `Ctrl+P` — cursor/history motion — and no amount of agent-side keybinding configuration could fix it, because the distinction was already gone before the agent saw the bytes.

#227 established the whole mechanism for this and scoped its CSI-u diversion to `/`, `7`, and `_`, which left letters on the lossy path. This extends that same `match`; the terminal side needed no changes.

## Verification

- [x] `cargo test --locked` — 1260 passed, 0 failed (1 new)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Manual testing, if applicable

New test `control_shift_letters_reach_nested_tuis_distinctly`, placed beside `control_slash_reaches_nested_tuis_across_terminal_encodings` and following its shape. It pins the collapse in legacy mode (both chords `0x10`), the distinct CSI-u forms once negotiated (`0x10` vs `CSI 112;6u`), that an uppercase `P` still reports 112 rather than 80, and that unshifted Ctrl chords, plain typing, and Shift-only capitals are unaffected.

Manual, on macOS/arm64: built `--release` and ran a server under an isolated `--session` so my own session was untouched, then probed a real pane. Pushing `CSI > 1 u` and querying `CSI ? u` returns `\E[?1u`, with `CSI c` unchanged at `\E[?6c` confirming the same emulator answered. Verified against a stock 0.13.2 pane, where the same probe gets no reply to the keyboard query at all.

## Notes

- My manual testing was macOS/arm64 only. CI has since covered the rest: `windows protocol · ConPTY`, `macos test`, and both nix flake jobs all pass, so the Windows console-record path into `encode_key` is exercised.
- Only ASCII letters are diverted. Other Ctrl chords whose legacy byte is unambiguous are intentionally left alone, matching #227's conservatism. Non-ASCII and remaining punctuation could follow separately if you want fuller coverage.
- I first wrote this against `d382cf1` and had independently changed the terminal side — `kitty_keyboard: true` at both config sites, an accessor, and a regression test for the `set_options` teardown. #227 landed the same fixes while I was working, including the two-site detail, so I dropped all of it and rebased onto yours rather than introduce a second accessor beside `disambiguate_escape_codes()`. Mentioning it only in case the earlier force-pushed revision showed up in your notifications.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard input handling for panes using the Kitty keyboard protocol.
  * Ctrl key combinations involving slash, underscore, and shifted letters now preserve their intended key identities.
  * Added support for more precise reporting of Ctrl+Shift letter combinations.

* **Tests**
  * Added coverage for the updated keyboard encoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->