### PR TITLE
fix(detect): treat OMP π : title as working (incl. Windows brand mojibake)

### DIFF
--- a/src/detect.rs
+++ b/src/detect.rs
@@ -431,38 +431,43 @@ fn builtin_rules() -> Vec<Rule> {
         // OMP publishes its state in the OSC title as `π <state> label`.
         // Current builds use `:` while working, `!` for attention, and `>` for
         // the user's turn. Older builds animated a braille spinner after `π `
-        // instead of `:`; keep that form so both contracts classify. Scope the
-        // rules to OMP: the generic spinner rule requires a line-leading
-        // spinner, and weakening it would create false positives for ordinary
-        // branded titles. The explicit idle title outranks retained screen
-        // activity but not a live confirmation panel.
+        // instead of `:`; keep that form so both contracts classify.
+        //
+        // On some Windows ConPTY paths the brand glyph arrives as U+87FA
+        // (UTF-8 E8 9F BA) instead of Greek pi U+03C0. Live inventory on this
+        // host shows that consistently while ASCII state markers stay intact,
+        // so match both brand codepoints until the title encoding path is fixed.
+        // Scope the rules to OMP: the generic spinner rule requires a
+        // line-leading spinner, and weakening it would create false positives
+        // for ordinary branded titles. The explicit idle title outranks
+        // retained screen activity but not a live confirmation panel.
         per(
             "omp",
             State::Blocked,
             325,
             Region::Title,
-            vec![starts_with(&["π !"])],
+            vec![starts_with(&["π !", "\u{87FA} !"])],
         ),
         per(
             "omp",
             State::Working,
             125,
             Region::Title,
-            vec![starts_with(&["π :"])],
+            vec![starts_with(&["π :", "\u{87FA} :"])],
         ),
         per(
             "omp",
             State::Working,
             124,
             Region::Title,
-            vec![spinner_after_prefix(&["π "])],
+            vec![spinner_after_prefix(&["π ", "\u{87FA} "])],
         ),
         per(
             "omp",
             State::Idle,
             210,
             Region::Title,
-            vec![starts_with(&["π >"])],
+            vec![starts_with(&["π >", "\u{87FA} >"])],
         ),
         // fx suppresses its activity row while it needs user input. Its
         // narrowest approval and question hints retain these paired controls,
@@ -1698,6 +1703,10 @@ Would you like to proceed?
         assert_eq!(detect("π ⠋ sudos", "").state, State::Working);
         assert_eq!(detect("π ! sudos", "").state, State::Blocked);
         assert_eq!(detect("π > sudos", "esc to interrupt").state, State::Idle);
+        // Windows ConPTY-mangled brand observed in live inventory titles.
+        assert_eq!(detect("\u{87FA} : sudos", "").state, State::Working);
+        assert_eq!(detect("\u{87FA} ! sudos", "").state, State::Blocked);
+        assert_eq!(detect("\u{87FA} > sudos", "esc to interrupt").state, State::Idle);
 
         let pi = classify(
             Some("π ⠙ sudos"),

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -428,13 +428,14 @@ fn builtin_rules() -> Vec<Rule> {
             Region::Screen,
             vec![any(&["ctrl+c to stop"])],
         ),
-        // OMP 18.x publishes its state in the OSC title as `π <state> label`.
-        // The working separator is a non-blank braille spinner, while `!` means
-        // attention and `>` means the user's turn. Keep these rules scoped to
-        // OMP: the generic spinner rule deliberately requires a spinner at the
-        // start of a line, and weakening it would create false positives for
-        // ordinary branded titles. The explicit idle title outranks retained
-        // screen activity but not a live confirmation panel.
+        // OMP publishes its state in the OSC title as `π <state> label`.
+        // Current builds use `:` while working, `!` for attention, and `>` for
+        // the user's turn. Older builds animated a braille spinner after `π `
+        // instead of `:`; keep that form so both contracts classify. Scope the
+        // rules to OMP: the generic spinner rule requires a line-leading
+        // spinner, and weakening it would create false positives for ordinary
+        // branded titles. The explicit idle title outranks retained screen
+        // activity but not a live confirmation panel.
         per(
             "omp",
             State::Blocked,
@@ -446,6 +447,13 @@ fn builtin_rules() -> Vec<Rule> {
             "omp",
             State::Working,
             125,
+            Region::Title,
+            vec![starts_with(&["π :"])],
+        ),
+        per(
+            "omp",
+            State::Working,
+            124,
             Region::Title,
             vec![spinner_after_prefix(&["π "])],
         ),
@@ -1681,12 +1689,13 @@ Would you like to proceed?
             )
         };
 
-        let working = detect("π ⠋ sudos", "");
+        let working = detect("π : sudos", "");
         assert_eq!(working.agent, "omp");
         assert_eq!(working.identity_source, "process_tree");
         assert_eq!(working.state, State::Working);
         assert_eq!(working.state_source, "manifest_rule");
 
+        assert_eq!(detect("π ⠋ sudos", "").state, State::Working);
         assert_eq!(detect("π ! sudos", "").state, State::Blocked);
         assert_eq!(detect("π > sudos", "esc to interrupt").state, State::Idle);
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1706,7 +1706,10 @@ Would you like to proceed?
         // Windows ConPTY-mangled brand observed in live inventory titles.
         assert_eq!(detect("\u{87FA} : sudos", "").state, State::Working);
         assert_eq!(detect("\u{87FA} ! sudos", "").state, State::Blocked);
-        assert_eq!(detect("\u{87FA} > sudos", "esc to interrupt").state, State::Idle);
+        assert_eq!(
+            detect("\u{87FA} > sudos", "esc to interrupt").state,
+            State::Idle
+        );
 
         let pi = classify(
             Some("π ⠙ sudos"),


### PR DESCRIPTION
## Summary
- #252 taught Luvus to read OMP OSC titles, but treated working as a braille spinner after `π`.
- Live OMP 18.1.x uses `π : label` while working, `π !` blocked, `π >` idle.
- Add an explicit `π :` Working title rule (priority 125) and keep the legacy spinner rule (124).
- On Windows ConPTY, live inventory shows the brand glyph as **U+87FA** (UTF-8 `E8 9F BA`) instead of Greek pi **U+03C0**, while ASCII state markers (`:`, `!`, `>`) stay intact. Match both brand codepoints so sidebar status classifies until the title encoding path is fixed.

## Test plan
- [x] `cargo test --locked detect::` — 47 passed, including `omp_title_states_work_without_the_optional_integration` with both `π` and `\u{87FA}` samples
- [ ] After install: `luvus server restart` (not only `server stop`) so the new binary loads
- [ ] Working OMP pane → `agent explain` shows Working / `manifest_rule`
- [ ] Idle OMP pane with `U+87FA > …` title → Idle via `manifest_rule`

## Validation
Unit coverage: `π :` / spinner / `!` / `>` plus Windows-mangled brand `U+87FA` variants. Pi isolation unchanged.

## Note
A deeper fix is still needed for OSC title decoding on Windows (non-ASCII title text such as Chinese is also garbled in `terminal_title`). This PR only unblocks OMP state classification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OMP OSC-title state detection on Windows to recognize the ConPTY-mangled brand character alongside Greek pi.
  * Detection now correctly identifies blocked, working, idle, and legacy spinner title markers while preserving support for existing Greek pi and older spinner formats.
  * This improves status display reliability in Windows terminals using ConPTY, ensuring terminal indicators continue to reflect the correct operation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->