### PR TITLE
perf(render): replace working spinner with static status

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1646,7 +1646,6 @@ pub struct App {
     /// outlives its windows. Closing the last project replaces it with a neutral
     /// terminal rooted at `$HOME`; only `server stop` ends the server.
     pub server_mode: bool,
-    pub spinner: u64,
     /// Structure changed since the last save; the loop persists when set.
     pub session_dirty: bool,
     pub events: EventBus,
@@ -2206,7 +2205,6 @@ impl App {
             zoomed: false,
             should_quit: false,
             server_mode: false,
-            spinner: 0,
             session_dirty: true,
             events: api::new_bus(),
             orch: crate::orch::OrchState::load(),
@@ -2821,7 +2819,6 @@ impl App {
             zoomed: false,
             should_quit: false,
             server_mode: false,
-            spinner: 0,
             session_dirty: false,
             events: api::new_bus(),
             orch: crate::orch::OrchState::load(),
@@ -3292,14 +3289,6 @@ impl App {
     }
 
     // ── accessors ───────────────────────────────────────────────────────────
-
-    /// True if any pane is currently Working — drives the sidebar spinner and
-    /// how often the loop repaints to animate it.
-    pub fn any_working(&self) -> bool {
-        self.status
-            .values()
-            .any(|s| s.state == crate::ui::theme::State::Working)
-    }
 
     /// Re-arm every pane's PTY wake-coalescing flag (see `Pane.data_pending`),
     /// letting the readers announce fresh output again. Returns whether any
@@ -10427,8 +10416,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
-    // A working agent shows an animated rotating-circle spinner in the AGENTS
-    // list dot slot (not the static `●`), advancing with `App.spinner`.
     // Clicking a pane's title opens the running-command overlay. The point is
     // that the command comes from the OS, not the screen: an agent's own UI
     // elides long commands and those characters never reach luvus at all.
@@ -10488,10 +10475,10 @@ mod tests {
     }
 
     #[test]
-    fn working_agent_shows_spinner() {
+    fn working_agent_shows_filled_status() {
         use ratatui::{backend::TestBackend, Terminal};
         // Isolate `$LUVUS_HOME`: with the developer's real config a different
-        // dock layout can push the AGENTS rows out of view, so the spinner is
+        // dock layout can push the AGENTS rows out of view, so the status is
         // never drawn and this fails depending on test order.
         let _env = crate::persist::test_env("spinner");
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -10502,27 +10489,21 @@ mod tests {
         ps.state = crate::ui::theme::State::Working;
         app.status.insert(pid, ps);
 
-        // Take the frame set from the theme rather than hardcoding glyphs, so
-        // changing the spinner's look never silently breaks this test.
-        let frames: Vec<&str> = (0..crate::ui::theme::SPINNER_FRAMES)
-            .map(crate::ui::theme::spinner_frame)
-            .collect();
-        let frame_at = |app: &mut App, spin: u64| -> String {
-            app.spinner = spin;
-            let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
-            term.draw(|f| crate::ui::render(f, app)).unwrap();
-            let buf = term.backend().buffer().clone();
-            // The dot is the first glyph of the agent row inside the sidebar.
-            (0..buf.area.height)
-                .flat_map(|r| (0..buf.area.width).map(move |c| (c, r)))
-                .filter_map(|(c, r)| buf.cell((c, r)).map(|x| x.symbol().to_string()))
-                .find(|s| frames.contains(&s.as_str()))
-                .unwrap_or_default()
-        };
-        let f0 = frame_at(&mut app, 0);
-        let f1 = frame_at(&mut app, 1);
-        assert!(!f0.is_empty(), "a working agent shows a spinner glyph");
-        assert_ne!(f0, f1, "the spinner advances with app.spinner");
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let buf = term.backend().buffer();
+        let rows = (0..buf.area.height)
+            .map(|r| {
+                (0..buf.area.width)
+                    .map(|c| buf.cell((c, r)).map(|cell| cell.symbol()).unwrap_or(" "))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("● working") && row.contains("claude")),
+            "a working agent shows a static filled status marker"
+        );
     }
 
     // An agent that finishes a working stretch (Working → Idle) queues the

--- a/src/bar/mod.rs
+++ b/src/bar/mod.rs
@@ -578,31 +578,6 @@ impl BarState {
         changed
     }
 
-    pub fn has_visible_working(&self, config: &crate::config::BarConfig, compact: bool) -> bool {
-        let widgets = self.widgets.iter().filter_map(|(key, widget)| {
-            let visible = if key == CORE_AGENTS {
-                compact
-            } else {
-                config.region_for(key, widget.region).is_some()
-            };
-            visible.then_some(widget)
-        });
-        let notifications = (!compact)
-            .then_some(
-                self.notifications
-                    .iter()
-                    .map(|notification| &notification.widget),
-            )
-            .into_iter()
-            .flatten();
-        widgets
-            .chain(notifications)
-            .flat_map(|widget| widget.content.iter().chain(&widget.compact_content))
-            .any(|segment| {
-                matches!(&segment.kind, BarSegmentKind::State { state, .. } if state == "working")
-            })
-    }
-
     pub fn declaration(&self, canonical: &str) -> Option<&BarDeclaration> {
         self.declarations.get(canonical)
     }
@@ -1189,33 +1164,6 @@ mod tests {
             1,
         );
         assert!(bad.unwrap_err().contains("control"));
-    }
-
-    #[test]
-    fn spinner_work_only_tracks_widgets_visible_in_the_current_chrome() {
-        let mut state = BarState::default();
-        let working = BarWidget::new(
-            BarWidgetKey::new("test", "job"),
-            BarRegion::TopRight,
-            vec![BarSegment {
-                kind: BarSegmentKind::State {
-                    state: "working".into(),
-                    label: None,
-                },
-                tone: BarTone::Normal,
-                action: None,
-                value: None,
-            }],
-            Vec::new(),
-            1,
-        )
-        .unwrap();
-        state.push_widget(working).unwrap();
-
-        let mut config = crate::config::BarConfig::default();
-        assert!(state.has_visible_working(&config, false));
-        config.place("test:job", None);
-        assert!(!state.has_visible_working(&config, false));
     }
 
     #[test]

--- a/src/bar/render.rs
+++ b/src/bar/render.rs
@@ -9,7 +9,7 @@ use super::{
     BarHit, BarLayout, BarRegion, BarSegment, BarSegmentKind, BarState, BarTone, OverflowHit,
     WidgetCandidate,
 };
-use crate::ui::theme::{spinner_frame, State, Theme};
+use crate::ui::theme::{State, Theme};
 use crate::ui::RenderTarget;
 use std::borrow::Cow;
 
@@ -19,7 +19,6 @@ pub fn draw_region(
     region: BarRegion,
     candidates: &[WidgetCandidate<'_>],
     layout: &BarLayout,
-    spinner: u64,
     t: &Theme,
 ) -> (Vec<BarHit>, Option<OverflowHit>) {
     if area.width == 0 || area.height == 0 || layout.is_empty() {
@@ -47,7 +46,6 @@ pub fn draw_region(
                 f,
                 rect,
                 segment,
-                spinner,
                 candidate.key == super::CORE_RUNTIME && segment_index == 0,
                 t,
             );
@@ -98,7 +96,6 @@ fn draw_segment(
     f: &mut RenderTarget,
     rect: Rect,
     segment: &BarSegment,
-    spinner: u64,
     core_runtime_label: bool,
     t: &Theme,
 ) {
@@ -108,12 +105,7 @@ fn draw_segment(
         }
         BarSegmentKind::State { state, label } => {
             let state = parse_state(state);
-            let glyph = if state == State::Working {
-                f.mark_working_animation();
-                spinner_frame(spinner)
-            } else {
-                state.dot()
-            };
+            let glyph = state.dot();
             let text = label
                 .as_ref()
                 .map(|label| format!("{glyph} {label}"))
@@ -253,6 +245,35 @@ pub fn draw_overflow(f: &mut RenderTarget, area: Rect, state: &mut BarState, t: 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::buffer::Buffer;
+
+    #[test]
+    fn working_state_uses_static_filled_marker() {
+        let area = Rect::new(0, 0, 16, 1);
+        let mut buffer = Buffer::empty(area);
+        let mut target = RenderTarget::new(&mut buffer, area);
+        let segment = BarSegment {
+            kind: BarSegmentKind::State {
+                state: "working".into(),
+                label: Some("agent".into()),
+            },
+            tone: BarTone::Normal,
+            action: None,
+            value: None,
+        };
+        draw_segment(
+            &mut target,
+            area,
+            &segment,
+            false,
+            &crate::ui::theme::by_name("quattro-rally"),
+        );
+
+        let rendered = (0..area.width)
+            .map(|x| buffer.cell((x, 0)).map(|cell| cell.symbol()).unwrap_or(" "))
+            .collect::<String>();
+        assert!(rendered.starts_with("● agent"));
+    }
 
     #[test]
     fn top_overflow_reserves_its_anchor_row_without_losing_a_fitting_item() {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -60,6 +60,8 @@ static CAUSE_VISIBLE_PTY: AtomicU64 = AtomicU64::new(0);
 static CAUSE_BACKGROUND_PTY: AtomicU64 = AtomicU64::new(0);
 static CAUSE_DETECTION: AtomicU64 = AtomicU64::new(0);
 static CAUSE_METADATA: AtomicU64 = AtomicU64::new(0);
+// Retained in diagnostics for consumers that compare snapshots across releases.
+// Working-state indicators are static, so this counter remains zero.
 static CAUSE_ANIMATION: AtomicU64 = AtomicU64::new(0);
 static CAUSE_UI: AtomicU64 = AtomicU64::new(0);
 static CAUSE_API_MAINTENANCE: AtomicU64 = AtomicU64::new(0);
@@ -105,7 +107,6 @@ enum RenderCause {
     VisiblePty,
     Detection,
     Metadata,
-    Animation,
     UserInterface,
     ApiOrMaintenance,
     ForcedRepair,
@@ -123,7 +124,6 @@ impl RenderCause {
             Self::VisiblePty => &CAUSE_VISIBLE_PTY,
             Self::Detection => &CAUSE_DETECTION,
             Self::Metadata => &CAUSE_METADATA,
-            Self::Animation => &CAUSE_ANIMATION,
             Self::UserInterface => &CAUSE_UI,
             Self::ApiOrMaintenance => &CAUSE_API_MAINTENANCE,
             Self::ForcedRepair => &CAUSE_FORCED,
@@ -213,7 +213,6 @@ struct ClientState {
     behind: bool,
     force_full: bool,
     last_activity: u64,
-    animation_mask: ui::AnimationMask,
 }
 
 impl ClientState {
@@ -234,7 +233,6 @@ impl ClientState {
             behind: false,
             force_full: true,
             last_activity,
-            animation_mask: ui::AnimationMask::default(),
         }
     }
 
@@ -393,10 +391,6 @@ pub fn run() -> Result<()> {
     // Un-rendered activity waiting for the frame cap to expire — drives a trailing
     // render so a change that lands mid-interval isn't stuck until the next event.
     let mut render_request = RenderRequest::default();
-    // Advances only a spinner that the renderer reported visible. Its deadline
-    // participates in the wait calculation, so quiet servers pay no timer cost.
-    let mut last_spin = Instant::now();
-    const SPIN_INTERVAL: Duration = Duration::from_millis(100);
     // Fallback re-arm cadence for PTY wake coalescing when frames aren't being
     // rendered (no client attached / nothing dirty): readers may announce new
     // output ~10x/s. While rendering, the render path re-arms at the frame rate.
@@ -414,12 +408,6 @@ pub fn run() -> Result<()> {
             } else {
                 IDLE_INTERVAL
             };
-            if clients
-                .values()
-                .any(|client| client.animation_mask.has_working_spinner())
-            {
-                idle = idle.min(SPIN_INTERVAL.saturating_sub(last_spin.elapsed()));
-            }
             if app.has_pending_pty_output() {
                 idle = idle.min(REARM_INTERVAL.saturating_sub(last_rearm.elapsed()));
             }
@@ -558,17 +546,6 @@ pub fn run() -> Result<()> {
         }
         if app.tick_bar_notifications(now) {
             render_request.record(RenderCause::Metadata);
-        }
-        // Animate the sidebar spinner while any agent is working: advance the
-        // frame and mark dirty so the diff sends only the changed dot cell.
-        if last_spin.elapsed() >= SPIN_INTERVAL
-            && clients
-                .values()
-                .any(|client| client.animation_mask.has_working_spinner())
-        {
-            app.spinner = app.spinner.wrapping_add(1);
-            last_spin = Instant::now();
-            render_request.record(RenderCause::Animation);
         }
         // Fallback re-arm (the render path below re-arms at the frame rate): a
         // flag still set here means un-rendered output → schedule a frame.
@@ -878,20 +855,15 @@ fn render_client(
         client.render_buf.reset();
     }
 
-    let (cursor, cursor_visible, animation_mask) = {
+    let (cursor, cursor_visible) = {
         let mut target = ui::RenderTarget::new(&mut client.render_buf, area);
         if interactive {
             ui::render_into(&mut target, app);
         } else {
             ui::render_projection(&mut target, app);
         }
-        (
-            target.cursor(),
-            target.cursor_visible(),
-            target.animation_mask(),
-        )
+        (target.cursor(), target.cursor_visible())
     };
-    client.animation_mask = animation_mask;
 
     let full = force_all
         || client.force_full
@@ -1411,45 +1383,6 @@ mod tests {
             app.panes[&focus].size(),
             (content.width, content.height),
             "secondary projection must not resize the shared PTY"
-        );
-    }
-
-    #[test]
-    fn animation_mask_tracks_a_spinner_that_is_actually_rendered() {
-        let _env = crate::persist::test_env("rendered-animation-mask");
-        let (app_tx, _app_rx) = mpsc::channel();
-        let mut app = App::new(120, 40, app_tx).expect("app starts");
-        app.server_mode = true;
-        let focus = app.layout().focus;
-        let status = app.status.get_mut(&focus).expect("focused pane status");
-        status.agent = "claude".into();
-        status.state = crate::ui::theme::State::Working;
-
-        let (client, _rx) = display_client(120, 40, 1);
-        let mut clients = HashMap::from([(1, client)]);
-        let mut foreground = Some(1);
-        let mut interactive_size = (120, 40);
-        render_clients(
-            &mut app,
-            &mut clients,
-            &mut foreground,
-            &mut interactive_size,
-            false,
-        );
-        assert!(clients[&1].animation_mask.has_working_spinner());
-
-        app.sidebars.left.visible = false;
-        app.sidebars.right.visible = false;
-        render_clients(
-            &mut app,
-            &mut clients,
-            &mut foreground,
-            &mut interactive_size,
-            false,
-        );
-        assert!(
-            !clients[&1].animation_mask.has_working_spinner(),
-            "a hidden AGENTS dock must not keep scheduling animation frames"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1308,8 +1308,6 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
     let mut last_draw = Instant::now();
     let mut last_save = Instant::now();
     let mut immediate_save_attempted = false;
-    let mut last_spin = Instant::now();
-
     loop {
         match rx.recv_timeout(Duration::from_millis(50)) {
             Ok(ev) => {
@@ -1359,13 +1357,6 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
         }
         if let Some(signal) = app.pending_sound.take() {
             emit_sound(signal);
-        }
-        // Advance the working spinner ~10x/s (the loop redraws every frame).
-        if last_spin.elapsed() >= Duration::from_millis(100)
-            && (app.any_working() || app.bar.has_visible_working(&app.config.bars, app.compact))
-        {
-            app.spinner = app.spinner.wrapping_add(1);
-            last_spin = Instant::now();
         }
         if let Some(url) = app.pending_open_url.take() {
             crate::platform::open_url(&url);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -27,21 +27,6 @@ pub struct RenderTarget<'a> {
     area: Rect,
     cursor: Option<(u16, u16)>,
     cursor_visible: bool,
-    animation_mask: AnimationMask,
-}
-
-/// Allocation-free record of animated surfaces that were actually drawn into a
-/// client projection. The server uses this instead of global agent state, which
-/// avoids repainting when every working indicator is clipped or hidden.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct AnimationMask(u8);
-
-impl AnimationMask {
-    const WORKING_SPINNER: u8 = 1 << 0;
-
-    pub fn has_working_spinner(self) -> bool {
-        self.0 & Self::WORKING_SPINNER != 0
-    }
 }
 
 impl<'a> RenderTarget<'a> {
@@ -52,7 +37,6 @@ impl<'a> RenderTarget<'a> {
             area,
             cursor: None,
             cursor_visible: false,
-            animation_mask: AnimationMask::default(),
         }
     }
     pub fn area(&self) -> Rect {
@@ -78,15 +62,6 @@ impl<'a> RenderTarget<'a> {
     }
     pub fn cursor_visible(&self) -> bool {
         self.cursor_visible
-    }
-
-    /// Mark that this projection contains a live working-state spinner.
-    pub fn mark_working_animation(&mut self) {
-        self.animation_mask.0 |= AnimationMask::WORKING_SPINNER;
-    }
-
-    pub fn animation_mask(&self) -> AnimationMask {
-        self.animation_mask
     }
 }
 
@@ -122,7 +97,6 @@ pub fn render(f: &mut Frame, app: &mut App) {
             area,
             cursor: None,
             cursor_visible: false,
-            animation_mask: AnimationMask::default(),
         };
         render_into(&mut target, app);
         (target.cursor, target.cursor_visible)

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -599,14 +599,9 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                     Style::new().fg(t.subtext1)
                 };
                 agent_rects.push((id, Rect::new(area.x, y, area.width, 2)));
-                // A working agent gets a live rotating-circle spinner in the dot
-                // slot; every other state keeps its static dot.
-                let dot = if st == State::Working {
-                    f.mark_working_animation();
-                    crate::ui::theme::spinner_frame(app.spinner)
-                } else {
-                    st.dot()
-                };
+                // Working stays visually prominent without scheduling animation
+                // frames while the agent is busy.
+                let dot = st.dot();
                 let label = format!(" {}  ", st.label());
                 let prefix_w = crate::ui::display_width(dot) + crate::ui::display_width(&label);
                 let agent = crate::ui::truncate(&agent, (cw as usize).saturating_sub(prefix_w));
@@ -821,9 +816,7 @@ mod tests {
     }
 
     // The state icon sits in a fixed one-column slot, so the text after it must
-    // start at the same column no matter which state is shown — and, for a
-    // working agent, at every frame of the spinner. Otherwise the row visibly
-    // shifts as the icon animates.
+    // start at the same column no matter which state is shown.
     /// The fg colour of the first cell of the row containing `needle`.
     fn fg_of_row(term: &Terminal<TestBackend>, needle: &str) -> Option<ratatui::style::Color> {
         let buf = term.backend().buffer();
@@ -926,22 +919,13 @@ mod tests {
         app.status.get_mut(&id).unwrap().agent = "claude".into();
         let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
 
-        // Where the label lands for each static state.
+        // Where the label lands for each state.
         let mut columns = Vec::new();
-        for st in [State::Idle, State::Blocked, State::Done] {
+        for st in [State::Idle, State::Blocked, State::Working, State::Done] {
             app.status.get_mut(&id).unwrap().state = st;
             term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
             let cols = label_columns(&term, st.label());
             assert!(!cols.is_empty(), "the {st:?} row should be drawn");
-            columns.extend(cols);
-        }
-        // …and for every frame of the working spinner.
-        app.status.get_mut(&id).unwrap().state = State::Working;
-        for frame in 0..crate::ui::theme::SPINNER_FRAMES {
-            app.spinner = frame;
-            term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
-            let cols = label_columns(&term, State::Working.label());
-            assert!(!cols.is_empty(), "the working row should be drawn");
             columns.extend(cols);
         }
 

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -72,7 +72,6 @@ pub(super) fn draw_status(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
             crate::bar::BarRegion::BottomRight,
             &candidates,
             &layout,
-            app.spinner,
             t,
         );
         (hits, overflow, visible)

--- a/src/ui/tabbar.rs
+++ b/src/ui/tabbar.rs
@@ -92,7 +92,6 @@ pub(super) fn draw_tabbar(f: &mut RenderTarget, area: Rect, app: &mut App, t: &T
             crate::bar::BarRegion::TopRight,
             &candidates,
             &layout,
-            app.spinner,
             t,
         );
         (hits, overflow, width)

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -783,45 +783,6 @@ impl State {
     }
 }
 
-/// The working spinner's frames: a braille mark rotating around the **middle**
-/// of the cell, so it sits level with the `○`/`●` dots on neighbouring rows.
-///
-/// A braille cell has four dot rows, and which rows a glyph uses decides where it
-/// sits vertically. The classic CLI spinner (`⠋⠙⠹…`) uses dots 1-6 (the upper
-/// three rows) and visibly rides high; the bottom two rows (dots 3/6/7/8) ride
-/// just as visibly low. These frames use dots **2/3/5/6** — rows two and three —
-/// which is the vertical centre of the cell.
-///
-/// Each frame is one edge of that 2x2 dot square, so the mark sweeps clockwise:
-/// left → top → right → bottom. Every frame is exactly two dots, so the spinner
-/// keeps constant weight as it turns (no pulsing).
-///
-/// Glyph choice matters for alignment, so don't swap these casually:
-///
-/// * **Every frame is the same width.** Braille (U+2800..=U+28FF) is East Asian
-///   *Neutral* — exactly one column in every terminal, whatever its
-///   ambiguous-width setting. The old half-circle set (`◐◓◑◒`) mixed classes:
-///   `◐`/`◑` are *Ambiguous* (2 cells wherever a terminal draws ambiguous glyphs
-///   wide) while `◒`/`◓` are Narrow, so the icon changed size every other frame
-///   and drifted against the 1-column slot ratatui reserves for it.
-/// * **Every frame carries the same ink.** All ten are six-dot patterns, so the
-///   spinner never looks like it grows or shrinks as it turns.
-/// * **Font coverage is effectively universal.** Braille is *the* spinner block,
-///   so there is no fallback to another face at a different size.
-///
-/// [`state_glyphs_are_one_column`] guards these properties.
-const FRAMES: [&str; 4] = ["⠆", "⠒", "⠰", "⠤"];
-
-/// Frames in one full revolution. Iterate this instead of hardcoding a count so
-/// changing the animation can't silently desync a caller or a test.
-pub const SPINNER_FRAMES: u64 = FRAMES.len() as u64;
-
-/// One frame of the "working" spinner, advanced by `App.spinner` while an agent
-/// is working — a busy agent shows live motion instead of a static `●`.
-pub fn spinner_frame(n: u64) -> &'static str {
-    FRAMES[(n % SPINNER_FRAMES) as usize]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -830,12 +791,11 @@ mod tests {
     // with `UnicodeWidthStr::width` (== 1 for all of these), so any glyph a
     // terminal draws two cells wide pushes the label right and breaks the column.
     // Requiring `width_cjk == 1` too keeps every icon *unambiguously* narrow, so
-    // the slot is honored even where ambiguous-width glyphs render wide — and
-    // every spinner frame stays exactly the same size as the static dots.
+    // the slot is honored even where ambiguous-width glyphs render wide.
     #[test]
     fn state_glyphs_are_one_column() {
         use unicode_width::UnicodeWidthStr;
-        let mut glyphs: Vec<&str> = [
+        let glyphs: Vec<&str> = [
             State::Blocked,
             State::Working,
             State::Done,
@@ -845,29 +805,11 @@ mod tests {
         .iter()
         .map(|s| s.dot())
         .collect();
-        glyphs.extend((0..SPINNER_FRAMES).map(spinner_frame));
-
         for g in glyphs {
             assert_eq!(g.chars().count(), 1, "{g:?} must be a single glyph");
             assert_eq!(g.width(), 1, "{g:?} must occupy one column");
         }
 
-        // The regression this guards: the spinner animates *in place*, so if its
-        // frames disagree on East Asian width the icon visibly changes size as it
-        // turns (the old `◐◓◑◒` mixed Ambiguous `◐`/`◑` with Narrow `◒`/`◓`).
-        // Every frame must sit in the same width class as every other.
-        let widths: std::collections::HashSet<usize> = (0..SPINNER_FRAMES)
-            .map(|i| spinner_frame(i).width_cjk())
-            .collect();
-        assert_eq!(
-            widths.len(),
-            1,
-            "spinner frames disagree on East Asian width, so the icon changes \
-             size mid-animation: {:?}",
-            (0..SPINNER_FRAMES)
-                .map(|i| (spinner_frame(i), spinner_frame(i).width_cjk()))
-                .collect::<Vec<_>>()
-        );
         // The static dots must likewise agree with each other, so an idle row and
         // a blocked row never sit at different widths.
         assert_eq!(
@@ -875,17 +817,6 @@ mod tests {
             State::Blocked.dot().width_cjk(),
             "the idle and active dots must be the same width class"
         );
-
-        // The four frames must be distinct, or the spinner would stutter…
-        let frames: std::collections::HashSet<&str> =
-            (0..SPINNER_FRAMES).map(spinner_frame).collect();
-        assert_eq!(
-            frames.len() as u64,
-            SPINNER_FRAMES,
-            "spinner frames must all differ"
-        );
-        // …and it must cycle with that period.
-        assert_eq!(spinner_frame(0), spinner_frame(SPINNER_FRAMES));
     }
 
     #[test]

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -20,10 +20,10 @@ Kiro, Aider, Amp, Droid, or fx) appears in the sidebar with a live state:
 | 🟢 **done** | finished while unfocused | sustained quiet after working |
 | **idle** | quiet, nothing pending | no recent activity |
 
-A **working** agent shows a rotating-circle spinner in its status dot, so you
-can tell at a glance which agents are still busy. When one finishes or blocks,
-luvus can play a Retro, Soft, or Pulse cue. Sounds are optional and off by
-default, turn on the events you want in **Settings → General**.
+A **working** agent shows a filled amber status dot, so you can tell at a glance
+which agents are still busy without continuous UI animation. When one finishes
+or blocks, luvus can play a Retro, Soft, or Pulse cue. Sounds are optional and
+off by default, turn on the events you want in **Settings → General**.
 
 Click a row to jump to that agent's pane from anywhere, across workspaces.
 


### PR DESCRIPTION
## Summary

- replace animated working indicators in the Agents dock and Luvus Bar with the existing filled amber status marker
- remove spinner frame state, client animation masks, and the server's 100 ms animation deadline
- stop scheduling render passes solely to advance a working indicator
- retain the `render_causes.animation` diagnostic field at zero for compatibility with existing performance tooling
- update the public agent guide to describe the static working state

## Why

A visible working agent previously kept the detached server on a 100 ms animation cadence even when no workspace state had changed. Each tick could wake the server, project the full interface, diff the frame, and send the changed indicator cell.

The filled working marker preserves the same state, color, alignment, and navigation behavior without generating periodic render work. Detection, PTY processing, notifications, and agent state transitions are unchanged.

## Verification

- `cargo fmt --all --check`
- focused working-state, bar rendering, alignment, and glyph-width tests
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked` with 1,300 tests passing
- isolated debug server start, status, pane inspection, and stop under `~/.luvus-dev` using the `static-indicator-test` named session
- debug performance diagnostics reported `render_causes.animation: 0`

The production Luvus server and `~/.luvus` were not touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Replaced animated working-agent spinners with a static filled status dot.
  * Updated status indicators across the agent sidebar, bars, and other views for consistent display.
  * Removed continuous spinner animation from local and headless rendering, providing a steadier interface.
* **Documentation**
  * Updated the Agents guide to describe the static working indicator and available completion or blocking sound cues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->