### PR TITLE
fix(search): hide pane cursor behind modal

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -968,6 +968,7 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
     }
 
     let cursor = if settings_hits.is_some()
+        || app.search.is_some()
         || picker_open
         || app.bar.overflow.is_some()
         || app.help_open


### PR DESCRIPTION
## Summary

- Hide the underlying PTY caret while Global Search is active.
- Keep the fuzzy-search layout, input behavior, and visual query marker unchanged.

## Reason

Global Search was missing from the shared overlay cursor-suppression condition, so the focused pane cursor could remain visible through the modal. This makes it consistent with Settings and the other modal surfaces.

## Verification

- cargo fmt --all --check
- cargo test ui::search -- --nocapture
- cargo clippy --bin luvus -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The underlying pane cursor is now hidden while the search overlay is open, preventing it from appearing beneath the overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->