### PR TITLE
fix(files): preserve Claude terminal file links

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3102,7 +3102,49 @@ impl App {
             // column the underline lands on (or which cells Ctrl-click opens).
             engine.visible_rows_aligned()
         };
-        let link = crate::links::link_at(rows.rows(), col - content.x, row - content.y)?;
+        let grid_col = col - content.x;
+        let grid_row = row - content.y;
+
+        // OSC 8 carries an authoritative target which can differ from the label
+        // Claude and other terminal programs render. Preserve it rather than
+        // reclassifying a visible filename as a website. An unsupported or
+        // malformed target is deliberately inert and never falls back to the
+        // label, since that would undo the safety boundary.
+        if let Some(hyperlink) = rows.hyperlink_at(grid_row, grid_col) {
+            let uri = hyperlink.uri();
+            let visible = crate::links::link_at(rows.rows(), grid_col, grid_row);
+            let line = visible.as_ref().and_then(|link| match &link.hit {
+                crate::links::Hit::Path { line, .. } => *line,
+                crate::links::Hit::Url(_) => None,
+            });
+            let (hit, target) = if let Some(path) = crate::links::file_uri_path(uri) {
+                if !path.is_file() {
+                    return None;
+                }
+                (
+                    crate::links::Hit::Path {
+                        raw: uri.to_string(),
+                        text: path.to_string_lossy().into_owned(),
+                        line,
+                    },
+                    LinkTarget::File { path, line },
+                )
+            } else if crate::platform::is_openable_url(uri) {
+                (
+                    crate::links::Hit::Url(uri.to_string()),
+                    LinkTarget::Url(uri.to_string()),
+                )
+            } else {
+                return None;
+            };
+            let link = crate::links::Link {
+                hit,
+                spans: hyperlink.spans().to_vec(),
+            };
+            return Some(HoverLink { pane, link, target });
+        }
+
+        let link = crate::links::link_at(rows.rows(), grid_col, grid_row)?;
         let target = match &link.hit {
             crate::links::Hit::Url(u) => {
                 crate::platform::is_openable_url(u).then(|| LinkTarget::Url(u.clone()))?
@@ -5289,6 +5331,35 @@ mod link_click_tests {
         (app, term, (content.x + at, content.y))
     }
 
+    /// A fixture whose visible label and OSC 8 target intentionally differ.
+    fn fixture_showing_osc8(
+        label: &str,
+        uri: &str,
+        at: u16,
+    ) -> (App, Terminal<TestBackend>, (u16, u16)) {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let pane = app.layout().focus;
+        let sequence = format!("\x1b[H\x1b[2J\x1b]8;id=agent;{uri}\x1b\\{label}\x1b]8;;\x1b\\\r\n");
+        app.panes
+            .get(&pane)
+            .unwrap()
+            .engine
+            .lock()
+            .unwrap()
+            .advance(sequence.as_bytes());
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        let content = app
+            .pane_content_rects
+            .iter()
+            .find(|(p, _)| *p == pane)
+            .map(|(_, r)| *r)
+            .expect("pane content rect");
+        (app, term, (content.x + at, content.y))
+    }
+
     fn double_click(app: &mut App, at: (u16, u16)) {
         app.handle_event(mouse(
             MouseEventKind::Down(MouseButton::Left),
@@ -5338,6 +5409,58 @@ mod link_click_tests {
         let (app, id, tabs) = click_cargo_toml(KeyModifiers::CONTROL);
         assert_eq!(app.ws().tabs.len(), tabs, "no new tab");
         assert!(app.preview_views.contains(&id), "it is the preview pane");
+    }
+
+    #[test]
+    fn osc8_file_target_overrides_a_domain_shaped_label() {
+        let _env = crate::persist::test_env("link-osc8-file");
+        let path = std::env::current_dir().unwrap().join("Cargo.toml");
+        let uri = format!("file://{}", path.display());
+        let (app, _term, at) = fixture_showing_osc8("luvus.dev", &uri, 2);
+
+        match app.link_at_screen(at.0, at.1).map(|hover| hover.target) {
+            Some(LinkTarget::File {
+                path: target,
+                line: None,
+            }) => assert_eq!(target, path),
+            other => panic!("OSC 8 file target must win over its label, got {other:?}"),
+        }
+        assert!(app.pending_open_url.is_none());
+    }
+
+    #[test]
+    fn osc8_file_label_preserves_a_visible_line_number() {
+        let _env = crate::persist::test_env("link-osc8-line");
+        let path = std::env::current_dir().unwrap().join("Cargo.toml");
+        let uri = format!("file://{}", path.display());
+        let (app, _term, at) = fixture_showing_osc8("Cargo.toml:42", &uri, 3);
+
+        assert!(matches!(
+            app.link_at_screen(at.0, at.1).map(|hover| hover.target),
+            Some(LinkTarget::File {
+                path: target,
+                line: Some(42)
+            }) if target == path
+        ));
+    }
+
+    #[test]
+    fn unsupported_osc8_target_is_inert_without_label_fallback() {
+        let _env = crate::persist::test_env("link-osc8-inert");
+        let (app, _term, at) = fixture_showing_osc8("luvus.dev", "vscode://file/repo/main.rs", 2);
+
+        assert_eq!(app.link_at_screen(at.0, at.1), None);
+    }
+
+    #[test]
+    fn http_osc8_target_opens_even_when_its_label_looks_like_a_file() {
+        let _env = crate::persist::test_env("link-osc8-http");
+        let (app, _term, at) = fixture_showing_osc8("Cargo.toml", "https://example.com/actual", 2);
+
+        assert_eq!(
+            app.link_at_screen(at.0, at.1).map(|hover| hover.target),
+            Some(LinkTarget::Url("https://example.com/actual".into()))
+        );
     }
 
     /// `Open in tab` is the other click behavior, and the only placement that

--- a/src/links.rs
+++ b/src/links.rs
@@ -7,6 +7,86 @@
 //! one cell to the token's edges and stops. A pane full of text costs the same
 //! as an empty one, which is what keeps this off the render hot path.
 
+use std::path::PathBuf;
+
+/// Decode an OSC 8 `file://` target into an absolute local path.
+///
+/// Only an empty authority or `localhost` is accepted. Invalid escaping,
+/// control characters, query strings, fragments, and relative paths are
+/// rejected so terminal output cannot hand an arbitrary URI to the OS.
+pub fn file_uri_path(uri: &str) -> Option<PathBuf> {
+    if uri
+        .chars()
+        .any(|character| character.is_control() || character.is_whitespace())
+    {
+        return None;
+    }
+    let rest = uri.strip_prefix("file://")?;
+    if rest.contains(['?', '#']) {
+        return None;
+    }
+    let encoded_path = if rest.starts_with('/') {
+        rest
+    } else {
+        let slash = rest.find('/')?;
+        let authority = &rest[..slash];
+        if !authority.eq_ignore_ascii_case("localhost") {
+            return None;
+        }
+        &rest[slash..]
+    };
+    let decoded = percent_decode_uri_path(encoded_path)?;
+    if decoded.starts_with("//") || decoded.starts_with("\\\\") {
+        return None;
+    }
+
+    #[cfg(windows)]
+    let decoded = {
+        let bytes = decoded.as_bytes();
+        if bytes.len() >= 4
+            && bytes[0] == b'/'
+            && bytes[1].is_ascii_alphabetic()
+            && bytes[2] == b':'
+            && bytes[3] == b'/'
+        {
+            decoded[1..].to_string()
+        } else {
+            decoded
+        }
+    };
+
+    let path = PathBuf::from(decoded);
+    path.is_absolute().then_some(path)
+}
+
+fn percent_decode_uri_path(encoded: &str) -> Option<String> {
+    let bytes = encoded.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        let high = hex_value(*bytes.get(index + 1)?)?;
+        let low = hex_value(*bytes.get(index + 2)?)?;
+        decoded.push((high << 4) | low);
+        index += 3;
+    }
+    let decoded = String::from_utf8(decoded).ok()?;
+    (!decoded.chars().any(char::is_control)).then_some(decoded)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 /// What a grid token turned out to be.
 ///
 /// A path is returned **unresolved**: this module does no IO, so whether the file
@@ -317,6 +397,42 @@ pub fn link_at(rows: &[String], col: u16, row: u16) -> Option<Link> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decodes_only_absolute_local_file_uris() {
+        #[cfg(unix)]
+        {
+            assert_eq!(
+                file_uri_path("file:///Users/example/My%20File.rs"),
+                Some(PathBuf::from("/Users/example/My File.rs"))
+            );
+            assert_eq!(
+                file_uri_path("file://localhost/Users/example/main.rs"),
+                Some(PathBuf::from("/Users/example/main.rs"))
+            );
+        }
+        #[cfg(windows)]
+        assert_eq!(
+            file_uri_path("file:///C:/Users/example/main.rs"),
+            Some(PathBuf::from("C:/Users/example/main.rs"))
+        );
+
+        for rejected in [
+            "file://server/share/main.rs",
+            "file:////server/share/main.rs",
+            "file://relative.rs",
+            "file:///bad%2",
+            "file:///bad%GG",
+            "file:///bad%00name",
+            "file:///path.rs?query",
+            "file:///path.rs#fragment",
+            "file:///literal space.rs",
+            "vscode://file/path.rs",
+            "https://example.com/path.rs",
+        ] {
+            assert_eq!(file_uri_path(rejected), None, "accepted {rejected:?}");
+        }
+    }
 
     /// Pad to a fixed width, the way `visible_rows` hands them over.
     fn grid(lines: &[&str], w: usize) -> Vec<String> {

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -701,6 +701,14 @@ impl VtEngine for AlacrittyEngine {
             } else {
                 indexed.cell.zerowidth()
             };
+            if let Some(hyperlink) = indexed.cell.hyperlink() {
+                lines.push_hyperlink_cell(
+                    r as u16,
+                    indexed.point.column.0 as u16,
+                    hyperlink.id(),
+                    hyperlink.uri(),
+                );
+            }
             lines.push_cell(r as u16, indexed.point.column.0 as u16, c, zero_width);
         }
         lines
@@ -1188,6 +1196,22 @@ mod tests {
 
     fn budget_for_rows(cols: usize, rows: usize) -> usize {
         estimated_row_bytes(cols).saturating_mul(rows)
+    }
+
+    #[test]
+    fn visible_rows_retain_osc8_targets_and_spans() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(24, 2, tx, budget_for_rows(24, 20));
+        engine.advance(
+            b"before \x1b]8;id=claude;file:///repo/src/main.rs\x1b\\main.rs\x1b]8;;\x1b\\ after",
+        );
+
+        let rows = engine.visible_rows_aligned();
+        let hyperlink = rows.hyperlink_at(0, 8).expect("OSC 8 target retained");
+        assert_eq!(hyperlink.uri(), "file:///repo/src/main.rs");
+        assert_eq!(hyperlink.spans(), &[(0, 7, 14)]);
+        assert!(rows.hyperlink_at(0, 6).is_none());
+        assert!(rows.hyperlink_at(0, 14).is_none());
     }
 
     #[test]

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -17,6 +17,37 @@ use crate::terminal::pty::InputSender;
 /// a wide glyph without being confused with an actual space between words.
 pub(crate) const ALIGNED_WIDE_CELL: char = '\0';
 
+const MAX_TERMINAL_HYPERLINK_URI_BYTES: usize = 4_096;
+const MAX_TERMINAL_HYPERLINK_ID_BYTES: usize = 256;
+
+/// One OSC 8 hyperlink retained by the terminal engine.
+///
+/// The URI is engine-neutral and its spans use visible grid coordinates. This
+/// metadata is materialized only for deliberate text/link gestures, never for
+/// ordinary rendering or agent detection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TerminalHyperlink {
+    id: String,
+    uri: String,
+    spans: Vec<(u16, u16, u16)>,
+}
+
+impl TerminalHyperlink {
+    pub(crate) fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    pub(crate) fn spans(&self) -> &[(u16, u16, u16)] {
+        &self.spans
+    }
+
+    fn covers(&self, row: u16, col: u16) -> bool {
+        self.spans
+            .iter()
+            .any(|(span_row, start, end)| *span_row == row && col >= *start && col < *end)
+    }
+}
+
 /// Visible terminal text indexed one character per grid cell, plus the sparse
 /// zero-width components attached to base cells. Keeping the latter separate
 /// preserves column lookup without dropping combining marks, variation
@@ -24,6 +55,7 @@ pub(crate) const ALIGNED_WIDE_CELL: char = '\0';
 pub struct AlignedRows {
     rows: Vec<String>,
     zero_width: Vec<(u16, u16, Vec<char>)>,
+    hyperlinks: Vec<TerminalHyperlink>,
 }
 
 impl AlignedRows {
@@ -31,6 +63,7 @@ impl AlignedRows {
         Self {
             rows: vec![String::new(); row_count],
             zero_width: Vec::new(),
+            hyperlinks: Vec::new(),
         }
     }
 
@@ -39,6 +72,7 @@ impl AlignedRows {
         Self {
             rows,
             zero_width: Vec::new(),
+            hyperlinks: Vec::new(),
         }
     }
 
@@ -57,6 +91,47 @@ impl AlignedRows {
 
     pub(crate) fn rows(&self) -> &[String] {
         &self.rows
+    }
+
+    pub(crate) fn push_hyperlink_cell(&mut self, row: u16, col: u16, id: &str, uri: &str) {
+        if uri.is_empty()
+            || uri.len() > MAX_TERMINAL_HYPERLINK_URI_BYTES
+            || id.len() > MAX_TERMINAL_HYPERLINK_ID_BYTES
+            || uri.chars().any(char::is_control)
+            || id.chars().any(char::is_control)
+        {
+            return;
+        }
+        let hyperlink = match self
+            .hyperlinks
+            .iter_mut()
+            .rev()
+            .find(|hyperlink| hyperlink.id == id && hyperlink.uri == uri)
+        {
+            Some(hyperlink) => hyperlink,
+            None => {
+                self.hyperlinks.push(TerminalHyperlink {
+                    id: id.to_string(),
+                    uri: uri.to_string(),
+                    spans: Vec::new(),
+                });
+                self.hyperlinks
+                    .last_mut()
+                    .expect("the terminal hyperlink was just inserted")
+            }
+        };
+        match hyperlink.spans.last_mut() {
+            Some((span_row, _, end)) if *span_row == row && *end == col => {
+                *end = col.saturating_add(1)
+            }
+            _ => hyperlink.spans.push((row, col, col.saturating_add(1))),
+        }
+    }
+
+    pub(crate) fn hyperlink_at(&self, row: u16, col: u16) -> Option<&TerminalHyperlink> {
+        self.hyperlinks
+            .iter()
+            .find(|hyperlink| hyperlink.covers(row, col))
     }
 
     pub(crate) fn zero_width_at(&self, row: u16, col: u16) -> &[char] {

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -245,6 +245,10 @@ same as `Shift`+click on a FILES row.
 read-only tab placements. A configured terminal editor opens the file at the
 top, because line-jump arguments differ between editors.
 
+When an agent such as Claude prints a terminal file hyperlink, luvus uses its
+validated local file target rather than guessing from the visible label. It
+then follows the same **File click behavior** and **Open files with** settings.
+
 **A path only underlines if the file is really there.** Paths are resolved against
 that pane's working directory, so `src/main.rs` means what it means to the shell
 you are looking at. Text that merely looks like a path stays inert, and so do


### PR DESCRIPTION
## Summary

Fix Claude file paths opening in the browser when they are clicked inside a Luvus pane.

Luvus previously retained only the visible label from an OSC 8 terminal hyperlink. Claude can render a short or domain-shaped label while attaching an absolute `file://` target, so rescanning the label could classify it as a website instead of the file Claude referenced.

This change:

- carries OSC 8 hyperlink targets through the terminal engine boundary with their visible grid spans
- routes validated local `file://` targets through the existing Files behavior and configured editor path
- preserves line numbers when the visible label includes `:line` or `:line:column`
- keeps only `http` and `https` targets eligible for the browser
- makes malformed, remote, missing-file, and unsupported hyperlink targets inert without falling back to the visible label
- bounds retained hyperlink identifiers and targets and materializes them only during deliberate link gestures
- documents how agent-emitted terminal file links follow the existing file settings

## Security behavior

The file URI parser accepts absolute local paths with an empty authority or `localhost`. It strictly decodes percent escapes and rejects remote authorities, UNC-shaped targets, invalid UTF-8, control characters, literal whitespace, query strings, fragments, relative paths, missing files, and unsupported schemes.

## Verification

- `cargo test decodes_only_absolute_local_file_uris -- --nocapture`
- `cargo test visible_rows_retain_osc8_targets_and_spans -- --nocapture`
- `cargo test osc8_ -- --nocapture`
- `cargo test ctrl_click_on_a_file_path -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo build --release --locked`
- `npm run build` in `website/`
- isolated debug server restart, status, and stop using session `issue-240` under `~/.luvus-dev`

The full Rust suite passed with 1302 tests passed and 1 benchmark ignored.

Fixes #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal file and web links now honor OSC 8 hyperlink targets when clicked.
  * File links validate local paths, preserve line numbers, and reject unsupported or malformed targets.
  * Hyperlink metadata is preserved across terminal output, including link spans and adjacent cells.

* **Documentation**
  * Updated the layout guide to explain terminal file hyperlink behavior and related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->