### PR TITLE
feat(agent): add Antigravity CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Keyboard → Keyboard Shortcuts → Input Sources** to free `Ctrl+Space`.
 | Claude Code | ✓ | ✓ | ✓ |
 | GitHub Copilot CLI | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ |
+| Antigravity CLI | ✓ | ✓ | session only |
 | opencode | ✓ | ✓ | ✓ |
 | Kimi | ✓ | ✓ | ✓ |
 | Grok | ✓ | ✓ | ✓ |

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -395,6 +395,9 @@ surface:
   optional native session-resume hooks and must not be used merely to make an
   agent appear in the sidebar. Install or remove an integration only when the
   user explicitly requests that lifecycle integration.
+- For Antigravity CLI, `luvus integration install antigravity` adds exact
+  conversation identity for restore. It is session-only; native screen
+  detection remains authoritative for agent state.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership while native read-only session discovery remains the fallback.
 - Subscribe to events only for a live monitoring request. Stop when its

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -395,6 +395,9 @@ surface:
   optional native session-resume hooks and must not be used merely to make an
   agent appear in the sidebar. Install or remove an integration only when the
   user explicitly requests that lifecycle integration.
+- For Antigravity CLI, `luvus integration install antigravity` adds exact
+  conversation identity for restore. It is session-only; native screen
+  detection remains authoritative for agent state.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership while native read-only session discovery remains the fallback.
 - Subscribe to events only for a live monitoring request. Stop when its

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 
 pub(crate) mod aider;
 pub(crate) mod amp;
+pub(crate) mod antigravity;
 pub(crate) mod claude;
 pub(crate) mod codex;
 pub(crate) mod copilot;
@@ -143,6 +144,19 @@ fn filter_launch_flags(agent: &str, launch: &[String]) -> Vec<String> {
     while i < launch.len() {
         let t = launch[i].as_str();
         let head = t.split('=').next().unwrap_or(t);
+        // Antigravity resumes by conversation id and uses `-c` for the newest
+        // conversation. Neither selector may survive beside the exact id Luvus
+        // is restoring.
+        if agent == antigravity::NAME && matches!(head, "--conversation" | "-c") {
+            i += 1;
+            if head == "--conversation"
+                && !t.contains('=')
+                && launch.get(i).is_some_and(|value| !value.starts_with('-'))
+            {
+                i += 1;
+            }
+            continue;
+        }
         // Hermes accepts an optional name after continue. Neither the selector
         // nor its value may survive into an exact-id restore.
         if agent == "hermes" && matches!(head, "--continue" | "-c") {
@@ -377,6 +391,11 @@ mod tests {
             resume_command("gemini", "g1").as_deref(),
             Some("gemini --resume 'g1'\r")
         );
+        assert_eq!(
+            resume_command("agy", "ec33ebf9-0cba-4100-8142-c61503f6c587").as_deref(),
+            Some("agy --conversation 'ec33ebf9-0cba-4100-8142-c61503f6c587'\r")
+        );
+        assert!(is_resumable("antigravity-cli"));
         assert_eq!(
             resume_command("qwen", "q1").as_deref(),
             Some("qwen --resume 'q1'\r")
@@ -682,6 +701,17 @@ mod tests {
             f("hermes", &["--continue", "old title", "--tui"]),
             vec!["--tui"],
             "Hermes drops its optional continue title"
+        );
+        assert_eq!(
+            f(
+                "antigravity",
+                &["--conversation", "old-id", "--model", "gemini-3.1-pro"]
+            ),
+            vec!["--model", "gemini-3.1-pro"]
+        );
+        assert_eq!(
+            f("antigravity", &["--conversation=old-id", "-c", "--sandbox"]),
+            vec!["--sandbox"]
         );
         // A kept flag keeps its value.
         assert_eq!(

--- a/src/agent/antigravity/hook.ps1
+++ b/src/agent/antigravity/hook.ps1
@@ -1,0 +1,19 @@
+# Luvus Antigravity CLI integration. Antigravity passes the hook JSON through
+# stdin; the Luvus binary parses it with a bounded reader and returns JSON.
+
+if (
+    $env:LUVUS_ENV -ne "1" -or
+    [string]::IsNullOrWhiteSpace($env:LUVUS_SOCKET_PATH) -or
+    [string]::IsNullOrWhiteSpace($env:LUVUS_PANE_ID)
+) {
+    Write-Output "{}"
+    exit 0
+}
+
+$luvus = if ([string]::IsNullOrWhiteSpace($env:LUVUS_BIN_PATH)) { "luvus" } else { $env:LUVUS_BIN_PATH }
+try {
+    & $luvus integration hook antigravity 2>$null
+    if ($LASTEXITCODE -ne 0) { Write-Output "{}" }
+} catch {
+    Write-Output "{}"
+}

--- a/src/agent/antigravity/hook.sh
+++ b/src/agent/antigravity/hook.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Luvus Antigravity CLI integration. Antigravity passes the hook JSON through
+# stdin; the Luvus binary parses it with a bounded reader and returns JSON.
+
+if [ "${LUVUS_ENV:-}" != "1" ] || [ -z "${LUVUS_SOCKET_PATH:-}" ] || [ -z "${LUVUS_PANE_ID:-}" ]; then
+  printf '{}\n'
+  exit 0
+fi
+
+luvus_bin="${LUVUS_BIN_PATH:-luvus}"
+"$luvus_bin" integration hook antigravity 2>/dev/null || printf '{}\n'

--- a/src/agent/antigravity/integration.rs
+++ b/src/agent/antigravity/integration.rs
@@ -12,6 +12,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: Some(run_hook),
 };
 
 const BLOCK_NAME: &str = "luvus";
@@ -121,7 +122,7 @@ fn install() -> Result<()> {
     fs::write(&script, SCRIPT)?;
     integration::set_executable(&script)?;
     hooks.insert(BLOCK_NAME.to_string(), managed_block(&command));
-    fs::write(&config, serde_json::to_string_pretty(&value)?)?;
+    integration::write_json_atomic(&config, &value)?;
     Ok(())
 }
 
@@ -134,7 +135,7 @@ fn uninstall() -> Result<()> {
             .ok_or_else(|| anyhow!("Antigravity hooks must contain a JSON object"))?;
         if hooks.get(BLOCK_NAME).is_some_and(block_is_managed) {
             hooks.remove(BLOCK_NAME);
-            fs::write(&config, serde_json::to_string_pretty(&value)?)?;
+            integration::write_json_atomic(&config, &value)?;
         }
     }
     let _ = fs::remove_file(script_path());
@@ -178,7 +179,7 @@ fn read_hook_input() -> Option<Vec<u8>> {
     Some(input)
 }
 
-pub(super) fn run_hook() -> i32 {
+fn run_hook() -> i32 {
     let environment_matches = std::env::var_os("LUVUS_ENV").as_deref()
         == Some(std::ffi::OsStr::new("1"))
         && std::env::var_os("LUVUS_SOCKET_PATH").is_some_and(|path| !path.is_empty());

--- a/src/agent/antigravity/integration.rs
+++ b/src/agent/antigravity/integration.rs
@@ -118,6 +118,7 @@ fn install() -> Result<()> {
 
 fn uninstall() -> Result<()> {
     let config = config_path();
+    let mut removed_managed_block = false;
     if config.is_file() {
         let mut value = read_config(&config)?;
         let hooks = value
@@ -126,9 +127,12 @@ fn uninstall() -> Result<()> {
         if hooks.get(BLOCK_NAME).is_some_and(block_is_managed) {
             hooks.remove(BLOCK_NAME);
             integration::write_json_atomic(&config, &value)?;
+            removed_managed_block = true;
         }
     }
-    let _ = fs::remove_file(script_path());
+    if removed_managed_block {
+        let _ = fs::remove_file(script_path());
+    }
     Ok(())
 }
 
@@ -344,6 +348,51 @@ mod tests {
 
         let collision = managed_block(&format!("echo {SCRIPT_NAME}"));
         assert!(!block_is_managed(&collision));
+
+        std::env::remove_var("ANTIGRAVITY_CLI_CONFIG_DIR");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn uninstall_preserves_unmanaged_block_and_referenced_script() {
+        let _env = crate::persist::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let root = temp_root("unmanaged-uninstall");
+        let _ = fs::remove_dir_all(&root);
+        std::env::set_var("ANTIGRAVITY_CLI_CONFIG_DIR", &root);
+        fs::create_dir_all(script_path().parent().unwrap()).unwrap();
+
+        let command = hook_command(&script_path()).unwrap();
+        let unmanaged = json!({
+            (BLOCK_NAME): {
+                "PreInvocation": [
+                    {
+                        "type": "command",
+                        "command": command,
+                        "timeout": HOOK_TIMEOUT_SECONDS,
+                    },
+                    {
+                        "type": "command",
+                        "command": "echo user-owned",
+                    },
+                ],
+            },
+        });
+        fs::write(
+            root.join("hooks.json"),
+            serde_json::to_string_pretty(&unmanaged).unwrap(),
+        )
+        .unwrap();
+        fs::write(script_path(), "user-owned script").unwrap();
+
+        uninstall().unwrap();
+
+        assert_eq!(read_config(&root.join("hooks.json")).unwrap(), unmanaged);
+        assert_eq!(
+            fs::read_to_string(script_path()).unwrap(),
+            "user-owned script"
+        );
 
         std::env::remove_var("ANTIGRAVITY_CLI_CONFIG_DIR");
         let _ = fs::remove_dir_all(root);

--- a/src/agent/antigravity/integration.rs
+++ b/src/agent/antigravity/integration.rs
@@ -78,19 +78,9 @@ fn managed_block(command: &str) -> Value {
 }
 
 fn block_is_managed(block: &Value) -> bool {
-    block
-        .get("PreInvocation")
-        .and_then(Value::as_array)
-        .is_some_and(|handlers| {
-            handlers.iter().any(|handler| {
-                handler
-                    .get("command")
-                    .and_then(Value::as_str)
-                    .is_some_and(|command| {
-                        command.contains("luvus-agent-hook") || command.contains("bohay-agent-hook")
-                    })
-            })
-        })
+    hook_command(&script_path())
+        .map(|command| block == &managed_block(&command))
+        .unwrap_or(false)
 }
 
 fn read_config(path: &Path) -> Result<Value> {
@@ -166,17 +156,19 @@ fn hook_params(input: &[u8], pane: &str) -> Option<Value> {
     }))
 }
 
-fn read_hook_input() -> Option<Vec<u8>> {
-    let stdin = io::stdin();
-    let mut stdin = stdin.lock();
+fn read_hook_input_from(reader: &mut impl Read) -> Option<Vec<u8>> {
     let mut input = Vec::new();
-    let mut limited = (&mut stdin).take(MAX_HOOK_PAYLOAD + 1);
+    let mut limited = reader.take(MAX_HOOK_PAYLOAD + 1);
     limited.read_to_end(&mut input).ok()?;
     if input.len() as u64 > MAX_HOOK_PAYLOAD {
-        let _ = io::copy(&mut stdin, &mut io::sink());
         return None;
     }
     Some(input)
+}
+
+fn read_hook_input() -> Option<Vec<u8>> {
+    let stdin = io::stdin();
+    read_hook_input_from(&mut stdin.lock())
 }
 
 fn run_hook() -> i32 {
@@ -279,6 +271,37 @@ mod tests {
         assert_eq!(fs::read_to_string(&config).unwrap(), collision);
         assert!(!script_path().exists());
 
+        let substring_collision = r#"{"luvus":{"PreInvocation":[{"type":"command","command":"echo luvus-agent-hook.sh","timeout":5}]}}"#;
+        fs::write(&config, substring_collision).unwrap();
+        assert!(install().is_err());
+        assert_eq!(fs::read_to_string(&config).unwrap(), substring_collision);
+        assert!(!script_path().exists());
+
+        let command = hook_command(&script_path()).unwrap();
+        let mixed_handlers = json!({
+            (BLOCK_NAME): {
+                "PreInvocation": [
+                    {
+                        "type": "command",
+                        "command": command,
+                        "timeout": HOOK_TIMEOUT_SECONDS,
+                    },
+                    {
+                        "type": "command",
+                        "command": "echo user-owned",
+                    },
+                ],
+            },
+        });
+        fs::write(
+            &config,
+            serde_json::to_string_pretty(&mixed_handlers).unwrap(),
+        )
+        .unwrap();
+        assert!(install().is_err());
+        assert_eq!(read_config(&config).unwrap(), mixed_handlers);
+        assert!(!script_path().exists());
+
         std::env::remove_var("ANTIGRAVITY_CLI_CONFIG_DIR");
         let _ = fs::remove_dir_all(root);
     }
@@ -296,5 +319,40 @@ mod tests {
         assert!(params.get("transcriptPath").is_none());
         assert!(hook_params(br#"{"conversationId":"bad id"}"#, "42").is_none());
         assert!(hook_params(&vec![b'x'; MAX_HOOK_PAYLOAD as usize + 1], "42").is_none());
+    }
+
+    #[test]
+    fn managed_block_requires_the_exact_generated_shape() {
+        let _env = crate::persist::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let root = temp_root("ownership");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        std::env::set_var("ANTIGRAVITY_CLI_CONFIG_DIR", &root);
+
+        let command = hook_command(&script_path()).unwrap();
+        let generated = managed_block(&command);
+        assert!(block_is_managed(&generated));
+
+        let mut mixed = generated.clone();
+        mixed["PreInvocation"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({"type": "command", "command": "echo user-owned"}));
+        assert!(!block_is_managed(&mixed));
+
+        let collision = managed_block(&format!("echo {SCRIPT_NAME}"));
+        assert!(!block_is_managed(&collision));
+
+        std::env::remove_var("ANTIGRAVITY_CLI_CONFIG_DIR");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn oversized_hook_input_stops_at_the_bound() {
+        let mut input = io::Cursor::new(vec![b'x'; MAX_HOOK_PAYLOAD as usize + 64]);
+        assert!(read_hook_input_from(&mut input).is_none());
+        assert_eq!(input.position(), MAX_HOOK_PAYLOAD + 1);
     }
 }

--- a/src/agent/antigravity/integration.rs
+++ b/src/agent/antigravity/integration.rs
@@ -1,0 +1,299 @@
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+
+use super::super::types::IntegrationOperations;
+use crate::integration;
+
+pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
+    install,
+    uninstall,
+    is_installed,
+};
+
+const BLOCK_NAME: &str = "luvus";
+const HOOK_TIMEOUT_SECONDS: u64 = 5;
+const MAX_HOOK_PAYLOAD: u64 = 1024 * 1024;
+
+#[cfg(windows)]
+const SCRIPT_NAME: &str = "luvus-agent-hook.ps1";
+#[cfg(not(windows))]
+const SCRIPT_NAME: &str = "luvus-agent-hook.sh";
+
+#[cfg(any(not(windows), test))]
+const SHELL_SCRIPT: &str = include_str!("hook.sh");
+#[cfg(any(windows, test))]
+const POWERSHELL_SCRIPT: &str = include_str!("hook.ps1");
+
+#[cfg(windows)]
+const SCRIPT: &str = POWERSHELL_SCRIPT;
+#[cfg(not(windows))]
+const SCRIPT: &str = SHELL_SCRIPT;
+
+fn config_dir() -> PathBuf {
+    std::env::var_os("ANTIGRAVITY_CLI_CONFIG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| integration::home().join(".gemini").join("config"))
+}
+
+fn config_path() -> PathBuf {
+    config_dir().join("hooks.json")
+}
+
+fn script_path() -> PathBuf {
+    config_dir().join("hooks").join(SCRIPT_NAME)
+}
+
+#[cfg(not(windows))]
+fn hook_command(path: &Path) -> Result<String> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| anyhow!("Antigravity integration path is not valid Unicode"))?;
+    Ok(format!("sh '{}'", path.replace('\'', "'\\''")))
+}
+
+#[cfg(windows)]
+fn hook_command(path: &Path) -> Result<String> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| anyhow!("Antigravity integration path is not valid Unicode"))?;
+    Ok(format!(
+        "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{}\"",
+        path.replace('"', "\"\"")
+    ))
+}
+
+fn managed_block(command: &str) -> Value {
+    json!({
+        "PreInvocation": [{
+            "type": "command",
+            "command": command,
+            "timeout": HOOK_TIMEOUT_SECONDS,
+        }]
+    })
+}
+
+fn block_is_managed(block: &Value) -> bool {
+    block
+        .get("PreInvocation")
+        .and_then(Value::as_array)
+        .is_some_and(|handlers| {
+            handlers.iter().any(|handler| {
+                handler
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .is_some_and(|command| {
+                        command.contains("luvus-agent-hook") || command.contains("bohay-agent-hook")
+                    })
+            })
+        })
+}
+
+fn read_config(path: &Path) -> Result<Value> {
+    match fs::read_to_string(path) {
+        Ok(contents) => serde_json::from_str(&contents).map_err(Into::into),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(json!({})),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn install() -> Result<()> {
+    let config = config_path();
+    let mut value = read_config(&config)?;
+    let hooks = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("Antigravity hooks must contain a JSON object"))?;
+    if hooks
+        .get(BLOCK_NAME)
+        .is_some_and(|block| !block_is_managed(block))
+    {
+        return Err(anyhow!(
+            "Antigravity hooks already contain an unmanaged `{BLOCK_NAME}` block"
+        ));
+    }
+
+    let script = script_path();
+    let command = hook_command(&script)?;
+    fs::create_dir_all(script.parent().expect("hook path has a parent"))?;
+    fs::write(&script, SCRIPT)?;
+    integration::set_executable(&script)?;
+    hooks.insert(BLOCK_NAME.to_string(), managed_block(&command));
+    fs::write(&config, serde_json::to_string_pretty(&value)?)?;
+    Ok(())
+}
+
+fn uninstall() -> Result<()> {
+    let config = config_path();
+    if config.is_file() {
+        let mut value = read_config(&config)?;
+        let hooks = value
+            .as_object_mut()
+            .ok_or_else(|| anyhow!("Antigravity hooks must contain a JSON object"))?;
+        if hooks.get(BLOCK_NAME).is_some_and(block_is_managed) {
+            hooks.remove(BLOCK_NAME);
+            fs::write(&config, serde_json::to_string_pretty(&value)?)?;
+        }
+    }
+    let _ = fs::remove_file(script_path());
+    Ok(())
+}
+
+fn is_installed() -> bool {
+    if !script_path().is_file() {
+        return false;
+    }
+    read_config(&config_path())
+        .ok()
+        .and_then(|value| value.get(BLOCK_NAME).cloned())
+        .is_some_and(|block| block_is_managed(&block))
+}
+
+fn hook_params(input: &[u8], pane: &str) -> Option<Value> {
+    if input.len() as u64 > MAX_HOOK_PAYLOAD || pane.is_empty() {
+        return None;
+    }
+    let payload: Value = serde_json::from_slice(input).ok()?;
+    let session = payload.get("conversationId")?.as_str()?;
+    crate::agent::resume_command(super::NAME, session)?;
+    Some(json!({
+        "pane": pane,
+        "agent": super::NAME,
+        "session_id": session,
+    }))
+}
+
+fn read_hook_input() -> Option<Vec<u8>> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    let mut input = Vec::new();
+    let mut limited = (&mut stdin).take(MAX_HOOK_PAYLOAD + 1);
+    limited.read_to_end(&mut input).ok()?;
+    if input.len() as u64 > MAX_HOOK_PAYLOAD {
+        let _ = io::copy(&mut stdin, &mut io::sink());
+        return None;
+    }
+    Some(input)
+}
+
+pub(super) fn run_hook() -> i32 {
+    let environment_matches = std::env::var_os("LUVUS_ENV").as_deref()
+        == Some(std::ffi::OsStr::new("1"))
+        && std::env::var_os("LUVUS_SOCKET_PATH").is_some_and(|path| !path.is_empty());
+    if !environment_matches {
+        println!("{{}}");
+        return 0;
+    }
+
+    if let (Some(input), Ok(pane)) = (read_hook_input(), std::env::var("LUVUS_PANE_ID")) {
+        if let Some(params) = hook_params(&input, &pane) {
+            let _ = crate::cli::send_request("pane.report_session", params);
+        }
+    }
+    println!("{{}}");
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "luvus-antigravity-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ))
+    }
+
+    #[test]
+    fn install_is_idempotent_and_uninstall_preserves_other_hooks() {
+        let _env = crate::persist::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let root = temp_root("install");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        std::env::set_var("ANTIGRAVITY_CLI_CONFIG_DIR", &root);
+        fs::write(
+            root.join("hooks.json"),
+            r#"{
+  "my-hook": {"enabled": false, "PreInvocation": [{"command": "echo mine"}]},
+  "private": {"token": "keep-secret"}
+}"#,
+        )
+        .unwrap();
+
+        install().unwrap();
+        install().unwrap();
+        assert!(is_installed());
+        let value: Value =
+            serde_json::from_str(&fs::read_to_string(root.join("hooks.json")).unwrap()).unwrap();
+        assert_eq!(value["private"]["token"], "keep-secret");
+        assert_eq!(value["my-hook"]["enabled"], false);
+        assert_eq!(
+            value[BLOCK_NAME]["PreInvocation"][0]["timeout"],
+            HOOK_TIMEOUT_SECONDS
+        );
+        let script = fs::read_to_string(script_path()).unwrap();
+        assert!(script.contains("LUVUS_BIN_PATH"));
+        assert!(script.contains("integration hook antigravity"));
+        assert!(SHELL_SCRIPT.contains("integration hook antigravity"));
+        assert!(POWERSHELL_SCRIPT.contains("integration hook antigravity"));
+
+        uninstall().unwrap();
+        assert!(!is_installed());
+        assert!(!script_path().exists());
+        let value: Value =
+            serde_json::from_str(&fs::read_to_string(root.join("hooks.json")).unwrap()).unwrap();
+        assert!(value.get(BLOCK_NAME).is_none());
+        assert_eq!(value["private"]["token"], "keep-secret");
+        assert_eq!(value["my-hook"]["enabled"], false);
+
+        std::env::remove_var("ANTIGRAVITY_CLI_CONFIG_DIR");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn malformed_or_colliding_config_is_never_replaced() {
+        let _env = crate::persist::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let root = temp_root("invalid");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        std::env::set_var("ANTIGRAVITY_CLI_CONFIG_DIR", &root);
+        let config = root.join("hooks.json");
+
+        fs::write(&config, "{ user hooks").unwrap();
+        assert!(install().is_err());
+        assert_eq!(fs::read_to_string(&config).unwrap(), "{ user hooks");
+        assert!(!script_path().exists());
+
+        let collision = r#"{"luvus":{"PreInvocation":[{"command":"echo user-owned"}]}}"#;
+        fs::write(&config, collision).unwrap();
+        assert!(install().is_err());
+        assert_eq!(fs::read_to_string(&config).unwrap(), collision);
+        assert!(!script_path().exists());
+
+        std::env::remove_var("ANTIGRAVITY_CLI_CONFIG_DIR");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn hook_accepts_only_bounded_resumable_conversations() {
+        let params = hook_params(
+            br#"{"conversationId":"ec33ebf9-0cba-4100-8142-c61503f6c587","transcriptPath":"/private/transcript"}"#,
+            "42",
+        )
+        .unwrap();
+        assert_eq!(params["pane"], "42");
+        assert_eq!(params["agent"], super::super::NAME);
+        assert_eq!(params["session_id"], "ec33ebf9-0cba-4100-8142-c61503f6c587");
+        assert!(params.get("transcriptPath").is_none());
+        assert!(hook_params(br#"{"conversationId":"bad id"}"#, "42").is_none());
+        assert!(hook_params(&vec![b'x'; MAX_HOOK_PAYLOAD as usize + 1], "42").is_none());
+    }
+}

--- a/src/agent/antigravity/mod.rs
+++ b/src/agent/antigravity/mod.rs
@@ -32,7 +32,3 @@ pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
     }),
     integration: Some(integration::OPERATIONS),
 };
-
-pub(crate) fn run_hook() -> i32 {
-    integration::run_hook()
-}

--- a/src/agent/antigravity/mod.rs
+++ b/src/agent/antigravity/mod.rs
@@ -1,0 +1,38 @@
+use super::types::{AgentDescriptor, DiscoveryOperations, IdentityDescriptor, SessionOperations};
+
+mod integration;
+mod sessions;
+
+pub(crate) const NAME: &str = "antigravity";
+
+pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
+    id: NAME,
+    aliases: &["agy", "antigravity-cli"],
+    launch_command: "agy",
+    // Antigravity's positional argument starts an interactive TUI prompt only
+    // in legacy editor builds. Current CLI releases use print mode for a
+    // bounded non-interactive ORCH task.
+    task_prompt_args: &["-p"],
+    identity: IdentityDescriptor {
+        distinct: &["antigravity-cli"],
+        ambiguous: &["agy"],
+        binary_matcher: None,
+        interpreter_packages: &[],
+        overlap_priority: 0,
+    },
+    sessions: Some(SessionOperations {
+        discovery: Some(DiscoveryOperations {
+            base: sessions::base,
+            recent: sessions::recent,
+            latest: sessions::latest,
+            list: Some(sessions::list),
+        }),
+        resume: |session| format!("agy --conversation {session}\r"),
+        fork: None,
+    }),
+    integration: Some(integration::OPERATIONS),
+};
+
+pub(crate) fn run_hook() -> i32 {
+    integration::run_hook()
+}

--- a/src/agent/antigravity/sessions.rs
+++ b/src/agent/antigravity/sessions.rs
@@ -1,0 +1,126 @@
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use super::super::SessionInfo;
+
+const MAX_CACHE_BYTES: u64 = 256 * 1024;
+
+pub(in crate::agent) fn base() -> PathBuf {
+    super::super::home().join(".gemini").join("antigravity-cli")
+}
+
+fn cache_path(base: &Path) -> PathBuf {
+    base.join("cache").join("last_conversations.json")
+}
+
+fn sessions(base: &Path) -> Vec<SessionInfo> {
+    let path = cache_path(base);
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) if metadata.len() <= MAX_CACHE_BYTES => metadata,
+        _ => return Vec::new(),
+    };
+    let mut input = Vec::new();
+    let Ok(file) = std::fs::File::open(&path) else {
+        return Vec::new();
+    };
+    if file
+        .take(MAX_CACHE_BYTES + 1)
+        .read_to_end(&mut input)
+        .is_err()
+        || input.len() as u64 > MAX_CACHE_BYTES
+    {
+        return Vec::new();
+    }
+    let Ok(entries) = serde_json::from_slice::<BTreeMap<String, String>>(&input) else {
+        return Vec::new();
+    };
+    let updated = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    entries
+        .into_iter()
+        .filter(|(cwd, session_id)| {
+            !cwd.is_empty() && super::super::resume_command(super::NAME, session_id).is_some()
+        })
+        .map(|(cwd, session_id)| SessionInfo {
+            agent: super::NAME.to_string(),
+            session_id,
+            cwd: PathBuf::from(cwd),
+            updated,
+        })
+        .collect()
+}
+
+pub(in crate::agent) fn list(base: &Path, cwd: &Path) -> Vec<String> {
+    sessions(base)
+        .into_iter()
+        .filter(|session| crate::platform::same_path(&session.cwd, cwd))
+        .map(|session| session.session_id)
+        .collect()
+}
+
+pub(in crate::agent) fn latest(base: &Path, cwd: &Path) -> Option<String> {
+    list(base, cwd).into_iter().next()
+}
+
+pub(in crate::agent) fn recent(base: &Path, limit: usize) -> Vec<SessionInfo> {
+    sessions(base).into_iter().take(limit).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn fixture(label: &str) -> PathBuf {
+        let root = crate::persist::skills_dir().join(format!(
+            "antigravity-sessions-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("cache")).unwrap();
+        root
+    }
+
+    #[test]
+    fn reads_the_documented_workspace_conversation_cache() {
+        let root = fixture("valid");
+        fs::write(
+            cache_path(&root),
+            r#"{
+  "/workspace/alpha": "ec33ebf9-0cba-4100-8142-c61503f6c587",
+  "/workspace/beta": "f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            latest(&root, Path::new("/workspace/alpha")).as_deref(),
+            Some("ec33ebf9-0cba-4100-8142-c61503f6c587")
+        );
+        assert_eq!(list(&root, Path::new("/workspace/beta")).len(), 1);
+        let recent = recent(&root, 1);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].agent, super::super::NAME);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rejects_malformed_oversized_and_unsafe_cache_data() {
+        let root = fixture("invalid");
+        let path = cache_path(&root);
+        fs::write(&path, b"not json").unwrap();
+        assert!(recent(&root, 8).is_empty());
+
+        fs::write(&path, vec![b'x'; MAX_CACHE_BYTES as usize + 1]).unwrap();
+        assert!(recent(&root, 8).is_empty());
+
+        fs::write(&path, r#"{"/workspace/alpha":"bad id; exit 1"}"#).unwrap();
+        assert!(recent(&root, 8).is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src/agent/claude/integration.rs
+++ b/src/agent/claude/integration.rs
@@ -11,6 +11,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: None,
 };
 
 fn config_dir() -> PathBuf {

--- a/src/agent/codex/integration.rs
+++ b/src/agent/codex/integration.rs
@@ -11,6 +11,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: None,
 };
 
 fn config_dir() -> PathBuf {

--- a/src/agent/copilot/integration.rs
+++ b/src/agent/copilot/integration.rs
@@ -9,6 +9,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: None,
 };
 
 fn config_dir() -> PathBuf {

--- a/src/agent/grok/integration.rs
+++ b/src/agent/grok/integration.rs
@@ -11,6 +11,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: None,
 };
 
 fn hooks_dir() -> PathBuf {

--- a/src/agent/hermes/integration.rs
+++ b/src/agent/hermes/integration.rs
@@ -9,6 +9,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: None,
 };
 
 const PLUGIN_NAME: &str = "luvus-agent-state";

--- a/src/agent/kimi/integration.rs
+++ b/src/agent/kimi/integration.rs
@@ -11,6 +11,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: None,
 };
 
 const HOOK_EVENTS: &[(&str, Option<&str>)] = &[

--- a/src/agent/omp/mod.rs
+++ b/src/agent/omp/mod.rs
@@ -45,6 +45,7 @@ pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
         install: || install_extension().map(|_| ()),
         uninstall: uninstall_extension,
         is_installed: extension_installed,
+        hook: None,
     }),
 };
 

--- a/src/agent/opencode/integration.rs
+++ b/src/agent/opencode/integration.rs
@@ -10,6 +10,7 @@ pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
     install,
     uninstall,
     is_installed,
+    hook: None,
 };
 
 const PLUGIN: &str = r#"// luvus opencode integration (docs/23) — reports the session id for native resume.

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -4,6 +4,7 @@ pub(crate) static BUILTINS: &[&AgentDescriptor] = &[
     &super::claude::DESCRIPTOR,
     &super::codex::DESCRIPTOR,
     &super::gemini::DESCRIPTOR,
+    &super::antigravity::DESCRIPTOR,
     &super::aider::DESCRIPTOR,
     &super::opencode::DESCRIPTOR,
     &super::copilot::DESCRIPTOR,
@@ -27,6 +28,7 @@ static INTEGRATIONS: &[&AgentDescriptor] = &[
     &super::claude::DESCRIPTOR,
     &super::copilot::DESCRIPTOR,
     &super::codex::DESCRIPTOR,
+    &super::antigravity::DESCRIPTOR,
     &super::opencode::DESCRIPTOR,
     &super::kimi::DESCRIPTOR,
     &super::grok::DESCRIPTOR,
@@ -134,6 +136,11 @@ mod tests {
     fn aliases_resolve_to_the_canonical_descriptor() {
         assert_eq!(find("cursor-agent").map(|agent| agent.id), Some("cursor"));
         assert_eq!(find("CURSOR").map(|agent| agent.id), Some("cursor"));
+        assert_eq!(find("agy").map(|agent| agent.id), Some("antigravity"));
+        assert_eq!(
+            find("ANTIGRAVITY-CLI").map(|agent| agent.id),
+            Some("antigravity")
+        );
         assert!(find("not-an-agent").is_none());
     }
 
@@ -153,6 +160,7 @@ mod tests {
             ("claude", &["claude"][..], &[][..]),
             ("codex", &["codex"][..], &[][..]),
             ("gemini", &["gemini"][..], &[][..]),
+            ("antigravity", &["antigravity-cli"][..], &["agy"][..]),
             ("aider", &["aider"][..], &[][..]),
             ("opencode", &["opencode"][..], &[][..]),
             ("copilot", &["copilot"][..], &[][..]),
@@ -195,8 +203,21 @@ mod tests {
         assert_eq!(
             resumable,
             [
-                "claude", "codex", "gemini", "opencode", "copilot", "kimi", "qwen", "cursor",
-                "grok", "hermes", "muse", "omp", "pi", "fx",
+                "claude",
+                "codex",
+                "gemini",
+                "antigravity",
+                "opencode",
+                "copilot",
+                "kimi",
+                "qwen",
+                "cursor",
+                "grok",
+                "hermes",
+                "muse",
+                "omp",
+                "pi",
+                "fx",
             ]
         );
 
@@ -214,8 +235,20 @@ mod tests {
         assert_eq!(
             discoverable,
             [
-                "claude", "codex", "gemini", "opencode", "copilot", "kimi", "qwen", "grok",
-                "hermes", "muse", "omp", "pi", "fx",
+                "claude",
+                "codex",
+                "gemini",
+                "antigravity",
+                "opencode",
+                "copilot",
+                "kimi",
+                "qwen",
+                "grok",
+                "hermes",
+                "muse",
+                "omp",
+                "pi",
+                "fx",
             ]
         );
 
@@ -237,7 +270,17 @@ mod tests {
                 .iter()
                 .map(|descriptor| descriptor.id)
                 .collect::<Vec<_>>(),
-            ["claude", "copilot", "codex", "opencode", "kimi", "grok", "hermes", "omp",]
+            [
+                "claude",
+                "copilot",
+                "codex",
+                "antigravity",
+                "opencode",
+                "kimi",
+                "grok",
+                "hermes",
+                "omp",
+            ]
         );
     }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -39,6 +39,8 @@ pub(crate) struct IntegrationOperations {
     pub install: fn() -> Result<()>,
     pub uninstall: fn() -> Result<()>,
     pub is_installed: fn() -> bool,
+    /// Optional private hook entrypoint owned by the agent adapter.
+    pub hook: Option<fn() -> i32>,
 }
 
 #[derive(Clone, Copy)]

--- a/src/agent/usage.rs
+++ b/src/agent/usage.rs
@@ -192,7 +192,7 @@ pub fn session_usage(agent: &str, cwd: &Path, session_id: &str) -> Option<AgentU
         "fx" => fx_usage(&fx_dir(&fx::sessions::base(), session_id)),
         // These agents currently expose identity/state but no stable,
         // structured, per-session usage store Luvus can read safely.
-        "aider" | "kiro" | "cursor" | "amp" | "droid" => None,
+        "aider" | "antigravity" | "kiro" | "cursor" | "amp" | "droid" => None,
         _ => None, // manifest-defined agents degrade honestly too.
     }
 }
@@ -1193,6 +1193,8 @@ mod tests {
     fn unsupported_agents_never_receive_guessed_usage() {
         for agent in [
             "aider",
+            "antigravity",
+            "agy",
             "kiro",
             "cursor",
             "cursor-agent",

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -2347,6 +2347,7 @@ mod tests {
         let expected = [
             ("aider", "aider --message"),
             ("amp", "amp --execute"),
+            ("antigravity", "agy -p"),
             ("claude", "claude"),
             ("codex", "codex"),
             ("copilot", "copilot --interactive"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -316,7 +316,7 @@ server:
   server restart             stop + start (load a newly-installed binary)
   server update-manifest     fetch the latest agent-detection rules from luvus.dev
                              (applies live if the server is up; else on next start)
-  integration install|uninstall <claude|copilot|codex|opencode|kimi|grok|hermes|omp>
+  integration install|uninstall <claude|copilot|codex|antigravity|opencode|kimi|grok|hermes|omp>
                              add/remove luvus's session-resume hook (uninstall
                              removes only luvus's hook, never the agent)
 ";

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1838,6 +1838,28 @@ Would you like to proceed?
             ]),
             Some("pi".into())
         );
+        let antigravity_unix = "/Users/me/.local/bin/agy --conversation ec33ebf9-0cba-4100-8142-c61503f6c587 --sandbox";
+        assert_eq!(
+            m.agent_in_processes(&[antigravity_unix.into()]),
+            Some("antigravity".into())
+        );
+        assert_eq!(
+            m.launch_args_for(&[antigravity_unix.into()], "antigravity"),
+            Some(vec![
+                "--conversation".into(),
+                "ec33ebf9-0cba-4100-8142-c61503f6c587".into(),
+                "--sandbox".into(),
+            ])
+        );
+        let antigravity_windows = r#"C:\Users\me\AppData\Local\agy\bin\agy.exe -p "fix the tests""#;
+        assert_eq!(
+            m.agent_in_processes(&[antigravity_windows.into()]),
+            Some("antigravity".into())
+        );
+        assert_eq!(
+            m.launch_args_for(&[antigravity_windows.into()], "antigravity"),
+            Some(vec!["-p".into(), "fix the tests".into()])
+        );
     }
 
     #[test]
@@ -2587,6 +2609,47 @@ Would you like to proceed?
             "zsh"
         );
         assert_eq!(named("gemini is a constellation\n", &proc("-zsh")), "zsh");
+        assert_eq!(
+            named("read the Antigravity documentation\n", &proc("-zsh")),
+            "zsh"
+        );
+        assert_eq!(
+            named(
+                "",
+                &proc("/Applications/Antigravity.app/Contents/MacOS/Antigravity")
+            ),
+            "zsh",
+            "the desktop editor binary is not the Antigravity CLI"
+        );
+        assert_eq!(
+            named(
+                "Requesting permission for:\nDo you want to proceed?",
+                &proc("/Users/me/.local/bin/agy")
+            ),
+            "antigravity"
+        );
+        let blocked = classify(
+            Some("agy"),
+            "Requesting permission for:\nDo you want to proceed?",
+            true,
+            false,
+            "zsh",
+            "",
+            &proc("/Users/me/.local/bin/agy"),
+            &m,
+        );
+        assert_eq!(blocked.state, State::Blocked);
+        let working = classify(
+            Some("agy"),
+            "⠹ Working on the task",
+            true,
+            false,
+            "zsh",
+            "",
+            &proc("C:\\Users\\me\\AppData\\Local\\agy\\bin\\agy.exe"),
+            &m,
+        );
+        assert_eq!(working.state, State::Working);
 
         // Flags never count as the binary, and .exe is stripped.
         assert_eq!(named("", &proc("cargo test --example amp")), "zsh");

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -7,7 +7,9 @@
 //! process/screen detection; they are never required for sidebar recognition.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
@@ -60,12 +62,9 @@ pub fn run(args: &[String], context: crate::i18n::cli::Context) -> Result<i32> {
         args.get(2).map(String::as_str),
         args.get(3).map(String::as_str),
     ) {
-        (Some("hook"), Some(agent))
-            if crate::agent::registry::find(agent)
-                .is_some_and(|descriptor| descriptor.id == crate::agent::antigravity::NAME) =>
-        {
-            Ok(crate::agent::antigravity::run_hook())
-        }
+        (Some("hook"), Some(agent)) => hook_operation(agent)
+            .map(|hook| hook())
+            .ok_or_else(|| anyhow!("unsupported integration hook")),
         (Some("install"), Some(agent)) if operation(agent).is_some() => {
             install(agent)?;
             println!(
@@ -104,6 +103,55 @@ pub fn run(args: &[String], context: crate::i18n::cli::Context) -> Result<i32> {
 
 pub(crate) fn home() -> PathBuf {
     crate::platform::home_dir().unwrap_or_default()
+}
+
+static ATOMIC_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Serialize JSON into a same-directory temporary file, sync it, and atomically
+/// replace `path`. A failed write or replacement leaves the previous file
+/// untouched and removes the incomplete temporary file.
+pub(crate) fn write_json_atomic(path: &Path, value: &Value) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("configuration path has no parent"))?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("configuration filename is not valid Unicode"))?;
+    let output = serde_json::to_vec_pretty(value)?;
+
+    let (temporary, mut file) = (0..16)
+        .find_map(|_| {
+            let sequence = ATOMIC_WRITE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let temporary = parent.join(format!(
+                ".{file_name}.luvus-{}-{sequence}.tmp",
+                std::process::id()
+            ));
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temporary)
+            {
+                Ok(file) => Some(Ok((temporary, file))),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
+                Err(error) => Some(Err(error)),
+            }
+        })
+        .transpose()?
+        .ok_or_else(|| anyhow!("could not reserve a temporary configuration file"))?;
+
+    let result = (|| -> Result<()> {
+        file.write_all(&output)?;
+        file.flush()?;
+        file.sync_all()?;
+        drop(file);
+        crate::platform::atomic_replace_file(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
 }
 
 /// Where + how an agent's shell hook is configured (docs/23). `file` is the JSON
@@ -159,6 +207,10 @@ pub fn agent_at(index: usize) -> Option<&'static str> {
 
 fn operation(agent: &str) -> Option<crate::agent::types::IntegrationOperations> {
     crate::agent::registry::find(agent)?.integration
+}
+
+fn hook_operation(agent: &str) -> Option<fn() -> i32> {
+    operation(agent)?.hook
 }
 
 /// Install the integration for `agent` (used by the Settings tab + CLI).
@@ -312,6 +364,54 @@ mod tests {
 
     fn omp_extension() -> &'static str {
         crate::agent::omp::extension_source()
+    }
+
+    #[test]
+    fn internal_hook_dispatch_is_owned_by_the_agent_descriptor() {
+        assert!(operation("antigravity")
+            .and_then(|operations| operations.hook)
+            .is_some());
+        assert!(operation("agy")
+            .and_then(|operations| operations.hook)
+            .is_some());
+        assert!(operation("claude")
+            .and_then(|operations| operations.hook)
+            .is_none());
+    }
+
+    #[test]
+    fn atomic_json_write_replaces_complete_files_and_cleans_failed_temps() {
+        let root = std::env::temp_dir().join(format!(
+            "luvus-atomic-json-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        let config = root.join("hooks.json");
+        fs::write(&config, r#"{"existing":{"token":"keep"}}"#).unwrap();
+        write_json_atomic(
+            &config,
+            &json!({"existing": {"token": "keep"}, "luvus": {"enabled": true}}),
+        )
+        .unwrap();
+        let value: Value = serde_json::from_slice(&fs::read(&config).unwrap()).unwrap();
+        assert_eq!(value["existing"]["token"], "keep");
+        assert_eq!(value["luvus"]["enabled"], true);
+
+        let blocked = root.join("blocked.json");
+        fs::create_dir(&blocked).unwrap();
+        assert!(write_json_atomic(&blocked, &json!({"never": "replace"})).is_err());
+        assert!(blocked.is_dir());
+        assert!(fs::read_dir(&root).unwrap().flatten().all(|entry| {
+            !entry
+                .file_name()
+                .to_string_lossy()
+                .contains(".blocked.json.luvus-")
+        }));
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -60,6 +60,12 @@ pub fn run(args: &[String], context: crate::i18n::cli::Context) -> Result<i32> {
         args.get(2).map(String::as_str),
         args.get(3).map(String::as_str),
     ) {
+        (Some("hook"), Some(agent))
+            if crate::agent::registry::find(agent)
+                .is_some_and(|descriptor| descriptor.id == crate::agent::antigravity::NAME) =>
+        {
+            Ok(crate::agent::antigravity::run_hook())
+        }
         (Some("install"), Some(agent)) if operation(agent).is_some() => {
             install(agent)?;
             println!(

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2,6 +2,20 @@
 
 use std::path::{Path, PathBuf};
 
+/// Atomically move a completed same-directory temporary file over `destination`.
+/// Windows needs replace-existing semantics that `std::fs::rename` does not
+/// provide consistently; Unix rename already has the required behavior.
+pub fn atomic_replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        windows::atomic_replace_file(source, destination)
+    }
+    #[cfg(not(windows))]
+    {
+        std::fs::rename(source, destination)
+    }
+}
+
 #[cfg(windows)]
 mod windows;
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -6,11 +6,16 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::mem::size_of;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
 
 use windows_sys::Wdk::System::Threading::{NtQueryInformationProcess, ProcessBasicInformation};
 use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::Security::{
     EqualSid, GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
 };
 use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
 use windows_sys::Win32::System::Diagnostics::ToolHelp::{
@@ -25,6 +30,38 @@ use windows_sys::Win32::System::Threading::{
 const MAX_PROCESS_ENTRIES: usize = 16_384;
 const MAX_DESCENDANTS_PER_ROOT: usize = 64;
 const MAX_COMMAND_LINE_BYTES: usize = 64 * 1024;
+
+pub(super) fn atomic_replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fn wide(path: &Path) -> std::io::Result<Vec<u16>> {
+        let mut value: Vec<u16> = path.as_os_str().encode_wide().collect();
+        if value.contains(&0) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "path contains a null character",
+            ));
+        }
+        value.push(0);
+        Ok(value)
+    }
+
+    let source = wide(source)?;
+    let destination = wide(destination)?;
+    // SAFETY: both pointers reference live, null-terminated UTF-16 buffers for
+    // the duration of the call. The files share a directory, so replacement
+    // stays on one volume and MOVEFILE_WRITE_THROUGH waits for completion.
+    let moved = unsafe {
+        MoveFileExW(
+            source.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
 
 struct OwnedHandle(HANDLE);
 

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -282,6 +282,10 @@ discovery rather than inferring support from an agent name.
   and terminal state.
 - Supported agents can reopen their own conversation through native session
   discovery and resume commands.
+- Antigravity CLI is detected natively. Its optional
+  `luvus integration install antigravity` hook reports only the exact
+  conversation id needed for `agy --conversation <id>` restore; screen
+  detection remains authoritative for state.
 - Hermes session discovery works without setup. When exact pane ownership is
   required, `luvus integration install hermes` adds an opt-in Hermes plugin
   that reports each session once while retaining the native database fallback.

--- a/website/public/manifests/antigravity.toml
+++ b/website/public/manifests/antigravity.toml
@@ -1,0 +1,25 @@
+# Official Luvus detection manifest for Antigravity CLI.
+# This provides detection-only compatibility to older identity-enabled Luvus
+# versions; native launch, session, resume, and integration support still ships
+# in the Luvus binary.
+agent = "antigravity"
+
+[identity]
+distinct = ["antigravity-cli"]
+ambiguous = ["agy"]
+
+# Antigravity's permission panel identifies both the pending operation and its
+# proceed control. Requiring both avoids matching ordinary transcript prose.
+[[rule]]
+state = "blocked"
+priority = 320
+region = "screen"
+all = ["requesting permission for:", "proceed"]
+
+# The live CLI uses a spinner while a model turn is active. Restrict the rule to
+# Antigravity so unrelated terminal animation cannot affect another agent.
+[[rule]]
+state = "working"
+priority = 200
+region = "screen"
+spinner = true

--- a/website/public/manifests/gemini.toml
+++ b/website/public/manifests/gemini.toml
@@ -1,0 +1,14 @@
+# Official Luvus detection manifest for Gemini CLI.
+# Served by `luvus server update-manifest` and merged with built-in rules.
+agent = "gemini"
+
+[identity]
+distinct = ["gemini"]
+
+# Gemini's edit and command confirmation cards use these stable action labels.
+# Either label is sufficient because both are specific to an active approval UI.
+[[rule]]
+state = "blocked"
+priority = 310
+region = "screen"
+any = ["│ apply this change", "│ allow execution"]

--- a/website/public/manifests/index.json
+++ b/website/public/manifests/index.json
@@ -1,3 +1,7 @@
 {
-  "files": ["claude.toml"]
+  "files": [
+    "antigravity.toml",
+    "claude.toml",
+    "gemini.toml"
+  ]
 }

--- a/website/src/content/docs/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/docs/getting-started/installation.mdx
@@ -145,7 +145,7 @@ session ids and lifecycle events used by sound alerts and module automation,
 install the integration hook for your agent:
 
 ```sh
-luvus integration install claude     # or: copilot · codex · opencode
+luvus integration install claude     # or: copilot · codex · antigravity · opencode
 ```
 
 Also available from **Settings → Integrations** inside luvus.

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -124,6 +124,7 @@ command for you:
 | Claude Code | its project transcript store |
 | GitHub Copilot CLI | its session-state store |
 | Codex | its rollout files |
+| Antigravity CLI | its workspace conversation cache (`~/.gemini/antigravity-cli/cache/last_conversations.json`) |
 | opencode | its session storage |
 | Kimi | its session index (`~/.kimi-code/session_index.jsonl`) |
 | Grok | its session directory (`~/.grok/sessions`) |
@@ -194,17 +195,21 @@ so it is not listed as a native pane-fork target.
 ## Precise events: the integration hook
 
 Screen-based detection needs no setup and works for everything. The optional
-**hook** adds precision: the agent itself reports its exact session id and
-lifecycle events (permission prompt raised, turn ended) into luvus:
+**hook** adds precision: the agent itself reports its exact session id and,
+where its hook contract supports them safely, lifecycle events into luvus:
 
 ```sh
-luvus integration install claude    # or: copilot · codex · opencode · kimi · grok · hermes · omp
+luvus integration install claude    # or: copilot · codex · antigravity · opencode · kimi · grok · hermes · omp
 ```
 
 or toggle it in **Settings → Integrations**. What it does per agent:
 
 - **claude / copilot / codex**: registers a small session-start hook script in
   the agent's own settings file.
+- **antigravity**: adds one Luvus-owned `PreInvocation` entry to
+  `~/.gemini/config/hooks.json`. It reports only the exact conversation id for
+  `agy --conversation <id>` restore; screen detection continues to own agent
+  state, and every other named Antigravity hook is preserved.
 - **opencode**: installs a tiny plugin file.
 - **kimi**: adds a `[[hooks]]` entry to `~/.kimi-code/config.toml`, edited in
   place so your API keys, comments, and own hooks are left untouched.

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -8,6 +8,7 @@ description: What luvus supports per agent, covering live status, session resume
 | Claude Code | ✓ | ✓ | ✓ | ✓ |
 | GitHub Copilot CLI | ✓ | ✓ | no | ✓ |
 | Codex | ✓ | ✓ | ✓ | ✓ |
+| Antigravity CLI (`agy`) | ✓ | ✓ | no | session only |
 | opencode | ✓ | ✓ | no | ✓ |
 | Kimi Code CLI | ✓ | ✓ | no | ✓ |
 | Grok Build | ✓ | ✓ | ✓ | ✓ |
@@ -51,6 +52,15 @@ description: What luvus supports per agent, covering live status, session resume
   `luvus integration install omp` drops a single `luvus.ts` there — no config
   file is edited. Named profiles, `PI_CODING_AGENT_DIR`, `PI_CONFIG_DIR`, and
   OMP's XDG session store remain supported.
+
+  Antigravity CLI publishes its newest conversation per workspace in
+  `~/.gemini/antigravity-cli/cache/last_conversations.json`, which Luvus reads
+  offline and with a strict size bound. `luvus integration install
+  antigravity` additionally registers one Luvus-owned `PreInvocation` hook
+  under `~/.gemini/config/hooks.json` for exact live pane ownership. Luvus
+  restores either source with `agy --conversation <id>`. Screen detection
+  remains responsible for idle/working/blocked state, and uninstall preserves
+  every other named hook.
 
   Hermes installs `~/.hermes/plugins/luvus-agent-state`, or the equivalent
   directory under `HERMES_HOME`, and enables only that plugin in

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -257,7 +257,7 @@ server:
   server restart             stop + start (load a newly-installed binary)
   server update-manifest     fetch the latest agent-detection rules from luvus.dev
                              (applies live if the server is up; else on next start)
-  integration install|uninstall <claude|copilot|codex|opencode|kimi|grok|hermes|omp>
+  integration install|uninstall <claude|copilot|codex|antigravity|opencode|kimi|grok|hermes|omp>
                              add/remove luvus's session-resume hook (uninstall
                              removes only luvus's hook, never the agent)
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -85,6 +85,7 @@ const AGENTS = [
   { name: 'Claude Code', Icon: IconClaudeCode, hook: true },
   { name: 'Codex', Icon: IconCodex, hook: true },
   { name: 'Gemini', Icon: IconGemini },
+  { name: 'Antigravity', letter: 'A', hook: true },
   { name: 'Aider', Icon: IconAider },
   { name: 'opencode', Icon: IconOpencode, mono: true, hook: true },
   { name: 'Copilot', Icon: IconCopilot, mono: true, hook: true },


### PR DESCRIPTION
Add native Antigravity CLI detection, orchestration, session restore, and an optional exact-session hook without adding background work.

## What

- Registers `antigravity` as the canonical built-in agent with `agy` and `antigravity-cli` aliases.
- Detects direct `agy` processes on Unix and Windows while avoiding false positives from prose and the Antigravity desktop editor binary.
- Uses Antigravity's documented `agy -p` headless syntax for ORCH workers.
- Reads the documented workspace-to-conversation cache at `~/.gemini/antigravity-cli/cache/last_conversations.json` with a strict 256 KiB bound for native latest-session discovery.
- Restores exact conversations with `agy --conversation <id>` and strips stale `--conversation` / `-c` selectors from captured launch flags.
- Adds an optional `luvus integration install antigravity` `PreInvocation` hook for exact live pane ownership. The handler accepts at most 1 MiB, forwards only pane, agent, and conversation identity, and returns the required empty JSON response.
- Preserves unrelated Antigravity hook blocks and configuration during idempotent install/uninstall, and refuses malformed or colliding user-owned configuration.
- Keeps screen detection authoritative for live state and reports no guessed usage data.
- Updates CLI help, bundled automation guidance, README, homepage support grid, and public agent documentation.

## Why

Antigravity CLI previously had no native Luvus adapter. A detection-only rule could identify the process, but it could not provide the agent-specific `-p` task contract, documented workspace cache, exact resume command, or safe optional hook lifecycle.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Focused adapter, registry, detection, resume, ORCH, integration, and CLI-help tests
- [x] `cargo test --locked` — 1308 passed, 1 ignored
- [x] `cargo build --release --locked`
- [x] `npm run build` in `website/`

## Notes

- The locally installed `agy` is the older Antigravity editor launcher (`1.107.0`), not the current terminal CLI, so an authenticated end-to-end run of the current CLI was not performed. Command, cache, hook, and resume contracts are covered by fixtures against the current official Antigravity CLI documentation.
- Windows command paths are covered by focused tests; the PowerShell hook still requires Windows CI/runtime verification.
- Publishing Antigravity through the managed `server update-manifest` feed is intentionally left for a focused follow-up. This PR provides the complete binary-level adapter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Antigravity CLI agent, including native detection, live status, session discovery, and conversation resume.
  * Added an optional Antigravity integration hook for restoring exact conversations while preserving existing hooks.
  * Added Gemini CLI detection for approval and blocked states.
  * Added Antigravity to supported-agent listings and the homepage.

* **Documentation**
  * Documented Antigravity installation, session resume, detection, and session-only hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->