### PR TITLE
fix(config): preserve shared settings across sessions

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1292,13 +1292,13 @@ impl App {
                     )
                 })?;
                 let next = patched_config(&self.config, patch)?;
-                self.apply_socket_config(next)?;
+                self.apply_socket_config(next, Some(patch))?;
                 Ok(json!({"type":"config", "config":self.config}))
             }
             "server.reload_config" => {
                 reject_api_fields(p, &[])?;
                 let next = crate::config::load();
-                self.apply_socket_config(next)?;
+                self.apply_socket_config(next, None)?;
                 Ok(json!({"type":"config_reloaded", "config":self.config}))
             }
             "server.agent_manifests" => {
@@ -3112,7 +3112,7 @@ impl App {
                 let key = declaration.key.canonical();
                 if !self.config.bars.is_explicitly_placed(&key, region) {
                     self.config.bars.place(&key, region);
-                    crate::config::save(&self.config);
+                    self.persist_config();
                     self.bar.clear_geometry();
                 }
                 Ok(
@@ -5410,6 +5410,7 @@ impl App {
     pub(super) fn apply_socket_config(
         &mut self,
         next: crate::config::Config,
+        persist_patch: Option<&Value>,
     ) -> Result<(), (String, String)> {
         let prefix = keys::PrefixSpec::parse(&next.prefix).ok_or_else(|| {
             (
@@ -5445,8 +5446,11 @@ impl App {
         }
         self.config = next;
         self.changelog_rows = None;
-        let persisted = self.config.clone();
-        std::thread::spawn(move || crate::config::save(&persisted));
+        if let Some(patch) = persist_patch {
+            self.persist_config_patch(patch);
+        } else {
+            self.reset_config_baseline();
+        }
         self.emit_event("config.changed", json!({}));
         Ok(())
     }

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -295,7 +295,7 @@ impl App {
         self.file_tree.show_hidden = show;
         self.file_tree.scroll = 0;
         self.config.layout.files_show_hidden = show;
-        crate::config::save(&self.config);
+        self.persist_config();
     }
 
     /// What a plain left click on a FILES row does, from `layout.file_click`

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -457,7 +457,7 @@ impl App {
                 return true;
             }
             AppEvent::ConfigReloaded { id, config, reply } => {
-                let response = match self.apply_socket_config(config) {
+                let response = match self.apply_socket_config(config, None) {
                     Ok(()) => {
                         json!({"id":id,"result":{"type":"config_reloaded","config":self.config}})
                     }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -790,14 +790,14 @@ impl App {
         }
         self.config.keybindings.insert(cmd.id().to_string(), key);
         self.keymap = build_keymap(&self.config.keybindings);
-        crate::config::save(&self.config);
+        self.persist_config();
     }
 
     /// Reset `cmd` to its default key (drop any override), persist, and rebuild.
     pub fn reset_binding(&mut self, cmd: Cmd) {
         self.config.keybindings.remove(cmd.id());
         self.keymap = build_keymap(&self.config.keybindings);
-        crate::config::save(&self.config);
+        self.persist_config();
     }
 
     /// Set the command-mode prefix from a safe spec such as `ctrl+b`, `alt+\`,
@@ -808,7 +808,7 @@ impl App {
             Some(p) => {
                 self.config.prefix = p.spec();
                 self.prefix = p;
-                crate::config::save(&self.config);
+                self.persist_config();
                 true
             }
             None => false,
@@ -831,7 +831,7 @@ impl App {
         }
         self.set_prefix(preset.prefix); // also saves config
         self.keymap = build_keymap(&self.config.keybindings);
-        crate::config::save(&self.config);
+        self.persist_config();
         true
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1557,6 +1557,9 @@ pub struct App {
     pub catalog: &'static crate::i18n::Catalog,
     /// Persisted user configuration (theme, layout, notifications, keys).
     pub config: crate::config::Config,
+    /// This server's last local config snapshot. Persistence diffs against this
+    /// snapshot so another named server's newer, unrelated fields survive.
+    config_baseline: crate::config::Config,
     /// Active `key → Cmd` map for prefix mode (defaults + config overrides).
     pub keymap: std::collections::HashMap<String, Cmd>,
     /// Explicit normal-mode shortcuts. Empty by default so pane input remains
@@ -2101,6 +2104,7 @@ impl App {
         let name = ws_name(&cwd);
 
         let config = crate::config::load();
+        let config_baseline = config.clone();
         let files_show_hidden = config.layout.files_show_hidden;
         let agents_active_only = config.agents_active_only;
         crate::layout::set_gaps(config.layout.col_gap, config.layout.row_gap);
@@ -2173,6 +2177,7 @@ impl App {
             theme_registry,
             catalog,
             config,
+            config_baseline,
             keymap,
             direct_keymap,
             prefix,
@@ -2427,6 +2432,7 @@ impl App {
 
     fn from_snapshot(snap: SessionSnapshot, app_tx: Sender<AppEvent>) -> Option<App> {
         let config = crate::config::load();
+        let config_baseline = config.clone();
         let files_show_hidden = config.layout.files_show_hidden;
         let agents_active_only = config.agents_active_only;
         let theme_registry = crate::theme::ThemeRegistry::load();
@@ -2788,6 +2794,7 @@ impl App {
             theme_registry,
             catalog,
             config,
+            config_baseline,
             keymap,
             direct_keymap,
             prefix,
@@ -3094,7 +3101,30 @@ impl App {
     pub fn save_sidebars(&mut self) {
         self.config.sidebars = Some(self.sidebars.to_config());
         self.config.sidebar_width = self.sidebars.left.width;
-        crate::config::save(&self.config);
+        self.persist_config();
+    }
+
+    /// Merge only this server's local changes into the shared home-level config.
+    /// A failed best-effort write keeps the old baseline so the next mutation
+    /// retries every unsaved field.
+    pub(crate) fn persist_config(&mut self) {
+        if crate::config::save_changes(&self.config_baseline, &self.config) {
+            self.config_baseline = self.config.clone();
+        }
+    }
+
+    /// Persist local changes while forcing an explicit user/API patch even when
+    /// this server already held the requested value in memory.
+    pub(crate) fn persist_config_patch(&mut self, patch: &serde_json::Value) {
+        if crate::config::save_changes_with_patch(&self.config_baseline, &self.config, Some(patch))
+        {
+            self.config_baseline = self.config.clone();
+        }
+    }
+
+    /// Adopt an externally reloaded config without writing it back to disk.
+    pub(crate) fn reset_config_baseline(&mut self) {
+        self.config_baseline = self.config.clone();
     }
 
     /// Apply the AGENTS All / Active projection without performing I/O. This is
@@ -3116,7 +3146,7 @@ impl App {
         let config_changed = self.config.agents_active_only != active_only;
         if config_changed {
             self.config.agents_active_only = active_only;
-            crate::config::save(&self.config);
+            self.persist_config();
         }
         runtime_changed || config_changed
     }
@@ -6443,6 +6473,34 @@ mod tests {
             restored.agents_active_only,
             "snapshot restoration reads config instead of snapshot state"
         );
+    }
+
+    #[test]
+    fn stale_named_app_change_does_not_restore_an_old_theme() {
+        let _env = crate::persist::test_env("named-app-config-merge");
+        let initial = crate::config::Config {
+            theme: "gruvbox-light".into(),
+            ..crate::config::Config::default()
+        };
+        crate::config::save(&initial);
+
+        let (alpha_tx, _alpha_rx) = mpsc::channel();
+        let (beta_tx, _beta_rx) = mpsc::channel();
+        let mut alpha = App::new(80, 24, alpha_tx).unwrap();
+        let mut beta = App::new(80, 24, beta_tx).unwrap();
+        assert_eq!(alpha.config.theme, "gruvbox-light");
+        assert_eq!(beta.config.theme, "gruvbox-light");
+
+        alpha.apply_theme("quattro-rally");
+        assert!(beta.set_agents_filter(true));
+
+        let merged = crate::config::load();
+        assert_eq!(merged.theme, "quattro-rally");
+        assert!(merged.agents_active_only);
+
+        let (restarted_tx, _restarted_rx) = mpsc::channel();
+        let restarted = App::new(80, 24, restarted_tx).unwrap();
+        assert_eq!(restarted.config.theme, "quattro-rally");
     }
 
     // A saved pane whose cwd no longer exists (deleted project dir) must not

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -912,7 +912,7 @@ impl App {
         let theme_id = self.config.theme.clone();
         self.set_effective_theme(&theme_id, selected);
         self.changelog_rows = None;
-        config::save(&self.config);
+        self.persist_config_patch(&serde_json::json!({"theme": theme_id}));
     }
 
     /// Swap the server's in-memory registry after an off-loop scan. A missing
@@ -935,7 +935,7 @@ impl App {
     fn apply_language(&mut self, code: &str) {
         self.config.language = code.to_string();
         self.catalog = crate::i18n::by_code(code);
-        config::save(&self.config);
+        self.persist_config_patch(&serde_json::json!({"language": code}));
     }
 
     /// Layout tab ‹ ›/click on a row's control (docs/29). Width sliders step by
@@ -974,7 +974,7 @@ impl App {
                 ) as usize;
                 self.config.layout.scrollback_bytes = Some(next);
                 self.apply_history_budget();
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::MobileWidth => {
                 let current = self.config.layout.mobile_width;
@@ -984,20 +984,20 @@ impl App {
                     (24, std::cmp::Ordering::Less) => 0,
                     _ => (current as i32 + 4 * delta).clamp(24, 200) as u16,
                 };
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::PaneTitles => {
                 self.config.layout.show_titles = !self.config.layout.show_titles;
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::PaneTitlePath => {
                 self.config.layout.pane_title_path = !self.config.layout.pane_title_path;
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::ResumeWs => {
                 self.config.layout.resume_in_new_workspace =
                     !self.config.layout.resume_in_new_workspace;
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::DiffLayout => {
                 self.config.layout.diff_layout = if delta < 0 {
@@ -1015,23 +1015,23 @@ impl App {
                 } else {
                     self.config.layout.diff_layout.cycle()
                 };
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::DiffWrap => {
                 self.config.layout.diff_wrap = !self.config.layout.diff_wrap;
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::DiffContext => {
                 self.config.layout.diff_context_lines =
                     (self.config.layout.diff_context_lines as i32 + delta)
                         .clamp(0, i32::from(crate::diff::MAX_CONTEXT_LINES))
                         as u16;
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::DiffLineNumbers => {
                 self.config.layout.diff_show_line_numbers =
                     !self.config.layout.diff_show_line_numbers;
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::DiffMarkers => {
                 self.config.layout.diff_marker_style = if delta < 0 {
@@ -1039,15 +1039,15 @@ impl App {
                 } else {
                     self.config.layout.diff_marker_style.cycle()
                 };
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::DiffColors => {
                 self.config.layout.diff_color_mode = self.config.layout.diff_color_mode.cycle();
-                config::save(&self.config);
+                self.persist_config();
             }
             LayoutRow::DiffLiveRefresh => {
                 self.config.layout.diff_live_refresh = !self.config.layout.diff_live_refresh;
-                config::save(&self.config);
+                self.persist_config();
             }
             #[cfg(windows)]
             LayoutRow::Shell => self.cycle_shell(delta),
@@ -1080,7 +1080,7 @@ impl App {
                 };
                 self.config.bars.place(&key, region);
                 self.bar.clear_geometry();
-                config::save(&self.config);
+                self.persist_config();
                 if let Some(next) = self
                     .layout_rows()
                     .iter()
@@ -1135,7 +1135,7 @@ impl App {
                 };
                 self.config.bars.place(&key, next);
                 self.bar.clear_geometry();
-                config::save(&self.config);
+                self.persist_config();
                 if let Some(cursor) = self
                     .layout_rows()
                     .iter()
@@ -1165,7 +1165,7 @@ impl App {
             .unwrap_or(0) as i32;
         let next = (((cur + delta) % n + n) % n) as usize;
         self.config.layout.file_open = opts[next].clone();
-        config::save(&self.config);
+        self.persist_config();
     }
 
     /// Cycle what a plain FILES click does (docs/38): preview ⇄ open in tab.
@@ -1181,7 +1181,7 @@ impl App {
             .unwrap_or(0) as i32;
         let next = (((cur + delta) % n + n) % n) as usize;
         self.config.layout.file_click = opts[next].to_string();
-        config::save(&self.config);
+        self.persist_config();
     }
 
     /// The current click-behavior choice as a display string. An unrecognized
@@ -1204,7 +1204,7 @@ impl App {
             .unwrap_or(0) as i32;
         let next = (((cur + delta) % n + n) % n) as usize;
         self.config.layout.shift_enter = opts[next].0.to_string();
-        config::save(&self.config);
+        self.persist_config();
     }
 
     /// The current Shift+Enter choice's display label (the raw keyword if unknown).
@@ -1245,12 +1245,12 @@ impl App {
             .unwrap_or(0) as i32;
         let next = (((cur + delta) % n + n) % n) as usize;
         self.config.shell = choices[next].0.to_string();
-        config::save(&self.config);
+        self.persist_config();
     }
 
     fn apply_gaps(&mut self) {
         crate::layout::set_gaps(self.config.layout.col_gap, self.config.layout.row_gap);
-        config::save(&self.config);
+        self.persist_config();
     }
 
     /// Push the retained-history budget to every live pane. Alacritty's
@@ -1274,30 +1274,30 @@ impl App {
             Some(GeneralRow::ShiftEnter) => self.cycle_shift_enter(delta),
             Some(GeneralRow::CheckUpdates) => {
                 self.config.check_updates = !self.config.check_updates;
-                config::save(&self.config);
+                self.persist_config();
             }
             Some(GeneralRow::ResumeFlags) => {
                 self.config.resume_launch_flags = !self.config.resume_launch_flags;
-                config::save(&self.config);
+                self.persist_config();
             }
             Some(GeneralRow::NewPaneToWorkspaceRoot) => {
                 self.config.layout.new_pane_to_workspace_root =
                     !self.config.layout.new_pane_to_workspace_root;
-                config::save(&self.config);
+                self.persist_config();
             }
             Some(GeneralRow::AgentTitle) => {
                 self.config.layout.agent_title = !self.config.layout.agent_title;
-                config::save(&self.config);
+                self.persist_config();
             }
             Some(GeneralRow::SoundStyle) => self.cycle_sound_style(delta),
             Some(GeneralRow::SoundDone) => {
                 self.config.notifications.sound_on_done = !self.config.notifications.sound_on_done;
-                config::save(&self.config);
+                self.persist_config();
             }
             Some(GeneralRow::SoundBlocked) => {
                 self.config.notifications.sound_on_blocked =
                     !self.config.notifications.sound_on_blocked;
-                config::save(&self.config);
+                self.persist_config();
             }
             // Test rows fire on Enter/click only (see `settings_activate`) —
             // arrows must not ring them, or holding ‹ › would spam cues.
@@ -1315,7 +1315,7 @@ impl App {
         let count = crate::sound::STYLES.len() as i32;
         let next = ((index + delta) % count + count) % count;
         self.config.notifications.sound_style = crate::sound::STYLES[next as usize].key().into();
-        config::save(&self.config);
+        self.persist_config();
     }
 
     pub fn sound_style_label(&self) -> &'static str {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1228,11 +1228,13 @@ fn theme_cmd(args: &[String], context: crate::i18n::cli::Context) -> Result<i32>
                     let mut config = crate::config::load();
                     let baseline = config.clone();
                     config.theme = selected;
-                    crate::config::save_changes_with_patch(
+                    if !crate::config::save_changes_with_patch(
                         &baseline,
                         &config,
                         Some(&json!({"theme": config.theme.clone()})),
-                    );
+                    ) {
+                        return Err(anyhow!(context.text("could not save the theme selection")));
+                    }
                     println!(
                         "{} {} — {}",
                         context.text("using theme"),
@@ -4016,6 +4018,22 @@ mod tests {
                 "{invalid:?}"
             );
         }
+    }
+
+    #[test]
+    fn theme_use_reports_a_config_write_failure() {
+        let _env = crate::persist::test_env("theme-write-failure");
+        let home = crate::persist::config_dir();
+        fs::write(&home, "not a directory").unwrap();
+
+        let result = theme_cmd(
+            &["use".into(), "quattro-rally".into()],
+            crate::i18n::cli::Context::for_language(crate::i18n::cli::Language::En),
+        );
+        fs::remove_file(home).unwrap();
+
+        let error = result.unwrap_err();
+        assert_eq!(error.to_string(), "could not save the theme selection");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1226,8 +1226,13 @@ fn theme_cmd(args: &[String], context: crate::i18n::cli::Context) -> Result<i32>
                 }
                 Ok(_) | Err(_) => {
                     let mut config = crate::config::load();
+                    let baseline = config.clone();
                     config.theme = selected;
-                    crate::config::save(&config);
+                    crate::config::save_changes_with_patch(
+                        &baseline,
+                        &config,
+                        Some(&json!({"theme": config.theme.clone()})),
+                    );
                     println!(
                         "{} {} — {}",
                         context.text("using theme"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,11 +3,14 @@
 //! has a serde default, so old/new configs round-trip and a missing or corrupt
 //! file just yields defaults.
 
-use std::fs;
-use std::io::Write;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 use crate::app::{SIDEBAR_WIDTH_DEFAULT, SIDEBAR_WIDTH_MAX, SIDEBAR_WIDTH_MIN};
 
@@ -549,6 +552,10 @@ fn config_path() -> PathBuf {
     crate::persist::config_dir().join("config.json")
 }
 
+fn config_lock_path() -> PathBuf {
+    crate::persist::config_dir().join("config.lock")
+}
+
 /// Load the config, or defaults if missing / unparsable.
 pub fn load() -> Config {
     fs::read_to_string(config_path())
@@ -596,20 +603,162 @@ fn legacy_scrollback_bytes(lines: usize) -> usize {
         .clamp(SCROLLBACK_BYTES_MIN, SCROLLBACK_BYTES_MAX)
 }
 
-/// Save the config atomically (best effort).
+static CONFIG_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Save a complete config atomically (best effort).
+///
+/// Runtime app code should use [`save_changes`] instead. A complete write is
+/// appropriate for isolated initialization and tests, but a long-running named
+/// server may hold an older copy of fields changed by another server.
+#[cfg(test)]
 pub fn save(cfg: &Config) {
+    let _ = with_config_lock(|| write_config_atomic(cfg));
+}
+
+/// Persist only fields changed between one server's last local config and its
+/// current config. The newest shared config is reloaded under a cross-process
+/// lock before applying the deep patch, so a named server cannot overwrite an
+/// unrelated setting with an older in-memory value.
+///
+/// Returns `true` after either a successful write or a no-op. Callers retain
+/// their old baseline on `false`, allowing the next change to retry everything
+/// that has not reached disk yet.
+pub fn save_changes(base: &Config, desired: &Config) -> bool {
+    save_changes_with_patch(base, desired, None)
+}
+
+/// Persist local changes and also apply an explicit user/API patch. The
+/// explicit patch matters when a stale server is asked to select the value it
+/// already has in memory: there may be no local delta, but the shared file must
+/// still record the user's choice.
+pub fn save_changes_with_patch(base: &Config, desired: &Config, explicit: Option<&Value>) -> bool {
+    let Ok(base) = serde_json::to_value(base) else {
+        return false;
+    };
+    let Ok(desired) = serde_json::to_value(desired) else {
+        return false;
+    };
+    let delta = value_delta(&base, &desired);
+    if delta.is_none() && explicit.is_none() {
+        return true;
+    }
+
+    with_config_lock(|| {
+        let mut latest = serde_json::to_value(load()).map_err(io::Error::other)?;
+        if let Some(delta) = &delta {
+            apply_delta(&mut latest, delta);
+        }
+        if let Some(explicit) = explicit {
+            apply_delta(&mut latest, explicit);
+        }
+        let merged: Config = serde_json::from_value(latest).map_err(io::Error::other)?;
+        write_config_atomic(&normalize_config(merged))
+    })
+    .is_ok()
+}
+
+fn with_config_lock<T>(operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
     let dir = crate::persist::ensure_config_dir();
     if !dir.is_dir() {
-        return;
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "configuration directory is unavailable",
+        ));
     }
-    let Ok(json) = serde_json::to_string_pretty(cfg) else {
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(config_lock_path())?;
+    lock.lock_exclusive()?;
+    operation()
+}
+
+fn write_config_atomic(cfg: &Config) -> io::Result<()> {
+    let json = serde_json::to_vec_pretty(cfg).map_err(io::Error::other)?;
+    let path = config_path();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config.json");
+    let (temporary, mut file): (PathBuf, File) = (0..16)
+        .find_map(|_| {
+            let sequence = CONFIG_WRITE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let temporary = path.with_file_name(format!(
+                ".{file_name}.luvus-{}-{sequence}.tmp",
+                std::process::id()
+            ));
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temporary)
+            {
+                Ok(file) => Some(Ok((temporary, file))),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => None,
+                Err(error) => Some(Err(error)),
+            }
+        })
+        .transpose()?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::AlreadyExists, "temporary config files"))?;
+
+    let result = (|| {
+        file.write_all(&json)?;
+        file.flush()?;
+        drop(file);
+        crate::platform::atomic_replace_file(&temporary, &path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+/// Produce a JSON Merge Patch style delta, recursing into maps so independent
+/// nested settings such as two Layout fields do not replace each other.
+fn value_delta(base: &Value, desired: &Value) -> Option<Value> {
+    match (base, desired) {
+        (Value::Object(base), Value::Object(desired)) => {
+            let mut delta = Map::new();
+            for key in base.keys() {
+                if !desired.contains_key(key) {
+                    delta.insert(key.clone(), Value::Null);
+                }
+            }
+            for (key, desired) in desired {
+                match base.get(key).and_then(|base| value_delta(base, desired)) {
+                    Some(value) => {
+                        delta.insert(key.clone(), value);
+                    }
+                    None if !base.contains_key(key) => {
+                        delta.insert(key.clone(), desired.clone());
+                    }
+                    None => {}
+                }
+            }
+            (!delta.is_empty()).then_some(Value::Object(delta))
+        }
+        _ if base == desired => None,
+        _ => Some(desired.clone()),
+    }
+}
+
+fn apply_delta(target: &mut Value, delta: &Value) {
+    let Value::Object(delta) = delta else {
+        *target = delta.clone();
         return;
     };
-    let path = config_path();
-    let tmp = path.with_extension("json.tmp");
-    if let Ok(mut f) = fs::File::create(&tmp) {
-        if f.write_all(json.as_bytes()).is_ok() && f.flush().is_ok() {
-            let _ = fs::rename(&tmp, &path);
+    if !target.is_object() {
+        *target = Value::Object(Map::new());
+    }
+    let target = target.as_object_mut().expect("object assigned above");
+    for (key, value) in delta {
+        if value.is_null() {
+            target.remove(key);
+        } else if let Some(current) = target.get_mut(key) {
+            apply_delta(current, value);
+        } else {
+            target.insert(key.clone(), value.clone());
         }
     }
 }
@@ -728,6 +877,62 @@ mod tests {
         config.agents_active_only = false;
         save(&config);
         assert!(!load().agents_active_only);
+    }
+
+    #[test]
+    fn stale_named_server_changes_preserve_newer_shared_fields() {
+        let _env = crate::persist::test_env("config-named-server-merge");
+        let mut initial = Config {
+            theme: "gruvbox-light".into(),
+            ..Config::default()
+        };
+        initial.keybindings.insert("close_pane".into(), "x".into());
+        save(&initial);
+
+        // Alpha and Beta model two named servers that loaded the same shared
+        // config before either one changed it.
+        let alpha_base = load();
+        let beta_base = load();
+
+        let mut alpha = alpha_base.clone();
+        alpha.theme = "quattro-rally".into();
+        assert!(save_changes(&alpha_base, &alpha));
+
+        // Beta still remembers the old light theme. Its unrelated change must
+        // not write that stale theme back to disk.
+        let mut beta = beta_base.clone();
+        beta.check_updates = false;
+        beta.keybindings.remove("close_pane");
+        assert!(save_changes(&beta_base, &beta));
+
+        let merged = load();
+        assert_eq!(merged.theme, "quattro-rally");
+        assert!(!merged.check_updates);
+        assert!(!merged.keybindings.contains_key("close_pane"));
+
+        // Deep patches also preserve independent fields in one nested section.
+        let alpha_base = alpha;
+        let beta_base = beta;
+        let mut alpha = alpha_base.clone();
+        alpha.layout.show_titles = false;
+        assert!(save_changes(&alpha_base, &alpha));
+        let mut beta = beta_base.clone();
+        beta.layout.files_show_hidden = true;
+        assert!(save_changes(&beta_base, &beta));
+
+        let merged = load();
+        assert!(!merged.layout.show_titles);
+        assert!(merged.layout.files_show_hidden);
+        assert_eq!(merged.theme, "quattro-rally");
+
+        // An explicit selection still wins when it matches this stale server's
+        // local value and therefore would not appear in the computed delta.
+        assert!(save_changes_with_patch(
+            &beta,
+            &beta,
+            Some(&serde_json::json!({"theme":"gruvbox-light"})),
+        ));
+        assert_eq!(load().theme, "gruvbox-light");
     }
 
     #[test]

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -2694,6 +2694,8 @@ static TEXT: &[Translation] = &[
         "사용 중인 테마"),
     tr!("applies when Luvus starts", "se aplica cuando Luvus se inicia", "aplica quando o Luvus iniciar", "s'applique au démarrage de Luvus", "wird beim Start von Luvus angewendet", "berlaku saat Luvus dimulai", "将在 Luvus 启动时应用", "Luvus 起動時に適用されます",
         "Luvus 시작 시 적용됨"),
+    tr!("could not save the theme selection", "no se pudo guardar la selección del tema", "não foi possível salvar a seleção do tema", "impossible d’enregistrer la sélection du thème", "Theme-Auswahl konnte nicht gespeichert werden", "pilihan tema tidak dapat disimpan", "无法保存主题选择", "テーマの選択を保存できませんでした",
+        "테마 선택을 저장할 수 없습니다"),
     tr!("uninstalled", "desinstalado", "desinstalado", "désinstallé", "deinstalliert", "dihapus", "已卸载", "アンインストール済み",
         "제거됨"),
     tr!("reloaded", "recargados", "recarregados", "rechargés", "neu geladen", "dimuat ulang", "已重新加载", "再読み込みしました",

--- a/website/src/content/docs/docs/guides/themes.mdx
+++ b/website/src/content/docs/docs/guides/themes.mdx
@@ -175,8 +175,10 @@ one palette or one intentional parent/child family.
 
 Theme files and `config.theme` are shared at the Luvus-home level. `theme use`
 updates the selected server immediately and persists the choice. Other already
-running named servers retain their in-memory registry until `theme reload` or a
-restart; target one explicitly with `luvus --session <name> theme reload`.
+running named servers retain their in-memory selection until a restart or an
+explicit `luvus --session <name> theme use <id>`. Config writes merge only the
+fields changed by that server, so changing an unrelated setting in another
+session cannot restore an older theme.
 
 Normal custom themes are rendered by the server, so every attached client sees
 the same palette. **Terminal** remains special and client-derived. A custom


### PR DESCRIPTION
## What changed

- persist only the fields changed by each running server instead of rewriting its entire in-memory config
- serialize cross-process config updates with a home-level lock
- merge deep nested settings so independent Layout, keybinding, notification, bar, and sidebar changes survive
- use unique same-directory temporary files and the existing cross-platform atomic replacement helper
- preserve explicit `theme use` and `config.patch` intent even when the requested value already matches a stale server's local state
- reset the local persistence baseline when `server.reload_config` adopts the on-disk configuration
- document how shared theme selection behaves across named sessions

## Why

Every named server loaded the shared `config.json` into its own memory. Changing any setting later wrote that entire copy back to disk. A server that still remembered an older theme could therefore restore that theme while saving an unrelated setting. The stale value only became visible in another session after its server restarted and reloaded the shared file.

This change keeps configuration global while making each write a locked field-level merge against the newest file on disk.

## Performance and resource use

There is no polling, watcher, timer, or permanent writer thread. Work happens only when a setting changes. Each server retains one small config baseline, while terminal rendering, PTY output, agent detection, and idle processing remain untouched.

## Verification

- reproduced the original failure with two isolated debug servers
- confirmed the stale server kept its old live theme before restart
- confirmed its unrelated setting no longer overwrote the newer shared theme
- confirmed the restarted server loaded the newer theme and preserved the unrelated setting
- added focused config and app regression tests covering stale servers, deep nested fields, removals, and explicit selections
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked` with 1,330 passing and 1 ignored benchmark
- `cargo build --release --locked`

Production Luvus was not started, stopped, or modified during validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration saving across named sessions so unrelated changes are preserved.
  - Theme and language updates now preserve other settings while applying the selected change.
  - Configuration changes are written more safely during concurrent updates to reduce data loss.
  - Sidebar, layout, file visibility, keybinding, and other settings now retain changes consistently.
  - Theme selection commands now report an error when saving fails instead of showing false success.

- **Documentation**
  - Clarified named-server theme behavior and session-specific updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->