### PR TITLE
perf(runtime): reuse terminal damage and consolidate PTY I/O

### DIFF
--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -936,7 +936,7 @@ fn capture_visible_terminal_generations(
 }
 
 fn capture_visible_terminal_damage(
-    app: &mut App,
+    app: &App,
     snapshots: &mut HashMap<crate::ids::PaneId, crate::terminal::vt::DamageSnapshot>,
 ) {
     snapshots.clear();

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -54,6 +54,11 @@ static CHANGED_PROJECTIONS: AtomicU64 = AtomicU64::new(0);
 static UNCHANGED_PROJECTIONS: AtomicU64 = AtomicU64::new(0);
 static FRAMES_ENQUEUED: AtomicU64 = AtomicU64::new(0);
 static FRAMES_BACKPRESSURED: AtomicU64 = AtomicU64::new(0);
+static FULL_TERMINAL_PROJECTIONS: AtomicU64 = AtomicU64::new(0);
+static PARTIAL_TERMINAL_PROJECTIONS: AtomicU64 = AtomicU64::new(0);
+static RETAINED_RENDER_FALLBACKS: AtomicU64 = AtomicU64::new(0);
+static TERMINAL_DAMAGE_ROWS: AtomicU64 = AtomicU64::new(0);
+static TERMINAL_DAMAGE_CELLS: AtomicU64 = AtomicU64::new(0);
 static LOOP_EVENT_WAKES: AtomicU64 = AtomicU64::new(0);
 static LOOP_DEADLINE_WAKES: AtomicU64 = AtomicU64::new(0);
 static CAUSE_VISIBLE_PTY: AtomicU64 = AtomicU64::new(0);
@@ -82,6 +87,13 @@ pub fn performance_snapshot() -> serde_json::Value {
         "unchanged_projections": UNCHANGED_PROJECTIONS.load(Ordering::Relaxed),
         "frames_enqueued": FRAMES_ENQUEUED.load(Ordering::Relaxed),
         "frames_backpressured": FRAMES_BACKPRESSURED.load(Ordering::Relaxed),
+        "terminal_projection": {
+            "full": FULL_TERMINAL_PROJECTIONS.load(Ordering::Relaxed),
+            "partial": PARTIAL_TERMINAL_PROJECTIONS.load(Ordering::Relaxed),
+            "fallbacks": RETAINED_RENDER_FALLBACKS.load(Ordering::Relaxed),
+            "damage_rows": TERMINAL_DAMAGE_ROWS.load(Ordering::Relaxed),
+            "damage_cells": TERMINAL_DAMAGE_CELLS.load(Ordering::Relaxed),
+        },
         "render_causes": {
             "visible_pty": CAUSE_VISIBLE_PTY.load(Ordering::Relaxed),
             "background_pty": CAUSE_BACKGROUND_PTY.load(Ordering::Relaxed),
@@ -164,6 +176,10 @@ impl RenderRequest {
         self.causes != 0
     }
 
+    fn is_visible_pty_only(self) -> bool {
+        self.causes == RenderCause::VisiblePty.bit()
+    }
+
     fn clear(&mut self) {
         *self = Self::default();
     }
@@ -212,7 +228,17 @@ struct ClientState {
     last_frame: Option<protocol::FrameData>,
     behind: bool,
     force_full: bool,
+    retained_pane_content: Vec<(crate::ids::PaneId, Rect)>,
+    retained_ready: bool,
     last_activity: u64,
+}
+
+#[derive(Default)]
+struct RenderScratch {
+    damage: HashMap<crate::ids::PaneId, crate::terminal::vt::DamageSnapshot>,
+    generations: HashMap<crate::ids::PaneId, u64>,
+    order: Vec<u64>,
+    dead: Vec<u64>,
 }
 
 impl ClientState {
@@ -232,6 +258,8 @@ impl ClientState {
             last_frame: None,
             behind: false,
             force_full: true,
+            retained_pane_content: Vec::new(),
+            retained_ready: false,
             last_activity,
         }
     }
@@ -381,6 +409,7 @@ pub fn run() -> Result<()> {
 
     let mut clients: Clients = HashMap::new();
     let mut foreground: Option<u64> = None;
+    let mut render_scratch = RenderScratch::default();
     // Geometry last committed to the shared PTYs and interactive hit-test state.
     // Secondary-client projections never change it.
     let mut interactive_size = DEFAULT_SIZE;
@@ -583,6 +612,8 @@ pub fn run() -> Result<()> {
                 &mut foreground,
                 &mut interactive_size,
                 forced,
+                render_request.is_visible_pty_only(),
+                &mut render_scratch,
             );
             render_request.clear();
             // Re-arm the PTY readers now that their output is on screen. A flag
@@ -697,9 +728,10 @@ fn apply(
             }
             let target_size = clients.get(&id).map(|client| client.size);
             if promoted || target_size.is_some_and(|size| size != *interactive_size) {
-                let disconnected = clients
-                    .get_mut(&id)
-                    .is_some_and(|client| render_client(app, client, true, false).disconnected);
+                let no_damage = HashMap::new();
+                let disconnected = clients.get_mut(&id).is_some_and(|client| {
+                    render_client(app, client, true, false, false, &no_damage).disconnected
+                });
                 if disconnected {
                     clients.remove(&id);
                     *foreground = latest_client(clients);
@@ -804,37 +836,166 @@ fn render_clients(
     foreground: &mut Option<u64>,
     interactive_size: &mut (u16, u16),
     force_all: bool,
+    visible_pty_only: bool,
+    scratch: &mut RenderScratch,
 ) -> bool {
     RENDER_PASSES.fetch_add(1, Ordering::Relaxed);
+    if clients.is_empty() {
+        return false;
+    }
     if foreground.is_none_or(|id| !clients.contains_key(&id)) {
         *foreground = latest_client(clients);
         apply_foreground_theme(app, clients, *foreground);
     }
 
-    let mut order: Vec<u64> = clients.keys().copied().collect();
-    order.sort_unstable_by_key(|id| (*foreground != Some(*id), *id));
-    let mut dead = Vec::new();
+    let retained_client_ready = foreground
+        .and_then(|id| clients.get(&id))
+        .is_some_and(|client| {
+            client.retained_ready
+                && !client.force_full
+                && !client.behind
+                && client.last_frame.is_some()
+        });
+    let partial_candidate =
+        visible_pty_only && !force_all && retained_client_ready && ui::retained_pty_eligible(app);
+    if partial_candidate {
+        capture_visible_terminal_damage(app, &mut scratch.damage);
+    } else {
+        capture_visible_terminal_generations(app, &mut scratch.generations);
+    }
+    let partial_pass = partial_candidate
+        && !scratch.damage.is_empty()
+        && scratch
+            .damage
+            .values()
+            .all(|snapshot| snapshot.kind == crate::terminal::vt::DamageKind::Partial);
+
+    scratch.order.clear();
+    scratch.order.extend(clients.keys().copied());
+    scratch
+        .order
+        .sort_unstable_by_key(|id| (*foreground != Some(*id), *id));
+    scratch.dead.clear();
     let mut presented = false;
-    for id in order {
+    for id in scratch.order.iter().copied() {
         let interactive = *foreground == Some(id);
         if let Some(client) = clients.get_mut(&id) {
-            let outcome = render_client(app, client, interactive, force_all);
+            let outcome = render_client(
+                app,
+                client,
+                interactive,
+                force_all,
+                partial_pass,
+                &scratch.damage,
+            );
             presented |= outcome.enqueued;
             if outcome.disconnected {
-                dead.push(id);
+                scratch.dead.push(id);
             } else if interactive {
                 *interactive_size = client.size;
             }
         }
     }
-    for id in dead {
+    for id in scratch.dead.drain(..) {
         clients.remove(&id);
     }
     if foreground.is_some_and(|id| !clients.contains_key(&id)) {
         *foreground = latest_client(clients);
         apply_foreground_theme(app, clients, *foreground);
     }
+    if partial_candidate {
+        acknowledge_visible_terminal_damage(app, &mut scratch.damage);
+    } else {
+        acknowledge_visible_terminal_generations(app, &mut scratch.generations);
+    }
     presented
+}
+
+fn capture_visible_terminal_generations(
+    app: &App,
+    generations: &mut HashMap<crate::ids::PaneId, u64>,
+) {
+    generations.clear();
+    if app.workspaces.is_empty()
+        || app.active_is_git()
+        || app.active_is_orch()
+        || app.active_is_mission()
+    {
+        return;
+    }
+    let pane_ids = app.layout().leaves();
+    generations.reserve(pane_ids.len());
+    for id in pane_ids {
+        let Some(pane) = app.panes.get(&id) else {
+            continue;
+        };
+        if let Ok(engine) = pane.engine.lock() {
+            generations.insert(id, engine.output_generation());
+        }
+    }
+}
+
+fn capture_visible_terminal_damage(
+    app: &mut App,
+    snapshots: &mut HashMap<crate::ids::PaneId, crate::terminal::vt::DamageSnapshot>,
+) {
+    snapshots.clear();
+    if app.workspaces.is_empty()
+        || app.active_is_git()
+        || app.active_is_orch()
+        || app.active_is_mission()
+    {
+        return;
+    }
+    let pane_ids = app.layout().leaves();
+    snapshots.reserve(pane_ids.len());
+    for id in pane_ids {
+        let Some(pane) = app.panes.get(&id) else {
+            continue;
+        };
+        if let Ok(mut engine) = pane.engine.lock() {
+            let snapshot = engine.damage_snapshot();
+            TERMINAL_DAMAGE_ROWS.fetch_add(snapshot.rows.len() as u64, Ordering::Relaxed);
+            TERMINAL_DAMAGE_CELLS.fetch_add(
+                snapshot
+                    .rows
+                    .iter()
+                    .map(|row| row.cells.len() as u64)
+                    .sum::<u64>(),
+                Ordering::Relaxed,
+            );
+            snapshots.insert(id, snapshot);
+        }
+    }
+}
+
+fn acknowledge_visible_terminal_damage(
+    app: &App,
+    snapshots: &mut HashMap<crate::ids::PaneId, crate::terminal::vt::DamageSnapshot>,
+) {
+    for (id, snapshot) in snapshots.drain() {
+        let Some(pane) = app.panes.get(&id) else {
+            continue;
+        };
+        if let Ok(mut engine) = pane.engine.lock() {
+            let _ = engine.acknowledge_damage(snapshot.generation);
+            engine.recycle_damage_snapshot(snapshot);
+        }
+    }
+}
+
+fn acknowledge_visible_terminal_generations(
+    app: &App,
+    generations: &mut HashMap<crate::ids::PaneId, u64>,
+) {
+    for (id, generation) in generations.drain() {
+        let Some(pane) = app.panes.get(&id) else {
+            continue;
+        };
+        if let Ok(mut engine) = pane.engine.lock() {
+            let _ = engine.acknowledge_damage(generation);
+        }
+    }
 }
 
 /// Render and enqueue one client's next frame. Returns true when its writer is
@@ -844,6 +1005,8 @@ fn render_client(
     client: &mut ClientState,
     interactive: bool,
     force_all: bool,
+    partial_pass: bool,
+    damage: &HashMap<crate::ids::PaneId, crate::terminal::vt::DamageSnapshot>,
 ) -> RenderClientOutcome {
     CLIENT_PROJECTIONS.fetch_add(1, Ordering::Relaxed);
     let area = Rect::new(0, 0, client.size.0, client.size.1);
@@ -851,16 +1014,43 @@ fn render_client(
         client.render_buf = Buffer::empty(area);
         client.last_frame = None;
         client.force_full = true;
-    } else {
-        client.render_buf.reset();
+        client.retained_ready = false;
     }
 
-    let (cursor, cursor_visible) = {
+    let may_patch = partial_pass
+        && interactive
+        && client.retained_ready
+        && !client.force_full
+        && !client.behind
+        && client.last_frame.is_some();
+    let patched = if may_patch {
+        let mut target = ui::RenderTarget::new(&mut client.render_buf, area);
+        ui::patch_terminal_damage(&mut target, app, &client.retained_pane_content, damage)
+            .map(|()| (target.cursor(), target.cursor_visible()))
+            .ok()
+    } else {
+        None
+    };
+
+    let (cursor, cursor_visible) = if let Some(cursor) = patched {
+        PARTIAL_TERMINAL_PROJECTIONS.fetch_add(1, Ordering::Relaxed);
+        cursor
+    } else {
+        if partial_pass {
+            RETAINED_RENDER_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+        }
+        FULL_TERMINAL_PROJECTIONS.fetch_add(1, Ordering::Relaxed);
+        client.render_buf.reset();
         let mut target = ui::RenderTarget::new(&mut client.render_buf, area);
         if interactive {
             ui::render_into(&mut target, app);
+            client
+                .retained_pane_content
+                .clone_from(&app.pane_content_rects);
+            client.retained_ready = true;
         } else {
             ui::render_projection(&mut target, app);
+            client.retained_ready = false;
         }
         (target.cursor(), target.cursor_visible())
     };
@@ -918,6 +1108,7 @@ fn render_client(
         Err(FrameSendError::Full) => {
             FRAMES_BACKPRESSURED.fetch_add(1, Ordering::Relaxed);
             client.behind = true;
+            client.retained_ready = false;
             RenderClientOutcome::default()
         }
         Err(FrameSendError::Disconnected) => RenderClientOutcome {
@@ -1181,14 +1372,16 @@ mod tests {
     use super::{
         apply, broadcast, frame_cadence_ready, frame_wait, record_event_render_request,
         render_clients, ClientSender, ClientState, EventRenderSource, FrameSendError, RenderCause,
-        RenderRequest, FRAME_INTERVAL,
+        RenderRequest, RenderScratch, FRAME_INTERVAL,
     };
     use crate::app::App;
     use crate::event::{AppEvent, ClientInput};
     use crate::ipc::protocol::FrameDiff;
+    use crate::terminal::appearance::PaneAppearance;
+    use crate::terminal::vt::{create_engine, VtEngineKind};
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::collections::HashMap;
-    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
     use std::sync::Arc;
     use std::time::Duration;
@@ -1220,6 +1413,98 @@ mod tests {
             ServerMessage::FrameDiff(frame) => (frame.width, frame.height),
             _ => panic!("expected rendered frame"),
         }
+    }
+
+    #[test]
+    fn visible_pty_only_frame_uses_retained_rows_after_full_baseline() {
+        let _env = crate::persist::test_env("server-retained-terminal-rows");
+        let (app_tx, _app_rx) = mpsc::channel();
+        let mut app = App::new(100, 30, app_tx).expect("app starts");
+        app.server_mode = true;
+        let focus = app.layout().focus;
+        let (response_tx, _response_rx) = mpsc::channel();
+        let engine = create_engine(
+            VtEngineKind::Alacritty,
+            100,
+            30,
+            response_tx,
+            4 * 1024 * 1024,
+            PaneAppearance::default(),
+        );
+        app.panes.get_mut(&focus).expect("focused pane").engine = engine.clone();
+
+        let (client, rx) = display_client(100, 30, 1);
+        let mut clients = HashMap::from([(1, client)]);
+        let mut foreground = Some(1);
+        let mut interactive_size = (100, 30);
+        let mut scratch = RenderScratch::default();
+        assert!(render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            false,
+            false,
+            &mut scratch,
+        ));
+        assert!(matches!(rx.recv().unwrap(), ServerMessage::Frame(_)));
+        clients[&1]
+            .sender
+            .frame_pending
+            .store(false, Ordering::Release);
+
+        engine
+            .lock()
+            .expect("engine lock")
+            .advance(b"one changed row");
+        let before = super::PARTIAL_TERMINAL_PROJECTIONS.load(Ordering::Relaxed);
+        assert!(render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            false,
+            true,
+            &mut scratch,
+        ));
+        assert!(matches!(rx.recv().unwrap(), ServerMessage::FrameDiff(_)));
+        assert!(
+            super::PARTIAL_TERMINAL_PROJECTIONS.load(Ordering::Relaxed) > before,
+            "PTY-only render patched the retained client buffer"
+        );
+        assert!(!clients[&1].behind);
+
+        // A slow client may reject the next partial frame. Its retained buffer
+        // is then deliberately abandoned and the next accepted render is a
+        // complete resynchronization, so acknowledging shared VT damage cannot
+        // leave that client permanently behind.
+        engine.lock().expect("engine lock").advance(b" more");
+        assert!(!render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            false,
+            true,
+            &mut scratch,
+        ));
+        assert!(clients[&1].behind);
+        assert!(!clients[&1].retained_ready);
+        clients[&1]
+            .sender
+            .frame_pending
+            .store(false, Ordering::Release);
+        assert!(render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            false,
+            false,
+            &mut scratch,
+        ));
+        assert!(matches!(rx.recv().unwrap(), ServerMessage::Frame(_)));
+        assert!(!clients[&1].behind);
     }
 
     #[test]
@@ -1357,6 +1642,7 @@ mod tests {
         let mut clients = HashMap::from([(1, large), (2, small)]);
         let mut foreground = Some(1);
         let mut interactive_size = (120, 40);
+        let mut scratch = RenderScratch::default();
 
         render_clients(
             &mut app,
@@ -1364,6 +1650,8 @@ mod tests {
             &mut foreground,
             &mut interactive_size,
             false,
+            false,
+            &mut scratch,
         );
 
         assert_eq!(received_frame_size(&large_rx), (120, 40));

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -1,8 +1,11 @@
-//! PTY pane: spawn a child against a pseudo-terminal and pump its output
-//! through a `VtEngine`. In M0 we use portable-pty's reader/writer directly;
-//! the dedicated fd-owning actor thread (needed for live handoff) lands later.
+//! PTY pane lifecycle. Unix panes use one poll-driven descriptor actor for
+//! ordered input and output; Windows keeps portable-pty's split reader/writer
+//! backend. Child waiting is shared process-wide.
 
-use std::io::{Read, Write};
+#[cfg(windows)]
+use std::io::Read;
+#[cfg(any(windows, test))]
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
@@ -19,6 +22,8 @@ use crate::terminal::appearance::PaneAppearance;
 use crate::terminal::backend::TerminalRuntime;
 use crate::terminal::vt::{create_engine, VtEngine, VtEngineKind};
 
+mod io;
+
 const CHILD_REAPER_INTERVAL: Duration = Duration::from_millis(50);
 
 struct ReaperEntry {
@@ -33,10 +38,9 @@ static CHILD_REAPER: OnceLock<Sender<ReaperEntry>> = OnceLock::new();
 #[cfg(test)]
 static CHILD_REAPER_STARTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
-/// Hand a child to the process-wide reaper. A pane still owns dedicated reader
-/// and writer threads so one blocked PTY cannot stall another pane, but waiting
-/// for child exit needs no per-pane thread: `try_wait` is non-blocking on every
-/// portable-pty backend.
+/// Hand a child to the process-wide reaper. Pane I/O remains isolated behind
+/// its platform backend, but waiting for child exit needs no per-pane thread:
+/// `try_wait` is non-blocking on every portable-pty backend.
 fn register_child_reaper(
     id: PaneId,
     child: Box<dyn portable_pty::Child + Send + Sync>,
@@ -127,6 +131,52 @@ pub(crate) enum InputAction {
     },
 }
 
+/// Ordered PTY input plus an optional Unix actor wakeup. Terminal-generated
+/// replies and user input share this sender, preserving their FIFO order.
+#[derive(Clone)]
+pub(crate) struct InputSender {
+    sender: Sender<InputAction>,
+    #[cfg(unix)]
+    wake: Arc<OnceLock<Arc<io::unix_actor::WakePipe>>>,
+}
+
+impl InputSender {
+    #[cfg(unix)]
+    fn with_wake_slot(
+        sender: Sender<InputAction>,
+        wake: Arc<OnceLock<Arc<io::unix_actor::WakePipe>>>,
+    ) -> Self {
+        Self { sender, wake }
+    }
+
+    pub(crate) fn send(
+        &self,
+        action: InputAction,
+    ) -> std::result::Result<(), mpsc::SendError<InputAction>> {
+        self.sender.send(action)?;
+        self.wake();
+        Ok(())
+    }
+
+    fn wake(&self) {
+        #[cfg(unix)]
+        if let Some(wake) = self.wake.get() {
+            wake.wake();
+        }
+    }
+}
+
+impl From<Sender<InputAction>> for InputSender {
+    fn from(sender: Sender<InputAction>) -> Self {
+        Self {
+            sender,
+            #[cfg(unix)]
+            wake: Arc::new(OnceLock::new()),
+        }
+    }
+}
+
+#[cfg(any(windows, test))]
 fn write_input_action(writer: &mut dyn Write, action: InputAction) -> std::io::Result<()> {
     match action {
         InputAction::Bytes(bytes) => writer.write_all(&bytes)?,
@@ -163,7 +213,7 @@ pub struct Pane {
     pub engine: Arc<Mutex<dyn VtEngine>>,
     /// `None` until a deferred spawn's worker stores it (docs/82).
     master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
-    input_tx: Sender<InputAction>,
+    input_tx: InputSender,
     pub cwd: PathBuf,
     pub command: String,
     /// The shell's pid, for reading its live working directory and process
@@ -214,6 +264,7 @@ impl Drop for Pane {
         // A deferred spawn that hasn't forked yet aborts in the worker; one
         // that has forked is killed by the worker's own post-fork check.
         self.cancelled.store(true, Ordering::SeqCst);
+        self.input_tx.wake();
         // Already reaped → the pid may belong to someone else now.
         if self.child_exited.load(Ordering::SeqCst) {
             return;
@@ -491,9 +542,9 @@ impl Pane {
         };
         drop(pair.slave);
 
-        // All bytes (user input + terminal responses) funnel through one channel
-        // to a single writer thread — keeps ordering correct, needs no mutex.
-        let (input_tx, input_rx) = mpsc::channel::<InputAction>();
+        // User input and terminal-generated responses share one ordered queue.
+        // Unix wakes one poll-driven actor; Windows retains the split backend.
+        let (input_tx, input_rx) = io::input_channel();
         let engine = create_engine(
             VtEngineKind::default(),
             cols,
@@ -509,23 +560,22 @@ impl Pane {
             }
         }
 
-        let mut writer = pair.master.take_writer()?;
-        thread::spawn(move || {
-            while let Ok(action) = input_rx.recv() {
-                if write_input_action(writer.as_mut(), action).is_err() {
-                    break;
-                }
-            }
-        });
-
-        let reader = pair.master.try_clone_reader()?;
-        let eng = engine.clone();
-        let tx = app_tx.clone();
         let data_pending = Arc::new(AtomicBool::new(false));
-        let pending = data_pending.clone();
         let content_revision = Arc::new(AtomicU64::new(0));
-        let revision = content_revision.clone();
-        thread::spawn(move || read_loop(id, reader, eng, tx, pending, revision));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        if let Err(error) = io::start(
+            id,
+            pair.master.as_ref(),
+            input_rx,
+            engine.clone(),
+            app_tx.clone(),
+            data_pending.clone(),
+            content_revision.clone(),
+            cancelled.clone(),
+        ) {
+            terminate_spawned_child(child.as_mut());
+            return Err(error.into());
+        }
 
         // Reap the child so we notice it exiting. The shared reaper sets the
         // exit flag *before* the event goes out, so by the time the loop closes
@@ -547,7 +597,7 @@ impl Pane {
             data_pending,
             child_exited,
             size: Arc::new(Mutex::new((cols, rows))),
-            cancelled: Arc::new(AtomicBool::new(false)),
+            cancelled,
         })
     }
 
@@ -572,7 +622,7 @@ impl Pane {
     ) -> Pane {
         // Everything a caller can observe before the child exists: the engine
         // (pane.read, detection, rendering) and the input queue.
-        let (input_tx, input_rx) = mpsc::channel::<InputAction>();
+        let (input_tx, input_rx) = io::input_channel();
         let engine = create_engine(
             VtEngineKind::default(),
             cols,
@@ -586,22 +636,6 @@ impl Pane {
                 engine.advance(screen.as_bytes());
             }
         }
-
-        // The writer thread starts with the pane and blocks until the spawn
-        // worker hands over the PTY writer; bytes sent meanwhile queue in
-        // input_rx. On every failure path the worker drops `master_tx`, so
-        // this thread exits with the queue instead of leaking.
-        let (master_tx, master_rx) = mpsc::channel::<Box<dyn Write + Send>>();
-        thread::spawn(move || {
-            let Ok(mut writer) = master_rx.recv() else {
-                return;
-            };
-            while let Ok(action) = input_rx.recv() {
-                if write_input_action(writer.as_mut(), action).is_err() {
-                    break;
-                }
-            }
-        });
 
         let child_pid = Arc::new(AtomicU32::new(0));
         let terminal_runtime: Arc<Mutex<Option<TerminalRuntime>>> = Arc::new(Mutex::new(None));
@@ -726,28 +760,25 @@ impl Pane {
                     });
                 }
 
-                let writer = match pair.master.take_writer() {
-                    Ok(writer) => writer,
-                    Err(_) => {
-                        let _ = tx.send(AppEvent::PtyExit(id));
-                        return;
-                    }
-                };
-                let reader = match pair.master.try_clone_reader() {
-                    Ok(reader) => reader,
-                    Err(_) => return fail(),
-                };
-                *master.lock().unwrap_or_else(|p| p.into_inner()) = Some(pair.master);
-                let read_tx = tx.clone();
-                let ready_tx = tx.clone();
-                thread::spawn(move || {
-                    read_loop(id, reader, engine, read_tx, data_pending, content_revision)
-                });
-                register_child_reaper(id, child, child_exited, tx.clone());
-
-                if master_tx.send(writer).is_err() {
+                if io::start(
+                    id,
+                    pair.master.as_ref(),
+                    input_rx,
+                    engine,
+                    tx.clone(),
+                    data_pending,
+                    content_revision,
+                    cancelled.clone(),
+                )
+                .is_err()
+                {
+                    terminate_spawned_child(child.as_mut());
+                    child_exited.store(true, Ordering::SeqCst);
                     return fail();
                 }
+                *master.lock().unwrap_or_else(|p| p.into_inner()) = Some(pair.master);
+                let ready_tx = tx.clone();
+                register_child_reaper(id, child, child_exited, tx.clone());
                 *terminal_runtime
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(runtime);
@@ -1192,6 +1223,7 @@ fn apply_pane_env(
     }
 }
 
+#[cfg(windows)]
 fn read_loop(
     id: PaneId,
     mut reader: Box<dyn Read + Send>,

--- a/src/terminal/pty/io.rs
+++ b/src/terminal/pty/io.rs
@@ -1,0 +1,78 @@
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::mpsc;
+#[cfg(unix)]
+use std::sync::OnceLock;
+use std::sync::{Arc, Mutex};
+
+use portable_pty::MasterPty;
+
+use crate::event::AppEvent;
+use crate::ids::PaneId;
+use crate::terminal::vt::VtEngine;
+
+use super::{InputAction, InputSender};
+
+#[cfg(windows)]
+mod split;
+#[cfg(unix)]
+pub(super) mod unix_actor;
+
+pub(super) struct InputReceiver {
+    receiver: mpsc::Receiver<InputAction>,
+    #[cfg(unix)]
+    wake: Arc<OnceLock<Arc<unix_actor::WakePipe>>>,
+}
+
+pub(super) fn input_channel() -> (InputSender, InputReceiver) {
+    let (sender, receiver) = mpsc::channel();
+    #[cfg(unix)]
+    {
+        let wake = Arc::new(OnceLock::new());
+        let sender = InputSender::with_wake_slot(sender, wake.clone());
+        (sender, InputReceiver { receiver, wake })
+    }
+    #[cfg(windows)]
+    {
+        (InputSender::from(sender), InputReceiver { receiver })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn start(
+    id: PaneId,
+    master: &(dyn MasterPty + Send),
+    input: InputReceiver,
+    engine: Arc<Mutex<dyn VtEngine>>,
+    app_tx: mpsc::Sender<AppEvent>,
+    data_pending: Arc<AtomicBool>,
+    content_revision: Arc<AtomicU64>,
+    _cancelled: Arc<AtomicBool>,
+) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        unix_actor::start(
+            id,
+            master,
+            input.receiver,
+            input.wake,
+            engine,
+            app_tx,
+            data_pending,
+            content_revision,
+            _cancelled,
+        )
+    }
+    #[cfg(windows)]
+    {
+        split::start(
+            id,
+            master,
+            input.receiver,
+            engine,
+            app_tx,
+            data_pending,
+            content_revision,
+        )
+    }
+}

--- a/src/terminal/pty/io/split.rs
+++ b/src/terminal/pty/io/split.rs
@@ -22,7 +22,9 @@ pub(super) fn start(
     data_pending: Arc<AtomicBool>,
     content_revision: Arc<AtomicU64>,
 ) -> io::Result<()> {
-    let mut writer = master.take_writer()?;
+    let mut writer = master
+        .take_writer()
+        .map_err(|error| io::Error::other(format!("take PTY writer: {error:#}")))?;
     thread::Builder::new()
         .name(format!("luvus-pty-writer-{}", id.0))
         .spawn(move || {
@@ -33,7 +35,9 @@ pub(super) fn start(
             }
         })?;
 
-    let reader = master.try_clone_reader()?;
+    let reader = master
+        .try_clone_reader()
+        .map_err(|error| io::Error::other(format!("clone PTY reader: {error:#}")))?;
     thread::Builder::new()
         .name(format!("luvus-pty-reader-{}", id.0))
         .spawn(move || read_loop(id, reader, engine, app_tx, data_pending, content_revision))?;

--- a/src/terminal/pty/io/split.rs
+++ b/src/terminal/pty/io/split.rs
@@ -1,0 +1,41 @@
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use portable_pty::MasterPty;
+
+use crate::event::AppEvent;
+use crate::ids::PaneId;
+use crate::terminal::vt::VtEngine;
+
+use super::super::{read_loop, write_input_action, InputAction};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn start(
+    id: PaneId,
+    master: &(dyn MasterPty + Send),
+    input: mpsc::Receiver<InputAction>,
+    engine: Arc<Mutex<dyn VtEngine>>,
+    app_tx: mpsc::Sender<AppEvent>,
+    data_pending: Arc<AtomicBool>,
+    content_revision: Arc<AtomicU64>,
+) -> io::Result<()> {
+    let mut writer = master.take_writer()?;
+    thread::Builder::new()
+        .name(format!("luvus-pty-writer-{}", id.0))
+        .spawn(move || {
+            while let Ok(action) = input.recv() {
+                if write_input_action(writer.as_mut(), action).is_err() {
+                    break;
+                }
+            }
+        })?;
+
+    let reader = master.try_clone_reader()?;
+    thread::Builder::new()
+        .name(format!("luvus-pty-reader-{}", id.0))
+        .spawn(move || read_loop(id, reader, engine, app_tx, data_pending, content_revision))?;
+    Ok(())
+}

--- a/src/terminal/pty/io/unix_actor.rs
+++ b/src/terminal/pty/io/unix_actor.rs
@@ -1,0 +1,438 @@
+use std::collections::VecDeque;
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use portable_pty::MasterPty;
+
+use crate::event::AppEvent;
+use crate::ids::PaneId;
+use crate::terminal::vt::VtEngine;
+
+use super::super::InputAction;
+
+const IO_BUDGET: usize = 64 * 1024;
+
+pub(crate) struct WakePipe {
+    read: OwnedFd,
+    write: OwnedFd,
+}
+
+impl WakePipe {
+    pub(super) fn new() -> io::Result<Self> {
+        let mut fds = [-1; 2];
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a successful pipe call initializes two independently owned
+        // descriptors. They are transferred into OwnedFd exactly once.
+        let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+        set_nonblocking_cloexec(read.as_raw_fd())?;
+        set_nonblocking_cloexec(write.as_raw_fd())?;
+        Ok(Self { read, write })
+    }
+
+    pub(crate) fn wake(&self) {
+        let byte = [1u8];
+        // The pipe is nonblocking and acts as an edge coalescer. EAGAIN means a
+        // prior byte already guarantees that poll will wake.
+        let _ = unsafe { libc::write(self.write.as_raw_fd(), byte.as_ptr().cast(), byte.len()) };
+    }
+
+    fn drain(&self) {
+        let mut bytes = [0u8; 64];
+        loop {
+            let count = unsafe {
+                libc::read(
+                    self.read.as_raw_fd(),
+                    bytes.as_mut_ptr().cast(),
+                    bytes.len(),
+                )
+            };
+            if count <= 0 {
+                break;
+            }
+        }
+    }
+}
+
+fn set_nonblocking_cloexec(fd: RawFd) -> io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let descriptor_flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if descriptor_flags < 0
+        || unsafe { libc::fcntl(fd, libc::F_SETFD, descriptor_flags | libc::FD_CLOEXEC) } < 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn duplicate_nonblocking(fd: RawFd) -> io::Result<OwnedFd> {
+    let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicate < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: F_DUPFD_CLOEXEC returned a new owned descriptor.
+    let duplicate = unsafe { OwnedFd::from_raw_fd(duplicate) };
+    set_nonblocking_cloexec(duplicate.as_raw_fd())?;
+    Ok(duplicate)
+}
+
+enum PendingWrite {
+    Bytes {
+        bytes: Vec<u8>,
+        offset: usize,
+    },
+    SubmitDelay {
+        settle: Duration,
+        deadline: Option<Instant>,
+    },
+}
+
+impl PendingWrite {
+    fn bytes(bytes: Vec<u8>) -> Option<Self> {
+        (!bytes.is_empty()).then_some(Self::Bytes { bytes, offset: 0 })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn start(
+    id: PaneId,
+    master: &(dyn MasterPty + Send),
+    input: mpsc::Receiver<InputAction>,
+    wake_slot: Arc<OnceLock<Arc<WakePipe>>>,
+    engine: Arc<Mutex<dyn VtEngine>>,
+    app_tx: mpsc::Sender<AppEvent>,
+    data_pending: Arc<AtomicBool>,
+    content_revision: Arc<AtomicU64>,
+    cancelled: Arc<AtomicBool>,
+) -> io::Result<()> {
+    let source = master
+        .as_raw_fd()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "PTY has no Unix descriptor"))?;
+    let master = duplicate_nonblocking(source)?;
+    let wake = Arc::new(WakePipe::new()?);
+    wake_slot.set(wake.clone()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "PTY actor wake pipe was already installed",
+        )
+    })?;
+    thread::Builder::new()
+        .name(format!("luvus-pty-actor-{}", id.0))
+        .spawn(move || {
+            actor_loop(
+                id,
+                master,
+                input,
+                wake,
+                engine,
+                app_tx,
+                data_pending,
+                content_revision,
+                cancelled,
+            );
+        })?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn actor_loop(
+    id: PaneId,
+    master: OwnedFd,
+    input: mpsc::Receiver<InputAction>,
+    wake: Arc<WakePipe>,
+    engine: Arc<Mutex<dyn VtEngine>>,
+    app_tx: mpsc::Sender<AppEvent>,
+    data_pending: Arc<AtomicBool>,
+    content_revision: Arc<AtomicU64>,
+    cancelled: Arc<AtomicBool>,
+) {
+    let mut pending = VecDeque::new();
+    let mut read_buffer = [0u8; 8192];
+    loop {
+        wake.drain();
+        drain_input(&input, &mut pending);
+        if cancelled.load(Ordering::Acquire) {
+            break;
+        }
+
+        let now = Instant::now();
+        arm_or_finish_submit_delay(&mut pending, now);
+        let wants_write = matches!(pending.front(), Some(PendingWrite::Bytes { .. }));
+        let timeout = poll_timeout(&pending, now);
+        let mut fds = [
+            libc::pollfd {
+                fd: master.as_raw_fd(),
+                events: libc::POLLIN | if wants_write { libc::POLLOUT } else { 0 },
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: wake.read.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        let result = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as _, timeout) };
+        if result < 0 {
+            if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            break;
+        }
+        if fds[1].revents & libc::POLLIN != 0 {
+            wake.drain();
+            drain_input(&input, &mut pending);
+        }
+        if cancelled.load(Ordering::Acquire) {
+            break;
+        }
+
+        arm_or_finish_submit_delay(&mut pending, Instant::now());
+        if fds[0].revents & libc::POLLOUT != 0
+            && write_pending(master.as_raw_fd(), &mut pending).is_err()
+        {
+            break;
+        }
+
+        let terminal_events = fds[0].revents;
+        if terminal_events & (libc::POLLIN | libc::POLLHUP) != 0 {
+            match read_available(
+                master.as_raw_fd(),
+                &mut read_buffer,
+                &engine,
+                &content_revision,
+            ) {
+                Ok(ReadState::Data) => {
+                    if !data_pending.swap(true, Ordering::AcqRel)
+                        && app_tx.send(AppEvent::PtyData(id)).is_err()
+                    {
+                        break;
+                    }
+                }
+                Ok(ReadState::WouldBlock) if terminal_events & libc::POLLHUP == 0 => {}
+                Ok(ReadState::WouldBlock | ReadState::Eof) | Err(_) => break,
+            }
+        }
+        if terminal_events & (libc::POLLERR | libc::POLLNVAL) != 0 {
+            break;
+        }
+    }
+    let _ = app_tx.send(AppEvent::PtyExit(id));
+}
+
+fn drain_input(input: &mpsc::Receiver<InputAction>, pending: &mut VecDeque<PendingWrite>) {
+    while let Ok(action) = input.try_recv() {
+        match action {
+            InputAction::Bytes(bytes) => {
+                if let Some(bytes) = PendingWrite::bytes(bytes) {
+                    pending.push_back(bytes);
+                }
+            }
+            InputAction::Submit { paste, settle } => {
+                if let Some(paste) = PendingWrite::bytes(paste) {
+                    pending.push_back(paste);
+                }
+                pending.push_back(PendingWrite::SubmitDelay {
+                    settle,
+                    deadline: None,
+                });
+            }
+        }
+    }
+}
+
+fn arm_or_finish_submit_delay(pending: &mut VecDeque<PendingWrite>, now: Instant) {
+    let Some(PendingWrite::SubmitDelay { settle, deadline }) = pending.front_mut() else {
+        return;
+    };
+    let due = *deadline.get_or_insert_with(|| now + *settle);
+    if now >= due {
+        pending.pop_front();
+        pending.push_front(PendingWrite::Bytes {
+            bytes: vec![b'\r'],
+            offset: 0,
+        });
+    }
+}
+
+fn poll_timeout(pending: &VecDeque<PendingWrite>, now: Instant) -> libc::c_int {
+    match pending.front() {
+        Some(PendingWrite::SubmitDelay {
+            deadline: Some(deadline),
+            ..
+        }) => deadline
+            .saturating_duration_since(now)
+            .as_millis()
+            .max(1)
+            .min(libc::c_int::MAX as u128) as libc::c_int,
+        Some(PendingWrite::SubmitDelay { deadline: None, .. }) => 0,
+        Some(PendingWrite::Bytes { .. }) => -1,
+        None => -1,
+    }
+}
+
+fn write_pending(fd: RawFd, pending: &mut VecDeque<PendingWrite>) -> io::Result<()> {
+    let mut budget = IO_BUDGET;
+    while budget > 0 {
+        let Some(PendingWrite::Bytes { bytes, offset }) = pending.front_mut() else {
+            break;
+        };
+        let remaining = &bytes[*offset..];
+        let count =
+            unsafe { libc::write(fd, remaining.as_ptr().cast(), remaining.len().min(budget)) };
+        if count < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            if error.kind() == io::ErrorKind::WouldBlock {
+                return Ok(());
+            }
+            return Err(error);
+        }
+        if count == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "PTY write returned zero",
+            ));
+        }
+        *offset += count as usize;
+        budget -= count as usize;
+        if *offset == bytes.len() {
+            pending.pop_front();
+            arm_or_finish_submit_delay(pending, Instant::now());
+        }
+    }
+    Ok(())
+}
+
+enum ReadState {
+    Data,
+    WouldBlock,
+    Eof,
+}
+
+fn read_available(
+    fd: RawFd,
+    buffer: &mut [u8],
+    engine: &Arc<Mutex<dyn VtEngine>>,
+    content_revision: &AtomicU64,
+) -> io::Result<ReadState> {
+    let mut budget = IO_BUDGET;
+    let mut read_any = false;
+    while budget > 0 {
+        let count = unsafe { libc::read(fd, buffer.as_mut_ptr().cast(), buffer.len().min(budget)) };
+        if count == 0 {
+            return Ok(if read_any {
+                ReadState::Data
+            } else {
+                ReadState::Eof
+            });
+        }
+        if count < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            if error.kind() == io::ErrorKind::WouldBlock {
+                return Ok(if read_any {
+                    ReadState::Data
+                } else {
+                    ReadState::WouldBlock
+                });
+            }
+            return if read_any {
+                Ok(ReadState::Data)
+            } else {
+                Err(error)
+            };
+        }
+        let count = count as usize;
+        if let Ok(mut engine) = engine.lock() {
+            engine.advance(&buffer[..count]);
+            content_revision.fetch_add(1, Ordering::Release);
+        }
+        read_any = true;
+        budget -= count;
+    }
+    Ok(ReadState::Data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn submit_delay_preserves_fifo_order() {
+        let mut pending = VecDeque::new();
+        pending.push_back(PendingWrite::Bytes {
+            bytes: b"prompt".to_vec(),
+            offset: 0,
+        });
+        pending.push_back(PendingWrite::SubmitDelay {
+            settle: Duration::from_millis(10),
+            deadline: None,
+        });
+        pending.push_back(PendingWrite::Bytes {
+            bytes: b"later".to_vec(),
+            offset: 0,
+        });
+        assert!(matches!(pending.front(), Some(PendingWrite::Bytes { .. })));
+        pending.pop_front();
+        let start = Instant::now();
+        arm_or_finish_submit_delay(&mut pending, start);
+        assert!(matches!(
+            pending.front(),
+            Some(PendingWrite::SubmitDelay { .. })
+        ));
+        arm_or_finish_submit_delay(&mut pending, start + Duration::from_millis(11));
+        assert!(matches!(
+            pending.front(),
+            Some(PendingWrite::Bytes { bytes, .. }) if bytes == b"\r"
+        ));
+    }
+
+    #[test]
+    fn zero_delay_submit_writes_paste_enter_and_following_bytes_in_order() {
+        let mut sockets = [-1; 2];
+        assert_eq!(
+            unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, sockets.as_mut_ptr()) },
+            0
+        );
+        // SAFETY: socketpair returned two distinct owned descriptors.
+        let writer = unsafe { OwnedFd::from_raw_fd(sockets[0]) };
+        let reader = unsafe { OwnedFd::from_raw_fd(sockets[1]) };
+        set_nonblocking_cloexec(writer.as_raw_fd()).unwrap();
+
+        let mut pending = VecDeque::from([
+            PendingWrite::Bytes {
+                bytes: b"prompt".to_vec(),
+                offset: 0,
+            },
+            PendingWrite::SubmitDelay {
+                settle: Duration::ZERO,
+                deadline: None,
+            },
+            PendingWrite::Bytes {
+                bytes: b"later".to_vec(),
+                offset: 0,
+            },
+        ]);
+        write_pending(writer.as_raw_fd(), &mut pending).unwrap();
+        assert!(pending.is_empty());
+
+        let mut bytes = [0u8; 32];
+        let count =
+            unsafe { libc::read(reader.as_raw_fd(), bytes.as_mut_ptr().cast(), bytes.len()) };
+        assert_eq!(&bytes[..count as usize], b"prompt\rlater");
+    }
+}

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -1,24 +1,23 @@
 //! `alacritty_terminal` implementation of `VtEngine`. Pure Rust — no Zig, no FFI.
 
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
 use alacritty_terminal::event::{Event, EventListener};
 use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::index::{Column, Line, Point};
 use alacritty_terminal::term::cell::Flags;
-use alacritty_terminal::term::{Config, Term, TermMode};
+use alacritty_terminal::term::{Config, Term, TermDamage, TermMode};
 use alacritty_terminal::vte::ansi::{Color as VtColor, NamedColor, Processor, Rgb};
 
 use ratatui::style::{Color, Modifier};
 
 use super::{
-    AlignedRows, CodexComposerRegion, Cursor, HistoryMetrics, RenderCell, RetainedRowLayout,
-    VtEngine, ALIGNED_WIDE_CELL,
+    AlignedRows, CodexComposerRegion, Cursor, DamageCell, DamageKind, DamageRow, DamageSnapshot,
+    HistoryMetrics, RenderCell, RetainedRowLayout, VtEngine, ALIGNED_WIDE_CELL,
 };
 use crate::terminal::appearance::PaneAppearance;
 use crate::terminal::backend::{CaptureMode, CaptureResult};
-use crate::terminal::pty::InputAction;
+use crate::terminal::pty::{InputAction, InputSender};
 
 type TitleSlot = Arc<Mutex<Option<String>>>;
 
@@ -27,7 +26,7 @@ type TitleSlot = Arc<Mutex<Option<String>>>;
 /// Also captures the window title (OSC 0/2) for agent detection.
 #[derive(Clone)]
 pub struct EventProxy {
-    tx: Sender<InputAction>,
+    tx: InputSender,
     title: TitleSlot,
     appearance: Arc<Mutex<PaneAppearance>>,
 }
@@ -93,18 +92,23 @@ pub struct AlacrittyEngine {
     term: Term<EventProxy>,
     parser: Processor,
     title: TitleSlot,
-    response_tx: Sender<InputAction>,
+    response_tx: InputSender,
     appearance: Arc<Mutex<PaneAppearance>>,
     history_budget_bytes: usize,
     output_generation: u64,
+    damage_line_indices: Vec<u16>,
+    damage_rows: Vec<DamageRow>,
 }
+
+const MAX_PARTIAL_DAMAGE_ROWS: usize = 8;
+const MAX_PARTIAL_DAMAGE_CELLS: usize = 2_048;
 
 impl AlacrittyEngine {
     #[cfg(test)]
     pub fn new(
         cols: u16,
         rows: u16,
-        resp_tx: Sender<InputAction>,
+        resp_tx: impl Into<InputSender>,
         history_budget_bytes: usize,
     ) -> Self {
         Self::with_appearance(
@@ -119,10 +123,11 @@ impl AlacrittyEngine {
     pub(crate) fn with_appearance(
         cols: u16,
         rows: u16,
-        resp_tx: Sender<InputAction>,
+        resp_tx: impl Into<InputSender>,
         history_budget_bytes: usize,
         initial_appearance: PaneAppearance,
     ) -> Self {
+        let resp_tx = resp_tx.into();
         let dims = Dims {
             cols: cols.max(1) as usize,
             rows: rows.max(1) as usize,
@@ -152,6 +157,8 @@ impl AlacrittyEngine {
             appearance,
             history_budget_bytes,
             output_generation: 0,
+            damage_line_indices: Vec::new(),
+            damage_rows: Vec::new(),
         }
     }
 
@@ -458,6 +465,126 @@ impl VtEngine for AlacrittyEngine {
                 },
             );
         }
+    }
+
+    fn damage_snapshot(&mut self) -> DamageSnapshot {
+        self.term.finish_output_batch();
+        self.damage_line_indices.clear();
+        let kind = match self.term.damage() {
+            TermDamage::Full => DamageKind::Full,
+            TermDamage::Partial(lines) => {
+                self.damage_line_indices
+                    .extend(lines.map(|line| line.line as u16));
+                DamageKind::Partial
+            }
+        };
+
+        let cursor = self.cursor();
+        let composer_region = self.codex_composer_region();
+        let scroll_offset = self.term.grid().display_offset();
+        let columns = self.term.grid().columns();
+        let too_large = self.damage_line_indices.len() > MAX_PARTIAL_DAMAGE_ROWS
+            || self.damage_line_indices.len().saturating_mul(columns) > MAX_PARTIAL_DAMAGE_CELLS;
+        if kind == DamageKind::Full || too_large {
+            return DamageSnapshot {
+                generation: self.output_generation,
+                kind: DamageKind::Full,
+                cursor,
+                composer_region,
+                scroll_offset,
+                rows: Vec::new(),
+            };
+        }
+
+        let mut row_indices = std::mem::take(&mut self.damage_line_indices);
+        let screen_lines = self.term.grid().screen_lines();
+        row_indices.retain(|row| (*row as usize) < screen_lines);
+        let grid = self.term.grid();
+        let display_offset = grid.display_offset() as i32;
+        let mut damaged_rows = std::mem::take(&mut self.damage_rows);
+        while damaged_rows.len() < row_indices.len() {
+            damaged_rows.push(DamageRow {
+                row: 0,
+                cells: Vec::with_capacity(columns),
+            });
+        }
+        damaged_rows.truncate(row_indices.len());
+        for (damaged_row, row) in damaged_rows.iter_mut().zip(row_indices.iter().copied()) {
+            if row as usize >= grid.screen_lines() {
+                continue;
+            }
+            damaged_row.row = row;
+            let line = Line(row as i32 - display_offset);
+            let mut used = 0;
+            for column in 0..columns {
+                let cell = &grid[line][Column(column)];
+                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                    continue;
+                }
+                let style = RenderCell {
+                    fg: map_color(cell.fg),
+                    bg: map_color(cell.bg),
+                    mods: map_flags(cell.flags),
+                };
+                if let Some(damage_cell) = damaged_row.cells.get_mut(used) {
+                    damage_cell.column = column as u16;
+                    damage_cell.character = cell.c;
+                    damage_cell.zero_width.clear();
+                    if let Some(zero_width) = cell.zerowidth() {
+                        damage_cell.zero_width.extend(zero_width);
+                    }
+                    damage_cell.style = style;
+                } else {
+                    damaged_row.cells.push(DamageCell {
+                        column: column as u16,
+                        character: cell.c,
+                        zero_width: cell.zerowidth().unwrap_or_default().to_vec(),
+                        style,
+                    });
+                }
+                used += 1;
+            }
+            damaged_row.cells.truncate(used);
+        }
+        row_indices.clear();
+        self.damage_line_indices = row_indices;
+
+        DamageSnapshot {
+            generation: self.output_generation,
+            kind: DamageKind::Partial,
+            cursor,
+            composer_region,
+            scroll_offset,
+            rows: damaged_rows,
+        }
+    }
+
+    fn acknowledge_damage(&mut self, generation: u64) -> bool {
+        if self.output_generation != generation {
+            return false;
+        }
+        self.term.reset_damage();
+        true
+    }
+
+    fn recycle_damage_snapshot(&mut self, mut snapshot: DamageSnapshot) {
+        if snapshot.kind != DamageKind::Partial
+            || snapshot.rows.len() > MAX_PARTIAL_DAMAGE_ROWS
+            || snapshot
+                .rows
+                .iter()
+                .map(|row| row.cells.capacity())
+                .sum::<usize>()
+                > MAX_PARTIAL_DAMAGE_CELLS
+        {
+            return;
+        }
+        for row in &mut snapshot.rows {
+            for cell in &mut row.cells {
+                cell.zero_width.clear();
+            }
+        }
+        self.damage_rows = snapshot.rows;
     }
 
     fn detection_text(&self, n: u16) -> String {
@@ -1061,6 +1188,115 @@ mod tests {
 
     fn budget_for_rows(cols: usize, rows: usize) -> usize {
         estimated_row_bytes(cols).saturating_mul(rows)
+    }
+
+    #[test]
+    fn damage_snapshot_is_owned_bounded_and_generation_safe() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(8, 3, tx, budget_for_rows(8, 20));
+
+        let initial = engine.damage_snapshot();
+        assert_eq!(initial.kind, DamageKind::Full);
+        assert!(initial.rows.is_empty());
+        assert!(engine.acknowledge_damage(initial.generation));
+        engine.recycle_damage_snapshot(initial);
+
+        engine.advance("A界e\u{301}".as_bytes());
+        let first = engine.damage_snapshot();
+        assert_eq!(first.kind, DamageKind::Partial);
+        assert_eq!(first.rows.len(), 1);
+        assert_eq!(first.rows[0].row, 0);
+        assert!(first.rows[0].cells.len() <= 8);
+        assert!(first.rows[0]
+            .cells
+            .iter()
+            .any(|cell| cell.character == '界' && cell.zero_width.is_empty()));
+        assert!(first.rows[0]
+            .cells
+            .iter()
+            .any(|cell| cell.character == 'e' && cell.zero_width.as_ref() == ['\u{301}']));
+
+        // Output arriving after capture invalidates the acknowledgement. The
+        // newer byte and the old damage must both survive in the next snapshot.
+        engine.advance(b"Z");
+        assert!(!engine.acknowledge_damage(first.generation));
+        let first_generation = first.generation;
+        engine.recycle_damage_snapshot(first);
+        let second = engine.damage_snapshot();
+        assert!(second.generation > first_generation);
+        assert!(second.rows.iter().any(|row| row.row == 0));
+        assert!(engine.acknowledge_damage(second.generation));
+        engine.recycle_damage_snapshot(second);
+        let cursor_only = engine.damage_snapshot();
+        assert!(cursor_only.rows.len() <= 1, "only cursor damage remains");
+        engine.recycle_damage_snapshot(cursor_only);
+    }
+
+    #[test]
+    fn partial_damage_reuses_row_and_cell_storage() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(80, 24, tx, budget_for_rows(80, 20));
+
+        let initial = engine.damage_snapshot();
+        assert!(engine.acknowledge_damage(initial.generation));
+        engine.recycle_damage_snapshot(initial);
+
+        engine.advance(b"first");
+        let first = engine.damage_snapshot();
+        assert_eq!(first.kind, DamageKind::Partial);
+        assert_eq!(first.rows.len(), 1);
+        let row_ptr = first.rows.as_ptr();
+        let cell_ptr = first.rows[0].cells.as_ptr();
+        let row_capacity = first.rows.capacity();
+        let cell_capacity = first.rows[0].cells.capacity();
+        assert!(engine.acknowledge_damage(first.generation));
+        engine.recycle_damage_snapshot(first);
+
+        engine.advance(b"\rsecond");
+        let second = engine.damage_snapshot();
+        assert_eq!(second.kind, DamageKind::Partial);
+        assert_eq!(second.rows.as_ptr(), row_ptr);
+        assert_eq!(second.rows.capacity(), row_capacity);
+        assert_eq!(second.rows[0].cells.as_ptr(), cell_ptr);
+        assert_eq!(second.rows[0].cells.capacity(), cell_capacity);
+        assert!(engine.acknowledge_damage(second.generation));
+        engine.recycle_damage_snapshot(second);
+    }
+
+    #[test]
+    fn structural_terminal_changes_force_full_damage() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(8, 3, tx, budget_for_rows(8, 20));
+
+        let initial = engine.damage_snapshot();
+        assert!(engine.acknowledge_damage(initial.generation));
+        engine.recycle_damage_snapshot(initial);
+
+        engine.advance(b"\x1b[31;1mX");
+        let styled = engine.damage_snapshot();
+        assert_eq!(styled.kind, DamageKind::Partial);
+        let cell = styled.rows[0]
+            .cells
+            .iter()
+            .find(|cell| cell.character == 'X')
+            .expect("styled cell captured");
+        assert_eq!(cell.style.fg, Color::Indexed(1));
+        assert!(cell.style.mods.contains(Modifier::BOLD));
+        assert!(engine.acknowledge_damage(styled.generation));
+        engine.recycle_damage_snapshot(styled);
+
+        engine.resize(10, 4);
+        let resized = engine.damage_snapshot();
+        assert_eq!(resized.kind, DamageKind::Full);
+        assert!(resized.rows.is_empty());
+        assert!(engine.acknowledge_damage(resized.generation));
+        engine.recycle_damage_snapshot(resized);
+
+        engine.advance(b"\x1b[?1049h");
+        let alternate_screen = engine.damage_snapshot();
+        assert_eq!(alternate_screen.kind, DamageKind::Full);
+        assert!(engine.acknowledge_damage(alternate_screen.generation));
+        engine.recycle_damage_snapshot(alternate_screen);
     }
 
     // docs/07: agent detection must read the **live** screen, never the

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -5,13 +5,12 @@
 
 pub mod alacritty;
 
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
 use ratatui::style::{Color, Modifier};
 
 use crate::terminal::appearance::PaneAppearance;
-use crate::terminal::pty::InputAction;
+use crate::terminal::pty::InputSender;
 
 /// Internal continuation marker used by [`VtEngine::visible_rows_aligned`].
 /// A terminal never renders NUL as text, so it can represent the second cell of
@@ -88,10 +87,11 @@ pub(crate) fn create_engine(
     kind: VtEngineKind,
     cols: u16,
     rows: u16,
-    resp_tx: Sender<InputAction>,
+    resp_tx: impl Into<InputSender>,
     history_budget_bytes: usize,
     appearance: PaneAppearance,
 ) -> Arc<Mutex<dyn VtEngine>> {
+    let resp_tx = resp_tx.into();
     match kind {
         VtEngineKind::Alacritty => {
             Arc::new(Mutex::new(alacritty::AlacrittyEngine::with_appearance(
@@ -109,17 +109,59 @@ pub(crate) fn create_engine(
 /// trait surface stays free of engine-specific types. The cell's *symbol* (its
 /// grapheme cluster) is passed alongside as a `&str`, not stored here, so the
 /// common one-char case needs no per-cell allocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RenderCell {
     pub fg: Color,
     pub bg: Color,
     pub mods: Modifier,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Cursor {
     pub x: u16,
     pub y: u16,
     pub visible: bool,
+}
+
+/// One owned terminal cell captured at a render boundary. Ordinary cells keep
+/// only their scalar value; reusable suffix storage preserves the rare
+/// combining, variation-selector, or joined-glyph case. The VT lock is released
+/// before the UI projects this data into client buffers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DamageCell {
+    pub column: u16,
+    pub character: char,
+    pub zero_width: Vec<char>,
+    pub style: RenderCell,
+}
+
+/// A complete visible terminal row affected by the latest output generation.
+///
+/// Alacritty records narrower column bounds, but Luvus snapshots a complete
+/// damaged row. This keeps wide-character bases, spacer cells, cleared tails,
+/// and combining sequences correct while still avoiding work for every other
+/// visible row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DamageRow {
+    pub row: u16,
+    pub cells: Vec<DamageCell>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DamageKind {
+    Full,
+    Partial,
+}
+
+/// Engine-neutral terminal damage captured under the VT lock.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DamageSnapshot {
+    pub generation: u64,
+    pub kind: DamageKind,
+    pub cursor: Cursor,
+    pub composer_region: Option<CodexComposerRegion>,
+    pub scroll_offset: usize,
+    pub rows: Vec<DamageRow>,
 }
 
 /// Visible rows occupied by Codex's composer, including its blank padding rows.
@@ -212,6 +254,20 @@ pub trait VtEngine: Send {
     /// so emoji and accented text render whole. Wide-char spacer cells are
     /// skipped by the implementation.
     fn for_each_cell(&self, f: &mut dyn FnMut(u16, u16, &str, RenderCell));
+
+    /// Capture owned visible rows affected since the last acknowledged render.
+    /// Implementations may conservatively return [`DamageKind::Full`].
+    fn damage_snapshot(&mut self) -> DamageSnapshot;
+
+    /// Forget damage through `generation` only when no newer output exists.
+    /// Returns `true` when the acknowledgement was accepted. A rejected
+    /// acknowledgement must preserve all damage so a later frame can safely
+    /// repeat work rather than lose output.
+    fn acknowledge_damage(&mut self, generation: u64) -> bool;
+
+    /// Return owned row and cell storage after the caller has finished using a
+    /// snapshot. Implementations may retain a bounded pool or simply drop it.
+    fn recycle_damage_snapshot(&mut self, snapshot: DamageSnapshot);
 
     /// Bottom `n` rows of the visible grid, for agent detection. Independent of
     /// the user's scroll position.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -391,6 +391,65 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     }
 }
 
+/// Whether a PTY-only frame may reuse the active client's complete UI buffer.
+/// Every state that draws over pane content or changes terminal styling forces
+/// the ordinary full renderer. Conservative false negatives cost one full
+/// frame; a false positive could corrupt visible output.
+pub(crate) fn retained_pty_eligible(app: &App) -> bool {
+    app.mode == Mode::Normal
+        // OSC title changes arrive with PTY output and can alter an agent row
+        // outside the pane. Until retained chrome has its own invalidation,
+        // keep that optional projection on the full path.
+        && !app.config.layout.agent_title
+        && app.selection.is_none()
+        && app.copy_mode.is_none()
+        && app.hover_link.is_none()
+        && app.search_flash.is_none()
+        && app.settings.is_none()
+        && app.picker.is_none()
+        && !app.help_open
+        && !app.changelog_open
+        && app.cmd_inspect.is_none()
+        && app.worktree_prompt.is_none()
+        && app.tab_rename.is_none()
+        && app.tab_menu.is_none()
+        && app.ws_rename.is_none()
+        && app.pane_rename.is_none()
+        && app.ws_menu.is_none()
+        && app.pane_menu.is_none()
+        && app.agent_menu.is_none()
+        && app.file_menu.is_none()
+        && app.diff_menu.is_none()
+        && app.orch_menu.is_none()
+        && app.dock_menu.is_none()
+        && app.file_prompt.is_none()
+        && app.file_delete.is_none()
+        && app.worktree_delete.is_none()
+        && !app.switcher
+        && app.named_session_menu.is_none()
+        && app.search.is_none()
+        && app.orch_form.is_none()
+        && app.orch_start.is_none()
+        && app.orch_detail.is_none()
+        && app.mission_detail.is_none()
+        && app.mission_answer.is_none()
+        && app.bar.overflow.is_none()
+        && app.toast.is_none()
+        && !app.active_is_git()
+        && !app.active_is_orch()
+        && !app.active_is_mission()
+}
+
+/// Apply owned VT damage to an already complete active-client projection.
+pub(crate) fn patch_terminal_damage(
+    target: &mut RenderTarget,
+    app: &App,
+    content_rects: &[(PaneId, Rect)],
+    snapshots: &std::collections::HashMap<PaneId, crate::terminal::vt::DamageSnapshot>,
+) -> Result<(), ()> {
+    panes::patch_terminal_damage(target, app, content_rects, snapshots)
+}
+
 fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
     let t = app.theme.clone();
     // The active i18n catalog (Copy `&'static`), passed to draw fns that don't
@@ -1190,6 +1249,155 @@ fn short_path(p: &Path, max: u16) -> String {
         format!("…{tail}")
     } else {
         s
+    }
+}
+
+#[cfg(test)]
+mod retained_render_tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::mpsc;
+
+    use crate::terminal::appearance::PaneAppearance;
+    use crate::terminal::vt::{create_engine, VtEngineKind};
+
+    #[test]
+    fn damaged_rows_match_a_forced_full_projection() {
+        let _env = crate::persist::test_env("retained-render-equivalence");
+        let (app_tx, _app_rx) = mpsc::channel();
+        let mut app = App::new(100, 30, app_tx).expect("app starts");
+        let focus = app.layout().focus;
+        let (response_tx, _response_rx) = mpsc::channel();
+        let engine = create_engine(
+            VtEngineKind::Alacritty,
+            100,
+            30,
+            response_tx,
+            4 * 1024 * 1024,
+            PaneAppearance::default(),
+        );
+        app.panes.get_mut(&focus).expect("focused pane").engine = engine.clone();
+
+        {
+            let mut engine = engine.lock().expect("engine lock");
+            engine.advance("hello 界\r\nsecond line".as_bytes());
+        }
+        let area = Rect::new(0, 0, 100, 30);
+        let mut retained = Buffer::empty(area);
+        let mut initial_target = RenderTarget::new(&mut retained, area);
+        render_into(&mut initial_target, &mut app);
+        let content_rects = app.pane_content_rects.clone();
+        {
+            let mut engine = engine.lock().expect("engine lock");
+            let initial = engine.damage_snapshot();
+            assert!(engine.acknowledge_damage(initial.generation));
+            engine.recycle_damage_snapshot(initial);
+            engine.advance(b"\rA\x1b[K");
+        }
+        let snapshot = engine.lock().expect("engine lock").damage_snapshot();
+        assert_eq!(snapshot.kind, crate::terminal::vt::DamageKind::Partial);
+        let snapshots = HashMap::from([(focus, snapshot)]);
+
+        let partial_cursor = {
+            let mut target = RenderTarget::new(&mut retained, area);
+            patch_terminal_damage(&mut target, &app, &content_rects, &snapshots)
+                .expect("partial projection eligible");
+            (target.cursor(), target.cursor_visible())
+        };
+
+        let mut forced = Buffer::empty(area);
+        let full_cursor = {
+            let mut target = RenderTarget::new(&mut forced, area);
+            render_into(&mut target, &mut app);
+            (target.cursor(), target.cursor_visible())
+        };
+        assert_eq!(retained, forced);
+        assert_eq!(partial_cursor, full_cursor);
+        let snapshot = snapshots.into_values().next().expect("damage snapshot");
+        engine
+            .lock()
+            .expect("engine lock")
+            .recycle_damage_snapshot(snapshot);
+    }
+
+    /// Projection-only evidence for docs/115. Ignored in the ordinary suite
+    /// because wall-clock ratios are machine dependent; run in release mode.
+    #[test]
+    #[ignore]
+    fn retained_projection_benchmark() {
+        let _env = crate::persist::test_env("retained-render-benchmark");
+        let (app_tx, _app_rx) = mpsc::channel();
+        let mut app = App::new(160, 40, app_tx).expect("app starts");
+        let focus = app.layout().focus;
+        let (response_tx, _response_rx) = mpsc::channel();
+        let engine = create_engine(
+            VtEngineKind::Alacritty,
+            160,
+            40,
+            response_tx,
+            4 * 1024 * 1024,
+            PaneAppearance::default(),
+        );
+        app.panes.get_mut(&focus).expect("focused pane").engine = engine.clone();
+        let area = Rect::new(0, 0, 160, 40);
+        let mut retained = Buffer::empty(area);
+        let mut target = RenderTarget::new(&mut retained, area);
+        render_into(&mut target, &mut app);
+        let content_rects = app.pane_content_rects.clone();
+        let initial = engine.lock().expect("engine lock").damage_snapshot();
+        assert!(engine
+            .lock()
+            .expect("engine lock")
+            .acknowledge_damage(initial.generation));
+        engine
+            .lock()
+            .expect("engine lock")
+            .recycle_damage_snapshot(initial);
+
+        const ITERATIONS: usize = 2_000;
+        let partial_started = std::time::Instant::now();
+        for index in 0..ITERATIONS {
+            engine
+                .lock()
+                .expect("engine lock")
+                .advance(format!("\rrow {index:04}").as_bytes());
+            let snapshot = engine.lock().expect("engine lock").damage_snapshot();
+            let generation = snapshot.generation;
+            let snapshots = HashMap::from([(focus, snapshot)]);
+            let mut target = RenderTarget::new(&mut retained, area);
+            patch_terminal_damage(&mut target, &app, &content_rects, &snapshots).unwrap();
+            assert!(engine
+                .lock()
+                .expect("engine lock")
+                .acknowledge_damage(generation));
+            let snapshot = snapshots.into_values().next().expect("damage snapshot");
+            engine
+                .lock()
+                .expect("engine lock")
+                .recycle_damage_snapshot(snapshot);
+            std::hint::black_box(target.cursor());
+        }
+        let partial = partial_started.elapsed();
+
+        let mut forced = Buffer::empty(area);
+        let full_started = std::time::Instant::now();
+        for index in 0..ITERATIONS {
+            engine
+                .lock()
+                .expect("engine lock")
+                .advance(format!("\rfull {index:04}").as_bytes());
+            forced.reset();
+            let mut target = RenderTarget::new(&mut forced, area);
+            render_into(&mut target, &mut app);
+            std::hint::black_box(target.cursor());
+        }
+        let full = full_started.elapsed();
+        eprintln!(
+            "retained_projection iterations={ITERATIONS} partial_ns={} full_ns={} ratio={:.3}",
+            partial.as_nanos(),
+            full.as_nanos(),
+            partial.as_secs_f64() / full.as_secs_f64()
+        );
     }
 }
 

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -205,6 +205,86 @@ pub(super) fn draw_panes(
     cursor
 }
 
+/// Patch only terminal rows captured by the VT damage ledger into a retained
+/// client buffer. The caller has already proved that geometry and every
+/// non-terminal layer are unchanged. Any uncertainty returns `Err(())` and the
+/// server immediately uses the ordinary full renderer.
+pub(super) fn patch_terminal_damage(
+    f: &mut RenderTarget,
+    app: &App,
+    content_rects: &[(PaneId, Rect)],
+    snapshots: &std::collections::HashMap<PaneId, crate::terminal::vt::DamageSnapshot>,
+) -> Result<(), ()> {
+    let leaves = app.layout().leaves();
+    if leaves.len() != content_rects.len()
+        || leaves.iter().any(|id| app.views.contains_key(id))
+        || leaves
+            .iter()
+            .any(|id| !snapshots.contains_key(id) || !app.panes.contains_key(id))
+    {
+        return Err(());
+    }
+
+    let theme = &app.theme;
+    let focus = app.layout().focus;
+    let mut cursor = None;
+    for id in leaves {
+        let content = content_rects
+            .iter()
+            .find_map(|(candidate, rect)| (*candidate == id).then_some(*rect))
+            .ok_or(())?;
+        let snapshot = snapshots.get(&id).ok_or(())?;
+        if snapshot.kind != crate::terminal::vt::DamageKind::Partial
+            || snapshot.composer_region.is_some()
+            || snapshot.scroll_offset != 0
+            || app
+                .status
+                .get(&id)
+                .is_some_and(|status| status.agent == "pi")
+        {
+            return Err(());
+        }
+
+        let blank = Style::new().bg(theme.mantle);
+        let buffer = f.buffer_mut();
+        let mut stack = [0u8; 4];
+        let mut combined = String::new();
+        for row in &snapshot.rows {
+            if row.row >= content.height {
+                continue;
+            }
+            let y = content.y + row.row;
+            for x in content.x..content.x.saturating_add(content.width) {
+                let cell = &mut buffer[(x, y)];
+                cell.reset();
+                cell.set_symbol(" ");
+                cell.set_style(blank);
+            }
+            for cell in &row.cells {
+                let style = terminal_cell_style(cell.style, theme, app.downsample);
+                let symbol: &str = if cell.zero_width.is_empty() {
+                    cell.character.encode_utf8(&mut stack)
+                } else {
+                    combined.clear();
+                    combined.push(cell.character);
+                    combined.extend(cell.zero_width.iter());
+                    &combined
+                };
+                paint_terminal_cell(buffer, content, row.row, cell.column, symbol, style);
+            }
+        }
+
+        if id == focus {
+            cursor = pane_ime_cursor(content, snapshot.cursor);
+        }
+    }
+
+    if let Some((x, y, visible)) = cursor {
+        f.set_cursor_anchor(x, y, visible);
+    }
+    Ok(())
+}
+
 fn draw_one_pane(
     f: &mut RenderTarget,
     area: Rect,
@@ -345,25 +425,7 @@ fn draw_one_pane(
                     }
                     let x = content.x + col;
                     let y = content.y + row;
-                    let conv = |c: Color| {
-                        if downsample {
-                            crate::ipc::protocol::to_256(c)
-                        } else {
-                            c
-                        }
-                    };
-                    let fg = if cell.fg == Color::Reset {
-                        t.text
-                    } else {
-                        conv(cell.fg)
-                    };
-                    let mut style = Style::new().fg(fg);
-                    if !cell.mods.is_empty() {
-                        style = style.add_modifier(cell.mods);
-                    }
-                    if cell.bg != Color::Reset {
-                        style = style.bg(conv(cell.bg));
-                    }
+                    let mut style = terminal_cell_style(cell, t, downsample);
                     // Highlight the cell if it's inside the mouse selection.
                     if sel.is_some_and(|selection| {
                         selection.retained.map_or_else(
@@ -405,33 +467,7 @@ fn draw_one_pane(
                             .fg(t.accent)
                             .add_modifier(ratatui::style::Modifier::UNDERLINED);
                     }
-                    // ratatui panics if a control char reaches the buffer; the VT
-                    // grid can hold stray C0/C1 bytes, so render those blank. `sym`
-                    // is the whole grapheme cluster (base + combining/VS16/ZWJ), so
-                    // emoji and accents print whole instead of losing their modifier
-                    // chars to a tofu box.
-                    let sym = if sym.starts_with(|c: char| c.is_control()) {
-                        " "
-                    } else {
-                        sym
-                    };
-                    let target = &mut buf[(x, y)];
-                    target.set_symbol(sym);
-                    target.set_style(style);
-                    // A double-width glyph (emoji / CJK) spans this cell *and* the
-                    // next. The VT engine skips the spacer, so that next cell keeps
-                    // the reset blank — which the client would blit as a space over
-                    // the glyph's right half (crossterm advances its cursor +1 per
-                    // cell, but the terminal advances +2 for the glyph), corrupting
-                    // it and shifting the row. Mark it as a wide-char continuation:
-                    // an empty symbol prints nothing, realigning the accounting.
-                    if x + 1 < content.x + content.width
-                        && unicode_width::UnicodeWidthStr::width(sym) == 2
-                    {
-                        let next = &mut buf[(x + 1, y)];
-                        next.set_symbol("");
-                        next.set_style(style); // carry bg so a highlight stays contiguous
-                    }
+                    paint_terminal_cell(buf, content, row, col, sym, style);
                 });
             }
             scrolled = engine.scroll_offset();
@@ -507,6 +543,66 @@ fn pane_ime_cursor(content: Rect, cur: crate::terminal::vt::Cursor) -> Option<(u
         return None;
     }
     Some((content.x + cur.x, content.y + cur.y, cur.visible))
+}
+
+fn terminal_cell_style(
+    cell: crate::terminal::vt::RenderCell,
+    t: &Theme,
+    downsample: bool,
+) -> Style {
+    let convert = |color: Color| {
+        if downsample {
+            crate::ipc::protocol::to_256(color)
+        } else {
+            color
+        }
+    };
+    let foreground = if cell.fg == Color::Reset {
+        t.text
+    } else {
+        convert(cell.fg)
+    };
+    let mut style = Style::new().fg(foreground);
+    if !cell.mods.is_empty() {
+        style = style.add_modifier(cell.mods);
+    }
+    if cell.bg != Color::Reset {
+        style = style.bg(convert(cell.bg));
+    }
+    style
+}
+
+fn paint_terminal_cell(
+    buf: &mut Buffer,
+    content: Rect,
+    row: u16,
+    column: u16,
+    symbol: &str,
+    style: Style,
+) {
+    if row >= content.height || column >= content.width {
+        return;
+    }
+    // Ratatui rejects C0/C1 text. The symbol is otherwise the complete
+    // grapheme cluster, including combining marks and emoji joiners.
+    let symbol = if symbol.starts_with(char::is_control) {
+        " "
+    } else {
+        symbol
+    };
+    let x = content.x + column;
+    let y = content.y + row;
+    let target = &mut buf[(x, y)];
+    target.set_symbol(symbol);
+    target.set_style(style);
+
+    // The engine omits a wide glyph's spacer cell. Preserve it as an empty
+    // Ratatui symbol so the client does not print a space over the right half.
+    if x + 1 < content.x + content.width && unicode_width::UnicodeWidthStr::width(symbol) == 2 {
+        let next = &mut buf[(x + 1, y)];
+        next.set_symbol("");
+        next.set_style(style);
+    }
 }
 
 /// Pi's `CURSOR_MARKER` (`ESC_pi:c BEL`) is stripped in `extractCursorPosition`


### PR DESCRIPTION
Luvus now patches bounded terminal damage and uses one Unix PTY I/O actor per pane, reducing sparse render work and pane-fleet resource usage without changing user-facing behavior.

## What

- retain the foreground client's terminal projection and patch only eligible damaged rows
- reuse bounded damage row, cell, combining-character, and server scratch storage across frames
- keep full rendering as the correctness fallback for structural changes, uncertain state, passive clients, scrolling, overlays, and backpressure recovery
- acknowledge terminal damage only when the captured output generation is still current
- replace the Unix reader and writer thread pair with one nonblocking poll actor per pane
- preserve the existing split reader and writer backend on Windows
- expose focused terminal projection counters through the existing performance data

## Why

Sparse terminal output previously rebuilt the full client projection even when only one row changed. Settled Unix panes also retained separate reader and writer threads, increasing thread count and stack overhead as the pane fleet grew.

The retained renderer reduces repeat projection work while generation checks and full-frame resynchronization preserve correctness. The Unix actor handles reads, writes, wakeups, partial I/O, and cancellation through one bounded owner without changing the PTY lifecycle facade.

## Measured result

All measurements used locked release builds, three fresh isolated sessions per case, identical dimensions and workloads, and commit `18c4244` as the pre-change baseline.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Sparse server CPU | 2.62% | 1.80% | 31.2% lower |
| Attached sparse RSS | 14,763 KiB | 14,336 KiB | 2.9% lower |
| Fresh ten-pane server threads | 24 | 14 | 41.7% lower |
| Fresh ten-pane RSS | 10,731 KiB | 10,309 KiB | 3.9% lower |
| Attached ten-pane server threads | 26 | 16 | 38.5% lower |
| Attached ten-pane RSS | 13,232 KiB | 12,832 KiB | 3.0% lower |
| Dense two-million-line completion | 1.4243 s | 1.4194 s | 0.3% faster |

The release projection benchmark completed 2,000 retained updates in 3,920,583 ns versus 212,157,833 ns through forced full projection, a ratio of 0.018. This is projection-layer evidence and is not presented as an end-to-end CPU ratio.

## Verification

- [x] `cargo test --locked`
  - 1,293 unit tests passed with one intentional ignored benchmark
  - 15 CLI, session, and theme integration tests passed
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --locked`
- [x] release retained-projection benchmark
- [x] isolated ten-pane debug lifecycle
  - all panes concurrently completed 500 output lines
  - nine panes closed cleanly
  - the named server stopped and was deleted cleanly

## Notes

- No CLI, API, UHP, persistence, keybinding, agent-detection, or configuration behavior changes.
- Windows keeps its existing PTY I/O backend.
- macOS runtime validation passed. Windows and Linux runtime coverage remains with CI.
- Production Luvus was not attached, restarted, or measured during development.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved terminal rendering efficiency by updating only changed visible rows when conditions allow.
  * Added automatic fallback to full rendering when screen state or layout changes require it.
  * Added performance tracking for partial renders, full renders, and fallbacks.

* **Reliability**
  * Improved Unix terminal input/output handling with more responsive processing.
  * Added recovery and resynchronization after rendering backpressure.

* **Testing**
  * Added coverage for partial rendering, damage tracking, terminal input ordering, and resynchronization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->