### PR TITLE
feat(agents): scope agent list to one workspace

### DIFF
--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -14,6 +14,7 @@ AGENT = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 REQUEST_ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 SESSION_NAME = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 INTEGRATION_AGENT = re.compile(r"^[a-z0-9._-]{1,64}$")
+WORKSPACE_INDEX = re.compile(r"^[0-9]+$")
 EMPTY_HOST_METHODS = {
     "host.capabilities", "host.info", "host.doctor", "host.update.check",
     "session.list", "skill.status", "integration.status",
@@ -369,6 +370,26 @@ def valid_global_request(value, methods):
             and params["confirm"] is True
             and session_name(params["name"])
         )
+    if value["method"] == "agent.list":
+        params = value["params"]
+        if not set(params) <= {"workspace", "node", "workspace_id"}:
+            return False
+        for key in ("workspace", "node"):
+            if key not in params:
+                continue
+            scope = params[key]
+            if integer(scope):
+                if scope < 0:
+                    return False
+            elif not (isinstance(scope, str) and WORKSPACE_INDEX.fullmatch(scope)):
+                return False
+        if "workspace_id" in params and not bounded_string(
+            params["workspace_id"], 128, allow_empty=False
+        ):
+            return False
+        # One selector at a time: index, alias, or stable id.
+        if len(set(params) & {"workspace", "node", "workspace_id"}) > 1:
+            return False
     if value["method"] == "task.start":
         params = value["params"]
         if not set(params) <= {"id", "branch", "agent", "mode", "workspace_id"}:

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -191,8 +191,12 @@ Resolve existing agents with:
 
 ```sh
 luvus agent list
+luvus agent list --workspace <i>
 luvus agent get <target>
 ```
+
+`agent list` covers the whole session. Scope it with `--workspace <i>` (0-based)
+or `--workspace-id <id>` when only one project's agents matter.
 
 Targets are a live name, pane id, or unique agent kind. If a kind is ambiguous,
 ask the user to choose or name the panes. Never guess.

--- a/protocol/uhp/v1/fixtures/invalid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/invalid/requests.jsonl
@@ -15,3 +15,7 @@
 {"id":"bad-session-extra","method":"session.start","params":{"name":"review","extra":true}}
 {"id":"bad-session-name","method":"session.start","params":{"name":"."}}
 {"id":"bad-integration-status","method":"integration.status","params":{"agent":"claude"}}
+{"id":"bad-agent-list-unknown","method":"agent.list","params":{"workspace_name":"docs"}}
+{"id":"bad-agent-list-both","method":"agent.list","params":{"workspace":"0","workspace_id":"workspace_example"}}
+{"id":"bad-agent-list-negative","method":"agent.list","params":{"workspace":-1}}
+{"id":"bad-agent-list-shape","method":"agent.list","params":{"workspace":"first"}}

--- a/protocol/uhp/v1/fixtures/manifest.json
+++ b/protocol/uhp/v1/fixtures/manifest.json
@@ -1,10 +1,10 @@
 {
   "protocol": { "name": "luvus-uhp", "major": 1, "minor": 0 },
   "files": [
-    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 36 },
+    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 39 },
     { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 5 },
     { "path": "valid/events.jsonl", "kind": "event", "expect": "valid", "count": 2 },
-    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 17 },
+    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 21 },
     { "path": "invalid/responses.jsonl", "kind": "response", "expect": "invalid", "count": 1 }
   ]
 }

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -34,3 +34,6 @@
 {"id":"34","method":"integration.status","params":{}}
 {"id":"35","method":"integration.install","params":{"agent":"claude","confirm":true}}
 {"id":"36","method":"integration.uninstall","params":{"agent":"claude","confirm":true}}
+{"id":"37","method":"agent.list","params":{}}
+{"id":"38","method":"agent.list","params":{"workspace":"1"}}
+{"id":"39","method":"agent.list","params":{"workspace_id":"workspace_example"}}

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -115,6 +115,19 @@
         }
       }
     },
+    "agentListParams": {
+      "type": "object", "additionalProperties": false,
+      "properties": {
+        "workspace": { "oneOf": [{ "type": "string", "pattern": "^[0-9]+$" }, { "type": "integer", "minimum": 0 }] },
+        "node": { "oneOf": [{ "type": "string", "pattern": "^[0-9]+$" }, { "type": "integer", "minimum": 0 }] },
+        "workspace_id": { "type": "string", "minLength": 1, "maxLength": 128 }
+      },
+      "allOf": [
+        { "not": { "required": ["workspace", "workspace_id"] } },
+        { "not": { "required": ["node", "workspace_id"] } },
+        { "not": { "required": ["workspace", "node"] } }
+      ]
+    },
     "taskStartParams": {
       "type": "object", "additionalProperties": false, "required": ["id"],
       "properties": {
@@ -165,6 +178,8 @@
       "then": { "properties": { "params": { "$ref": "#/$defs/integrationChangeParams" } } } },
     { "if": { "properties": { "method": { "const": "pane.report_session" } } },
       "then": { "properties": { "params": { "$ref": "#/$defs/paneReportSessionParams" } } } },
+    { "if": { "properties": { "method": { "const": "agent.list" } } },
+      "then": { "properties": { "params": { "$ref": "#/$defs/agentListParams" } } } },
     { "if": { "properties": { "method": { "const": "task.start" } } },
       "then": { "properties": { "params": { "$ref": "#/$defs/taskStartParams" } } } },
     { "if": { "properties": { "method": { "const": "task.next" } } },

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -191,8 +191,12 @@ Resolve existing agents with:
 
 ```sh
 luvus agent list
+luvus agent list --workspace <i>
 luvus agent get <target>
 ```
+
+`agent list` covers the whole session. Scope it with `--workspace <i>` (0-based)
+or `--workspace-id <id>` when only one project's agents matter.
 
 Targets are a live name, pane id, or unique agent kind. If a kind is ambiguous,
 ask the user to choose or name the panes. Never guess.

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2402,9 +2402,26 @@ impl App {
                 Ok(json!({"type":"ok","pane": id.0.to_string()}))
             }
             "agent.list" => {
+                // Optional scope. Unknown fields are rejected so a typo'd filter
+                // fails loudly instead of silently widening back to the whole
+                // fleet — the dangerous failure mode for a caller that meant to
+                // address one workspace.
+                reject_api_fields(p, &["workspace", "workspace_id", "node"])?;
+                let only = self.optional_socket_workspace(p)?;
+                // An index past the end is a caller mistake, not "no agents":
+                // report it like every other workspace selector does.
+                if let Some(scope) = only.filter(|scope| *scope >= self.workspaces.len()) {
+                    return Err(workspace_update_error(
+                        scope,
+                        WorkspaceUpdateError::NotFound,
+                    ));
+                }
                 let focus = self.layout().focus;
                 let mut arr = Vec::new();
                 for (wi, ws) in self.workspaces.iter().enumerate() {
+                    if only.is_some_and(|scope| scope != wi) {
+                        continue;
+                    }
                     // Node-level context, identical for every pane in the node.
                     // `project` deliberately repeats `workspace_name` so a consumer
                     // can use one field name across `agent.list` *and*
@@ -6952,6 +6969,87 @@ command = ["true"]
             .dispatch("agent.list", &json!({}))
             .expect("agent.list ok");
         assert_eq!(out["agents"][0]["session"], "sess-42");
+    }
+
+    /// `agent.list` scopes to one workspace by index or by stable id, and a
+    /// mistyped filter fails loudly instead of silently listing the whole fleet.
+    #[test]
+    fn agent_list_scopes_to_one_workspace_and_rejects_bad_filters() {
+        let _env = crate::persist::test_env("agent-list-workspace-filter");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+
+        let first_ws = app.active_ws;
+        let first_pane = app.layout().focus;
+        app.status.get_mut(&first_pane).unwrap().agent = "claude".into();
+
+        let second_root = crate::persist::config_dir().join("second-workspace");
+        std::fs::create_dir_all(&second_root).unwrap();
+        assert!(app.create_workspace_at(second_root));
+        let second_ws = app.active_ws;
+        assert_ne!(first_ws, second_ws);
+        let second_pane = app.layout().focus;
+        app.status.get_mut(&second_pane).unwrap().agent = "codex".into();
+
+        let panes_of = |value: &Value| -> Vec<String> {
+            value["agents"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|row| row["pane"].as_str().unwrap().to_string())
+                .collect()
+        };
+
+        // Unscoped keeps the historical contract: every agent in the session.
+        let all = app.dispatch("agent.list", &json!({})).unwrap();
+        assert_eq!(
+            panes_of(&all),
+            vec![first_pane.0.to_string(), second_pane.0.to_string()]
+        );
+
+        // 0-based index, the public workspace convention.
+        let scoped = app
+            .dispatch("agent.list", &json!({"workspace": second_ws.to_string()}))
+            .unwrap();
+        assert_eq!(panes_of(&scoped), vec![second_pane.0.to_string()]);
+        assert_eq!(scoped["agents"][0]["workspace"], second_ws.to_string());
+
+        // `node` stays an accepted alias for the same selector.
+        let aliased = app
+            .dispatch("agent.list", &json!({"node": first_ws}))
+            .unwrap();
+        assert_eq!(panes_of(&aliased), vec![first_pane.0.to_string()]);
+
+        // A stable id survives reordering, so automation can pin one workspace.
+        let id = app.workspaces[second_ws].id.clone();
+        let by_id = app
+            .dispatch("agent.list", &json!({"workspace_id": id}))
+            .unwrap();
+        assert_eq!(panes_of(&by_id), vec![second_pane.0.to_string()]);
+
+        // A workspace with no agent is an empty list, not an error.
+        app.status.remove(&second_pane);
+        let empty = app
+            .dispatch("agent.list", &json!({"workspace": second_ws.to_string()}))
+            .unwrap();
+        assert_eq!(empty["agents"].as_array().unwrap().len(), 0);
+
+        // Bad scopes are refused rather than widened.
+        let missing = app
+            .dispatch("agent.list", &json!({"workspace": "99"}))
+            .expect_err("an out-of-range workspace is not found");
+        assert_eq!(missing.0, "not_found");
+        let both = app
+            .dispatch(
+                "agent.list",
+                &json!({"workspace": "0", "workspace_id": app.workspaces[second_ws].id.clone()}),
+            )
+            .expect_err("index and id cannot be combined");
+        assert_eq!(both.0, "invalid_request");
+        let typo = app
+            .dispatch("agent.list", &json!({"workspace_name": "docs"}))
+            .expect_err("an unknown filter must not silently list everything");
+        assert_eq!(typo.0, "invalid_request");
     }
 
     /// A live alias set by `agent.name` shows up in `agent.list` and resolves an

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2604,16 +2604,19 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             let mut obj = serde_json::Map::new();
             let mut cursor = rest.iter();
             while let Some(argument) = cursor.next() {
-                let (key, canonical) = match argument.as_str() {
-                    "--workspace" | "--node" => ("workspace", "--workspace"),
-                    "--workspace-id" => ("workspace_id", "--workspace-id"),
+                // Diagnostics quote the flag the caller actually typed, so
+                // `--node` never reports itself as `--workspace`.
+                let typed = argument.as_str();
+                let key = match typed {
+                    "--workspace" | "--node" => "workspace",
+                    "--workspace-id" => "workspace_id",
                     other => {
                         return Err(anyhow!("unexpected agent list argument `{other}`. {usage}"))
                     }
                 };
                 let value = cursor
                     .next()
-                    .ok_or_else(|| anyhow!("{canonical} needs a value. {usage}"))?;
+                    .ok_or_else(|| anyhow!("{typed} needs a value. {usage}"))?;
                 if !obj.is_empty() {
                     return Err(anyhow!(
                         "--workspace and --workspace-id cannot be used together. {usage}"
@@ -2622,11 +2625,11 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
                 if key == "workspace" {
                     let index = value
                         .parse::<usize>()
-                        .map_err(|_| anyhow!("{canonical} must be a 0-based number. {usage}"))?;
+                        .map_err(|_| anyhow!("{typed} must be a 0-based number. {usage}"))?;
                     obj.insert(key.into(), json!(index.to_string()));
                 } else {
                     if value.is_empty() {
-                        return Err(anyhow!("{canonical} must not be empty. {usage}"));
+                        return Err(anyhow!("{typed} must not be empty. {usage}"));
                     }
                     obj.insert(key.into(), json!(value));
                 }
@@ -4128,6 +4131,22 @@ mod tests {
             "a mistyped filter must not silently list every workspace"
         );
         assert!(parse(&argv("luvus agent list extra")).is_err());
+
+        // Diagnostics name the flag the caller typed, not its canonical twin.
+        for (raw, flag) in [
+            ("luvus agent list --node docs", "--node"),
+            ("luvus agent list --workspace docs", "--workspace"),
+        ] {
+            let message = parse(&argv(raw)).unwrap_err().to_string();
+            assert!(
+                message.starts_with(&format!("{flag} must be a 0-based number")),
+                "{raw} reported: {message}"
+            );
+        }
+        assert!(parse(&argv("luvus agent list --node"))
+            .unwrap_err()
+            .to_string()
+            .starts_with("--node needs a value"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,8 @@ panes / agents:
   pane processes [<id>]      list cached executable identities without exposing arguments
   pane name <name>           name a pane so you can mention it (--pane <id>; --clear)
   pane close [<id>]          close a pane
-  agent list                 list every agent across all workspaces/tabs
+  agent list [--workspace <i> | --workspace-id <id>]
+                             list agents in every workspace/tab, or one workspace
   agent start <name> --kind <k> [--pane <id> | --anchor <id>] [--down] [--timeout <s>] [-- <args>]
                              spawn beside an anchor or reuse a pane, wait until ready, name it
   agent fork <target> [--name <alias>] [--no-focus]
@@ -2594,7 +2595,44 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             }
             ("agent.read".into(), Value::Object(obj))
         }
-        ("agent", _) => ("agent.list".into(), json!({})),
+        ("agent", _) => {
+            // `agent list [--workspace <i> | --node <i> | --workspace-id <id>]`.
+            // Unscoped stays the default: every agent in the session. Every
+            // token is consumed explicitly so a mistyped flag is refused here
+            // instead of quietly listing the whole fleet.
+            let usage = "usage: luvus agent list [--workspace <i> | --workspace-id <id>]";
+            let mut obj = serde_json::Map::new();
+            let mut cursor = rest.iter();
+            while let Some(argument) = cursor.next() {
+                let (key, canonical) = match argument.as_str() {
+                    "--workspace" | "--node" => ("workspace", "--workspace"),
+                    "--workspace-id" => ("workspace_id", "--workspace-id"),
+                    other => {
+                        return Err(anyhow!("unexpected agent list argument `{other}`. {usage}"))
+                    }
+                };
+                let value = cursor
+                    .next()
+                    .ok_or_else(|| anyhow!("{canonical} needs a value. {usage}"))?;
+                if !obj.is_empty() {
+                    return Err(anyhow!(
+                        "--workspace and --workspace-id cannot be used together. {usage}"
+                    ));
+                }
+                if key == "workspace" {
+                    let index = value
+                        .parse::<usize>()
+                        .map_err(|_| anyhow!("{canonical} must be a 0-based number. {usage}"))?;
+                    obj.insert(key.into(), json!(index.to_string()));
+                } else {
+                    if value.is_empty() {
+                        return Err(anyhow!("{canonical} must not be empty. {usage}"));
+                    }
+                    obj.insert(key.into(), json!(value));
+                }
+            }
+            ("agent.list".into(), Value::Object(obj))
+        }
 
         ("ui", "sidebar") => {
             let mut obj = serde_json::Map::new();
@@ -4061,8 +4099,35 @@ mod tests {
         assert_eq!(p.get("workspace").and_then(|v| v.as_str()), Some("2"));
         let (m, _) = parse(&argv("luvus tab new")).unwrap();
         assert_eq!(m, "tab.new");
-        let (m, _) = parse(&argv("luvus agent list")).unwrap();
+        let (m, p) = parse(&argv("luvus agent list")).unwrap();
         assert_eq!(m, "agent.list");
+        assert_eq!(p, json!({}), "an unscoped listing sends no filter");
+    }
+
+    #[test]
+    fn agent_list_accepts_one_workspace_scope() {
+        let (method, params) = parse(&argv("luvus agent list --workspace 2")).unwrap();
+        assert_eq!(method, "agent.list");
+        assert_eq!(params, json!({"workspace": "2"}));
+
+        // `--node` is the same 0-based selector under the other vocabulary.
+        let (_, params) = parse(&argv("luvus agent list --node 0")).unwrap();
+        assert_eq!(params, json!({"workspace": "0"}));
+
+        let (_, params) = parse(&argv("luvus agent list --workspace-id workspace-a")).unwrap();
+        assert_eq!(params, json!({"workspace_id": "workspace-a"}));
+
+        // A non-numeric index, a missing value, an unknown token, or two
+        // selectors at once all fail before any socket connection.
+        assert!(parse(&argv("luvus agent list --workspace docs")).is_err());
+        assert!(parse(&argv("luvus agent list --workspace")).is_err());
+        assert!(parse(&argv("luvus agent list --workspace-id")).is_err());
+        assert!(parse(&argv("luvus agent list --workspace 1 --workspace-id b")).is_err());
+        assert!(
+            parse(&argv("luvus agent list --workspace-nmae docs")).is_err(),
+            "a mistyped filter must not silently list every workspace"
+        );
+        assert!(parse(&argv("luvus agent list extra")).is_err());
     }
 
     #[test]

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -1322,15 +1322,15 @@ static HELP: &[Translation] = &[
         "패널 닫기"
     ),
     tr!(
-        "list every agent across all workspaces/tabs",
-        "listar todos los agentes de todos los espacios/pestañas",
-        "listar todos os agentes em todos os espaços/abas",
-        "lister tous les agents de tous les espaces/onglets",
-        "alle Agenten in allen Arbeitsbereichen/Tabs auflisten",
-        "daftar semua agen di seluruh ruang kerja/tab",
-        "列出所有工作区/标签页中的全部智能体",
-        "全ワークスペース/タブのエージェントを一覧表示",
-        "모든 작업 공간/탭의 에이전트 나열"
+        "list agents in every workspace/tab, or one workspace",
+        "listar agentes de todos los espacios/pestañas o de uno solo",
+        "listar agentes em todos os espaços/abas ou em apenas um",
+        "lister les agents de tous les espaces/onglets ou d'un seul",
+        "Agenten aus allen Arbeitsbereichen/Tabs oder nur einem auflisten",
+        "daftar agen di semua ruang kerja/tab atau hanya satu",
+        "列出所有工作区/标签页或单个工作区中的智能体",
+        "全ワークスペース/タブ、または 1 つのワークスペースのエージェントを一覧表示",
+        "모든 작업 공간/탭 또는 특정 작업 공간의 에이전트 나열"
     ),
     tr!(
         "spawn beside an anchor or reuse a pane, wait until ready, name it",

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -249,6 +249,7 @@ Discover the exact target first:
 ```sh
 luvus pane list
 luvus agent list
+luvus agent list --workspace <i>   # or --workspace-id <id>, one workspace only
 luvus agent get <target>
 luvus agent explain <target>
 luvus agent read <target> --lines 100

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -17,6 +17,7 @@ commands you would type yourself.
 
 ```sh
 luvus agent list                       # every live agent: name, pane, kind, status, cwd
+luvus agent list --workspace 1         # only that workspace's agents (--workspace-id also works)
 luvus agent name reviewer              # alias the current agent (or --pane <id>)
 luvus agent prompt reviewer "Review the diff" --wait --until idle --timeout 600
 luvus agent read reviewer --lines 120  # read what it produced

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -92,7 +92,8 @@ panes / agents:
   pane processes [<id>]      list cached executable identities without exposing arguments
   pane name <name>           name a pane so you can mention it (--pane <id>; --clear)
   pane close [<id>]          close a pane
-  agent list                 list every agent across all workspaces/tabs
+  agent list [--workspace <i> | --workspace-id <id>]
+                             list agents in every workspace/tab, or one workspace
   agent start <name> --kind <k> [--pane <id> | --anchor <id>] [--down] [--timeout <s>] [-- <args>]
                              spawn beside an anchor or reuse a pane, wait until ready, name it
   agent fork <target> [--name <alias>] [--no-focus]

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -116,6 +116,16 @@ pane owns that exact session.
 {"id":"usage","method":"pane.report_session","params":{"pane":"9","agent":"opencode","session_id":"ses_123","usage":{"model":"anthropic/claude-sonnet-4","tokens_in":1200,"tokens_out":340,"cache_read":800,"cache_write":40,"cost":0.42,"updated_at":1788330000000}}}
 ```
 
+`agent.list` returns every agent in the session unless it is scoped to one
+workspace with a 0-based `workspace` (`node` is an accepted alias) or a stable
+`workspace_id`. The two selectors cannot be combined, an unknown index or id is
+`not_found`, and an unknown parameter is `invalid_request` so a mistyped filter
+cannot silently widen back to the whole fleet.
+
+```json
+{"id":"agents","method":"agent.list","params":{"workspace":"1"}}
+```
+
 `task.start` and `task.next` with `start: true` accept `mode: "worktree"` or
 `mode: "workspace"`; omitted mode means worktree. Workspace mode may include a
 stable `workspace_id` and creates a dedicated branchless task tab in that


### PR DESCRIPTION
`luvus agent list` can now be scoped to one workspace instead of always returning the whole session.

## What

- `agent.list` accepts an optional 0-based `workspace` (`node` is an accepted alias) or a stable `workspace_id`. Omitting both keeps the existing behavior and output shape exactly.
- Scope resolution reuses the shared workspace selector, so combining two selectors, or naming an unknown id, fails the same way as every other workspace method.
- An out-of-range index returns `not_found` rather than an empty list, and an unknown parameter returns `invalid_request`. A filter that silently widens back to the whole fleet is the failure mode that matters here: a script meaning to address one project would broadcast to every agent instead.
- CLI: `luvus agent list [--workspace <i> | --node <i> | --workspace-id <id>]`. Arguments are consumed explicitly, so a mistyped flag, a missing value, or a stray positional argument is refused before any socket connection.
- UHP parity: new `agentListParams` definition plus the `agent.list` `allOf` entry in `request.schema.json`, 3 valid and 4 invalid fixtures with updated manifest counts, and the matching rule in the dependency-free `examples/uhp/consumer.py` validator.
- Docs and bundled guidance updated: CLI reference, UHP methods, agent-messaging guide, both skill copies, and `agent-readme.md`. The help description is retranslated for all nine registered languages, none partial.

No response field was added or removed, and no existing method changed shape.

## Why

Every `agent.list` row already carries `workspace`, `workspace_name`, and `tab`, but the method itself walked all workspaces unconditionally and discarded whatever params it was handed. Anyone driving a multi-project session had to pull the entire fleet and filter client-side on every poll, and there was no server-side way to say "just this project".

No existing issue tracks this. I searched open and closed issues and PRs before starting; the nearest match, #194 / #197, is the sidebar All/Active state filter, which is a different axis.

## Verification

- [x] `cargo test --locked` — 1,334 passed, 0 failed, 1 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Manual testing, if applicable

Also run:

- `cargo build --release --locked`
- `python3 examples/uhp/consumer.py` — validated 68 UHP fixtures and all JSON schema documents
- `python3 examples/uhp/terminal/consumer.py --fixtures` — validated 55 fixtures, all JSON schema documents, and snapshot replay
- `git diff --check` — clean

New focused tests: `agent_list_scopes_to_one_workspace_and_rejects_bad_filters` covers index, the `node` alias, `workspace_id`, an agent-free workspace, an out-of-range index, conflicting selectors, and an unknown parameter. `agent_list_accepts_one_workspace_scope` covers CLI parsing and every parse-time rejection.

The hand-rolled `consumer.py` validator and `request.schema.json` are two independent implementations, so passing the former does not prove the latter is correct. I cross-checked the schema with a real Draft 2020-12 validator (`jsonschema` 4.26) over 12 cases plus all published `agent.list` fixtures: zero disagreements with the reference validator.

Live run against a debug server in an isolated home (`LUVUS_HOME=~/.luvus-dev`, dedicated `--session agent-list-filter`, inherited socket and session selectors cleared, server stopped and temp dirs removed afterwards; no production session touched). Two workspaces with one reported agent each:

```
unscoped        -> pane 1 (claude, ws 0), pane 2 (codex, ws 1)
--workspace 0   -> pane 1
--workspace 1   -> pane 2
--node 1        -> pane 2
--workspace-id  -> the matching workspace only
--workspace 9   -> not_found: workspace 9 not found
--workspace-id nope -> not_found: workspace id nope not found
```

Parse-time rejections, all before connecting:

```
--workspace-nmae docs           -> unexpected agent list argument `--workspace-nmae`
--workspace                     -> --workspace needs a value
extra                           -> unexpected agent list argument `extra`
--workspace 1 --workspace-id b  -> --workspace and --workspace-id cannot be used together
--workspace docs                -> --workspace must be a 0-based number
```

## Notes

**Interaction with #257.** That PR replaces the same `("agent", _)` parser arm with `("agent", "" | "list") if rest.is_empty()`. Since `rest` is every argv token after the verb, including flags, `agent list --workspace 1` would be rejected as an unexpected argument if #257 landed as-is on top of this. The two changes are complementary rather than competing, so I deliberately made this arm strict in the same spirit and matched its `unexpected agent list argument ...` wording. Whichever merges first, reconciling them means keeping #257's unknown-verb arm alongside the flag-parsing list arm here; I did not touch the unknown-verb path, so that decision stays with #257.

Branched from `71f83d4` (#252), three commits behind `main` at the time of writing (#238, #251, #258). None of those touch any file in this diff, so it applies cleanly; happy to rebase if you would rather have it on current `main`.

Scoped to the workspace axis only. A `--tab` filter is the natural next step but is a separate user-facing change, so I left it out.

Verified on macOS only. The change is parameter validation and list filtering with no platform-specific code path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-scoped agent listings using workspace indexes, the node alias, or workspace IDs.
  * Unfiltered `agent list` continues to show agents across the session.
  * Added validation for supported filters, conflicting selectors, invalid indexes, and unknown parameters.

* **Documentation**
  * Updated CLI help, guides, reference documentation, examples, and translations.

* **Tests**
  * Added valid and invalid request coverage for workspace-scoped listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->