### PR TITLE
fix(agent): validate key batches before delivery

### DIFF
--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -286,7 +286,7 @@ def agent_key(value):
         return True
     if re.fullmatch(r"(?:ctrl\+|c-)[a-z]", lower) is not None:
         return True
-    return len(value) == 1 and unicodedata.category(value) != "Cc"
+    return len(value) == 1 and unicodedata.category(value) not in {"Cc", "Cs"}
 
 
 def valid_agent_keys_params(params):

--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -281,11 +281,12 @@ def valid_automation_definition(params, *, update):
 def agent_key(value):
     if not isinstance(value, str):
         return False
-    lower = value.lower()
-    if lower in KEY_NAMES:
-        return True
-    if re.fullmatch(r"(?:ctrl\+|c-)[a-z]", lower) is not None:
-        return True
+    if value.isascii():
+        lower = value.lower()
+        if lower in KEY_NAMES:
+            return True
+        if re.fullmatch(r"(?:ctrl\+|c-)[a-z]", lower) is not None:
+            return True
     return len(value) == 1 and unicodedata.category(value) not in {"Cc", "Cs"}
 
 
@@ -672,6 +673,7 @@ def valid_global_response(value):
 
 def main():
     assert not agent_key("\ud800"), "Unicode surrogates are not valid key scalars"
+    assert not agent_key("ctrl+K"), "Ctrl aliases accept ASCII letters only"
     manifest = json.loads((PACKAGE / "fixtures" / "manifest.json").read_text())
     assert manifest["protocol"] == {"name": "luvus-uhp", "major": 1, "minor": 0}
     request_schema = json.loads((PACKAGE / "schema" / "request.schema.json").read_text())

--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -671,6 +671,7 @@ def valid_global_response(value):
 
 
 def main():
+    assert not agent_key("\ud800"), "Unicode surrogates are not valid key scalars"
     manifest = json.loads((PACKAGE / "fixtures" / "manifest.json").read_text())
     assert manifest["protocol"] == {"name": "luvus-uhp", "major": 1, "minor": 0}
     request_schema = json.loads((PACKAGE / "schema" / "request.schema.json").read_text())

--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -5,6 +5,7 @@ import json
 import pathlib
 import re
 import sys
+import unicodedata
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 PACKAGE = ROOT / "protocol" / "uhp" / "v1"
@@ -22,6 +23,11 @@ SESSION_TARGET_METHODS = {
     "session.status", "session.start", "session.stop", "session.restart",
 }
 STATES = {"idle", "working", "blocked", "done"}
+KEY_NAMES = {
+    "enter", "return", "cr", "esc", "escape", "tab", "space", "backspace", "bs",
+    "delete", "del", "up", "down", "right", "left", "home", "end", "pageup",
+    "pgup", "pagedown", "pgdn",
+}
 RESULT_TYPES = {
     "uhp_capabilities",
     "session_snapshot",
@@ -69,6 +75,7 @@ FIELDS = {
     "agent.start": {"name", "kind", "pane", "anchor", "direction", "args", "timeout_s"},
     "agent.prompt": {"target", "text", "wait", "until", "timeout_s"},
     "agent.wait": {"pane", "status", "statuses", "timeout_s"},
+    "agent.keys": {"target", "keys"},
     "events.subscribe": set(),
 }
 
@@ -271,6 +278,27 @@ def valid_automation_definition(params, *, update):
     )
 
 
+def agent_key(value):
+    if not isinstance(value, str):
+        return False
+    lower = value.lower()
+    if lower in KEY_NAMES:
+        return True
+    if re.fullmatch(r"(?:ctrl\+|c-)[a-z]", lower) is not None:
+        return True
+    return len(value) == 1 and unicodedata.category(value) != "Cc"
+
+
+def valid_agent_keys_params(params):
+    return (
+        set(params) == {"target", "keys"}
+        and bounded_string(params["target"], 128, allow_empty=False)
+        and isinstance(params["keys"], list)
+        and bool(params["keys"])
+        and all(agent_key(key) for key in params["keys"])
+    )
+
+
 def valid_request(value):
     if not isinstance(value, dict) or set(value) != {"id", "method", "params"}:
         return False
@@ -361,6 +389,8 @@ def valid_request(value):
         return type(timeout) in {int, float} and 0 <= timeout <= 3600
     if method == "agent.wait":
         return valid_agent_wait_params(params)
+    if method == "agent.keys":
+        return valid_agent_keys_params(params)
     return False
 
 
@@ -515,6 +545,8 @@ def valid_global_request(value, methods):
         return integer(after) and after >= 0
     if value["method"] == "agent.wait":
         return valid_agent_wait_params(value["params"])
+    if value["method"] == "agent.keys":
+        return valid_agent_keys_params(value["params"])
     if value["method"] in EMPTY_HOST_METHODS:
         return not value["params"]
     if value["method"] in SESSION_TARGET_METHODS:

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -262,6 +262,10 @@ For a blocked agent:
 3. Identify the exact approval or question.
 4. Send `agent keys` only when the user's request authorizes that effect.
 
+`agent keys` accepts only a recognized agent pane and a non-empty list of known
+key names. It validates the entire list before queuing one ordered action; any
+invalid entry sends nothing, and a closed target returns `send_failed`.
+
 ## Control panes, tabs, and workspaces
 
 Use these read routes before a write whose target is not already known:

--- a/protocol/uhp/v1/fixtures/invalid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/invalid/requests.jsonl
@@ -32,4 +32,3 @@
 {"id":"bad-agent-keys-mixed","method":"agent.keys","params":{"target":"reviewer","keys":["enter",7]}}
 {"id":"bad-agent-keys-name","method":"agent.keys","params":{"target":"reviewer","keys":["f13"]}}
 {"id":"bad-agent-keys-extra","method":"agent.keys","params":{"target":"reviewer","keys":["enter"],"extra":true}}
-{"id":"bad-agent-keys-surrogate","method":"agent.keys","params":{"target":"reviewer","keys":["\ud800"]}}

--- a/protocol/uhp/v1/fixtures/invalid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/invalid/requests.jsonl
@@ -27,3 +27,8 @@
 {"id":"bad-automation-access","method":"automation.create","params":{"name":"bad","trigger":{"kind":"once","at_utc":1788393600},"task":{"title":"bad","prompt":"bad","agent_id":"codex","workspace_id":"workspace_example","access":"root"}}}
 {"id":"bad-automation-target","method":"automation.create","params":{"name":"bad target","trigger":{"kind":"once","at_utc":1788393600},"target":{"kind":"active_agent","pane_id":7,"terminal_id":"not-a-terminal-id"},"task":{"title":"bad","prompt":"bad","agent_id":"codex","workspace_id":"workspace_example"}}}
 {"id":"bad-task-heartbeat-progress","method":"task.heartbeat","params":{"id":"t1","context":1.1}}
+{"id":"bad-agent-keys-empty","method":"agent.keys","params":{"target":"reviewer","keys":[]}}
+{"id":"bad-agent-keys-shape","method":"agent.keys","params":{"target":"reviewer","keys":"enter"}}
+{"id":"bad-agent-keys-mixed","method":"agent.keys","params":{"target":"reviewer","keys":["enter",7]}}
+{"id":"bad-agent-keys-name","method":"agent.keys","params":{"target":"reviewer","keys":["f13"]}}
+{"id":"bad-agent-keys-extra","method":"agent.keys","params":{"target":"reviewer","keys":["enter"],"extra":true}}

--- a/protocol/uhp/v1/fixtures/invalid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/invalid/requests.jsonl
@@ -32,3 +32,4 @@
 {"id":"bad-agent-keys-mixed","method":"agent.keys","params":{"target":"reviewer","keys":["enter",7]}}
 {"id":"bad-agent-keys-name","method":"agent.keys","params":{"target":"reviewer","keys":["f13"]}}
 {"id":"bad-agent-keys-extra","method":"agent.keys","params":{"target":"reviewer","keys":["enter"],"extra":true}}
+{"id":"bad-agent-keys-surrogate","method":"agent.keys","params":{"target":"reviewer","keys":["\ud800"]}}

--- a/protocol/uhp/v1/fixtures/manifest.json
+++ b/protocol/uhp/v1/fixtures/manifest.json
@@ -1,10 +1,10 @@
 {
   "protocol": { "name": "luvus-uhp", "major": 1, "minor": 0 },
   "files": [
-    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 43 },
+    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 44 },
     { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 7 },
     { "path": "valid/events.jsonl", "kind": "event", "expect": "valid", "count": 3 },
-    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 29 },
+    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 34 },
     { "path": "invalid/responses.jsonl", "kind": "response", "expect": "invalid", "count": 4 }
   ]
 }

--- a/protocol/uhp/v1/fixtures/manifest.json
+++ b/protocol/uhp/v1/fixtures/manifest.json
@@ -4,7 +4,7 @@
     { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 44 },
     { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 7 },
     { "path": "valid/events.jsonl", "kind": "event", "expect": "valid", "count": 3 },
-    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 34 },
+    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 35 },
     { "path": "invalid/responses.jsonl", "kind": "response", "expect": "invalid", "count": 4 }
   ]
 }

--- a/protocol/uhp/v1/fixtures/manifest.json
+++ b/protocol/uhp/v1/fixtures/manifest.json
@@ -4,7 +4,7 @@
     { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 44 },
     { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 7 },
     { "path": "valid/events.jsonl", "kind": "event", "expect": "valid", "count": 3 },
-    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 35 },
+    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 34 },
     { "path": "invalid/responses.jsonl", "kind": "response", "expect": "invalid", "count": 4 }
   ]
 }

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -41,4 +41,4 @@
 {"id":"40-active","method":"automation.create","params":{"name":"Continue review","trigger":{"kind":"once","at_utc":1788393600},"target":{"kind":"active_agent","pane_id":7,"terminal_id":"0123456789abcdef0123456789abcdef","if_busy":"wait"},"task":{"title":"Continue review","prompt":"Continue with the next review step.","agent_id":"codex","workspace_id":"workspace_example","mode":"workspace","access":"workspace"}}}
 {"id":"41","method":"task.start","params":{"id":"t4","branch":"luvus/t4","mode":"worktree","workspace_id":"workspace_example","agent":"codex"}}
 {"id":"42","method":"task.heartbeat","params":{"id":"t1","context":0.6}}
-{"id":"37","method":"agent.keys","params":{"target":"reviewer","keys":["up","enter","CTRL+C","🙂"]}}
+{"id":"43","method":"agent.keys","params":{"target":"reviewer","keys":["up","enter","CTRL+C","x"]}}

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -41,3 +41,4 @@
 {"id":"40-active","method":"automation.create","params":{"name":"Continue review","trigger":{"kind":"once","at_utc":1788393600},"target":{"kind":"active_agent","pane_id":7,"terminal_id":"0123456789abcdef0123456789abcdef","if_busy":"wait"},"task":{"title":"Continue review","prompt":"Continue with the next review step.","agent_id":"codex","workspace_id":"workspace_example","mode":"workspace","access":"workspace"}}}
 {"id":"41","method":"task.start","params":{"id":"t4","branch":"luvus/t4","mode":"worktree","workspace_id":"workspace_example","agent":"codex"}}
 {"id":"42","method":"task.heartbeat","params":{"id":"t1","context":0.6}}
+{"id":"37","method":"agent.keys","params":{"target":"reviewer","keys":["up","enter","CTRL+C","🙂"]}}

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -41,4 +41,4 @@
 {"id":"40-active","method":"automation.create","params":{"name":"Continue review","trigger":{"kind":"once","at_utc":1788393600},"target":{"kind":"active_agent","pane_id":7,"terminal_id":"0123456789abcdef0123456789abcdef","if_busy":"wait"},"task":{"title":"Continue review","prompt":"Continue with the next review step.","agent_id":"codex","workspace_id":"workspace_example","mode":"workspace","access":"workspace"}}}
 {"id":"41","method":"task.start","params":{"id":"t4","branch":"luvus/t4","mode":"worktree","workspace_id":"workspace_example","agent":"codex"}}
 {"id":"42","method":"task.heartbeat","params":{"id":"t1","context":0.6}}
-{"id":"43","method":"agent.keys","params":{"target":"reviewer","keys":["up","enter","CTRL+C","x"]}}
+{"id":"43","method":"agent.keys","params":{"target":"reviewer","keys":["up","enter","CTRL+C","x","\u00e9"]}}

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -77,6 +77,16 @@
       },
       "oneOf": [ { "required": ["status"] }, { "required": ["statuses"] } ]
     },
+    "agentKeysParams": {
+      "type": "object", "additionalProperties": false, "required": ["target", "keys"],
+      "properties": {
+        "target": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "keys": {
+          "type": "array", "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "missionQueryParams": {
       "type": "object", "additionalProperties": false,
       "properties": {
@@ -268,6 +278,8 @@
       "then": { "properties": { "params": { "$ref": "#/$defs/eventWaitParams" } } } },
     { "if": { "properties": { "method": { "const": "agent.wait" } } },
       "then": { "properties": { "params": { "$ref": "#/$defs/agentWaitParams" } } } },
+    { "if": { "properties": { "method": { "const": "agent.keys" } } },
+      "then": { "properties": { "params": { "$ref": "#/$defs/agentKeysParams" } } } },
     { "if": { "properties": { "method": { "enum": ["mission.snapshot", "mission.refresh"] } } },
       "then": { "properties": { "params": { "$ref": "#/$defs/missionQueryParams" } } } },
     { "if": { "properties": { "method": { "enum": ["session.status", "session.start", "session.stop", "session.restart"] } } },

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -77,13 +77,21 @@
       },
       "oneOf": [ { "required": ["status"] }, { "required": ["statuses"] } ]
     },
+    "agentKey": {
+      "type": "string",
+      "anyOf": [
+        { "pattern": "^(?:[Ee][Nn][Tt][Ee][Rr]|[Rr][Ee][Tt][Uu][Rr][Nn]|[Cc][Rr]|[Ee][Ss][Cc]|[Ee][Ss][Cc][Aa][Pp][Ee]|[Tt][Aa][Bb]|[Ss][Pp][Aa][Cc][Ee]|[Bb][Aa][Cc][Kk][Ss][Pp][Aa][Cc][Ee]|[Bb][Ss]|[Dd][Ee][Ll][Ee][Tt][Ee]|[Dd][Ee][Ll]|[Uu][Pp]|[Dd][Oo][Ww][Nn]|[Rr][Ii][Gg][Hh][Tt]|[Ll][Ee][Ff][Tt]|[Hh][Oo][Mm][Ee]|[Ee][Nn][Dd]|[Pp][Aa][Gg][Ee][Uu][Pp]|[Pp][Gg][Uu][Pp]|[Pp][Aa][Gg][Ee][Dd][Oo][Ww][Nn]|[Pp][Gg][Dd][Nn])$" },
+        { "pattern": "^(?:[Cc][Tt][Rr][Ll]\\+|[Cc]-)[A-Za-z]$" },
+        { "pattern": "^[^\\u0000-\\u001F\\u007F-\\u009F\\uD800-\\uDFFF]$" }
+      ]
+    },
     "agentKeysParams": {
       "type": "object", "additionalProperties": false, "required": ["target", "keys"],
       "properties": {
         "target": { "type": "string", "minLength": 1, "maxLength": 128 },
         "keys": {
           "type": "array", "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+          "items": { "$ref": "#/$defs/agentKey" }
         }
       }
     },

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -262,6 +262,10 @@ For a blocked agent:
 3. Identify the exact approval or question.
 4. Send `agent keys` only when the user's request authorizes that effect.
 
+`agent keys` accepts only a recognized agent pane and a non-empty list of known
+key names. It validates the entire list before queuing one ordered action; any
+invalid entry sends nothing, and a closed target returns `send_failed`.
+
 ## Control panes, tabs, and workspaces
 
 Use these read routes before a write whose target is not already known:

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -3543,33 +3543,43 @@ impl App {
             // Send named control keys (enter, esc, ctrl+c, up, …) to a target agent,
             // e.g. to answer a blocked approval prompt. All keys validate first.
             "agent.keys" => {
+                reject_api_fields(p, &["target", "keys"])?;
                 let id = self.resolve_agent_target(p)?;
-                let keys: Vec<String> = p
-                    .get("keys")
-                    .and_then(|v| v.as_array())
-                    .map(|a| {
-                        a.iter()
-                            .filter_map(|k| k.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                if !self.is_agent_pane(id) {
+                    return Err((
+                        "agent_not_ready".to_string(),
+                        "target pane is not a running agent".to_string(),
+                    ));
+                }
+                let keys = p.get("keys").and_then(|v| v.as_array()).ok_or_else(|| {
+                    (
+                        "invalid_request".to_string(),
+                        "agent keys must be a non-empty array".to_string(),
+                    )
+                })?;
                 if keys.is_empty() {
                     return Err((
                         "invalid_request".to_string(),
-                        "agent keys needs at least one key".to_string(),
+                        "agent keys must be a non-empty array".to_string(),
                     ));
                 }
-                let mut seqs = Vec::with_capacity(keys.len());
-                for k in &keys {
-                    seqs.push(key_to_bytes(k).ok_or_else(|| {
-                        ("invalid_request".to_string(), format!("unknown key: {k}"))
+                let mut bytes = Vec::new();
+                for key in keys {
+                    let key = key.as_str().ok_or_else(|| {
+                        (
+                            "invalid_request".to_string(),
+                            "every agent key must be a string".to_string(),
+                        )
+                    })?;
+                    bytes.extend(key_to_bytes(key).ok_or_else(|| {
+                        ("invalid_request".to_string(), format!("unknown key: {key}"))
                     })?);
                 }
-                if let Some(pane) = self.panes.get(&id) {
-                    for b in seqs {
-                        pane.send(&b);
-                    }
-                }
+                self.panes
+                    .get(&id)
+                    .ok_or_else(not_found)?
+                    .try_send(&bytes)
+                    .map_err(|message| ("send_failed".to_string(), message))?;
                 Ok(json!({"type":"ok","pane": id.0.to_string()}))
             }
             // Read a target agent's output, addressed by name or pane id.
@@ -6854,7 +6864,7 @@ fn key_to_bytes(name: &str) -> Option<Vec<u8>> {
             }
             let mut cs = name.chars();
             return match (cs.next(), cs.next()) {
-                (Some(c), None) => Some(c.to_string().into_bytes()),
+                (Some(c), None) if !c.is_control() => Some(c.to_string().into_bytes()),
                 _ => None,
             };
         }
@@ -9180,38 +9190,145 @@ command = ["true"]
     }
 
     #[test]
-    fn agent_keys_validates_before_sending() {
+    fn agent_keys_requires_a_recognized_agent_before_sending() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let t = pane.0.to_string();
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
+
+        let error = app
+            .dispatch("agent.keys", &json!({"target": t, "keys": ["enter"]}))
+            .expect_err("plain shells are not agent targets");
+        assert_eq!(error.0, "agent_not_ready");
+        assert!(input_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn agent_keys_validates_the_entire_array_before_sending() {
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         let pane = app.layout().focus;
         app.status.get_mut(&pane).unwrap().agent = "claude".into();
         let t = pane.0.to_string();
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
 
-        app.dispatch("agent.keys", &json!({"target": t, "keys": ["enter"]}))
-            .expect("known keys ok");
-        // A bad key in the batch fails the whole call.
-        assert!(app
+        for keys in [
+            json!([]),
+            Value::Null,
+            json!("enter"),
+            json!(["enter", 7]),
+            json!(["enter", "not-a-key"]),
+        ] {
+            let error = app
+                .dispatch("agent.keys", &json!({"target": t, "keys": keys}))
+                .expect_err("invalid arrays must fail atomically");
+            assert_eq!(error.0, "invalid_request");
+            assert!(input_rx.try_recv().is_err(), "no prefix may be queued");
+        }
+        let error = app
             .dispatch(
                 "agent.keys",
-                &json!({"target": t, "keys": ["enter", "nope"]})
+                &json!({"target": t, "keys": ["enter"], "extra": true}),
             )
-            .is_err());
-        // No keys is a bad request.
-        assert!(app
-            .dispatch("agent.keys", &json!({"target": t, "keys": []}))
-            .is_err());
+            .expect_err("unknown fields must fail before delivery");
+        assert_eq!(error.0, "invalid_request");
+        assert!(input_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn agent_keys_queues_valid_bytes_once_in_request_order() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).unwrap().agent = "claude".into();
+        let t = pane.0.to_string();
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
+
+        app.dispatch(
+            "agent.keys",
+            &json!({"target": t, "keys": ["up", "enter", "ctrl+c"]}),
+        )
+        .expect("known keys queue");
+        let crate::terminal::pty::InputAction::Bytes(bytes) = input_rx.recv().unwrap() else {
+            panic!("agent.keys must enqueue bytes")
+        };
+        assert_eq!(bytes, b"\x1b[A\r\x03");
+        assert!(input_rx.try_recv().is_err(), "the batch is one queue item");
+    }
+
+    #[test]
+    fn agent_keys_reports_a_closed_writer() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).unwrap().agent = "claude".into();
+        let t = pane.0.to_string();
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        drop(input_rx);
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
+
+        let error = app
+            .dispatch(
+                "agent.keys",
+                &json!({"target": t, "keys": ["enter", "esc"]}),
+            )
+            .expect_err("a closed input queue is a delivery failure");
+        assert_eq!(error.0, "send_failed");
     }
 
     #[test]
     fn key_names_map_to_terminal_bytes() {
-        assert_eq!(key_to_bytes("enter").as_deref(), Some(&b"\r"[..]));
-        assert_eq!(key_to_bytes("esc").as_deref(), Some(&b"\x1b"[..]));
-        assert_eq!(key_to_bytes("up").as_deref(), Some(&b"\x1b[A"[..]));
+        for name in [
+            "enter",
+            "ENTER",
+            "return",
+            "cr",
+            "esc",
+            "escape",
+            "tab",
+            "space",
+            "backspace",
+            "bs",
+            "delete",
+            "del",
+            "up",
+            "down",
+            "right",
+            "left",
+            "home",
+            "end",
+            "pageup",
+            "pgup",
+            "pagedown",
+            "pgdn",
+            "a",
+            "é",
+            "🙂",
+        ] {
+            assert!(key_to_bytes(name).is_some(), "previously valid key {name}");
+        }
         assert_eq!(key_to_bytes("ctrl+c").as_deref(), Some(&[0x03u8][..]));
+        assert_eq!(key_to_bytes("CTRL+Z").as_deref(), Some(&[0x1au8][..]));
         assert_eq!(key_to_bytes("C-d").as_deref(), Some(&[0x04u8][..]));
-        assert_eq!(key_to_bytes("a").as_deref(), Some(&b"a"[..]));
         assert!(key_to_bytes("f13").is_none());
         assert!(key_to_bytes("ctrl+1").is_none());
+        assert!(key_to_bytes("\n").is_none());
     }
 
     #[test]

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -769,6 +769,11 @@ impl Pane {
             .map_err(|_| "target pane closed before input was delivered".to_string())
     }
 
+    #[cfg(test)]
+    pub(crate) fn replace_input_sender_for_test(&mut self, sender: Sender<InputAction>) {
+        self.input_tx = sender.into();
+    }
+
     /// Enqueue one atomic submitted-text action for protocol consumers. Queue
     /// success is dispatch evidence only; it does not claim the child consumed
     /// or acted on the bytes.

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -266,6 +266,7 @@ luvus pane split --down
 luvus pane run <pane-id> <command> [args...]
 luvus agent start reviewer --kind codex --anchor <pane-id> --timeout 60
 luvus agent prompt reviewer "Review the current diff" --wait --timeout 600
+luvus agent keys reviewer esc
 luvus wait agent-status <pane-id> --status done,blocked --timeout 600
 ```
 
@@ -276,6 +277,10 @@ user named a specific project.
 `agent prompt` submits one complete prompt and can wait semantically. Prefer it
 to separate text and Enter operations. A timeout does not prove that an agent
 failed or stopped. Inspect it before deciding what to do next.
+
+`agent keys` refuses plain shells, validates every named key before sending any
+bytes, and queues a valid list as one ordered action. A closed target returns a
+structured `send_failed` error.
 
 Identity, live state, lifecycle hooks, usage, native resume, and fork support
 are separate capabilities. An agent can be detected without supporting every

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -31,6 +31,11 @@ A `<target>` is one of three things:
 
 `agent prompt` and `agent keys` only target a pane that is actually running an agent, so a plain shell is refused. `agent send` remains a compatibility alias.
 
+`agent.keys` requires a non-empty array of named keys. Luvus validates every
+entry before it queues one ordered byte sequence, so a mixed-type or unknown-key
+batch sends no prefix. A closed PTY input queue returns `send_failed` instead of
+reporting delivery.
+
 For line-specific feedback, the native [DIFF review](/docs/guides/diff/) uses
 the same target validation. It groups selected local notes into one bounded
 message, quotes source context as untrusted review data, and records delivery

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -31,10 +31,11 @@ A `<target>` is one of three things:
 
 `agent prompt` and `agent keys` only target a pane that is actually running an agent, so a plain shell is refused. `agent send` remains a compatibility alias.
 
-`agent.keys` requires a non-empty array of named keys. Luvus validates every
-entry before it queues one ordered byte sequence, so a mixed-type or unknown-key
-batch sends no prefix. A closed PTY input queue returns `send_failed` instead of
-reporting delivery.
+`agent.keys` requires a recognized agent pane and a non-empty array of named
+keys. A target that resolves to a plain shell returns `agent_not_ready`. Luvus
+validates every entry before it queues one ordered byte sequence, so a
+mixed-type or unknown-key batch sends no prefix. A closed PTY input queue
+returns `send_failed` instead of reporting delivery.
 
 For line-specific feedback, the native [DIFF review](/docs/guides/diff/) uses
 the same target validation. It groups selected local notes into one bounded


### PR DESCRIPTION
## Problem

`agent.keys` reports success for a plain shell, silently drops non-string entries, and sends each validated key as a separate infallible queue action. A mixed batch can therefore be partially delivered, while a closed PTY writer is indistinguishable from success.

## Root cause

The dispatcher resolves any live pane but does not apply the recognized-agent gate used by prompt submission. It builds the key list with `filter_map`, validates only the retained strings, and calls the infallible `Pane::send` once per key.

## Fix

- Reject unknown request fields and require a recognized agent target before key validation.
- Require `keys` to be a non-empty array whose every entry is a string and an exact known key name.
- Preserve the complete existing key vocabulary: case-insensitive named aliases, `ctrl+<letter>`, `C-<letter>`, and non-control single Unicode characters.
- Validate the whole array into one byte buffer before performing any queue operation.
- Enqueue the buffer once through `Pane::try_send`, preserving key order atomically and returning structured `send_failed` on a closed writer.
- Add exact UHP request schema/fixture/consumer coverage and align the guide, both bundled skill copies, and public agent guidance. No response or event shape changes.

Previously accepted valid inputs retained: `enter`, `return`, `cr`, `esc`, `escape`, `tab`, `space`, `backspace`, `bs`, `delete`, `del`, all four arrows, `home`, `end`, `pageup`/`pgup`, `pagedown`/`pgdn`, arbitrary ASCII case, both Ctrl spellings for every ASCII letter, and every non-control single Unicode character.

## Tests

- Test-first red run: `cargo test --locked agent_keys_ -- --nocapture` failed with four missing `replace_input_sender_for_test` calls before the fallible queue path existed.
- `cargo test --locked agent_keys_ -- --nocapture` — 4 passed; 0 failed.
- `cargo test --locked key_names_map_to_terminal_bytes -- --nocapture` — 1 passed; 0 failed.
- `cargo test --locked` — 1,359 passed; 0 failed; 1 ignored.
- `cargo clippy --locked --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff upstream/main..HEAD --check` — passed.
- `python3 examples/uhp/consumer.py` — validated 67 UHP fixtures and all JSON schema documents.
- `python3 examples/uhp/terminal/consumer.py --fixtures` — validated 55 fixtures, all JSON schema documents, and snapshot replay.
- Draft 2020-12 `agent.keys` schema matrix — 28 valid key forms accepted; 6 invalid/control/surrogate forms rejected; `consumer.py` separately asserts a lone surrogate is rejected before fixture validation.
- Windows protocol/ConPTY CI — passed after its first run exposed a non-portable literal emoji fixture; Rust coverage retains printable Unicode and the schema matrix retains `é`/emoji cases.

Dedup immediately before opening: `gh issue list -R RizRiyz/luvus --state all --search '"agent keys" validation in:title,body'` returned `[]`; the matching PR query returned only merged feature PR #31, which introduced `agent.keys` but does not contain this validation/delivery fix.

Failure-path coverage: a numeric plain-shell target returns `agent_not_ready` with zero queued bytes; missing/null/non-array/empty keys, mixed types, an unknown key, and an unknown field each return `invalid_request` with zero queued bytes; existing missing and ambiguous target tests remain green; a dropped receiver returns `send_failed`; and a valid three-key batch is observed as exactly one queue item containing the bytes in request order.

Both live runs used fresh `LUVUS_HOME=$(mktemp -d)` directories, `env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION`, session `luvus-pr-test`, the default plain `bash` pane, and a real Codex pane:

```sh
$ LUVUS_HOME="$isolated" ./luvus --session luvus-pr-test server restart
$ LUVUS_HOME="$isolated" ./luvus --session luvus-pr-test pane list
{"agent":"bash","pane":"1","status":"idle"}
$ LUVUS_HOME="$isolated" ./luvus --session luvus-pr-test agent start keys-test --kind codex --timeout 45
{"kind":"codex","pane":"2","ready":true,"status":"working"}
```

Before (`upstream/main` at `66e7f0f83c84e0ce59084592bd5b4f0aa240b761`):

```json
{"id":"base-shell","method":"agent.keys","params":{"target":"1","keys":["esc"]}}
{"id":"base-shell","result":{"pane":"1","revision":9,"type":"ok"}}
{"id":"base-mixed","method":"agent.keys","params":{"target":"2","keys":["space",7]}}
{"id":"base-mixed","result":{"pane":"2","revision":9,"type":"ok"}}
```

After (`fix/agent-keys-validate`):

```json
{"id":"after-shell","method":"agent.keys","params":{"target":"1","keys":["esc"]}}
{"error":{"code":"agent_not_ready","message":"target pane is not a running agent"},"id":"after-shell"}
{"id":"after-mixed","method":"agent.keys","params":{"target":"2","keys":["space",7]}}
{"error":{"code":"invalid_request","message":"every agent key must be a string"},"id":"after-mixed"}
{"id":"after-valid","method":"agent.keys","params":{"target":"2","keys":["up","esc"]}}
{"id":"after-valid","result":{"pane":"2","revision":9,"type":"ok"}}
```

The unit receiver proves the rejected mixed request queued zero bytes and the valid request retained byte order; the isolated live run proves the public JSON behavior without touching the production socket/session.

## First-pass checklist

- R1 exact matching: no substring matching or silent dropping remains; the regression test enumerates every named alias plus case, Ctrl forms, ASCII, and Unicode single-character inputs.
- R2 failure paths: every new rejection is asserted to queue zero bytes, the closed writer has its own `send_failed` test, and the valid batch is one ordered queue action.
- R3 bot minors: CodeRabbit's surrogate and schema-parity findings are fixed in `b9b69eb`/`6f16ae1`; both threads are explicitly confirmed resolved by the bot, with no Greptile findings.
- R4 live evidence: isolated base/branch plain-bash and real-Codex requests with literal JSON are included above; no production socket or session was used.
- R5 current main/parity: rebased onto `66e7f0f`; UHP request schema/fixtures/consumer, guide, both skill copies, and public agent guidance are aligned; response and event catalogs are unchanged because their shapes did not change.
- R6 explicit result: success still returns the resolved pane/revision; delivery failure is now explicit as `send_failed`, with no implicit success on a closed writer.
- R7 scope: one agent-key validation/delivery concern, no drive-by refactors or unrelated formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157SP6ztLt1Lz91vWgXko8V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `agent.keys` validation for named keys, Ctrl-key combinations, and printable Unicode characters.
  * Valid key lists are delivered as one ordered action, with clearer errors for invalid, unavailable, or closed targets.
  * Expanded validation for `agent.wait`, automation requests, task heartbeats, and global responses.
  * `task.start` now permits combining worktree mode with a workspace ID.

* **Documentation**
  * Updated agent command guidance and examples.

* **Tests**
  * Added coverage for invalid inputs, Unicode handling, aliases, ordering, and delivery failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->