### PR TITLE
fix(input): restore macOS Option editing chords

### DIFF
--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -411,7 +411,7 @@ fn write_decoded_input(
 }
 
 fn event_message(event: Event) -> Option<ClientMessage> {
-    match event {
+    match crate::terminal::host_key::normalize_platform_modifiers(event) {
         Event::Key(k) => Some(ClientMessage::Key(k)),
         Event::Mouse(m) => Some(ClientMessage::Mouse(m)),
         Event::Resize(cols, rows) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1469,7 +1469,7 @@ fn send_decoded_input(
 }
 
 fn app_event(event: Event) -> Option<AppEvent> {
-    match event {
+    match crate::terminal::host_key::normalize_platform_modifiers(event) {
         Event::Key(k) => Some(AppEvent::Key(k)),
         Event::Mouse(m) => Some(AppEvent::Mouse(m)),
         Event::Resize(_, _) => Some(AppEvent::Resize),

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,6 +5,27 @@ use std::path::{Path, PathBuf};
 #[cfg(windows)]
 mod windows;
 
+#[cfg(target_os = "macos")]
+mod macos;
+
+/// Whether the physical Option modifier is currently held by the local user.
+///
+/// Some macOS terminal emulators consume Option while translating Backspace,
+/// leaving Crossterm with an indistinguishable plain Backspace event. Querying
+/// the combined session flags at that narrow boundary lets the client restore
+/// Option without changing terminal configuration or globally intercepting
+/// keyboard input. Other platforms already report Alt through their terminal
+/// or console event and deliberately return false here.
+#[cfg(target_os = "macos")]
+pub fn option_modifier_pressed() -> bool {
+    macos::option_modifier_pressed()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn option_modifier_pressed() -> bool {
+    false
+}
+
 /// Do two paths name the same folder? (docs/43 WIN-6.)
 ///
 /// Node lookup used to compare `PathBuf`s with `==`, so any difference in

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,0 +1,20 @@
+//! Narrow macOS host-input helpers.
+
+/// `CGEventSourceStateID::combinedSessionState`.
+const COMBINED_SESSION_STATE: i32 = 0;
+/// `CGEventFlags::maskAlternate`, which represents either Option key.
+const OPTION_FLAG: u64 = 1 << 19;
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGEventSourceFlagsState(state_id: i32) -> u64;
+}
+
+/// Read the current modifier state without installing an event tap, polling,
+/// spawning a thread, or requesting Accessibility permission.
+pub(super) fn option_modifier_pressed() -> bool {
+    // SAFETY: `CGEventSourceFlagsState` is a process-safe value query. The
+    // combined-session state id is a documented enum value and needs no owned
+    // pointer or callback lifetime.
+    unsafe { CGEventSourceFlagsState(COMBINED_SESSION_STATE) & OPTION_FLAG != 0 }
+}

--- a/src/terminal/host_key.rs
+++ b/src/terminal/host_key.rs
@@ -1,0 +1,73 @@
+//! Normalize host key events before they cross the client/server boundary.
+
+use ratatui::crossterm::event::{Event, KeyCode, KeyModifiers};
+
+/// Restore a macOS Option modifier that the outer terminal consumed while
+/// translating Backspace/Delete. This runs in the interactive client, while
+/// the physical key is still held, before the event crosses IPC to the server.
+///
+/// The correction is deliberately limited to otherwise-unmodified editing
+/// keys. Plain Backspace remains plain, and Linux/Windows retain the modifiers
+/// supplied by their terminal or console input implementations.
+pub fn normalize_platform_modifiers(event: Event) -> Event {
+    let should_probe = matches!(
+        &event,
+        Event::Key(key)
+            if key.modifiers.is_empty()
+                && matches!(key.code, KeyCode::Backspace | KeyCode::Delete)
+    );
+    if !should_probe {
+        return event;
+    }
+    restore_option_for_editing_key(event, crate::platform::option_modifier_pressed())
+}
+
+fn restore_option_for_editing_key(mut event: Event, option_pressed: bool) -> Event {
+    let Event::Key(key) = &mut event else {
+        return event;
+    };
+    if option_pressed
+        && key.modifiers.is_empty()
+        && matches!(key.code, KeyCode::Backspace | KeyCode::Delete)
+    {
+        key.modifiers.insert(KeyModifiers::ALT);
+    }
+    event
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::KeyEvent;
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn macos_option_is_restored_only_for_plain_editing_keys() {
+        for code in [KeyCode::Backspace, KeyCode::Delete] {
+            assert!(matches!(
+                restore_option_for_editing_key(key(code), true),
+                Event::Key(key) if key.code == code && key.modifiers == KeyModifiers::ALT
+            ));
+        }
+
+        assert!(matches!(
+            restore_option_for_editing_key(key(KeyCode::Char('x')), true),
+            Event::Key(key)
+                if key.code == KeyCode::Char('x') && key.modifiers.is_empty()
+        ));
+        assert!(matches!(
+            restore_option_for_editing_key(key(KeyCode::Backspace), false),
+            Event::Key(key)
+                if key.code == KeyCode::Backspace && key.modifiers.is_empty()
+        ));
+
+        let shifted = Event::Key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::SHIFT));
+        assert!(matches!(
+            restore_option_for_editing_key(shifted, true),
+            Event::Key(key) if key.modifiers == KeyModifiers::SHIFT
+        ));
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -5,6 +5,7 @@ pub mod appearance;
 pub mod backend;
 #[cfg(any(windows, test))]
 pub mod host_input;
+pub mod host_key;
 pub mod pty;
 pub mod theme_probe;
 pub mod vt;


### PR DESCRIPTION
## Summary

- restore the physical macOS Option modifier when a terminal reports Option+Backspace or Option+Delete as an unmodified editing key
- normalize host input in both the thin client and `--local` path before it reaches application or IPC handling
- preserve the existing cross-platform `Alt` key model without changing Linux, Windows, AltGr, or printable macOS Option characters

## Problem

The pane encoder already forwards Alt+Backspace as `ESC DEL`, but some macOS terminal configurations consume Option and deliver only a plain Backspace event. Luvus therefore cannot reach the existing Alt branch and deletes one character instead of one word.

## Implementation

A narrow macOS platform helper reads the current combined-session Option flag through CoreGraphics. The client queries it only for otherwise-unmodified Backspace/Delete events, while the physical key is still held. No event tap, Accessibility permission, polling loop, background thread, dependency, protocol change, or server work is introduced.

The recovery intentionally excludes printable keys. Option-based text such as accented or keyboard-layout-specific characters remains ordinary text rather than being converted into Luvus shortcuts.

## Verification

- `cargo test macos_option_is_restored_only_for_plain_editing_keys -- --nocapture`
- `cargo test alt_backspace_sends_meta_delete_for_word_deletion -- --nocapture`
- `cargo test direct_alt_arrows_switch_tabs_without_changing_prefix_bindings -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- confirmed the debug binary links CoreGraphics and resolves `CGEventSourceFlagsState`

A final physical Option+Backspace check in macOS terminal applications remains useful because automated tests cannot synthesize the exact host-terminal modifier-consumption boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS keyboard input handling by preserving the Option modifier for Backspace and Delete shortcuts.
  * Ensured normalized keyboard modifiers are consistently applied across application and client event processing.
  * Maintained existing behavior for mouse, resize, paste, focus, and unsupported events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->