### PR TITLE
fix(input): Clear highlight after mouse copy and double click copy. Same behaviour when using virtual copy mode.

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1849,11 +1849,11 @@ impl App {
                 return;
             }
             MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Up(MouseButton::Middle) => {
-                // A double-click already copied and highlighted on its press; its
-                // release keeps that selection rather than re-copying it or
-                // clearing it the way a plain click would.
+                // A double-click already copied on its press; clear its highlight on
+                // release so it behaves like a drag copy (toast is the feedback).
                 if self.dbl_click_release {
                     self.dbl_click_release = false;
+                    self.selection = None;
                     return;
                 }
                 if let Some(p) = self.link_press.take() {
@@ -1885,11 +1885,14 @@ impl App {
                 }
                 // A real drag copies its text + flashes a toast; a plain click
                 // clears the (1-cell) selection so nothing stays highlighted.
+                // After a successful copy the highlight is also cleared immediately
+                // — the toast is the feedback, not a lingering selection.
                 match self.selection_text() {
                     Some(text) => {
                         self.pending_clipboard = Some(text);
                         let msg = self.catalog.copied;
                         self.show_toast(msg);
+                        self.selection = None;
                     }
                     None => self.selection = None,
                 }


### PR DESCRIPTION
<!--
Thanks for contributing to Luvus.

Keep the PR focused on one problem. Write for someone who has not followed the
implementation, and remove any optional section that does not apply.
-->

## What

Clear mouse highlight immediately after copy — drag and double-click unified.

## Why

Release = done. Every terminal/editor clears on copy; Luvus left a stale visual state that implied selection still active.

<!-- Explain the problem this solves and its cause. Link an issue when one exists. -->

## Verification

<!-- Check what you ran and add any relevant manual testing. -->

- [x] `cargo test --locked`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Manual testing, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Selection highlights are now cleared after text is copied via double-click.
  - Drag-to-copy selections are cleared immediately after the copy confirmation appears.
  - Prevents copied text from retaining a lingering visual highlight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->