### PR TITLE
fix(api): reject invalid pane ids

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2670,11 +2670,10 @@ impl App {
                         "ttl_s",
                     ],
                 )?;
-                let id = match self.resolve_agent_pane(p) {
-                    Some(id) => Some(id),
-                    None => self.resolve_pane(p)?,
-                }
-                .ok_or_else(not_found)?;
+                // `target` is not an accepted field here, so `pane` is the only
+                // explicit target and a miss is terminal — the same rule
+                // `agent.explain` applies, with no fallback to the focused pane.
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let source = required_report_source(p)?;
                 let agent = p.get("agent").and_then(Value::as_str).ok_or_else(|| {
                     (
@@ -2800,11 +2799,10 @@ impl App {
             }
             "agent.release" => {
                 reject_api_fields(p, &["pane", "source"])?;
-                let id = match self.resolve_agent_pane(p) {
-                    Some(id) => Some(id),
-                    None => self.resolve_pane(p)?,
-                }
-                .ok_or_else(not_found)?;
+                // `target` is not an accepted field here, so `pane` is the only
+                // explicit target and a miss is terminal — the same rule
+                // `agent.explain` applies, with no fallback to the focused pane.
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let source = required_report_source(p)?;
                 let status = self.status.get_mut(&id).ok_or_else(not_found)?;
                 let Some(report) = status.agent_report.as_ref() else {
@@ -7024,6 +7022,58 @@ command = ["true"]
             .expect_err("an invalid explicit target must not fall back to focus");
         assert_eq!(error.0, "not_found");
         assert!(app.panes.contains_key(&pane));
+    }
+
+    /// `agent.report` and `agent.release` take their target only as `pane`, so an
+    /// explicit one that misses must be terminal rather than quietly acting on
+    /// the focused pane — the same rule `agent.explain` applies to `target`.
+    #[test]
+    fn explicit_agent_report_targets_never_fall_back_to_focus() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let missing = (pane.0 + 4321).to_string();
+        let report = json!({
+            "pane": missing, "source": "hook", "agent": "claude", "status": "working",
+        });
+        let release = json!({ "pane": missing, "source": "hook" });
+
+        for (method, params) in [
+            ("agent.report", report.clone()),
+            ("agent.release", release.clone()),
+        ] {
+            let error = app
+                .dispatch(method, &params)
+                .expect_err("a missing explicit pane is terminal");
+            assert_eq!(error.0, "not_found", "{method}");
+            assert!(
+                app.status
+                    .get(&pane)
+                    .is_none_or(|s| s.agent_report.is_none()),
+                "{method} must not have written authority to the focused pane"
+            );
+        }
+
+        // `target` is not part of either signature, so it stays an unknown field
+        // instead of opening a second resolution path.
+        for (method, extra) in [("agent.report", report), ("agent.release", release)] {
+            let mut params = extra;
+            params["target"] = json!("reviewer");
+            params.as_object_mut().unwrap().remove("pane");
+            let error = app
+                .dispatch(method, &params)
+                .expect_err("target is not an accepted field");
+            assert_eq!(error.0, "invalid_request", "{method}");
+        }
+
+        // A malformed explicit pane fails validation before any lookup.
+        let error = app
+            .dispatch(
+                "agent.release",
+                &json!({"pane": u64::from(u32::MAX) + 2, "source": "hook"}),
+            )
+            .expect_err("an out-of-range pane id must not wrap");
+        assert_eq!(error.0, "invalid_request");
     }
 
     /// A live alias set by `agent.name` shows up in `agent.list` and resolves an

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -590,6 +590,32 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn remaining_focus_default_methods_reject_missing_panes_atomically() {
+        let (_env, mut app) = app("remaining-missing-pane-fallbacks");
+        app.dispatch("pane.split", &json!({})).unwrap();
+        let before = layout_state_bytes(&app);
+
+        for (method, params) in [
+            ("pane.layout", json!({"pane": u32::MAX})),
+            ("pane.edges", json!({"pane": u32::MAX})),
+            (
+                "pane.focus_direction",
+                json!({"pane": u32::MAX, "direction": "left"}),
+            ),
+            (
+                "diff.navigate",
+                json!({"pane": u32::MAX, "action": "next_line"}),
+            ),
+        ] {
+            let error = app
+                .dispatch(method, &params)
+                .expect_err("an explicit missing pane must not use focus");
+            assert_eq!(error.0, "not_found", "{method}");
+            assert_eq!(layout_state_bytes(&app), before, "{method}");
+        }
+    }
+
+    #[test]
     fn omitted_and_null_pane_still_target_focus_where_supported() {
         let (_env, mut app) = app("default-pane-resolution");
         let first = app.layout().focus;

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -573,6 +573,23 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn invalid_zoom_enabled_does_not_change_focus_or_layout() {
+        let (_env, mut app) = app("invalid-zoom-enabled");
+        let first = app.layout().focus;
+        app.dispatch("pane.split", &json!({})).unwrap();
+        let before = layout_state_bytes(&app);
+        let zoomed_before = app.zoomed;
+
+        let error = app
+            .dispatch("pane.zoom", &json!({"pane": first.0, "enabled": "yes"}))
+            .expect_err("invalid enabled must fail before focus changes");
+
+        assert_eq!(error.0, "invalid_request");
+        assert_eq!(layout_state_bytes(&app), before);
+        assert_eq!(app.zoomed, zoomed_before);
+    }
+
+    #[test]
     fn explicit_missing_pane_neighbor_is_not_found_and_atomic() {
         let (_env, mut app) = app("missing-pane-neighbor");
         app.dispatch("pane.split", &json!({})).unwrap();
@@ -2964,7 +2981,6 @@ impl App {
             "pane.zoom" => {
                 reject_api_fields(p, &["pane", "enabled"])?;
                 let pane = self.resolve_pane_or_focus(p)?;
-                self.focus_pane_global(pane);
                 let enabled = match p.get("enabled") {
                     None => !self.zoomed,
                     Some(Value::Bool(enabled)) => *enabled,
@@ -2975,6 +2991,7 @@ impl App {
                         ))
                     }
                 };
+                self.focus_pane_global(pane);
                 self.zoomed = enabled;
                 let pane = self.layout().focus;
                 self.emit_event(

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2649,11 +2649,11 @@ impl App {
                         ));
                     }
                 }
-                let id = match self.resolve_agent_pane(p) {
-                    Some(id) => Some(id),
-                    None => self.resolve_pane(p)?,
-                }
-                .ok_or_else(not_found)?;
+                let id = if p.get("target").is_some() {
+                    self.resolve_agent_pane(p).ok_or_else(agent_not_found)?
+                } else {
+                    self.resolve_pane(p)?.ok_or_else(not_found)?
+                };
                 Ok(self.agent_explanation(id))
             }
             "agent.report" => {
@@ -7018,6 +7018,12 @@ command = ["true"]
             assert_eq!(app.layout().focus, focus);
             assert_eq!(app.panes[&pane].content_revision(), revision);
         }
+
+        let error = app
+            .dispatch("agent.explain", &json!({"target": alias_one.to_string()}))
+            .expect_err("an invalid explicit target must not fall back to focus");
+        assert_eq!(error.0, "not_found");
+        assert!(app.panes.contains_key(&pane));
     }
 
     /// A live alias set by `agent.name` shows up in `agent.list` and resolves an

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1461,12 +1461,12 @@ impl App {
             }
             "pane.layout" => {
                 reject_api_fields(p, &["pane"])?;
-                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane_or_focus(p)?;
                 self.socket_pane_layout(pane)
             }
             "pane.neighbor" => {
                 reject_api_fields(p, &["pane", "direction"])?;
-                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane_or_focus(p)?;
                 let direction = crate::api::topology::direction(p)?;
                 let (workspace, tab) = self.pane_location(pane).ok_or_else(not_found)?;
                 let layout = &self.workspaces[workspace].tabs[tab].layout;
@@ -1477,7 +1477,7 @@ impl App {
             }
             "pane.edges" => {
                 reject_api_fields(p, &["pane"])?;
-                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane_or_focus(p)?;
                 let (workspace, tab) = self.pane_location(pane).ok_or_else(not_found)?;
                 let area = crate::api::topology::logical_area();
                 let rect = self.workspaces[workspace].tabs[tab]
@@ -2354,7 +2354,7 @@ impl App {
             }
             "pane.focus_direction" => {
                 reject_api_fields(p, &["pane", "direction"])?;
-                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane_or_focus(p)?;
                 let direction = crate::api::topology::direction(p)?;
                 let (workspace, tab) = self.pane_location(pane).ok_or_else(not_found)?;
                 let next = self.workspaces[workspace].tabs[tab]
@@ -2372,7 +2372,7 @@ impl App {
             }
             "pane.resize" => {
                 reject_api_fields(p, &["pane", "direction", "cells"])?;
-                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane_or_focus(p)?;
                 let direction = crate::api::topology::direction(p)?;
                 let cells = p.get("cells").and_then(Value::as_i64).unwrap_or(1);
                 if !(1..=1000).contains(&cells) {
@@ -2407,9 +2407,8 @@ impl App {
             }
             "pane.zoom" => {
                 reject_api_fields(p, &["pane", "enabled"])?;
-                if let Some(pane) = self.resolve_pane(p)? {
-                    self.focus_pane_global(pane);
-                }
+                let pane = self.resolve_pane_or_focus(p)?;
+                self.focus_pane_global(pane);
                 let enabled = match p.get("enabled") {
                     None => !self.zoomed,
                     Some(Value::Bool(enabled)) => *enabled,
@@ -3630,7 +3629,7 @@ impl App {
                 }))
             }
             "diff.navigate" => {
-                let id = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
+                let id = self.resolve_pane_or_focus(p)?;
                 let action = req_str(p, "action")?;
                 let key = match action {
                     "next" | "next_line" => KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
@@ -4343,6 +4342,19 @@ impl App {
                 Ok(self.panes.contains_key(&id).then_some(id))
             }
             None => Ok(Some(self.layout().focus)),
+        }
+    }
+
+    fn resolve_pane_or_focus(&self, p: &Value) -> Result<PaneId, (String, String)> {
+        match p.get("pane") {
+            None | Some(Value::Null) => Ok(self.layout().focus),
+            Some(value) => {
+                let id = PaneId(parse_u32_value(value, "pane")?);
+                self.pane_location(id)
+                    .is_some()
+                    .then_some(id)
+                    .ok_or_else(not_found)
+            }
         }
     }
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -37,6 +37,28 @@ mod socket_api_tests {
         (env, app)
     }
 
+    fn layout_state_bytes(app: &App) -> (PaneId, Vec<u8>, Vec<u8>) {
+        let layout = app.layout();
+        let tree = serde_json::to_vec(&layout.to_tree()).unwrap();
+        let pane_sizes = serde_json::to_vec(
+            &layout
+                .panes(crate::api::topology::logical_area())
+                .into_iter()
+                .map(|pane| {
+                    json!({
+                        "pane": pane.id.0,
+                        "x": pane.rect.x,
+                        "y": pane.rect.y,
+                        "width": pane.rect.width,
+                        "height": pane.rect.height,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        (layout.focus, tree, pane_sizes)
+    }
+
     #[test]
     fn quiet_runtime_can_leave_the_fast_detection_cadence() {
         let (_env, mut app) = app("quiet-runtime-cadence");
@@ -179,6 +201,80 @@ mod socket_api_tests {
         assert_eq!(app.layout().focus, first);
         assert_eq!(app.layout().leaves().len(), 2);
         assert!(app.panes.contains_key(&first) && app.panes.contains_key(&second));
+    }
+
+    #[test]
+    fn explicit_missing_pane_resize_is_not_found_and_atomic() {
+        let (_env, mut app) = app("missing-pane-resize");
+        app.dispatch("pane.split", &json!({})).unwrap();
+        let before = layout_state_bytes(&app);
+
+        let error = app
+            .dispatch(
+                "pane.resize",
+                &json!({"pane": u32::MAX, "direction": "left", "cells": 1}),
+            )
+            .expect_err("an explicit missing pane must not resize the focused pane");
+
+        assert_eq!(error.0, "not_found");
+        assert_eq!(layout_state_bytes(&app), before);
+    }
+
+    #[test]
+    fn explicit_missing_pane_zoom_is_not_found_and_atomic() {
+        let (_env, mut app) = app("missing-pane-zoom");
+        let before = layout_state_bytes(&app);
+        let zoomed_before = app.zoomed;
+
+        let error = app
+            .dispatch(
+                "pane.zoom",
+                &json!({"pane": u32::MAX.to_string(), "enabled": true}),
+            )
+            .expect_err("an explicit missing pane must not zoom the focused pane");
+
+        assert_eq!(error.0, "not_found");
+        assert_eq!(layout_state_bytes(&app), before);
+        assert_eq!(app.zoomed, zoomed_before);
+    }
+
+    #[test]
+    fn explicit_missing_pane_neighbor_is_not_found_and_atomic() {
+        let (_env, mut app) = app("missing-pane-neighbor");
+        app.dispatch("pane.split", &json!({})).unwrap();
+        let before = layout_state_bytes(&app);
+
+        let error = app
+            .dispatch(
+                "pane.neighbor",
+                &json!({"pane": u32::MAX, "direction": "left"}),
+            )
+            .expect_err("an explicit missing pane must not inspect the focused pane");
+
+        assert_eq!(error.0, "not_found");
+        assert_eq!(layout_state_bytes(&app), before);
+    }
+
+    #[test]
+    fn omitted_and_null_pane_still_target_focus_where_supported() {
+        let (_env, mut app) = app("default-pane-resolution");
+        let first = app.layout().focus;
+        let second = PaneId(
+            app.dispatch("pane.split", &json!({})).unwrap()["pane"]
+                .as_str()
+                .unwrap()
+                .parse()
+                .unwrap(),
+        );
+
+        for params in [
+            json!({"direction": "left"}),
+            json!({"pane": null, "direction": "left"}),
+        ] {
+            let result = app.dispatch("pane.neighbor", &params).unwrap();
+            assert_eq!(result["pane"], second.0.to_string());
+            assert_eq!(result["neighbor"], first.0.to_string());
+        }
     }
 
     #[test]
@@ -6979,6 +7075,7 @@ command = ["true"]
             json!(overflow.to_string()),
             json!("-1"),
             json!("1.5"),
+            json!("abc"),
         ] {
             let error = app
                 .resolve_pane(&json!({"pane": invalid}))

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -4869,7 +4869,10 @@ impl App {
             Some(Value::Null) => Ok(None),
             Some(value) => {
                 let id = PaneId(parse_u32_value(value, "pane")?);
-                Ok(self.panes.contains_key(&id).then_some(id))
+                self.panes
+                    .contains_key(&id)
+                    .then_some(Some(id))
+                    .ok_or_else(not_found)
             }
             None => Ok(Some(self.layout().focus)),
         }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -655,6 +655,19 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn null_pane_targets_focus_for_terminal_focus_defaults() {
+        let (_env, mut app) = app("null-terminal-pane-resolution");
+        let pane = app.layout().focus;
+
+        for method in ["pane.get", "pane.read", "pane.processes"] {
+            let result = app
+                .dispatch(method, &json!({"pane": null}))
+                .unwrap_or_else(|error| panic!("{method} rejected null: {error:?}"));
+            assert_eq!(result["pane"], pane.0.to_string(), "{method}");
+        }
+    }
+
+    #[test]
     fn workspace_block_move_is_atomic_and_keeps_active_workspace() {
         let (_env, mut app) = app("socket-workspace-move");
         app.dispatch("workspace.new", &json!({})).unwrap();
@@ -7686,7 +7699,14 @@ command = ["true"]
             Some(pane)
         );
         assert_eq!(app.resolve_pane(&json!({})).unwrap(), Some(pane));
-        assert_eq!(app.resolve_pane(&json!({"pane": null})).unwrap(), None);
+        assert_eq!(
+            app.resolve_pane(&json!({"pane": null})).unwrap(),
+            Some(pane)
+        );
+        let no_pane = app
+            .orch_pane(&json!({"pane": null}))
+            .expect_err("orchestration keeps explicit null as absent context");
+        assert_eq!(no_pane.0, "no_pane");
         let missing = app
             .resolve_pane(&json!({"pane": u32::MAX}))
             .expect_err("a well-formed missing pane must be distinct from omission");

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1356,7 +1356,7 @@ impl App {
             }
             "pane.get" => {
                 reject_api_fields(p, &["pane"])?;
-                let pane = self.resolve_pane(p).ok_or_else(not_found)?;
+                let pane = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 self.socket_pane(pane)
             }
             "pane.current" => {
@@ -1365,12 +1365,12 @@ impl App {
             }
             "pane.layout" => {
                 reject_api_fields(p, &["pane"])?;
-                let pane = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
                 self.socket_pane_layout(pane)
             }
             "pane.neighbor" => {
                 reject_api_fields(p, &["pane", "direction"])?;
-                let pane = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
                 let direction = crate::api::topology::direction(p)?;
                 let (workspace, tab) = self.pane_location(pane).ok_or_else(not_found)?;
                 let layout = &self.workspaces[workspace].tabs[tab].layout;
@@ -1381,7 +1381,7 @@ impl App {
             }
             "pane.edges" => {
                 reject_api_fields(p, &["pane"])?;
-                let pane = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
                 let (workspace, tab) = self.pane_location(pane).ok_or_else(not_found)?;
                 let area = crate::api::topology::logical_area();
                 let rect = self.workspaces[workspace].tabs[tab]
@@ -1457,7 +1457,7 @@ impl App {
                 }
                 let base = match p.get("pane") {
                     None | Some(Value::Null) => self.layout().focus,
-                    Some(_) => self.resolve_pane(p).ok_or_else(not_found)?,
+                    Some(_) => self.resolve_pane(p)?.ok_or_else(not_found)?,
                 };
                 let dir = p
                     .get("direction")
@@ -1479,7 +1479,7 @@ impl App {
                 }))
             }
             "pane.move" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let new_tab = match p.get("new_tab") {
                     None => false,
                     Some(Value::Bool(v)) => *v,
@@ -1511,7 +1511,7 @@ impl App {
                 }))
             }
             "pane.run" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let cmd = p.get("command").and_then(|v| v.as_str()).unwrap_or("");
                 if let Some(pane) = self.panes.get(&id) {
                     pane.send(cmd.as_bytes());
@@ -1520,7 +1520,7 @@ impl App {
                 Ok(json!({"type":"ok"}))
             }
             "pane.send_input" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let text = p.get("text").and_then(|v| v.as_str()).unwrap_or("");
                 if let Some(pane) = self.panes.get(&id) {
                     pane.send(text.as_bytes());
@@ -1528,7 +1528,7 @@ impl App {
                 Ok(json!({"type":"ok"}))
             }
             "pane.read" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let lines = p.get("lines").and_then(|v| v.as_u64()).unwrap_or(200) as u16;
                 let text = self
                     .panes
@@ -1569,14 +1569,14 @@ impl App {
                 }))
             }
             "pane.close" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 self.close_pane(id);
                 Ok(json!({"type":"ok"}))
             }
             // A **global** single-pane status lookup (any workspace) — `pane.list` is
             // scoped to the active workspace, so `luvus wait agent-status` polls this.
             "pane.status" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let (agent, status, authority, state_source) = self
                     .status
                     .get(&id)
@@ -1607,12 +1607,12 @@ impl App {
             }
             "pane.processes" => {
                 reject_api_fields(p, &["pane"])?;
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 Ok(self.pane_processes(id))
             }
             "pane.report_session" => {
                 reject_api_fields(p, &["pane", "agent", "session_id", "usage"])?;
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let raw_agent = required_bounded_string(p, "agent", 64)?;
                 let agent = crate::agent::canonical_builtin(&raw_agent).ok_or_else(|| {
                     (
@@ -1720,7 +1720,7 @@ impl App {
             // permission prompt, question, turn end. Forwarded verbatim onto the
             // event bus as `agent.hook` for modules and API clients.
             "pane.report_event" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let agent = p.get("agent").and_then(|v| v.as_str()).unwrap_or("");
                 let kind = p.get("kind").and_then(|v| v.as_str()).unwrap_or("");
                 let message = p.get("message").and_then(|v| v.as_str()).unwrap_or("");
@@ -2252,13 +2252,13 @@ impl App {
             }
             // ── panes / agents ──
             "pane.focus" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 self.focus_pane_global(id);
                 Ok(json!({"type":"ok"}))
             }
             "pane.focus_direction" => {
                 reject_api_fields(p, &["pane", "direction"])?;
-                let pane = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
                 let direction = crate::api::topology::direction(p)?;
                 let (workspace, tab) = self.pane_location(pane).ok_or_else(not_found)?;
                 let next = self.workspaces[workspace].tabs[tab]
@@ -2276,7 +2276,7 @@ impl App {
             }
             "pane.resize" => {
                 reject_api_fields(p, &["pane", "direction", "cells"])?;
-                let pane = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
+                let pane = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
                 let direction = crate::api::topology::direction(p)?;
                 let cells = p.get("cells").and_then(Value::as_i64).unwrap_or(1);
                 if !(1..=1000).contains(&cells) {
@@ -2311,7 +2311,7 @@ impl App {
             }
             "pane.zoom" => {
                 reject_api_fields(p, &["pane", "enabled"])?;
-                if let Some(pane) = self.resolve_pane(p) {
+                if let Some(pane) = self.resolve_pane(p)? {
                     self.focus_pane_global(pane);
                 }
                 let enabled = match p.get("enabled") {
@@ -2334,7 +2334,7 @@ impl App {
             }
             "pane.rename" => {
                 reject_api_fields(p, &["pane", "name"])?;
-                let pane = self.resolve_pane(p).ok_or_else(not_found)?;
+                let pane = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let name = p
                     .get("name")
                     .and_then(Value::as_str)
@@ -2359,7 +2359,7 @@ impl App {
             }
             "pane.swap" => {
                 reject_api_fields(p, &["pane", "with"])?;
-                let first = self.resolve_pane(p).ok_or_else(not_found)?;
+                let first = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let second = PaneId(parse_u32_value(
                     p.get("with").ok_or_else(|| {
                         (
@@ -2396,7 +2396,7 @@ impl App {
             // `attach.pane` (docs/18 WA-2): focus a pane and zoom it, so a client
             // attaching next opens straight into that fullscreen terminal.
             "attach.pane" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 self.focus_pane_global(id);
                 self.zoomed = true;
                 Ok(json!({"type":"ok","pane": id.0.to_string()}))
@@ -2461,7 +2461,7 @@ impl App {
             // Give a pane's agent a live alias (or clear it) so `agent.send` /
             // `agent.keys` / `agent.read` can address it by name. Ephemeral.
             "agent.name" => {
-                let pane = self.resolve_pane(p).ok_or_else(not_found)?;
+                let pane = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 if p.get("clear").and_then(|v| v.as_bool()).unwrap_or(false) {
                     self.set_agent_name(pane, None);
                     return Ok(
@@ -2649,10 +2649,11 @@ impl App {
                         ));
                     }
                 }
-                let id = self
-                    .resolve_agent_pane(p)
-                    .or_else(|| self.resolve_pane(p))
-                    .ok_or_else(not_found)?;
+                let id = match self.resolve_agent_pane(p) {
+                    Some(id) => Some(id),
+                    None => self.resolve_pane(p)?,
+                }
+                .ok_or_else(not_found)?;
                 Ok(self.agent_explanation(id))
             }
             "agent.report" => {
@@ -2669,10 +2670,11 @@ impl App {
                         "ttl_s",
                     ],
                 )?;
-                let id = self
-                    .resolve_agent_pane(p)
-                    .or_else(|| self.resolve_pane(p))
-                    .ok_or_else(not_found)?;
+                let id = match self.resolve_agent_pane(p) {
+                    Some(id) => Some(id),
+                    None => self.resolve_pane(p)?,
+                }
+                .ok_or_else(not_found)?;
                 let source = required_report_source(p)?;
                 let agent = p.get("agent").and_then(Value::as_str).ok_or_else(|| {
                     (
@@ -2798,10 +2800,11 @@ impl App {
             }
             "agent.release" => {
                 reject_api_fields(p, &["pane", "source"])?;
-                let id = self
-                    .resolve_agent_pane(p)
-                    .or_else(|| self.resolve_pane(p))
-                    .ok_or_else(not_found)?;
+                let id = match self.resolve_agent_pane(p) {
+                    Some(id) => Some(id),
+                    None => self.resolve_pane(p)?,
+                }
+                .ok_or_else(not_found)?;
                 let source = required_report_source(p)?;
                 let status = self.status.get_mut(&id).ok_or_else(not_found)?;
                 let Some(report) = status.agent_report.as_ref() else {
@@ -3379,12 +3382,12 @@ impl App {
                 Ok(json!({"type":"module_setting","id": id,"key": key,"value": v}))
             }
             "module.pane.focus" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 self.focus_pane_global(id);
                 Ok(json!({"type":"ok"}))
             }
             "module.pane.close" => {
-                let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 self.close_pane(id);
                 Ok(json!({"type":"ok"}))
             }
@@ -3533,7 +3536,7 @@ impl App {
                 }))
             }
             "diff.navigate" => {
-                let id = self.resolve_pane(p).unwrap_or_else(|| self.layout().focus);
+                let id = self.resolve_pane(p)?.unwrap_or_else(|| self.layout().focus);
                 let action = req_str(p, "action")?;
                 let key = match action {
                     "next" | "next_line" => KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
@@ -4230,7 +4233,7 @@ impl App {
     /// The pane a task/lease call acts for: the passed `pane`, else the caller's
     /// `$LUVUS_PANE_ID`. Orchestration is pane-keyed, so this is required.
     fn orch_pane(&self, p: &Value) -> Result<u32, (String, String)> {
-        self.resolve_pane(p).map(|id| id.0).ok_or_else(|| {
+        self.resolve_pane(p)?.map(|id| id.0).ok_or_else(|| {
             (
                 "no_pane".to_string(),
                 "no pane id — run inside a luvus pane or pass a pane id".to_string(),
@@ -4238,17 +4241,14 @@ impl App {
         })
     }
 
-    pub(crate) fn resolve_pane(&self, p: &Value) -> Option<PaneId> {
+    pub(crate) fn resolve_pane(&self, p: &Value) -> Result<Option<PaneId>, (String, String)> {
         match p.get("pane") {
-            Some(v) => {
-                let raw = v
-                    .as_str()
-                    .and_then(|s| s.parse::<u32>().ok())
-                    .or_else(|| v.as_u64().map(|n| n as u32))?;
-                let id = PaneId(raw);
-                self.panes.contains_key(&id).then_some(id)
+            Some(Value::Null) => Ok(None),
+            Some(value) => {
+                let id = PaneId(parse_u32_value(value, "pane")?);
+                Ok(self.panes.contains_key(&id).then_some(id))
             }
-            None => Some(self.layout().focus),
+            None => Ok(Some(self.layout().focus)),
         }
     }
 
@@ -4615,18 +4615,29 @@ impl App {
                 return;
             }
             (Some(_), None) => match self.resolve_pane(&json!({"pane":p["pane"]})) {
-                Some(id) => (id, false),
-                None => {
+                Ok(Some(id)) => (id, false),
+                Ok(None) => {
                     fail("not_found", "pane not found".to_string());
+                    return;
+                }
+                Err((code, message)) => {
+                    fail(&code, message);
                     return;
                 }
             },
             (_, _) => {
                 let mut split = serde_json::Map::new();
                 if let Some(anchor) = p.get("anchor") {
-                    let Some(anchor) = self.resolve_pane(&json!({"pane":anchor})) else {
-                        fail("not_found", "anchor pane not found".to_string());
-                        return;
+                    let anchor = match self.resolve_pane(&json!({"pane":anchor})) {
+                        Ok(Some(anchor)) => anchor,
+                        Ok(None) => {
+                            fail("not_found", "anchor pane not found".to_string());
+                            return;
+                        }
+                        Err((code, message)) => {
+                            fail(&code, message);
+                            return;
+                        }
                     };
                     split.insert("pane".into(), json!(anchor.0.to_string()));
                 }
@@ -6952,6 +6963,61 @@ command = ["true"]
             .dispatch("agent.list", &json!({}))
             .expect("agent.list ok");
         assert_eq!(out["agents"][0]["session"], "sess-42");
+    }
+
+    #[test]
+    fn pane_ids_are_checked_before_resolution_or_mutation() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let overflow = u64::from(u32::MAX) + 1;
+        let alias_one = u64::from(u32::MAX) + 2;
+
+        for invalid in [
+            json!(overflow),
+            json!(alias_one),
+            json!(-1),
+            json!(1.5),
+            json!(overflow.to_string()),
+            json!("-1"),
+            json!("1.5"),
+        ] {
+            let error = app
+                .resolve_pane(&json!({"pane": invalid}))
+                .expect_err("malformed pane ids must be validation errors");
+            assert_eq!(error.0, "invalid_request", "{invalid}");
+        }
+        assert_eq!(
+            app.resolve_pane(&json!({"pane": pane.0})).unwrap(),
+            Some(pane)
+        );
+        assert_eq!(
+            app.resolve_pane(&json!({"pane": pane.0.to_string()}))
+                .unwrap(),
+            Some(pane)
+        );
+        assert_eq!(app.resolve_pane(&json!({})).unwrap(), Some(pane));
+        assert_eq!(app.resolve_pane(&json!({"pane": null})).unwrap(), None);
+
+        let leaves = app.layout().leaves();
+        let focus = app.layout().focus;
+        let revision = app.panes[&pane].content_revision();
+        for (method, params) in [
+            ("pane.close", json!({"pane": alias_one})),
+            (
+                "pane.send_input",
+                json!({"pane": alias_one, "text": "exit\r"}),
+            ),
+        ] {
+            let error = app
+                .dispatch(method, &params)
+                .expect_err("invalid pane ids must not mutate pane one");
+            assert_eq!(error.0, "invalid_request");
+            assert!(app.panes.contains_key(&pane));
+            assert_eq!(app.layout().leaves(), leaves);
+            assert_eq!(app.layout().focus, focus);
+            assert_eq!(app.panes[&pane].content_revision(), revision);
+        }
     }
 
     /// A live alias set by `agent.name` shows up in `agent.list` and resolves an

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -659,11 +659,18 @@ mod socket_api_tests {
         let (_env, mut app) = app("null-terminal-pane-resolution");
         let pane = app.layout().focus;
 
-        for method in ["pane.get", "pane.read", "pane.processes"] {
+        for (method, response_type) in [
+            ("pane.get", "pane"),
+            ("pane.read", "pane_read"),
+            ("pane.processes", "pane_processes"),
+        ] {
             let result = app
                 .dispatch(method, &json!({"pane": null}))
                 .unwrap_or_else(|error| panic!("{method} rejected null: {error:?}"));
-            assert_eq!(result["pane"], pane.0.to_string(), "{method}");
+            assert_eq!(result["type"], response_type, "{method}");
+            if result.get("pane").is_some() {
+                assert_eq!(result["pane"], pane.0.to_string(), "{method}");
+            }
         }
     }
 
@@ -4917,17 +4924,26 @@ impl App {
     /// The pane a task/lease call acts for: the passed `pane`, else the caller's
     /// `$LUVUS_PANE_ID`. Orchestration is pane-keyed, so this is required.
     fn orch_pane(&self, p: &Value) -> Result<u32, (String, String)> {
-        self.resolve_pane(p)?.map(|id| id.0).ok_or_else(|| {
-            (
-                "no_pane".to_string(),
-                "no pane id — run inside a luvus pane or pass a pane id".to_string(),
-            )
-        })
+        self.resolve_optional_pane(p)?
+            .map(|id| id.0)
+            .ok_or_else(|| {
+                (
+                    "no_pane".to_string(),
+                    "no pane id — run inside a luvus pane or pass a pane id".to_string(),
+                )
+            })
+    }
+
+    fn resolve_optional_pane(&self, p: &Value) -> Result<Option<PaneId>, (String, String)> {
+        if matches!(p.get("pane"), Some(Value::Null)) {
+            return Ok(None);
+        }
+        self.resolve_pane(p)
     }
 
     pub(crate) fn resolve_pane(&self, p: &Value) -> Result<Option<PaneId>, (String, String)> {
         match p.get("pane") {
-            Some(Value::Null) => Ok(None),
+            None | Some(Value::Null) => Ok(Some(self.layout().focus)),
             Some(value) => {
                 let id = PaneId(parse_u32_value(value, "pane")?);
                 self.panes
@@ -4935,7 +4951,6 @@ impl App {
                     .then_some(Some(id))
                     .ok_or_else(not_found)
             }
-            None => Ok(Some(self.layout().focus)),
         }
     }
 
@@ -5314,7 +5329,7 @@ impl App {
                 );
                 return;
             }
-            (Some(_), None) => match self.resolve_pane(&json!({"pane":p["pane"]})) {
+            (Some(_), None) => match self.resolve_optional_pane(&json!({"pane":p["pane"]})) {
                 Ok(Some(id)) => (id, false),
                 Ok(None) => {
                     fail("not_found", "pane not found".to_string());
@@ -5328,7 +5343,7 @@ impl App {
             (_, _) => {
                 let mut split = serde_json::Map::new();
                 if let Some(anchor) = p.get("anchor") {
-                    let anchor = match self.resolve_pane(&json!({"pane":anchor})) {
+                    let anchor = match self.resolve_optional_pane(&json!({"pane":anchor})) {
                         Ok(Some(anchor)) => anchor,
                         Ok(None) => {
                             fail("not_found", "anchor pane not found".to_string());
@@ -8126,6 +8141,42 @@ command = ["true"]
         assert_eq!(value["result"]["ready"], true);
         assert_eq!(value["result"]["name"], "reviewer");
         assert_eq!(value["result"]["status"], "working");
+    }
+
+    #[test]
+    fn server_owned_agent_start_keeps_null_targets_terminal() {
+        for params in [
+            json!({
+                "name":"reviewer", "kind":"codex", "pane":null,
+                "args":[], "timeout_s":10,
+            }),
+            json!({
+                "name":"reviewer", "kind":"codex", "anchor":null,
+                "args":[], "timeout_s":10,
+            }),
+        ] {
+            let (tx, _rx) = std::sync::mpsc::channel();
+            let mut app = App::new(80, 24, tx).unwrap();
+            let before_focus = app.layout().focus;
+            let before_leaves = app.layout().leaves();
+            let before_panes = app.panes.len();
+            let (reply, response) = std::sync::mpsc::channel();
+
+            app.start_agent_launch(
+                "start-null".into(),
+                params,
+                reply,
+                Arc::new(AtomicBool::new(false)),
+            );
+
+            let value: Value = serde_json::from_str(&response.recv().unwrap()).unwrap();
+            assert_eq!(value["error"]["code"], "not_found");
+            assert!(app.agent_names.is_empty());
+            assert!(app.agent_starts.is_empty());
+            assert_eq!(app.layout().focus, before_focus);
+            assert_eq!(app.layout().leaves(), before_leaves);
+            assert_eq!(app.panes.len(), before_panes);
+        }
     }
 
     #[test]

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -7636,6 +7636,10 @@ command = ["true"]
         );
         assert_eq!(app.resolve_pane(&json!({})).unwrap(), Some(pane));
         assert_eq!(app.resolve_pane(&json!({"pane": null})).unwrap(), None);
+        let missing = app
+            .resolve_pane(&json!({"pane": u32::MAX}))
+            .expect_err("a well-formed missing pane must be distinct from omission");
+        assert_eq!(missing.0, "not_found");
 
         let leaves = app.layout().leaves();
         let focus = app.layout().focus;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -706,15 +706,23 @@ impl App {
             } => {
                 let params = json!({ "pane": pane });
                 match self.resolve_pane(&params) {
-                    Some(id) => {
+                    Ok(Some(id)) => {
                         self.register_output_wait(
                             id, request_id, needle, reply, timeout, cancelled,
                         );
                     }
-                    None => {
+                    Ok(None) => {
                         let _ = reply.send(
                             json!({ "id": request_id, "error": {
                                 "code": "not_found", "message": "pane not found"
+                            }})
+                            .to_string(),
+                        );
+                    }
+                    Err((code, message)) => {
+                        let _ = reply.send(
+                            json!({ "id": request_id, "error": {
+                                "code": code, "message": message
                             }})
                             .to_string(),
                         );
@@ -735,18 +743,24 @@ impl App {
                     self.resolve_pane(&params),
                     crate::app::dispatch::parse_agent_wait_state(&state),
                 ) {
-                    (Some(id), Some(state)) => {
+                    (Ok(Some(id)), Some(state)) => {
                         self.register_agent_wait(id, request_id, state, reply, timeout, cancelled);
                     }
-                    (None, _) => {
+                    (Ok(None), _) => {
                         let _ = reply.send(
                             json!({"id":request_id,"error":{"code":"not_found","message":"pane not found"}})
                                 .to_string(),
                         );
                     }
-                    (_, None) => {
+                    (Ok(Some(_)), None) => {
                         let _ = reply.send(
                             json!({"id":request_id,"error":{"code":"invalid_request","message":"status must be idle, working, blocked, or done"}})
+                                .to_string(),
+                        );
+                    }
+                    (Err((code, message)), _) => {
+                        let _ = reply.send(
+                            json!({"id":request_id,"error":{"code":code,"message":message}})
                                 .to_string(),
                         );
                     }

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -97,9 +97,11 @@ Luvus release number.
 Parameter shapes mirror the CLI flags (`luvus task add --paths x` →
 `{"paths": ["x"]}`). For CLI commands, an omitted pane uses
 `$LUVUS_PANE_ID` when available; a raw API request with no pane uses the
-currently focused pane. Pane IDs accept an unsigned 32-bit JSON integer or
-its decimal string form; malformed or out-of-range values fail with
-`invalid_request` before any mutation.
+currently focused pane. Methods with a focus default also treat an explicit
+`null` pane as omitted. A well-formed explicit ID that does not name a live
+pane fails with `not_found`; malformed or out-of-range IDs fail with
+`invalid_request` before any mutation. Pane IDs accept an unsigned 32-bit JSON
+integer or its decimal string form.
 
 `pane.report_session` binds an exact built-in agent session to its owning pane.
 The identity-only form remains compatible with existing integrations:

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -97,7 +97,9 @@ Luvus release number.
 Parameter shapes mirror the CLI flags (`luvus task add --paths x` →
 `{"paths": ["x"]}`). For CLI commands, an omitted pane uses
 `$LUVUS_PANE_ID` when available; a raw API request with no pane uses the
-currently focused pane.
+currently focused pane. Pane IDs accept an unsigned 32-bit JSON integer or
+its decimal string form; malformed or out-of-range values fail with
+`invalid_request` before any mutation.
 
 `pane.report_session` binds an exact built-in agent session to its owning pane.
 The identity-only form remains compatible with existing integrations:


### PR DESCRIPTION
## Problem

JSON pane identifiers larger than `u32::MAX` are truncated with `as u32` during pane resolution. A malformed request can therefore alias a live pane and mutate it; negative, fractional, and out-of-range string values also collapse into the same undifferentiated lookup failure instead of a validation error. An unresolved explicit `agent.explain` target can additionally fall through to implicit focused-pane resolution.

## Root cause

`App::resolve_pane` parses string identifiers directly but casts JSON integers with `n as u32`. It returns only `Option<PaneId>`, so callers cannot distinguish a malformed identifier from a valid identifier whose pane does not exist. The `agent.explain` target branch also shares a fallback chain with pane resolution instead of treating an explicit missing target as terminal.

## Fix

- Route both JSON integer and decimal-string pane identifiers through the existing checked `parse_u32_value` helper.
- Return `invalid_request` for negative, fractional, and out-of-range identifiers before pane lookup or mutation.
- Preserve valid numeric/string IDs, omitted-pane focus fallback, explicit-null handling, and `not_found` for well-formed missing panes.
- Propagate structured validation errors through direct dispatch, parked waits, and `agent.start` pane/anchor selection.
- Keep an unresolved explicit `agent.explain` target from falling back to the focused pane.
- Document the accepted unsigned 32-bit pane-ID forms in the UHP method reference.

The public request and response shapes do not change.

## Tests

- Test-first red run: `cargo test pane_ids_are_checked_before_resolution_or_mutation -- --nocapture` failed to compile because `resolve_pane` still returned `Option<PaneId>` and could not expose validation errors.
- `cargo test pane_ids_are_checked_before_resolution_or_mutation -- --nocapture` — 1 passed; 0 failed.
- `cargo test --locked` — 1,357 passed; 0 failed; 1 ignored.
- `cargo clippy --locked --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff upstream/main...HEAD --check` — passed.
- `python3 examples/uhp/consumer.py` — validated 61 UHP fixtures and all JSON schema documents.
- `python3 examples/uhp/terminal/consumer.py --fixtures` — validated 55 fixtures, all JSON schema documents, and snapshot replay.

Dedup immediately before opening: `gh issue list -R RizRiyz/luvus --state all --search '"pane id" overflow in:title,body'` returned `[]`; the matching PR query also returned `[]`.

Failure-path coverage exercises `u32::MAX + 1`, `u32::MAX + 2` (which previously wrapped to pane 1), negative and fractional JSON numbers, and invalid decimal strings. Rejected `pane.close` and `pane.send_input` requests preserve the live pane, layout leaves, focus, and terminal content revision; an out-of-range explicit `agent.explain` target returns `not_found` without focused-pane fallback.

## First-pass checklist

- R1 exact matching: numeric and string identifiers share the checked `u32` parser; malformed values cannot truncate or fall through as ordinary lookup misses.
- R2 failure paths: rejected close and input mutations retain the pane, layout leaves, focus, and content revision; valid missing panes still return `not_found`.
- R3 bot minors: CodeRabbit's explicit-target fallback finding is fixed in `fff47c8`; the bot explicitly confirmed the regression and its review thread is resolved, with no Greptile findings.
- R4 live evidence: no live run is required for PR 3; the focused in-process regression directly proves pre-mutation rejection without touching any production session.
- R5 current main/parity: rebased onto `66e7f0f`; the UHP reference is aligned and both schema/fixture validators pass; no schema or fixture shape changed.
- R6 explicit result: malformed pane IDs now return structured `invalid_request`; success and `not_found` response meanings remain unchanged.
- R7 scope: one pane-ID validation concern, no drive-by refactors or unrelated formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157SP6ztLt1Lz91vWgXko8V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime updates are scheduled closer to upcoming deadlines, including when detached.
  * Process information refreshes automatically when cached data is stale.
  * Configuration changes now synchronize workspace agent settings.
  * Agent listings now include stable workspace identifiers.

* **Bug Fixes**
  * Invalid or missing pane targets return consistent errors without affecting another pane.
  * Invalid zoom settings no longer change focus or layout.
  * Wait actions correctly report pane-resolution errors.

* **Documentation**
  * Documented pane ID formats and validation behavior, including explicit null and missing panes.
  * Documented stable workspace identifiers in agent listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->