### PR TITLE
fix(cli): reject unknown agent commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2594,7 +2594,18 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             }
             ("agent.read".into(), Value::Object(obj))
         }
-        ("agent", _) => ("agent.list".into(), json!({})),
+        ("agent", "" | "list") if rest.is_empty() => ("agent.list".into(), json!({})),
+        ("agent", "list") => {
+            return Err(anyhow!(
+                "unexpected agent list argument `{}`. Try `luvus help agent`.",
+                rest[0]
+            ));
+        }
+        ("agent", other) => {
+            return Err(anyhow!(
+                "unknown agent command `{other}`. Try `luvus help agent`."
+            ));
+        }
 
         ("ui", "sidebar") => {
             let mut obj = serde_json::Map::new();
@@ -3956,6 +3967,26 @@ mod tests {
         assert_eq!(
             parse(&argv("luvus pane processes 7")).unwrap().0,
             "pane.processes"
+        );
+    }
+
+    #[test]
+    fn agent_list_requires_an_exact_subcommand_shape() {
+        for raw in ["luvus agent", "luvus agent list"] {
+            let (method, params) = parse(&argv(raw)).unwrap();
+            assert_eq!(method, "agent.list", "{raw}");
+            assert_eq!(params, json!({}), "{raw}");
+        }
+
+        assert_eq!(
+            parse(&argv("luvus agent lsit")).unwrap_err().to_string(),
+            "unknown agent command `lsit`. Try `luvus help agent`."
+        );
+        assert_eq!(
+            parse(&argv("luvus agent list extra"))
+                .unwrap_err()
+                .to_string(),
+            "unexpected agent list argument `extra`. Try `luvus help agent`."
         );
     }
 


### PR DESCRIPTION
## Problem

Any unrecognized `agent` subcommand currently falls through to `agent.list`. A typo such as `luvus agent lsit` therefore succeeds and prints the agent inventory, hiding the operator mistake; `luvus agent list extra` also silently ignores the unexpected argument.

## Root cause

The final agent parser arm is a wildcard that maps every remaining verb to `agent.list`, unlike the workspace, tab, and pane families that return a family-specific unknown-command error with focused help.

## Fix

- Keep only bare `luvus agent` and exact `luvus agent list` as agent-list aliases.
- Return `unknown agent command <verb>` with `luvus help agent` guidance for an unrecognized verb.
- Reject unexpected arguments after `agent list` with the same focused help route.
- Preserve every recognized agent subcommand arm unchanged.

The existing CLI help already advertises `agent list`; no UHP request/response or schema shape changes.

## Tests

- Test-first red run: `cargo test agent_list_requires_an_exact_subcommand_shape -- --nocapture` — 0 passed; 1 failed because `agent lsit` still returned `Ok(("agent.list", {}))`.
- `cargo test agent_list_requires_an_exact_subcommand_shape -- --nocapture` — 1 passed; 0 failed.
- `cargo test --locked` — 1,357 passed; 0 failed; 1 ignored.
- `cargo clippy --locked --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff upstream/main...HEAD --check` — passed.
- `python3 examples/uhp/consumer.py` — validated 61 UHP fixtures and all JSON schema documents.
- `python3 examples/uhp/terminal/consumer.py --fixtures` — validated 55 fixtures, all JSON schema documents, and snapshot replay.

Dedup immediately before opening: `gh issue list -R RizRiyz/luvus --state all --search '"unknown agent" subcommand in:title,body'` returned `[]`; the matching PR query also returned `[]`.

## First-pass checklist

- R1 exact matching: the list route requires an empty verb or literal `list` and an empty trailing-argument slice; no wildcard can silently list.
- R2 failure paths: the regression asserts the exact typo diagnostic and focused help plus rejection of an unexpected list argument, while both supported list forms remain green.
- R3 bot minors: the completed CodeRabbit pass reported no actionable comments, and no Greptile findings were posted.
- R4 live evidence: no live run is required for PR 4; the pure CLI parser test proves routing before any socket connection and cannot affect a production session.
- R5 current main/parity: rebased onto `66e7f0f`; existing help already documents `agent list`, and both UHP schema/fixture validators pass with no contract changes required.
- R6 explicit result: invalid syntax returns the offending command or argument and the exact family help route instead of an implicit list response.
- R7 scope: one CLI parser concern in `src/cli.rs`, no drive-by refactors or unrelated formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157SP6ztLt1Lz91vWgXko8V
