### PR TITLE
feat(keys): add opt-in direct shortcuts

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -268,6 +268,29 @@ mod socket_api_tests {
         );
         app.dispatch(
             "config.patch",
+            &json!({"patch":{"direct_keybindings":{"next_tab":"alt+right"}}}),
+        )
+        .unwrap();
+        assert_eq!(
+            keys::direct_command(
+                &app.direct_keymap,
+                &ratatui::crossterm::event::KeyEvent::new(
+                    ratatui::crossterm::event::KeyCode::Right,
+                    ratatui::crossterm::event::KeyModifiers::ALT,
+                ),
+            ),
+            Some(keys::Cmd::NextTab)
+        );
+        let direct_before = app.config.direct_keybindings.clone();
+        assert!(app
+            .dispatch(
+                "config.patch",
+                &json!({"patch":{"direct_keybindings":{"next_tab":"\u{1b}[1;3C"}}}),
+            )
+            .is_err());
+        assert_eq!(app.config.direct_keybindings, direct_before);
+        app.dispatch(
+            "config.patch",
             &json!({"patch":{"mission_pricing":{"new-model":[1.0,2.0,0.5]}}}),
         )
         .unwrap();
@@ -5297,6 +5320,8 @@ impl App {
                 "config prefix must be F1-F12 or a valid Ctrl/Alt chord".to_string(),
             )
         })?;
+        keys::validate_direct_keybindings(&next.direct_keybindings)
+            .map_err(|message| ("invalid_request".to_string(), message))?;
         if self.theme_registry.get(&next.theme).is_none() && next.theme != "terminal" {
             return Err((
                 "invalid_request".to_string(),
@@ -5306,11 +5331,13 @@ impl App {
         let theme = self.theme_registry.theme_or_default(&next.theme);
         let sidebars = Sidebars::from_config(&next.sidebars());
         let keymap = keys::build_keymap(&next.keybindings);
+        let direct_keymap = keys::build_direct_keymap(&next.direct_keybindings);
         let history_budget = next.scrollback_bytes();
         self.set_effective_theme(&next.theme, theme);
         self.catalog = crate::i18n::by_code(&next.language);
         self.prefix = prefix;
         self.keymap = keymap;
+        self.direct_keymap = direct_keymap;
         self.sidebars = sidebars;
         self.file_tree.show_hidden = next.layout.files_show_hidden;
         self.file_tree.scroll = 0;
@@ -5838,7 +5865,10 @@ fn merge_known_fields(
             format!("{path} cannot be patched as an object"),
         )
     })?;
-    let dynamic_map = matches!(path, "config.keybindings" | "config.mission_pricing");
+    let dynamic_map = matches!(
+        path,
+        "config.keybindings" | "config.direct_keybindings" | "config.mission_pricing"
+    );
     for (key, value) in patch {
         let Some(existing) = target.get_mut(key) else {
             if dynamic_map {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3467,6 +3467,15 @@ impl App {
         if self.mode == Mode::Resize {
             return self.handle_resize_mode_key(key);
         }
+        // Explicit direct shortcuts are the only normal-mode keys Luvus takes
+        // before pane/dashboard dispatch. The configured prefix retains
+        // precedence, and an empty direct map makes this a cheap no-op.
+        if self.mode == Mode::Normal && !self.prefix.matches(&key) {
+            if let Some(command) = keys::direct_command(&self.direct_keymap, &key) {
+                self.run_cmd(command);
+                return true;
+            }
+        }
         // FILES/DIFF dock focus is explicit and separate from terminal-pane
         // focus. The prefix remains available for global commands; ordinary
         // keys never leak into the pane until Esc/q returns control to it.

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -471,6 +471,146 @@ impl PrefixSpec {
     }
 }
 
+/// An opt-in shortcut handled directly in normal mode, without first entering
+/// prefix mode. The configuration stores semantic keys (`alt+right`), never
+/// terminal byte sequences, because the client has already decoded those bytes
+/// into a [`KeyEvent`] before application dispatch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DirectKeySpec {
+    modifiers: KeyModifiers,
+    code: KeyCode,
+}
+
+impl DirectKeySpec {
+    const RELEVANT_MODIFIERS: KeyModifiers = KeyModifiers::CONTROL
+        .union(KeyModifiers::ALT)
+        .union(KeyModifiers::SHIFT);
+
+    pub fn parse(spec: &str) -> Option<Self> {
+        let mut modifiers = KeyModifiers::NONE;
+        let mut code = None;
+        for raw in spec.split('+') {
+            let part = raw.trim().to_ascii_lowercase();
+            match part.as_str() {
+                "" => {}
+                "ctrl" | "control" => modifiers.insert(KeyModifiers::CONTROL),
+                "alt" | "option" | "opt" => modifiers.insert(KeyModifiers::ALT),
+                "shift" => modifiers.insert(KeyModifiers::SHIFT),
+                "left" if code.is_none() => code = Some(KeyCode::Left),
+                "right" if code.is_none() => code = Some(KeyCode::Right),
+                "up" if code.is_none() => code = Some(KeyCode::Up),
+                "down" if code.is_none() => code = Some(KeyCode::Down),
+                "home" if code.is_none() => code = Some(KeyCode::Home),
+                "end" if code.is_none() => code = Some(KeyCode::End),
+                "pageup" | "page-up" if code.is_none() => code = Some(KeyCode::PageUp),
+                "pagedown" | "page-down" if code.is_none() => code = Some(KeyCode::PageDown),
+                "tab" if code.is_none() => code = Some(KeyCode::Tab),
+                "enter" | "return" if code.is_none() => code = Some(KeyCode::Enter),
+                "esc" | "escape" if code.is_none() => code = Some(KeyCode::Esc),
+                "delete" | "del" if code.is_none() => code = Some(KeyCode::Delete),
+                "insert" | "ins" if code.is_none() => code = Some(KeyCode::Insert),
+                "space" | "spc" if code.is_none() => code = Some(KeyCode::Char(' ')),
+                "plus" if code.is_none() => code = Some(KeyCode::Char('+')),
+                other if code.is_none() => {
+                    if let Some(number) = other
+                        .strip_prefix('f')
+                        .and_then(|value| value.parse::<u8>().ok())
+                        .filter(|number| (1..=12).contains(number))
+                    {
+                        code = Some(KeyCode::F(number));
+                    } else if other.chars().count() == 1 && other.is_ascii() {
+                        code = Some(KeyCode::Char(other.chars().next()?));
+                    } else {
+                        return None;
+                    }
+                }
+                _ => return None,
+            }
+        }
+
+        let code = code?;
+        if modifiers.is_empty() {
+            return None;
+        }
+        if matches!(code, KeyCode::Char(_))
+            && !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            return None;
+        }
+        Some(Self { modifiers, code })
+    }
+
+    fn matches(&self, key: &KeyEvent) -> bool {
+        if key
+            .modifiers
+            .intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META)
+            || key.modifiers & Self::RELEVANT_MODIFIERS != self.modifiers
+        {
+            return false;
+        }
+        // A Windows AltGr character is reported as Ctrl+Alt. Never turn typed
+        // characters into direct commands merely because their layout needs
+        // AltGr; navigation keys with the same modifiers remain bindable.
+        if cfg!(windows)
+            && matches!(key.code, KeyCode::Char(_))
+            && key
+                .modifiers
+                .contains(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            return false;
+        }
+        match (self.code, key.code) {
+            (KeyCode::Char(expected), KeyCode::Char(actual)) => {
+                expected.eq_ignore_ascii_case(&actual)
+            }
+            (KeyCode::Tab, KeyCode::BackTab) => self.modifiers.contains(KeyModifiers::SHIFT),
+            (expected, actual) => expected == actual,
+        }
+    }
+}
+
+pub type DirectKeymap = Vec<(DirectKeySpec, Cmd)>;
+
+/// Build only explicitly configured direct shortcuts. Unlike prefix bindings,
+/// this has no defaults: normal pane input remains untouched after upgrades.
+pub fn build_direct_keymap(overrides: &HashMap<String, String>) -> DirectKeymap {
+    let mut bindings: DirectKeymap = Vec::new();
+    for &cmd in Cmd::ALL {
+        let Some(spec) = overrides
+            .get(cmd.id())
+            .filter(|spec| !spec.is_empty())
+            .and_then(|spec| DirectKeySpec::parse(spec))
+        else {
+            continue;
+        };
+        if let Some(index) = bindings.iter().position(|(existing, _)| *existing == spec) {
+            bindings.remove(index);
+        }
+        bindings.push((spec, cmd));
+    }
+    bindings
+}
+
+pub fn direct_command(bindings: &DirectKeymap, key: &KeyEvent) -> Option<Cmd> {
+    bindings
+        .iter()
+        .find_map(|(spec, command)| spec.matches(key).then_some(*command))
+}
+
+pub fn validate_direct_keybindings(overrides: &HashMap<String, String>) -> Result<(), String> {
+    for &cmd in Cmd::ALL {
+        if let Some(spec) = overrides.get(cmd.id()).filter(|spec| !spec.is_empty()) {
+            if DirectKeySpec::parse(spec).is_none() {
+                return Err(format!(
+                    "direct binding {} must be a modified semantic key such as alt+right",
+                    cmd.id()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Build the active `key → Cmd` map from the (id → key) config overrides on top
 /// of every command's [`Cmd::default_keys`] (docs/64). There is no separate
 /// hardcoded alias block: aliases are just extra default keys, so a user who
@@ -896,6 +1036,108 @@ mod tests {
             f12.key_event(),
             KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE)
         );
+    }
+
+    #[test]
+    fn direct_bindings_parse_semantic_modified_keys_only() {
+        let alt = KeyModifiers::ALT;
+        let right = DirectKeySpec::parse("alt+right").unwrap();
+        assert!(right.matches(&KeyEvent::new(KeyCode::Right, alt)));
+        assert!(!right.matches(&KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)));
+        assert!(!right.matches(&KeyEvent::new(KeyCode::Left, alt)));
+
+        assert!(DirectKeySpec::parse("ctrl+alt+left").is_some());
+        assert!(DirectKeySpec::parse("shift+f12").is_some());
+        assert!(DirectKeySpec::parse("alt+space").is_some());
+        assert_eq!(DirectKeySpec::parse("right"), None);
+        assert_eq!(DirectKeySpec::parse("shift+x"), None);
+        assert_eq!(DirectKeySpec::parse("\x1b[1;3C"), None);
+    }
+
+    #[test]
+    fn direct_bindings_are_opt_in_and_resolve_command_collisions() {
+        assert!(build_direct_keymap(&HashMap::new()).is_empty());
+
+        let mut configured = HashMap::new();
+        configured.insert(Cmd::PrevTab.id().to_string(), "alt+left".to_string());
+        configured.insert(Cmd::NextTab.id().to_string(), "alt+right".to_string());
+        let bindings = build_direct_keymap(&configured);
+        assert_eq!(
+            direct_command(&bindings, &KeyEvent::new(KeyCode::Left, KeyModifiers::ALT)),
+            Some(Cmd::PrevTab)
+        );
+        assert_eq!(
+            direct_command(&bindings, &KeyEvent::new(KeyCode::Right, KeyModifiers::ALT)),
+            Some(Cmd::NextTab)
+        );
+
+        configured.insert(Cmd::PrevTab.id().to_string(), "alt+right".to_string());
+        let bindings = build_direct_keymap(&configured);
+        assert_eq!(
+            direct_command(&bindings, &KeyEvent::new(KeyCode::Right, KeyModifiers::ALT)),
+            Some(Cmd::PrevTab),
+            "the later command in the stable command list owns a duplicate chord"
+        );
+    }
+
+    #[test]
+    fn direct_alt_arrows_switch_tabs_without_changing_prefix_bindings() {
+        let _env = crate::persist::test_env("direct-alt-tab-switch");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.run_cmd(Cmd::NewTab);
+        app.run_cmd(Cmd::NewTab);
+        assert_eq!(app.ws().active_tab, 2);
+
+        app.config
+            .direct_keybindings
+            .insert(Cmd::PrevTab.id().into(), "alt+left".into());
+        app.config
+            .direct_keybindings
+            .insert(Cmd::NextTab.id().into(), "alt+right".into());
+        app.direct_keymap = build_direct_keymap(&app.config.direct_keybindings);
+
+        assert!(app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Left,
+            KeyModifiers::ALT,
+        ))));
+        assert_eq!(app.ws().active_tab, 1);
+        assert!(app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Right,
+            KeyModifiers::ALT,
+        ))));
+        assert_eq!(app.ws().active_tab, 2);
+
+        app.direct_keymap.clear();
+        assert!(!app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Left,
+            KeyModifiers::ALT,
+        ))));
+        assert_eq!(
+            app.ws().active_tab,
+            2,
+            "unbound Alt+Left returns to the pane"
+        );
+    }
+
+    #[test]
+    fn configured_prefix_takes_precedence_over_a_direct_collision() {
+        let _env = crate::persist::test_env("direct-prefix-precedence");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.run_cmd(Cmd::NewTab);
+        let active = app.ws().active_tab;
+        app.config
+            .direct_keybindings
+            .insert(Cmd::PrevTab.id().into(), "ctrl+space".into());
+        app.direct_keymap = build_direct_keymap(&app.config.direct_keybindings);
+
+        assert!(app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char(' '),
+            KeyModifiers::CONTROL,
+        ))));
+        assert_eq!(app.mode, Mode::Prefix);
+        assert_eq!(app.ws().active_tab, active);
     }
 
     #[test]

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -24,6 +24,27 @@ pub fn is_ctrl_chord(mods: KeyModifiers) -> bool {
     mods.contains(KeyModifiers::CONTROL) && !(cfg!(windows) && mods.contains(KeyModifiers::ALT))
 }
 
+const SHORTCUT_MODIFIERS: KeyModifiers = KeyModifiers::CONTROL
+    .union(KeyModifiers::ALT)
+    .union(KeyModifiers::SHIFT);
+
+/// Ctrl+Space has several equivalent terminal encodings. Prefix and direct
+/// shortcuts must share this compatibility boundary.
+fn matches_ctrl_space_event(key: &KeyEvent) -> bool {
+    let modifiers = key.modifiers & SHORTCUT_MODIFIERS;
+    match key.code {
+        KeyCode::Null => key.modifiers.is_empty() || key.modifiers == KeyModifiers::CONTROL,
+        KeyCode::Char(' ') => modifiers == KeyModifiers::CONTROL,
+        // Some terminals retain the physical Shift used to type `@`; both
+        // Ctrl+@ forms represent NUL/Ctrl+Space.
+        KeyCode::Char('@') => {
+            modifiers == KeyModifiers::CONTROL
+                || modifiers == (KeyModifiers::CONTROL | KeyModifiers::SHIFT)
+        }
+        _ => false,
+    }
+}
+
 /// A prefix-mode command — the thing a key triggers after `Ctrl+Space`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Cmd {
@@ -341,10 +362,6 @@ impl Default for PrefixSpec {
 }
 
 impl PrefixSpec {
-    const RELEVANT_MODIFIERS: KeyModifiers = KeyModifiers::CONTROL
-        .union(KeyModifiers::ALT)
-        .union(KeyModifiers::SHIFT);
-
     /// Parse canonical specs such as `ctrl+space`, `alt+\`, `shift+f12`, or
     /// plain `f12`. Bare text remains invalid because it would swallow typing.
     pub fn parse(s: &str) -> Option<Self> {
@@ -424,21 +441,9 @@ impl PrefixSpec {
             return false;
         }
         if self.code == KeyCode::Char(' ') && self.modifiers == KeyModifiers::CONTROL {
-            if key.code == KeyCode::Null {
-                return key.modifiers.is_empty() || key.modifiers == KeyModifiers::CONTROL;
-            }
-            let modifiers = key.modifiers & Self::RELEVANT_MODIFIERS;
-            if matches!(key.code, KeyCode::Char(' ')) {
-                return modifiers == KeyModifiers::CONTROL;
-            }
-            // Some terminals spell Ctrl+Space as Ctrl+@ and may retain the
-            // physical Shift needed to type `@`; both encodings are NUL.
-            if matches!(key.code, KeyCode::Char('@')) {
-                return modifiers == KeyModifiers::CONTROL
-                    || modifiers == (KeyModifiers::CONTROL | KeyModifiers::SHIFT);
-            }
+            return matches_ctrl_space_event(key);
         }
-        if key.modifiers & Self::RELEVANT_MODIFIERS != self.modifiers {
+        if key.modifiers & SHORTCUT_MODIFIERS != self.modifiers {
             return false;
         }
         match (self.code, key.code) {
@@ -482,10 +487,6 @@ pub struct DirectKeySpec {
 }
 
 impl DirectKeySpec {
-    const RELEVANT_MODIFIERS: KeyModifiers = KeyModifiers::CONTROL
-        .union(KeyModifiers::ALT)
-        .union(KeyModifiers::SHIFT);
-
     pub fn parse(spec: &str) -> Option<Self> {
         let mut modifiers = KeyModifiers::NONE;
         let mut code = None;
@@ -544,8 +545,13 @@ impl DirectKeySpec {
         if key
             .modifiers
             .intersects(KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META)
-            || key.modifiers & Self::RELEVANT_MODIFIERS != self.modifiers
         {
+            return false;
+        }
+        if self.code == KeyCode::Char(' ') && self.modifiers == KeyModifiers::CONTROL {
+            return matches_ctrl_space_event(key);
+        }
+        if key.modifiers & SHORTCUT_MODIFIERS != self.modifiers {
             return false;
         }
         // A Windows AltGr character is reported as Ctrl+Alt. Never turn typed
@@ -1052,6 +1058,20 @@ mod tests {
         assert_eq!(DirectKeySpec::parse("right"), None);
         assert_eq!(DirectKeySpec::parse("shift+x"), None);
         assert_eq!(DirectKeySpec::parse("\x1b[1;3C"), None);
+
+        let ctrl_space = DirectKeySpec::parse("ctrl+space").unwrap();
+        assert!(ctrl_space.matches(&KeyEvent::new(KeyCode::Null, KeyModifiers::NONE)));
+        assert!(ctrl_space.matches(&KeyEvent::new(KeyCode::Null, KeyModifiers::CONTROL)));
+        assert!(ctrl_space.matches(&KeyEvent::new(KeyCode::Char('@'), KeyModifiers::CONTROL)));
+        assert!(ctrl_space.matches(&KeyEvent::new(
+            KeyCode::Char('@'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT
+        )));
+        assert!(!ctrl_space.matches(&KeyEvent::new(KeyCode::Char('@'), KeyModifiers::SHIFT)));
+        assert!(!ctrl_space.matches(&KeyEvent::new(
+            KeyCode::Char(' '),
+            KeyModifiers::CONTROL | KeyModifiers::SUPER
+        )));
     }
 
     #[test]
@@ -1138,6 +1158,41 @@ mod tests {
         ))));
         assert_eq!(app.mode, Mode::Prefix);
         assert_eq!(app.ws().active_tab, active);
+    }
+
+    #[test]
+    fn direct_shortcuts_remain_global_over_focused_surfaces() {
+        let _env = crate::persist::test_env("direct-global-surfaces");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.run_cmd(Cmd::NewTab);
+        app.config
+            .direct_keybindings
+            .insert(Cmd::PrevTab.id().into(), "alt+left".into());
+        app.direct_keymap = build_direct_keymap(&app.config.direct_keybindings);
+
+        app.files_focused = true;
+        assert!(app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Left,
+            KeyModifiers::ALT,
+        ))));
+        assert_eq!(
+            app.ws().active_tab,
+            0,
+            "FILES does not consume the shortcut"
+        );
+
+        app.files_focused = false;
+        app.open_mission_control(0);
+        assert!(app.active_is_mission());
+        assert!(app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Left,
+            KeyModifiers::ALT,
+        ))));
+        assert!(
+            !app.active_is_mission(),
+            "dashboard input does not consume the shortcut"
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1559,6 +1559,9 @@ pub struct App {
     pub config: crate::config::Config,
     /// Active `key → Cmd` map for prefix mode (defaults + config overrides).
     pub keymap: std::collections::HashMap<String, Cmd>,
+    /// Explicit normal-mode shortcuts. Empty by default so pane input remains
+    /// authoritative unless the user opts a chord into Luvus handling.
+    pub direct_keymap: keys::DirectKeymap,
     /// The parsed prefix chord (docs/64), from `config.prefix`. Default Ctrl+Space.
     pub prefix: keys::PrefixSpec,
     /// The open Settings modal, if any (`Some` ⇒ modal captures input).
@@ -2104,6 +2107,7 @@ impl App {
         let sidebars = Sidebars::from_config(&config.sidebars());
         let shell = crate::platform::resolve_shell(&config.shell);
         let keymap = keys::build_keymap(&config.keybindings);
+        let direct_keymap = keys::build_direct_keymap(&config.direct_keybindings);
         let prefix = keys::PrefixSpec::parse(&config.prefix).unwrap_or_default();
         let modules = crate::module::registry::load();
         let mut bar = crate::bar::BarState::default();
@@ -2166,6 +2170,7 @@ impl App {
             catalog,
             config,
             keymap,
+            direct_keymap,
             prefix,
             agent_names: HashMap::new(),
             settings: None,
@@ -2424,6 +2429,7 @@ impl App {
         let theme = theme_registry.theme_or_default(&config.theme);
         let pane_appearance = child_appearance(&theme_registry, &config.theme, &theme, None);
         let keymap = keys::build_keymap(&config.keybindings);
+        let direct_keymap = keys::build_direct_keymap(&config.direct_keybindings);
         let prefix = keys::PrefixSpec::parse(&config.prefix).unwrap_or_default();
         let shell = crate::platform::resolve_shell(&config.shell);
         let history_budget_bytes = config.scrollback_bytes();
@@ -2779,6 +2785,7 @@ impl App {
             catalog,
             config,
             keymap,
+            direct_keymap,
             prefix,
             agent_names,
             settings: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,11 @@ pub struct Config {
     /// An empty value means the command is explicitly unbound.
     #[serde(default)]
     pub keybindings: std::collections::HashMap<String, String>,
+    /// Opt-in shortcuts handled without the command prefix: command id →
+    /// structured chord such as `alt+right`. Empty by default so normal shell
+    /// and nested-TUI input is never intercepted unless the user requests it.
+    #[serde(default)]
+    pub direct_keybindings: std::collections::HashMap<String, String>,
     /// The safe prefix that opens command mode (docs/64): an F1-F12 key or a
     /// Ctrl/Alt character chord such as `ctrl+space`, `ctrl+b`, or `alt+\\`.
     /// Plain text keys are rejected so normal terminal typing is never swallowed.
@@ -443,6 +448,7 @@ impl Default for Config {
             resume_launch_flags: false,
             agents_active_only: false,
             keybindings: std::collections::HashMap::new(),
+            direct_keybindings: std::collections::HashMap::new(),
             prefix: default_prefix(),
             mission_pricing: std::collections::HashMap::new(),
             mission_budget: None,
@@ -624,6 +630,10 @@ mod tests {
         assert_eq!(from_empty.theme, "quattro-rally");
         assert_eq!(from_empty.sidebar_width, SIDEBAR_WIDTH_DEFAULT);
         assert!(
+            from_empty.direct_keybindings.is_empty(),
+            "existing configs do not gain input-stealing direct shortcuts"
+        );
+        assert!(
             !from_empty.agents_active_only,
             "old configs retain the All agents default"
         );
@@ -657,6 +667,16 @@ mod tests {
         // the new preview default without their `file_open` choice moving.
         assert_eq!(old.layout.file_click, FILE_CLICK_PREVIEW);
         assert_eq!(c.layout.file_click, FILE_CLICK_PREVIEW);
+        let mut direct = Config::default();
+        direct
+            .direct_keybindings
+            .insert("next_tab".into(), "alt+right".into());
+        let direct_json = serde_json::to_string(&direct).unwrap();
+        let direct_roundtrip: Config = serde_json::from_str(&direct_json).unwrap();
+        assert_eq!(
+            direct_roundtrip.direct_keybindings.get("next_tab"),
+            Some(&"alt+right".to_string())
+        );
         let picked: Config = serde_json::from_str(r#"{"layout":{"file_click":"tab"}}"#).unwrap();
         assert_eq!(picked.layout.file_click, FILE_CLICK_TAB);
         let old_custom: Config = serde_json::from_str(r#"{"layout":{"scrollback":5000}}"#).unwrap();

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -166,11 +166,11 @@ The default state root is `~/.luvus/`. Debug builds use `~/.luvus-dev/`, and
 another or copy state between them unless the human requests a migration.
 
 User preferences live in `config.json`, not TOML. It contains the theme,
-language, shell, layout, notifications, keybindings, sidebars, and Luvus Bar
-placement. Prefer the in-app Settings screen because it validates changes,
-applies supported settings live, and writes the file. Hand edits are loaded on
-restart. Preserve unknown keys and do not rewrite the file just to change one
-setting.
+language, shell, layout, notifications, prefix keybindings, opt-in direct
+keybindings, sidebars, and Luvus Bar placement. Prefer the in-app Settings
+screen because it validates changes, applies supported settings live, and
+writes the file. Hand edits are loaded on restart. Preserve unknown keys and do
+not rewrite the file just to change one setting.
 
 The default session stores runtime files directly under the state root. Named
 sessions keep their server-specific runtime files under

--- a/website/src/content/docs/docs/reference/api.mdx
+++ b/website/src/content/docs/docs/reference/api.mdx
@@ -174,9 +174,9 @@ the block keeps its supplied order, and the active workspace remains active.
 `config.get` returns the normalized live config. `config.patch` takes
 `{"patch":{...}}`, recursively merges only known fields, validates the result,
 applies theme, language, keymap, prefix, sidebars, layout gaps, file visibility,
-and pane history budgets live, then persists atomically. Unknown or invalid
-fields leave the current config unchanged. `server.reload_config` reloads the
-on-disk config through the same apply path.
+opt-in direct shortcuts, and pane history budgets live, then persists
+atomically. Unknown or invalid fields leave the current config unchanged.
+`server.reload_config` reloads the on-disk config through the same apply path.
 
 `server.agent_manifests` returns the active recognized agent names and rule
 count. `server.reload_agent_manifests` reloads built-in, managed, and user

--- a/website/src/content/docs/docs/reference/configuration.mdx
+++ b/website/src/content/docs/docs/reference/configuration.mdx
@@ -47,6 +47,7 @@ cleanly across versions because unknown fields get defaults.
 | `sidebars.files_side` | last side used by the FILES dock (`left` or `right`), retained while the dock is hidden |
 | `prefix` | the command-mode prefix (default `ctrl+space`). Accepts `f1`–`f12` as safe single keys, or a character/Space chord containing `Ctrl` or `Alt`, such as `ctrl+b`, `alt+\`, or `shift+f12` (see [Keybindings](/docs/reference/keybindings/)) |
 | `keybindings` | command id → key, overriding the defaults |
+| `direct_keybindings` | opt-in command id → modified semantic chord handled without the prefix. It is empty by default; configured chords are intercepted instead of reaching the focused pane (see [Keybindings](/docs/reference/keybindings/#opt-in-direct-shortcuts)). |
 | `bars.top_right` / `bars.bottom_right` / `bars.off` | canonical widget ids (`module:id`) in each Luvus Bar placement. `core:runtime-status` defaults to Bottom. Live content and notifications are never persisted. |
 
 ## Environment variables

--- a/website/src/content/docs/docs/reference/keybindings.mdx
+++ b/website/src/content/docs/docs/reference/keybindings.mdx
@@ -125,9 +125,11 @@ without the prefix. For example, this enables direct tab switching:
 ```
 
 Direct shortcuts deliberately take the configured keys away from the focused
-shell or nested TUI. Use semantic chords such as `alt+right`, not terminal byte
-sequences such as `ESC[1;3C`. Supported names include arrows, `home`, `end`,
-`pageup`, `pagedown`, `tab`, `enter`, `esc`, `delete`, `insert`, `space`, and
-`f1`–`f12`; every chord must contain `Ctrl`, `Alt`, or `Shift`, and printable
-characters additionally require `Ctrl` or `Alt`. The configured Luvus prefix
-wins if the same chord appears in both places.
+shell, nested TUI, focused FILES/DIFF dock, or dashboard. They are global in
+normal mode; an open modal, text editor, scroll/copy/resize mode, or the
+configured Luvus prefix still takes precedence. Use semantic chords such as
+`alt+right`, not terminal byte sequences such as `ESC[1;3C`. Supported names
+include arrows, `home`, `end`, `pageup`, `pagedown`, `tab`, `enter`, `esc`,
+`delete`, `insert`, `space`, and `f1`–`f12`; every chord must contain `Ctrl`,
+`Alt`, or `Shift`, and printable characters additionally require `Ctrl` or
+`Alt`.

--- a/website/src/content/docs/docs/reference/keybindings.mdx
+++ b/website/src/content/docs/docs/reference/keybindings.mdx
@@ -109,3 +109,25 @@ Custom bindings persist in `config.json`: `prefix` holds the prefix chord, and
 Pressing the configured prefix and then `?` shows the current map, and every command is editable in
 **Settings → Keys** (the vim `hjkl` and `Tab` aliases included, since nothing is
 bound behind your back).
+
+### Opt-in direct shortcuts
+
+`direct_keybindings` is a separate, empty-by-default map for shortcuts that run
+without the prefix. For example, this enables direct tab switching:
+
+```json
+{
+  "direct_keybindings": {
+    "prev_tab": "alt+left",
+    "next_tab": "alt+right"
+  }
+}
+```
+
+Direct shortcuts deliberately take the configured keys away from the focused
+shell or nested TUI. Use semantic chords such as `alt+right`, not terminal byte
+sequences such as `ESC[1;3C`. Supported names include arrows, `home`, `end`,
+`pageup`, `pagedown`, `tab`, `enter`, `esc`, `delete`, `insert`, `space`, and
+`f1`–`f12`; every chord must contain `Ctrl`, `Alt`, or `Shift`, and printable
+characters additionally require `Ctrl` or `Alt`. The configured Luvus prefix
+wins if the same chord appears in both places.


### PR DESCRIPTION
## Summary

Add an explicit `direct_keybindings` config surface for shortcuts that should run without entering Luvus prefix mode. This fixes direct Alt+Arrow tab switching while keeping the existing prefix-first model and focused-pane input behavior unchanged by default.

## What changed

- add an empty-by-default `direct_keybindings` map alongside the existing prefix `keybindings`
- parse semantic modified chords such as `alt+left`, `alt+right`, `ctrl+space`, navigation keys, and F1-F12
- reject unmodified keys, unsafe printable Shift-only shortcuts, and raw terminal byte sequences such as `ESC[1;3C`
- dispatch configured shortcuts in normal mode before pane forwarding
- preserve modal, focused mode, and configured prefix precedence
- avoid intercepting Windows AltGr character input
- apply and validate direct bindings live through `config.patch` and `server.reload_config`
- document configuration, UHP config behavior, supported chord names, and the Alt+Arrow example

## Example

```json
{
  "direct_keybindings": {
    "prev_tab": "alt+left",
    "next_tab": "alt+right"
  }
}
```

With no `direct_keybindings` entry, Alt+Arrow and all other normal input continue to reach the focused shell or nested TUI.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- focused direct parser, dispatch, prefix precedence, config patch, and config round-trip tests
- `cargo test --locked` — 1,276 tests passed
- `cargo build --release --locked`
- `bun run build` in `website/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in direct keyboard shortcuts that run commands without entering prefix mode.
  * Supports configured semantic key combinations such as `Alt+Left` and `Alt+Right`.
  * Prefix shortcuts take precedence when bindings overlap.
  * Invalid shortcut configurations are rejected without changing existing settings.

* **Documentation**
  * Added configuration and keybinding guidance for direct shortcuts, including input-handling considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->