### PR TITLE
perf(runtime): block idle wait instead of polling

### DIFF
--- a/src/app/backend.rs
+++ b/src/app/backend.rs
@@ -270,7 +270,7 @@ impl App {
             ],
         )?;
         let pane_id = self.resolve_backend_runtime(params, false)?;
-        self.request_proc_scan_if_unobserved(pane_id);
+        self.request_proc_scan_if_stale(pane_id);
         let process = self.pane_processes(pane_id);
         Ok(json!({
             "type":"terminal_backend_processes",
@@ -1561,7 +1561,7 @@ mod tests {
     }
 
     #[test]
-    fn process_inspection_uses_validated_identity_and_cached_executables() {
+    fn process_inspection_returns_cached_identity_and_refreshes_when_dirty() {
         let _env = crate::persist::test_env("backend-process-inspection");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
@@ -1574,6 +1574,7 @@ mod tests {
                 "/opt/bin/codex --api-key hidden".into(),
             ],
         );
+        app.runtime_proc_dirty = true;
         let result = app
             .backend_processes(&json!({
                 "server_generation":app.backend_server_generation,
@@ -1585,6 +1586,10 @@ mod tests {
         assert_eq!(result["executables"], json!(["zsh", "codex"]));
         assert_eq!(result["arguments_exposed"], false);
         assert!(!result.to_string().contains("hidden"));
+        assert!(
+            app.proc_scan_inflight,
+            "dirty backend process identity must trigger an off-loop refresh"
+        );
     }
 
     #[test]

--- a/src/app/backend.rs
+++ b/src/app/backend.rs
@@ -259,7 +259,7 @@ impl App {
         }))
     }
 
-    fn backend_processes(&self, params: &Value) -> BackendResult {
+    fn backend_processes(&mut self, params: &Value) -> BackendResult {
         backend::reject_unknown_fields(
             params,
             &[
@@ -270,6 +270,7 @@ impl App {
             ],
         )?;
         let pane_id = self.resolve_backend_runtime(params, false)?;
+        self.request_proc_scan_if_unobserved(pane_id);
         let process = self.pane_processes(pane_id);
         Ok(json!({
             "type":"terminal_backend_processes",

--- a/src/app/backend.rs
+++ b/src/app/backend.rs
@@ -1252,6 +1252,14 @@ impl App {
             .retain(|_, waits| !waits.is_empty());
     }
 
+    pub(crate) fn next_backend_revision_deadline(&self) -> Option<Instant> {
+        self.backend_revision_waits
+            .values()
+            .flatten()
+            .map(|wait| wait.deadline)
+            .min()
+    }
+
     pub(super) fn cancel_backend_revision_waits(&mut self, pane_id: PaneId) {
         if let Some(waits) = self.backend_revision_waits.remove(&pane_id) {
             for wait in waits {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -17,6 +17,7 @@ const DETECTION_INTERVAL: Duration = Duration::from_millis(100);
 const DETECTION_AUDIT_INTERVAL: Duration = Duration::from_secs(2);
 const CWD_SCAN_INTERVAL: Duration = Duration::from_secs(1);
 const PROC_SCAN_INTERVAL: Duration = Duration::from_secs(2);
+pub(crate) const PROC_SCAN_FAILURE_RETRIES: u8 = 1;
 const SESSION_SCAN_INTERVAL: Duration = Duration::from_secs(4);
 const WAIT_RETEST_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -96,10 +97,21 @@ mod socket_api_tests {
         for status in app.status.values_mut() {
             status.last_resize = Some(now - RESIZE_GRACE - Duration::from_millis(1));
         }
+        app.last_detect_at = now;
+        let cooling = app
+            .next_runtime_deadline(now, true)
+            .expect("expired resize work must retain a detection deadline");
+        assert!(
+            cooling > now,
+            "detection cooldown prevents a zero-timeout spin"
+        );
+        assert!(cooling <= now + DETECTION_INTERVAL);
+
+        app.last_detect_at = now - DETECTION_INTERVAL;
         assert_eq!(
             app.next_runtime_deadline(now, true),
-            None,
-            "an expired resize grace must not become a 1ms loop timeout"
+            Some(now),
+            "expired resize work wakes once detection is eligible"
         );
 
         let resized = now;
@@ -147,6 +159,30 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn overdue_dirty_runtime_scans_still_wake_with_a_client() {
+        let (_env, mut app) = app("overdue-runtime-scans");
+        let now = Instant::now();
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.candidate = status.state;
+            status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+        }
+        app.runtime_cwd_dirty = true;
+        app.runtime_proc_dirty = true;
+        app.runtime_sessions_dirty = true;
+        app.last_cwd_at = now - CWD_SCAN_INTERVAL - Duration::from_millis(1);
+        app.last_proc_at = now - PROC_SCAN_INTERVAL - Duration::from_millis(1);
+        app.last_sessions_at = now - SESSION_SCAN_INTERVAL - Duration::from_millis(1);
+        app.last_detection_audit_at = now;
+
+        assert_eq!(
+            app.next_runtime_deadline(now, true),
+            Some(now),
+            "overdue dirty runtime scans must wake this iteration"
+        );
+    }
+
+    #[test]
     fn detached_runtime_skips_heartbeat_scans() {
         let (_env, mut app) = app("detached-heartbeat-scans");
         let now = Instant::now();
@@ -184,6 +220,136 @@ mod socket_api_tests {
         assert!(
             app.proc_scan_inflight,
             "UHP process inspection must scan without a TUI attached"
+        );
+    }
+
+    #[test]
+    fn dirty_cached_process_api_requests_refresh_without_waiting() {
+        let (_env, mut app) = app("dirty-process-api-demand");
+        let pane = app.layout().focus;
+        app.proc_commands.insert(pane, vec!["cached-shell".into()]);
+        app.proc_scan_inflight = false;
+        app.runtime_proc_dirty = true;
+
+        let result = app
+            .dispatch("pane.processes", &json!({"pane": pane.0}))
+            .unwrap();
+
+        assert_eq!(
+            result["scan"], "observed",
+            "the cached response stays immediate"
+        );
+        assert_eq!(result["executables"], json!(["cached-shell"]));
+        assert!(
+            app.proc_scan_inflight,
+            "dirty cached process identity must trigger an off-loop refresh"
+        );
+    }
+
+    #[test]
+    fn process_api_demand_survives_a_failed_inflight_dirty_scan() {
+        let (_env, mut app) = app("inflight-process-api-demand");
+        let pane = app.layout().focus;
+        let now = Instant::now();
+        app.proc_commands.insert(pane, vec!["cached-shell".into()]);
+        app.runtime_cwd_dirty = false;
+        app.runtime_proc_dirty = true;
+        app.runtime_sessions_dirty = false;
+        app.last_proc_at = now - PROC_SCAN_INTERVAL;
+
+        app.detect_tick_with(now, true);
+        assert!(app.proc_scan_inflight, "the ordinary dirty scan starts");
+        app.request_proc_scan_if_stale(pane);
+        assert!(
+            app.proc_scan_demand_inflight,
+            "the API request attaches retry demand to the in-flight scan"
+        );
+
+        app.apply_proc_scan(None);
+        assert!(
+            app.proc_scan_requested,
+            "failure restores the API request for a throttled retry"
+        );
+    }
+
+    #[test]
+    fn failed_demanded_process_scan_rearms_without_an_idle_heartbeat() {
+        let (_env, mut app) = app("failed-process-demand");
+        let now = Instant::now();
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.candidate = status.state;
+            status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+        }
+        app.runtime_cwd_dirty = false;
+        app.runtime_proc_dirty = false;
+        app.runtime_sessions_dirty = false;
+        app.last_detection_audit_at = now;
+        app.last_proc_at = now - PROC_SCAN_INTERVAL;
+        app.proc_scan_requested = true;
+
+        app.detect_tick_with(now, false);
+        assert!(app.proc_scan_inflight);
+        assert!(app.proc_scan_demand_inflight);
+
+        app.apply_proc_scan(None);
+        assert!(app.proc_scan_requested, "a failed demanded scan must retry");
+        assert_eq!(
+            app.next_runtime_deadline(now, false),
+            Some(now + PROC_SCAN_INTERVAL),
+            "the retry remains throttled instead of hot-looping"
+        );
+    }
+
+    #[test]
+    fn detached_agent_start_demands_throttled_process_scans_only_while_active() {
+        let (_env, mut app) = app("detached-agent-start-process-demand");
+        let pane = app.layout().focus;
+        let now = Instant::now();
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.candidate = status.state;
+            status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+        }
+        app.runtime_cwd_dirty = false;
+        app.runtime_proc_dirty = false;
+        app.runtime_sessions_dirty = false;
+        app.last_detection_audit_at = now;
+        app.last_proc_at = now;
+
+        let (reply, _reply_rx) = std::sync::mpsc::channel();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        app.agent_starts.insert(
+            pane,
+            AgentStart {
+                request_id: "detached-start".into(),
+                name: "worker".into(),
+                kind: "claude".into(),
+                reply,
+                deadline: now + Duration::from_secs(30),
+                cancelled: cancelled.clone(),
+            },
+        );
+
+        assert_eq!(
+            app.next_runtime_deadline(now, false),
+            Some(now + PROC_SCAN_INTERVAL),
+            "a detached launch gets a finite process-identity deadline"
+        );
+        app.detect_tick_with(now + PROC_SCAN_INTERVAL, false);
+        assert!(
+            app.proc_scan_inflight,
+            "the due detached scan starts off-loop"
+        );
+
+        app.apply_proc_scan(None);
+        cancelled.store(true, Ordering::Release);
+        app.tick_agent_workflows(now + PROC_SCAN_INTERVAL);
+        assert!(app.agent_starts.is_empty());
+        assert_eq!(
+            app.next_runtime_deadline(now + PROC_SCAN_INTERVAL, false),
+            None,
+            "resolved launch workflows leave no process-scan heartbeat"
         );
     }
 
@@ -727,9 +893,7 @@ impl App {
                 status.force_detect
                     || status.candidate != status.state
                     || status.agent_report.is_some()
-                    || status
-                        .last_resize
-                        .is_some_and(|t| now.duration_since(t) < RESIZE_GRACE)
+                    || status.last_resize.is_some_and(|t| now >= t + RESIZE_GRACE)
                     || (status.state == State::Working
                         && now.saturating_duration_since(status.last_activity)
                             < ACTIVITY_WINDOW + QUIET_DWELL)
@@ -761,8 +925,8 @@ impl App {
 
     /// Next Instant the event loop must wake if no `AppEvent` arrives.
     /// `None` means block on the channel: PTY, API, client, and signals wake it.
-    /// Past Instants are not kept as a 1ms spin: expired resize grace must drop
-    /// out, while work that is already due wakes this iteration (`now`).
+    /// Past Instants become a single due wake only when work remains; detection
+    /// cooldowns cap that wake so an expired resize cannot create a 1ms spin.
     pub(crate) fn next_runtime_deadline(
         &self,
         now: Instant,
@@ -809,7 +973,10 @@ impl App {
                 consider(report.expires_at, true);
             }
             if let Some(resized) = status.last_resize {
-                consider(resized + RESIZE_GRACE, false);
+                consider(
+                    (resized + RESIZE_GRACE).max(self.last_detect_at + DETECTION_INTERVAL),
+                    true,
+                );
             }
             if status.state == State::Working {
                 consider(status.last_activity + ACTIVITY_WINDOW + QUIET_DWELL, false);
@@ -845,25 +1012,46 @@ impl App {
 
         if clients_attached {
             if self.runtime_cwd_dirty && !self.cwd_scan_inflight {
-                consider(self.last_cwd_at + CWD_SCAN_INTERVAL, false);
-            }
-            if self.runtime_proc_dirty && !self.proc_scan_inflight {
-                consider(self.last_proc_at + PROC_SCAN_INTERVAL, false);
+                consider(self.last_cwd_at + CWD_SCAN_INTERVAL, true);
             }
             if self.runtime_sessions_dirty && !self.sessions_scan_inflight {
-                consider(self.last_sessions_at + SESSION_SCAN_INTERVAL, false);
+                consider(self.last_sessions_at + SESSION_SCAN_INTERVAL, true);
             }
+        }
+        let proc_demanded = self.proc_scan_demanded();
+        if !self.proc_scan_inflight
+            && (proc_demanded || (clients_attached && self.runtime_proc_dirty))
+        {
+            consider(
+                self.last_proc_at + PROC_SCAN_INTERVAL,
+                proc_demanded || (clients_attached && self.runtime_proc_dirty),
+            );
         }
 
         deadline
     }
 
-    fn start_proc_scan(&mut self) {
+    fn proc_scan_demanded(&self) -> bool {
+        self.proc_scan_requested || !self.agent_starts.is_empty()
+    }
+
+    fn proc_scan_due(&self, now: Instant, include_runtime_dirty: bool) -> bool {
+        !self.proc_scan_inflight
+            && (self.proc_scan_demanded() || (include_runtime_dirty && self.runtime_proc_dirty))
+            && now.saturating_duration_since(self.last_proc_at) >= PROC_SCAN_INTERVAL
+    }
+
+    fn start_proc_scan(&mut self, now: Instant) {
         if self.proc_scan_inflight {
             return;
         }
         self.runtime_proc_dirty = false;
-        self.last_proc_at = Instant::now();
+        if self.proc_scan_requested {
+            self.proc_scan_failure_retries = PROC_SCAN_FAILURE_RETRIES;
+        }
+        self.proc_scan_demand_inflight = self.proc_scan_requested;
+        self.proc_scan_requested = false;
+        self.last_proc_at = now;
         self.proc_scan_inflight = true;
         let pids: Vec<u32> = self
             .panes
@@ -880,15 +1068,27 @@ impl App {
         });
     }
 
-    pub(crate) fn request_proc_scan_if_unobserved(&mut self, id: PaneId) {
-        if self.proc_commands.contains_key(&id) {
+    pub(crate) fn request_proc_scan_if_stale(&mut self, id: PaneId) {
+        if self.proc_scan_inflight {
+            // Treat the current snapshot as satisfying this request, but retain
+            // one bounded retry if the worker cannot obtain usable evidence.
+            self.proc_scan_demand_inflight = true;
+            self.proc_scan_failure_retries = PROC_SCAN_FAILURE_RETRIES;
             return;
         }
-        self.start_proc_scan();
+        if !self.runtime_proc_dirty && self.proc_commands.contains_key(&id) {
+            return;
+        }
+        self.proc_scan_requested = true;
+        self.proc_scan_failure_retries = PROC_SCAN_FAILURE_RETRIES;
+        self.start_proc_scan(Instant::now());
     }
 
     fn schedule_runtime_scans(&mut self, now: Instant, clients_attached: bool) {
         if !clients_attached {
+            if self.proc_scan_due(now, false) {
+                self.start_proc_scan(now);
+            }
             return;
         }
         // CWD/git follow the user after PTY activity, throttled to 1s. Quiet
@@ -900,11 +1100,11 @@ impl App {
             self.runtime_cwd_dirty = false;
             self.last_cwd_at = now;
             self.cwd_scan_inflight = true;
-            let include_processes = self.runtime_proc_dirty
-                && !self.proc_scan_inflight
-                && now.duration_since(self.last_proc_at) >= PROC_SCAN_INTERVAL;
+            let include_processes = self.proc_scan_due(now, true);
             if include_processes {
                 self.runtime_proc_dirty = false;
+                self.proc_scan_demand_inflight = self.proc_scan_requested;
+                self.proc_scan_requested = false;
                 self.last_proc_at = now;
                 self.proc_scan_inflight = true;
             }
@@ -967,10 +1167,10 @@ impl App {
                 let _ = tx.send(AppEvent::SessionsScanned(crate::agent::recent_sessions(12)));
             });
         }
-        // Identity comes from the pane's *processes* (docs/07). One `ps` covers
-        // every pane; it runs only after PTY activity, never as a heartbeat.
-        if self.runtime_proc_dirty && now.duration_since(self.last_proc_at) >= PROC_SCAN_INTERVAL {
-            self.start_proc_scan();
+        // Process scans are triggered by attached PTY activity or by a bounded
+        // identity demand (API inspection, launch readiness, or absence confirmation).
+        if self.proc_scan_due(now, true) {
+            self.start_proc_scan(now);
         }
     }
 
@@ -1086,6 +1286,7 @@ impl App {
                         status.force_detect
                             || status.candidate != status.state
                             || status.agent_report.is_some()
+                            || status.last_resize.is_some_and(|t| now >= t + RESIZE_GRACE)
                             || (status.state == State::Working
                                 && now.saturating_duration_since(status.last_activity)
                                     < ACTIVITY_WINDOW + QUIET_DWELL)
@@ -1285,6 +1486,7 @@ impl App {
                 {
                     continue;
                 }
+                s.last_resize = None;
                 // The done-latch and working history track the *raw* reading.
                 if s.prev_working && det.state == State::Idle && !focused {
                     s.done = true;
@@ -1883,7 +2085,7 @@ impl App {
             "pane.processes" => {
                 reject_api_fields(p, &["pane"])?;
                 let id = self.resolve_pane(p).ok_or_else(not_found)?;
-                self.request_proc_scan_if_unobserved(id);
+                self.request_proc_scan_if_stale(id);
                 Ok(self.pane_processes(id))
             }
             "pane.report_session" => {
@@ -4622,8 +4824,8 @@ impl App {
         })
     }
 
-    /// Cached process identity for a pane. Callers that need a first observation
-    /// queue `request_proc_scan_if_unobserved` first; this getter itself does no
+    /// Cached process identity for a pane. Callers that need a first or refreshed
+    /// observation queue `request_proc_scan_if_stale`; this getter itself does no
     /// IO and returns executable names rather than full argv, which may contain
     /// credentials or prompts.
     pub(crate) fn pane_processes(&self, id: PaneId) -> Value {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -273,6 +273,38 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn process_api_demand_retries_when_inflight_snapshot_omits_requested_pane() {
+        let (_env, mut app) = app("inflight-process-api-missing-pane");
+        let pane = app.layout().focus;
+        let now = Instant::now();
+        app.proc_commands.insert(pane, vec!["cached-shell".into()]);
+        app.runtime_cwd_dirty = false;
+        app.runtime_proc_dirty = true;
+        app.runtime_sessions_dirty = false;
+        app.last_proc_at = now - PROC_SCAN_INTERVAL;
+
+        app.detect_tick_with(now, true);
+        assert!(app.proc_scan_inflight, "the ordinary dirty scan starts");
+        app.request_proc_scan_if_stale(pane);
+
+        app.apply_proc_scan(Some(HashMap::new()));
+
+        assert!(
+            app.proc_scan_requested,
+            "an older snapshot must not consume a later pane request"
+        );
+        assert!(app.proc_scan_requested_panes.contains(&pane));
+        assert!(
+            !app.proc_scan_due(now, false),
+            "the follow-up must not hot-loop immediately"
+        );
+        assert!(
+            app.proc_scan_due(now + PROC_SCAN_INTERVAL, false),
+            "the throttled follow-up eventually becomes due"
+        );
+    }
+
+    #[test]
     fn failed_demanded_process_scan_rearms_without_an_idle_heartbeat() {
         let (_env, mut app) = app("failed-process-demand");
         let now = Instant::now();
@@ -287,6 +319,7 @@ mod socket_api_tests {
         app.last_detection_audit_at = now;
         app.last_proc_at = now - PROC_SCAN_INTERVAL;
         app.proc_scan_requested = true;
+        app.proc_scan_failure_retries = PROC_SCAN_FAILURE_RETRIES;
 
         app.detect_tick_with(now, false);
         assert!(app.proc_scan_inflight);
@@ -298,6 +331,15 @@ mod socket_api_tests {
             app.next_runtime_deadline(now, false),
             Some(now + PROC_SCAN_INTERVAL),
             "the retry remains throttled instead of hot-looping"
+        );
+
+        let retry_at = now + PROC_SCAN_INTERVAL;
+        app.detect_tick_with(retry_at, false);
+        assert!(app.proc_scan_inflight, "the one bounded retry starts");
+        app.apply_proc_scan(None);
+        assert!(
+            !app.proc_scan_requested,
+            "a persistent failure must not create an idle polling loop"
         );
     }
 
@@ -1046,11 +1088,10 @@ impl App {
             return;
         }
         self.runtime_proc_dirty = false;
-        if self.proc_scan_requested {
-            self.proc_scan_failure_retries = PROC_SCAN_FAILURE_RETRIES;
-        }
         self.proc_scan_demand_inflight = self.proc_scan_requested;
         self.proc_scan_requested = false;
+        self.proc_scan_demand_panes_inflight
+            .extend(std::mem::take(&mut self.proc_scan_requested_panes));
         self.last_proc_at = now;
         self.proc_scan_inflight = true;
         let pids: Vec<u32> = self
@@ -1070,9 +1111,11 @@ impl App {
 
     pub(crate) fn request_proc_scan_if_stale(&mut self, id: PaneId) {
         if self.proc_scan_inflight {
-            // Treat the current snapshot as satisfying this request, but retain
-            // one bounded retry if the worker cannot obtain usable evidence.
+            // The snapshot may have captured its pid list before this pane
+            // existed. Track the exact pane so a successful-but-older result
+            // cannot consume its demand without usable evidence.
             self.proc_scan_demand_inflight = true;
+            self.proc_scan_demand_panes_inflight.insert(id);
             self.proc_scan_failure_retries = PROC_SCAN_FAILURE_RETRIES;
             return;
         }
@@ -1080,6 +1123,7 @@ impl App {
             return;
         }
         self.proc_scan_requested = true;
+        self.proc_scan_requested_panes.insert(id);
         self.proc_scan_failure_retries = PROC_SCAN_FAILURE_RETRIES;
         self.start_proc_scan(Instant::now());
     }
@@ -1105,6 +1149,8 @@ impl App {
                 self.runtime_proc_dirty = false;
                 self.proc_scan_demand_inflight = self.proc_scan_requested;
                 self.proc_scan_requested = false;
+                self.proc_scan_demand_panes_inflight
+                    .extend(std::mem::take(&mut self.proc_scan_requested_panes));
                 self.last_proc_at = now;
                 self.proc_scan_inflight = true;
             }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -15,6 +15,10 @@ pub(crate) const MAX_AGENT_START_ARGS: usize = 64;
 const AGENT_PROMPT_QUIET: Duration = Duration::from_millis(1200);
 const DETECTION_INTERVAL: Duration = Duration::from_millis(100);
 const DETECTION_AUDIT_INTERVAL: Duration = Duration::from_secs(2);
+const CWD_SCAN_INTERVAL: Duration = Duration::from_secs(1);
+const PROC_SCAN_INTERVAL: Duration = Duration::from_secs(2);
+const SESSION_SCAN_INTERVAL: Duration = Duration::from_secs(4);
+const WAIT_RETEST_INTERVAL: Duration = Duration::from_millis(100);
 
 /// A parked `wait.output` request (docs/81): reply when the pane's recent
 /// output contains `needle`, or the optional deadline passes.
@@ -59,6 +63,79 @@ mod socket_api_tests {
             app.needs_fast_runtime_tick(now),
             "an in-flight state dwell retains the fast cadence"
         );
+    }
+
+    #[test]
+    fn quiet_runtime_has_no_loop_deadline() {
+        let (_env, mut app) = app("quiet-runtime-deadline");
+        let now = Instant::now();
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.candidate = status.state;
+            status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+        }
+        app.runtime_cwd_dirty = false;
+        app.runtime_proc_dirty = false;
+        app.runtime_sessions_dirty = false;
+        assert_eq!(
+            app.next_runtime_deadline(now, true),
+            None,
+            "a quiet attached fleet must not wake the loop on a timer"
+        );
+        assert_eq!(
+            app.next_runtime_deadline(now, false),
+            None,
+            "a quiet detached server must block on the event channel"
+        );
+
+        let until = now + Duration::from_secs(2);
+        app.toast = Some(("copied".into(), until));
+        assert_eq!(app.next_runtime_deadline(now, true), Some(until));
+        app.toast = None;
+
+        for status in app.status.values_mut() {
+            status.last_resize = Some(now - RESIZE_GRACE - Duration::from_millis(1));
+        }
+        assert_eq!(
+            app.next_runtime_deadline(now, true),
+            None,
+            "an expired resize grace must not become a 1ms loop timeout"
+        );
+
+        let resized = now;
+        app.last_detect_at = now;
+        for status in app.status.values_mut() {
+            status.last_resize = Some(resized);
+        }
+        let deadline = app
+            .next_runtime_deadline(now, true)
+            .expect("a live resize grace must keep a future loop deadline");
+        assert!(deadline > now);
+        assert!(deadline <= now + RESIZE_GRACE);
+    }
+
+    #[test]
+    fn detached_runtime_skips_heartbeat_scans() {
+        let (_env, mut app) = app("detached-heartbeat-scans");
+        let now = Instant::now();
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.candidate = status.state;
+            status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+        }
+        app.runtime_cwd_dirty = true;
+        app.runtime_proc_dirty = true;
+        app.runtime_sessions_dirty = true;
+        app.last_cwd_at = now - Duration::from_secs(10);
+        app.last_proc_at = now - Duration::from_secs(10);
+        app.last_sessions_at = now - Duration::from_secs(10);
+        app.detect_tick_with(now, false);
+        assert!(app.cwd_scan_inflight == false, "detached cwd scan");
+        assert!(app.proc_scan_inflight == false, "detached proc scan");
+        assert!(app.sessions_scan_inflight == false, "detached session scan");
+        assert!(app.runtime_cwd_dirty);
+        assert!(app.runtime_proc_dirty);
+        assert!(app.runtime_sessions_dirty);
     }
 
     #[test]
@@ -578,21 +655,14 @@ fn blocking_hint(bottom: &str) -> Option<String> {
 }
 
 impl App {
-    /// Whether the server loop must retain its 100 ms runtime cadence.
+    /// Whether any parked or detection work still has a near-term deadline.
     ///
-    /// Quiet panes do not need a 33 ms poll. Fresh output, an in-flight
-    /// classification dwell, an expiring integration lease, or a parked API
-    /// workflow does: these paths have user-visible deadlines and keep the
-    /// existing detection latency until the scheduler can sleep again.
+    /// Idle prompt redraws do not keep the 100 ms cadence. Working panes still
+    /// do until `ACTIVITY_WINDOW + QUIET_DWELL` elapses, as do in-flight dwells,
+    /// integration leases, and parked API waits.
+    #[cfg(test)]
     pub(crate) fn needs_fast_runtime_tick(&self, now: Instant) -> bool {
-        let detection_active = self.status.values().any(|status| {
-            status.force_detect
-                || status.candidate != status.state
-                || status.agent_report.is_some()
-                || now.saturating_duration_since(status.last_activity)
-                    < ACTIVITY_WINDOW + QUIET_DWELL
-        });
-        detection_active
+        self.detection_work_pending(now)
             || !self.output_waits.is_empty()
             || !self.agent_waits.is_empty()
             || !self.agent_starts.is_empty()
@@ -602,32 +672,159 @@ impl App {
             || self.search_flash.is_some()
     }
 
-    /// Recompute every pane's agent state. Cheap; called a few times a second.
-    /// Returns whether anything the sidebar shows changed, so the loop repaints a
-    /// silent agent's Working→Done transition even when no other event fires.
-    pub fn detect_tick(&mut self, now: Instant) -> bool {
-        // No node open (docs/43 §3.3 — the session was closed). Closing the last
-        // node also closed every pane, so there is nothing to classify, and
-        // `layout()` below would index an empty `workspaces`. The server keeps
-        // ticking here with no clients attached, so this is a live path, not a
-        // theoretical one.
-        if self.workspaces.is_empty() {
-            return false;
+    fn detection_work_pending(&self, now: Instant) -> bool {
+        !self.detection_dirty.is_empty()
+            || self.status.values().any(|status| {
+                status.force_detect
+                    || status.candidate != status.state
+                    || status.agent_report.is_some()
+                    || status
+                        .last_resize
+                        .is_some_and(|t| now.duration_since(t) < RESIZE_GRACE)
+                    || (status.state == State::Working
+                        && now.saturating_duration_since(status.last_activity)
+                            < ACTIVITY_WINDOW + QUIET_DWELL)
+            })
+    }
+
+    fn detection_audit_needed(&self) -> bool {
+        !self.detection_dirty.is_empty()
+            || self.status.values().any(|status| {
+                status.force_detect
+                    || status.candidate != status.state
+                    || status.agent_report.is_some()
+                    || matches!(status.state, State::Working | State::Blocked)
+            })
+    }
+
+    pub(crate) fn mark_runtime_scans_dirty(&mut self) {
+        self.runtime_cwd_dirty = true;
+        self.runtime_proc_dirty = true;
+        self.runtime_sessions_dirty = true;
+    }
+
+    pub(crate) fn sooner_deadline(slot: &mut Option<Instant>, candidate: Instant) {
+        *slot = Some(match *slot {
+            Some(current) => current.min(candidate),
+            None => candidate,
+        });
+    }
+
+    /// Next Instant the event loop must wake if no `AppEvent` arrives.
+    /// `None` means block on the channel: PTY, API, client, and signals wake it.
+    /// Past Instants are not kept as a 1ms spin: expired resize grace must drop
+    /// out, while work that is already due wakes this iteration (`now`).
+    pub(crate) fn next_runtime_deadline(
+        &self,
+        now: Instant,
+        clients_attached: bool,
+    ) -> Option<Instant> {
+        let mut deadline = None;
+        let mut consider = |candidate: Instant, due: bool| {
+            if candidate > now {
+                Self::sooner_deadline(&mut deadline, candidate);
+            } else if due {
+                Self::sooner_deadline(&mut deadline, now);
+            }
+        };
+
+        if let Some((_, exp)) = self.toast {
+            consider(exp, true);
         }
-        // Refresh working directories ~once a second so spaces follow the user.
-        // The file-viewer upkeep rides the same 1s cadence — sub-second freshness
-        // buys nothing (a node switch or an on-disk edit showing within a second
-        // is fine) and 10x/s stats + allocs would be wasted work on the loop.
-        if now.duration_since(self.last_cwd_at) >= Duration::from_secs(1) && !self.cwd_scan_inflight
+        if let Some(flash) = self.search_flash.as_ref() {
+            consider(flash.until, true);
+        }
+        if let Some(exp) = self.bar.notifications.iter().map(|n| n.expires_at).min() {
+            consider(exp, true);
+        }
+
+        if self.detection_work_pending(now) {
+            consider(self.last_detect_at + DETECTION_INTERVAL, true);
+        }
+        if self.detection_audit_needed() {
+            consider(
+                self.last_detection_audit_at + DETECTION_AUDIT_INTERVAL,
+                false,
+            );
+        }
+        for status in self.status.values() {
+            if status.candidate != status.state {
+                consider(
+                    status.candidate_since + commit_dwell(status.candidate),
+                    true,
+                );
+            }
+            if let Some(report) = status.agent_report.as_ref() {
+                consider(report.expires_at, true);
+            }
+            if let Some(resized) = status.last_resize {
+                consider(resized + RESIZE_GRACE, false);
+            }
+            if status.state == State::Working {
+                consider(status.last_activity + ACTIVITY_WINDOW + QUIET_DWELL, false);
+            }
+        }
+
+        if !self.output_waits.is_empty() {
+            consider(self.last_output_wait_scan + WAIT_RETEST_INTERVAL, true);
+            for waiter in self.output_waits.values().flatten() {
+                if let Some(exp) = waiter.deadline {
+                    consider(exp, true);
+                }
+            }
+        }
+        for waiter in self.agent_waits.values().flatten() {
+            consider(waiter.deadline, true);
+        }
+        for start in self.agent_starts.values() {
+            consider(start.deadline, true);
+        }
+        for prompt in self.agent_prompts.values().flatten() {
+            consider(prompt.deadline, true);
+            if prompt.saw_output {
+                consider(prompt.last_output_at + AGENT_PROMPT_QUIET, true);
+            }
+        }
+        if !self.backend_revision_waits.is_empty() {
+            consider(self.last_backend_wait_scan + WAIT_RETEST_INTERVAL, true);
+            if let Some(exp) = self.next_backend_revision_deadline() {
+                consider(exp, true);
+            }
+        }
+
+        if clients_attached {
+            if self.runtime_cwd_dirty && !self.cwd_scan_inflight {
+                consider(self.last_cwd_at + CWD_SCAN_INTERVAL, false);
+            }
+            if self.runtime_proc_dirty && !self.proc_scan_inflight {
+                consider(self.last_proc_at + PROC_SCAN_INTERVAL, false);
+            }
+            if self.runtime_sessions_dirty && !self.sessions_scan_inflight {
+                consider(self.last_sessions_at + SESSION_SCAN_INTERVAL, false);
+            }
+        }
+
+        deadline
+    }
+
+    fn schedule_runtime_scans(&mut self, now: Instant, clients_attached: bool) {
+        if !clients_attached {
+            return;
+        }
+        // CWD/git follow the user after PTY activity, throttled to 1s. Quiet
+        // panes do not spawn a worker or walk process trees.
+        if self.runtime_cwd_dirty
+            && !self.cwd_scan_inflight
+            && now.duration_since(self.last_cwd_at) >= CWD_SCAN_INTERVAL
         {
+            self.runtime_cwd_dirty = false;
             self.last_cwd_at = now;
             self.cwd_scan_inflight = true;
-            // Agent identity keeps its independent two-second cadence, but
-            // when its deadline lands on this CWD scan both projections share
-            // one OS process-table snapshot.
-            let include_processes = now.duration_since(self.last_proc_at) >= Duration::from_secs(2)
-                && !self.proc_scan_inflight;
+            let include_processes = self.runtime_proc_dirty
+                && !self.proc_scan_inflight
+                && now.duration_since(self.last_proc_at) >= PROC_SCAN_INTERVAL;
             if include_processes {
+                self.runtime_proc_dirty = false;
                 self.last_proc_at = now;
                 self.proc_scan_inflight = true;
             }
@@ -677,14 +874,12 @@ impl App {
             // Live-refresh open file views whose file changed on disk (FILE-5).
             self.ensure_file_views();
         }
-        // Rescan the agents' session stores a little less often. The scan is
-        // filesystem work that grows with on-disk history, so it runs on a
-        // worker thread and posts `SessionsScanned` back — never inline here
-        // (this tick is on the render-critical event loop). `inflight` stops
-        // scans from piling up if one is ever slower than the interval.
-        if now.duration_since(self.last_sessions_at) >= Duration::from_secs(4)
+        // Resumable-session disk scans run on attach/demand, not a 4s walk.
+        if self.runtime_sessions_dirty
             && !self.sessions_scan_inflight
+            && now.duration_since(self.last_sessions_at) >= SESSION_SCAN_INTERVAL
         {
+            self.runtime_sessions_dirty = false;
             self.last_sessions_at = now;
             self.sessions_scan_inflight = true;
             let tx = self.app_tx.clone();
@@ -692,14 +887,13 @@ impl App {
                 let _ = tx.send(AppEvent::SessionsScanned(crate::agent::recent_sessions(12)));
             });
         }
-        // Identity comes from the pane's *processes* (docs/07), which means a `ps`
-        // scan — a subprocess spawn, so it runs on a worker thread and posts
-        // `ProcScanned` back. Never inline: this tick is on the render-critical
-        // loop. 2s is well inside the human-visible window for "an agent started"
-        // while costing one `ps` for all panes, not one per pane.
-        if now.duration_since(self.last_proc_at) >= Duration::from_secs(2)
+        // Identity comes from the pane's *processes* (docs/07). One `ps` covers
+        // every pane; it runs only after PTY activity, never as a heartbeat.
+        if self.runtime_proc_dirty
             && !self.proc_scan_inflight
+            && now.duration_since(self.last_proc_at) >= PROC_SCAN_INTERVAL
         {
+            self.runtime_proc_dirty = false;
             self.last_proc_at = now;
             self.proc_scan_inflight = true;
             let pids: Vec<u32> = self
@@ -716,6 +910,25 @@ impl App {
                 let _ = tx.send(AppEvent::ProcScanned(found));
             });
         }
+    }
+
+    /// Recompute every pane's agent state. Cheap; called when the loop wakes.
+    /// Returns whether anything the sidebar shows changed, so the loop repaints a
+    /// silent agent's Working→Done transition even when no other event fires.
+    pub fn detect_tick(&mut self, now: Instant) -> bool {
+        self.detect_tick_with(now, true)
+    }
+
+    pub(crate) fn detect_tick_with(&mut self, now: Instant, clients_attached: bool) -> bool {
+        // No node open (docs/43 §3.3 — the session was closed). Closing the last
+        // node also closed every pane, so there is nothing to classify, and
+        // `layout()` below would index an empty `workspaces`. The server keeps
+        // ticking here with no clients attached, so this is a live path, not a
+        // theoretical one.
+        if self.workspaces.is_empty() {
+            return false;
+        }
+        self.schedule_runtime_scans(now, clients_attached);
         // Mission Control usage is demand-driven. Opening/focusing the dashboard,
         // changing scope, or pressing/clicking refresh queues one worker scan;
         // merely retaining a hidden mission tab performs no usage IO.
@@ -794,8 +1007,8 @@ impl App {
         let focus = self.layout().focus;
         self.detection_dirty
             .retain(|id| self.panes.contains_key(id));
-        let full_audit =
-            now.duration_since(self.last_detection_audit_at) >= DETECTION_AUDIT_INTERVAL;
+        let full_audit = self.detection_audit_needed()
+            && now.duration_since(self.last_detection_audit_at) >= DETECTION_AUDIT_INTERVAL;
         if full_audit {
             self.last_detection_audit_at = now;
             self.detection_full_fleet_audits = self.detection_full_fleet_audits.saturating_add(1);

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -171,6 +171,23 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn process_api_scans_without_a_tui() {
+        let (_env, mut app) = app("process-api-demand");
+        let pane = app.layout().focus;
+        app.proc_commands.clear();
+        app.proc_scan_inflight = false;
+        app.runtime_proc_dirty = false;
+        let result = app
+            .dispatch("pane.processes", &json!({"pane": pane.0}))
+            .unwrap();
+        assert_eq!(result["scan"], "unavailable");
+        assert!(
+            app.proc_scan_inflight,
+            "UHP process inspection must scan without a TUI attached"
+        );
+    }
+
+    #[test]
     fn detection_considers_changed_panes_between_bounded_audits() {
         let (_env, mut app) = app("dirty-pane-detection");
         let pane = app.layout().focus;
@@ -841,6 +858,35 @@ impl App {
         deadline
     }
 
+    fn start_proc_scan(&mut self) {
+        if self.proc_scan_inflight {
+            return;
+        }
+        self.runtime_proc_dirty = false;
+        self.last_proc_at = Instant::now();
+        self.proc_scan_inflight = true;
+        let pids: Vec<u32> = self
+            .panes
+            .values()
+            .filter_map(|p| {
+                let pid = p.child_pid.load(std::sync::atomic::Ordering::SeqCst);
+                (pid != 0).then_some(pid)
+            })
+            .collect();
+        let tx = self.app_tx.clone();
+        std::thread::spawn(move || {
+            let found = crate::platform::descendant_commands(&pids);
+            let _ = tx.send(AppEvent::ProcScanned(found));
+        });
+    }
+
+    pub(crate) fn request_proc_scan_if_unobserved(&mut self, id: PaneId) {
+        if self.proc_commands.contains_key(&id) {
+            return;
+        }
+        self.start_proc_scan();
+    }
+
     fn schedule_runtime_scans(&mut self, now: Instant, clients_attached: bool) {
         if !clients_attached {
             return;
@@ -923,26 +969,8 @@ impl App {
         }
         // Identity comes from the pane's *processes* (docs/07). One `ps` covers
         // every pane; it runs only after PTY activity, never as a heartbeat.
-        if self.runtime_proc_dirty
-            && !self.proc_scan_inflight
-            && now.duration_since(self.last_proc_at) >= PROC_SCAN_INTERVAL
-        {
-            self.runtime_proc_dirty = false;
-            self.last_proc_at = now;
-            self.proc_scan_inflight = true;
-            let pids: Vec<u32> = self
-                .panes
-                .values()
-                .filter_map(|p| {
-                    let pid = p.child_pid.load(std::sync::atomic::Ordering::SeqCst);
-                    (pid != 0).then_some(pid)
-                })
-                .collect();
-            let tx = self.app_tx.clone();
-            std::thread::spawn(move || {
-                let found = crate::platform::descendant_commands(&pids);
-                let _ = tx.send(AppEvent::ProcScanned(found));
-            });
+        if self.runtime_proc_dirty && now.duration_since(self.last_proc_at) >= PROC_SCAN_INTERVAL {
+            self.start_proc_scan();
         }
     }
 
@@ -1855,6 +1883,7 @@ impl App {
             "pane.processes" => {
                 reject_api_fields(p, &["pane"])?;
                 let id = self.resolve_pane(p).ok_or_else(not_found)?;
+                self.request_proc_scan_if_unobserved(id);
                 Ok(self.pane_processes(id))
             }
             "pane.report_session" => {
@@ -4593,10 +4622,10 @@ impl App {
         })
     }
 
-    /// Cached process identity for a pane. The process scan already runs once
-    /// for all panes off-loop; this endpoint does no spawn or filesystem IO and
-    /// deliberately returns executable names rather than full argv, which may
-    /// contain credentials or prompts.
+    /// Cached process identity for a pane. Callers that need a first observation
+    /// queue `request_proc_scan_if_unobserved` first; this getter itself does no
+    /// IO and returns executable names rather than full argv, which may contain
+    /// credentials or prompts.
     pub(crate) fn pane_processes(&self, id: PaneId) -> Value {
         let runtime = self
             .panes

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -130,9 +130,9 @@ mod socket_api_tests {
         app.last_proc_at = now - Duration::from_secs(10);
         app.last_sessions_at = now - Duration::from_secs(10);
         app.detect_tick_with(now, false);
-        assert!(app.cwd_scan_inflight == false, "detached cwd scan");
-        assert!(app.proc_scan_inflight == false, "detached proc scan");
-        assert!(app.sessions_scan_inflight == false, "detached session scan");
+        assert!(!app.cwd_scan_inflight, "detached cwd scan");
+        assert!(!app.proc_scan_inflight, "detached proc scan");
+        assert!(!app.sessions_scan_inflight, "detached session scan");
         assert!(app.runtime_cwd_dirty);
         assert!(app.runtime_proc_dirty);
         assert!(app.runtime_sessions_dirty);

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -115,6 +115,38 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn overdue_blocked_audit_still_wakes_the_loop() {
+        let (_env, mut app) = app("blocked-audit-deadline");
+        let now = Instant::now();
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.state = State::Blocked;
+            status.candidate = State::Blocked;
+            status.last_activity = now - ACTIVITY_WINDOW - QUIET_DWELL - Duration::from_secs(1);
+            status.agent_report = None;
+            status.last_resize = None;
+        }
+        app.runtime_cwd_dirty = false;
+        app.runtime_proc_dirty = false;
+        app.runtime_sessions_dirty = false;
+        app.last_detection_audit_at = now - DETECTION_AUDIT_INTERVAL - Duration::from_millis(1);
+
+        app.last_detect_at = now;
+        let cooling = app
+            .next_runtime_deadline(now, true)
+            .expect("a quiet Blocked pane must not block the loop forever");
+        assert!(cooling > now);
+        assert!(cooling <= now + DETECTION_INTERVAL);
+
+        app.last_detect_at = now - DETECTION_INTERVAL;
+        assert_eq!(
+            app.next_runtime_deadline(now, true),
+            Some(now),
+            "an overdue Blocked audit must wake this iteration once detection can run"
+        );
+    }
+
+    #[test]
     fn detached_runtime_skips_heartbeat_scans() {
         let (_env, mut app) = app("detached-heartbeat-scans");
         let now = Instant::now();
@@ -742,10 +774,12 @@ impl App {
             consider(self.last_detect_at + DETECTION_INTERVAL, true);
         }
         if self.detection_audit_needed() {
-            consider(
-                self.last_detection_audit_at + DETECTION_AUDIT_INTERVAL,
-                false,
-            );
+            // Overdue audits must still wake the loop. Dropping a past Instant
+            // here would `recv()` forever on a quiet Blocked pane. Cap the wake
+            // at the next detection tick so this cannot busy-loop at 1 ms.
+            let audit_at = self.last_detection_audit_at + DETECTION_AUDIT_INTERVAL;
+            let detect_at = self.last_detect_at + DETECTION_INTERVAL;
+            consider(audit_at.max(detect_at), true);
         }
         for status in self.status.values() {
             if status.candidate != status.state {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -438,6 +438,8 @@ impl App {
                 if let Some(pane) = self.panes.get_mut(&id) {
                     pane.cwd = cwd;
                 }
+                self.runtime_cwd_dirty = true;
+                self.runtime_proc_dirty = true;
                 self.register_backend_terminal(id);
                 crate::logging::event(
                     crate::logging::EventKind::PaneOpen,
@@ -667,6 +669,8 @@ impl App {
                     s.last_activity = Instant::now();
                 }
                 self.detection_dirty.insert(id);
+                self.runtime_cwd_dirty = true;
+                self.runtime_proc_dirty = true;
                 // A parked `wait.output` for this pane just got new output to
                 // test against — resolve it on the same wake (docs/81).
                 self.check_output_waits(id);
@@ -999,7 +1003,8 @@ impl App {
             // Handled by the server loop; never reaches here at runtime.
             AppEvent::ClientConnected { .. }
             | AppEvent::ClientDetach { .. }
-            | AppEvent::ClientInput { .. } => false,
+            | AppEvent::ClientInput { .. }
+            | AppEvent::Shutdown => false,
             // Consumed by the pre-dispatch worker-result branch above.
             AppEvent::ThemeUninstalled { .. }
             | AppEvent::ConfigReloaded { .. }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1892,6 +1892,12 @@ pub struct App {
     /// Throttle for rescanning the agents' on-disk session stores.
     last_sessions_at: Instant,
     last_proc_at: Instant,
+    /// CWD/git follow-up is scheduled from PTY activity, not a 1s heartbeat.
+    runtime_cwd_dirty: bool,
+    /// Process-table identity is scheduled from PTY activity, not a 2s `ps`.
+    runtime_proc_dirty: bool,
+    /// Resumable-session disk scans run on attach/demand, not a 4s walk.
+    runtime_sessions_dirty: bool,
     /// Mission Control usage is demand-driven: opening/focusing the dashboard,
     /// changing its scope, or choosing refresh queues one off-loop scan. No
     /// usage reader runs merely because a hidden Mission Control tab exists.
@@ -2367,6 +2373,9 @@ impl App {
             mission_active_workspace: None,
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
+            runtime_cwd_dirty: false,
+            runtime_proc_dirty: false,
+            runtime_sessions_dirty: false,
             last_detect_at: Instant::now()
                 .checked_sub(Duration::from_secs(1))
                 .unwrap_or_else(Instant::now),
@@ -2986,6 +2995,9 @@ impl App {
             mission_active_workspace: None,
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
+            runtime_cwd_dirty: false,
+            runtime_proc_dirty: false,
+            runtime_sessions_dirty: false,
             last_detect_at: Instant::now()
                 .checked_sub(Duration::from_secs(1))
                 .unwrap_or_else(Instant::now),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1887,6 +1887,15 @@ pub struct App {
     pub(crate) proc_commands: HashMap<PaneId, Vec<String>>,
     /// One process scan at a time, same guard as the session scan.
     proc_scan_inflight: bool,
+    /// A one-shot process scan explicitly requested by an API or by the first
+    /// confirmed absence of a bound agent. Unlike PTY dirtiness, this demand
+    /// survives detach and is consumed only by a successful scan.
+    proc_scan_requested: bool,
+    /// Whether the in-flight worker consumed an explicit one-shot demand.
+    proc_scan_demand_inflight: bool,
+    /// Remaining retries after a demanded worker cannot read the process table.
+    /// Bounded so a persistent platform failure cannot become an idle heartbeat.
+    proc_scan_failure_retries: u8,
     /// Session ids the user removed from the sidebar list (hidden, not deleted).
     pub dismissed_sessions: HashSet<String>,
     /// Throttle for rescanning the agents' on-disk session stores.
@@ -1894,7 +1903,7 @@ pub struct App {
     last_proc_at: Instant,
     /// CWD/git follow-up is scheduled from PTY activity, not a 1s heartbeat.
     runtime_cwd_dirty: bool,
-    /// Process-table identity is scheduled from PTY activity, not a 2s `ps`.
+    /// Attached PTY activity dirties process identity without creating a heartbeat.
     runtime_proc_dirty: bool,
     /// Resumable-session disk scans run on attach/demand, not a 4s walk.
     runtime_sessions_dirty: bool,
@@ -2367,6 +2376,9 @@ impl App {
             sessions_scan_inflight: false,
             proc_commands: HashMap::new(),
             proc_scan_inflight: false,
+            proc_scan_requested: false,
+            proc_scan_demand_inflight: false,
+            proc_scan_failure_retries: 0,
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
             mission_usage_requested: None,
@@ -2510,6 +2522,7 @@ impl App {
         // previous server run, so rebind/clear them (same as `from_snapshot`).
         app.orch_reconcile();
         app.refresh_core_bar_widgets();
+        app.mark_runtime_scans_dirty();
         Ok(app)
     }
 
@@ -2519,6 +2532,7 @@ impl App {
             if let Some(mut app) = App::from_snapshot(snap, app_tx.clone()) {
                 // Kick off the async fetch for any restored git tabs.
                 app.refetch_git_tabs();
+                app.mark_runtime_scans_dirty();
                 return Ok(app);
             }
         }
@@ -2989,6 +3003,9 @@ impl App {
             sessions_scan_inflight: false,
             proc_commands: HashMap::new(),
             proc_scan_inflight: false,
+            proc_scan_requested: false,
+            proc_scan_demand_inflight: false,
+            proc_scan_failure_retries: 0,
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
             mission_usage_requested: None,
@@ -5369,7 +5386,19 @@ impl App {
     /// agent back to text-only detection.
     pub(crate) fn apply_proc_scan(&mut self, found: Option<HashMap<u32, Vec<String>>>) -> bool {
         self.proc_scan_inflight = false;
-        let Some(by_pid) = found else { return false };
+        let demand_inflight = std::mem::take(&mut self.proc_scan_demand_inflight);
+        let Some(by_pid) = found else {
+            if demand_inflight && self.proc_scan_failure_retries > 0 {
+                self.proc_scan_failure_retries -= 1;
+                self.proc_scan_requested = true;
+            } else {
+                self.proc_scan_failure_retries = 0;
+            }
+            return false;
+        };
+        if demand_inflight {
+            self.proc_scan_failure_retries = 0;
+        }
         let mut next: HashMap<PaneId, Vec<String>> = HashMap::new();
         for (id, pane) in self.panes.iter() {
             let pid = pane.child_pid.load(std::sync::atomic::Ordering::SeqCst);
@@ -5404,6 +5433,8 @@ impl App {
 
             st.agent_absent_scans = st.agent_absent_scans.saturating_add(1);
             if st.agent_absent_scans < 2 {
+                self.proc_scan_requested = true;
+                self.proc_scan_failure_retries = dispatch::PROC_SCAN_FAILURE_RETRIES;
                 continue;
             }
 
@@ -7570,12 +7601,30 @@ mod tests {
         // One shell-only observation is not enough: an agent may be starting or
         // re-execing. Seeing it again resets the exit candidate, even when a
         // different recognised agent appears earlier in the same process tree.
+        let first_absence_at = Instant::now();
+        app.last_proc_at = first_absence_at;
         assert!(
             !app.apply_proc_scan(scan(&[&shell])),
             "the first missing scan only updates the process cache"
         );
         assert!(app.status.get(&id).unwrap().agent_session.is_some());
         assert_eq!(app.status.get(&id).unwrap().agent_absent_scans, 1);
+        assert!(
+            app.proc_scan_requested,
+            "the first confirmed absence queues exactly one follow-up scan"
+        );
+        for status in app.status.values_mut() {
+            status.force_detect = false;
+            status.candidate = status.state;
+            status.last_activity = first_absence_at - Duration::from_secs(60);
+        }
+        app.last_detection_audit_at = first_absence_at;
+        let follow_up = app
+            .next_runtime_deadline(first_absence_at, false)
+            .expect("the follow-up scan must wake a detached server");
+        assert!(follow_up > first_absence_at);
+        assert!(follow_up <= first_absence_at + Duration::from_secs(2));
+        app.proc_scan_requested = false;
         assert!(
             !app.apply_proc_scan(scan(&[&shell, "codex", "claude"])),
             "seeing the bound agent again does not change visible lifecycle state"
@@ -7589,6 +7638,11 @@ mod tests {
         app.session_dirty = false;
         assert!(!app.handle_event(AppEvent::ProcScanned(scan(&[&shell]))));
         assert!(app.status.get(&id).unwrap().agent_session.is_some());
+        assert!(
+            app.proc_scan_requested,
+            "the first absence re-arms confirmation"
+        );
+        app.proc_scan_requested = false;
         assert!(
             app.handle_event(AppEvent::ProcScanned(scan(&[&shell]))),
             "the confirmed exit dirties the sidebar through the event path"
@@ -11590,7 +11644,7 @@ mod tests {
     // burst must not flip an idle pane to a lingering "working". Detection is
     // frozen for `RESIZE_GRACE` after a resize, then resumes normally.
     #[test]
-    fn resize_grace_suppresses_a_transient_working_after_a_switch() {
+    fn resize_grace_expiry_wakes_and_reclassifies_once() {
         use crate::ui::theme::State;
         let _env = crate::persist::test_env("resize-grace");
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -11615,6 +11669,8 @@ mod tests {
             "a repaint right after a resize must not flip the pane to working"
         );
 
+        let considered = app.detection_panes_considered;
+
         // Past the grace window the same reading commits normally.
         let t1 = t0 + RESIZE_GRACE + std::time::Duration::from_millis(150);
         {
@@ -11622,13 +11678,19 @@ mod tests {
             s.last_activity = t1;
             s.last_input = t1 - std::time::Duration::from_secs(5);
         }
-        app.detection_dirty.insert(id);
+        assert_eq!(
+            app.next_runtime_deadline(t1, false),
+            Some(t1),
+            "expired resize grace is a due event even without a TUI"
+        );
         app.detect_tick(t1);
         assert_eq!(
             app.status.get(&id).unwrap().state,
             State::Working,
             "once the grid settles, a genuinely active pane reads working again"
         );
+        assert_eq!(app.status.get(&id).unwrap().last_resize, None);
+        assert_eq!(app.detection_panes_considered, considered + 1);
     }
 
     // docs/29: config with no `sidebars` migrates to today's default layout.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1893,8 +1893,16 @@ pub struct App {
     proc_scan_requested: bool,
     /// Whether the in-flight worker consumed an explicit one-shot demand.
     proc_scan_demand_inflight: bool,
-    /// Remaining retries after a demanded worker cannot read the process table.
-    /// Bounded so a persistent platform failure cannot become an idle heartbeat.
+    /// Panes whose explicit process request must be represented by the next
+    /// successful snapshot. Keeping the identities avoids treating an older
+    /// in-flight snapshot as satisfying a request for a newly created pane.
+    proc_scan_requested_panes: HashSet<PaneId>,
+    /// Requested panes assigned to the current process snapshot. Requests that
+    /// arrive while it runs join this set and are retried when absent.
+    proc_scan_demand_panes_inflight: HashSet<PaneId>,
+    /// Remaining retries after a demanded worker cannot read the process table
+    /// or its snapshot predates a requested pane. Bounded so a persistent
+    /// platform failure cannot become an idle heartbeat.
     proc_scan_failure_retries: u8,
     /// Session ids the user removed from the sidebar list (hidden, not deleted).
     pub dismissed_sessions: HashSet<String>,
@@ -2378,6 +2386,8 @@ impl App {
             proc_scan_inflight: false,
             proc_scan_requested: false,
             proc_scan_demand_inflight: false,
+            proc_scan_requested_panes: HashSet::new(),
+            proc_scan_demand_panes_inflight: HashSet::new(),
             proc_scan_failure_retries: 0,
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
@@ -3005,6 +3015,8 @@ impl App {
             proc_scan_inflight: false,
             proc_scan_requested: false,
             proc_scan_demand_inflight: false,
+            proc_scan_requested_panes: HashSet::new(),
+            proc_scan_demand_panes_inflight: HashSet::new(),
             proc_scan_failure_retries: 0,
             dismissed_sessions: HashSet::new(),
             last_sessions_at: Instant::now(),
@@ -5387,24 +5399,39 @@ impl App {
     pub(crate) fn apply_proc_scan(&mut self, found: Option<HashMap<u32, Vec<String>>>) -> bool {
         self.proc_scan_inflight = false;
         let demand_inflight = std::mem::take(&mut self.proc_scan_demand_inflight);
+        let demanded_panes = std::mem::take(&mut self.proc_scan_demand_panes_inflight);
         let Some(by_pid) = found else {
             if demand_inflight && self.proc_scan_failure_retries > 0 {
                 self.proc_scan_failure_retries -= 1;
                 self.proc_scan_requested = true;
+                self.proc_scan_requested_panes.extend(
+                    demanded_panes
+                        .into_iter()
+                        .filter(|id| self.panes.contains_key(id)),
+                );
             } else {
                 self.proc_scan_failure_retries = 0;
             }
             return false;
         };
-        if demand_inflight {
-            self.proc_scan_failure_retries = 0;
-        }
         let mut next: HashMap<PaneId, Vec<String>> = HashMap::new();
         for (id, pane) in self.panes.iter() {
             let pid = pane.child_pid.load(std::sync::atomic::Ordering::SeqCst);
             if let Some(cmds) = (pid != 0).then(|| by_pid.get(&pid)).flatten() {
                 next.insert(*id, cmds.clone());
             }
+        }
+        let missing_demanded_panes: Vec<PaneId> = demanded_panes
+            .into_iter()
+            .filter(|id| self.panes.contains_key(id) && !next.contains_key(id))
+            .collect();
+        if !missing_demanded_panes.is_empty() && self.proc_scan_failure_retries > 0 {
+            self.proc_scan_failure_retries -= 1;
+            self.proc_scan_requested = true;
+            self.proc_scan_requested_panes
+                .extend(missing_demanded_panes);
+        } else if demand_inflight {
+            self.proc_scan_failure_retries = 0;
         }
         let mut lifecycle_changed = false;
         for (id, cmds) in &next {

--- a/src/event.rs
+++ b/src/event.rs
@@ -346,5 +346,7 @@ pub enum AppEvent {
     },
     /// A termination signal arrived. The handler only writes a self-pipe; this
     /// event wakes a sleeping event loop so shutdown does not wait on a timer.
+    /// Windows has no POSIX signals; the detached server stops via `server stop`.
+    #[cfg_attr(not(unix), allow(dead_code))]
     Shutdown,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -344,4 +344,7 @@ pub enum AppEvent {
         reply: Sender<String>,
         cancelled: Arc<AtomicBool>,
     },
+    /// A termination signal arrived. The handler only writes a self-pipe; this
+    /// event wakes a sleeping event loop so shutdown does not wait on a timer.
+    Shutdown,
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1431,10 +1431,7 @@ mod shutdown {
             FLAG.store(true, Ordering::Relaxed);
             let fd = WRITE_FD.load(Ordering::Relaxed);
             if fd >= 0 {
-                let byte = 1u8;
-                unsafe {
-                    libc::write(fd, (&byte as *const u8).cast(), 1);
-                }
+                write_wake_preserving_errno(fd);
             }
         }
         unsafe {
@@ -1443,6 +1440,74 @@ mod shutdown {
             libc::signal(libc::SIGHUP, h);
             libc::signal(libc::SIGINT, h);
         }
+    }
+
+    fn write_wake_preserving_errno(fd: RawFd) {
+        let byte = 1u8;
+        unsafe {
+            let errno = errno_location();
+            let saved_errno = errno.as_ref().copied();
+            let _ = libc::write(fd, (&byte as *const u8).cast(), 1);
+            if let Some(saved_errno) = saved_errno {
+                *errno = saved_errno;
+            }
+        }
+    }
+
+    #[cfg(any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly"
+    ))]
+    unsafe fn errno_location() -> *mut libc::c_int {
+        libc::__error()
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "hurd", target_os = "redox"))]
+    unsafe fn errno_location() -> *mut libc::c_int {
+        libc::__errno_location()
+    }
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "nuttx"
+    ))]
+    unsafe fn errno_location() -> *mut libc::c_int {
+        libc::__errno()
+    }
+
+    #[cfg(any(target_os = "solaris", target_os = "illumos"))]
+    unsafe fn errno_location() -> *mut libc::c_int {
+        libc::___errno()
+    }
+
+    #[cfg(target_os = "aix")]
+    unsafe fn errno_location() -> *mut libc::c_int {
+        libc::_Errno()
+    }
+
+    // libc exposes no common errno accessor across every possible `unix`
+    // target. Unknown targets retain an async-signal-safe handler; null
+    // precisely disables save/restore instead of guessing an ABI symbol.
+    #[cfg(not(any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "linux",
+        target_os = "hurd",
+        target_os = "redox",
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "nuttx",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "aix"
+    )))]
+    unsafe fn errno_location() -> *mut libc::c_int {
+        std::ptr::null_mut()
     }
 
     fn set_cloexec(fd: RawFd) -> io::Result<()> {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -459,9 +459,17 @@ pub fn run() -> Result<()> {
                     Err(RecvTimeoutError::Disconnected) => break,
                 },
                 Some(_) => None,
-                None => match rx.recv() {
+                None if shutdown::wake_available() => match rx.recv() {
                     Ok(ev) => Some(ev),
                     Err(_) => break,
+                },
+                None => match rx.recv_timeout(Duration::from_secs(1)) {
+                    Ok(ev) => Some(ev),
+                    Err(RecvTimeoutError::Timeout) => {
+                        LOOP_DEADLINE_WAKES.fetch_add(1, Ordering::Relaxed);
+                        None
+                    }
+                    Err(RecvTimeoutError::Disconnected) => break,
                 },
             }
         };
@@ -523,7 +531,7 @@ pub fn run() -> Result<()> {
         // Closing the final project bypasses the debounce once. Failed writes
         // retain both flags and retry at the normal cadence instead of hot-looping.
         let immediate_save_due = app.persist_session_now && !immediate_save_attempted;
-        let debounced_save_due = app.session_dirty && last_save.elapsed() > SESSION_SAVE_DEBOUNCE;
+        let debounced_save_due = app.session_dirty && last_save.elapsed() >= SESSION_SAVE_DEBOUNCE;
         if immediate_save_due || debounced_save_due {
             immediate_save_attempted = app.persist_session_now;
             if persist::save(&app) {
@@ -1363,9 +1371,14 @@ mod shutdown {
 
     static FLAG: AtomicBool = AtomicBool::new(false);
     static WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+    static WAKE_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
     pub fn requested() -> bool {
         FLAG.load(Ordering::Relaxed)
+    }
+
+    pub fn wake_available() -> bool {
+        WAKE_AVAILABLE.load(Ordering::Relaxed)
     }
 
     pub fn install(tx: Sender<AppEvent>) {
@@ -1385,9 +1398,13 @@ mod shutdown {
         WRITE_FD.store(fds[1], Ordering::Relaxed);
         let read_fd = fds[0];
         install_handler();
-        let _ = thread::Builder::new()
+        if thread::Builder::new()
             .name("luvus-signal".into())
-            .spawn(move || wait_for_signal(read_fd, tx));
+            .spawn(move || wait_for_signal(read_fd, tx))
+            .is_ok()
+        {
+            WAKE_AVAILABLE.store(true, Ordering::Relaxed);
+        }
     }
 
     fn wait_for_signal(read_fd: RawFd, tx: Sender<AppEvent>) {
@@ -1455,6 +1472,11 @@ mod shutdown {
 
     pub fn requested() -> bool {
         false
+    }
+
+    pub fn wake_available() -> bool {
+        // Stop arrives as an API event, not a POSIX signal.
+        true
     }
 
     pub fn install(_tx: Sender<AppEvent>) {}

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -26,13 +26,7 @@ use crate::ui;
 const DEFAULT_SIZE: (u16, u16) = (120, 32);
 /// Minimum time between rendered frames — the fps cap during activity (60fps).
 const FRAME_INTERVAL: Duration = Duration::from_millis(16);
-/// A genuinely quiet server only needs a bounded maintenance/signalling audit.
-/// This is still short enough for clean signal shutdown while cutting idle
-/// timeout wakes by more than 80% compared with the former 33 ms poll.
-const IDLE_INTERVAL: Duration = Duration::from_millis(250);
-/// Detection hysteresis and parked API workflows retain their established
-/// 100 ms cadence while they have time-sensitive work.
-const FAST_IDLE_INTERVAL: Duration = Duration::from_millis(100);
+const SESSION_SAVE_DEBOUNCE: Duration = Duration::from_secs(2);
 
 fn frame_wait(elapsed_since_attempt: Duration) -> Duration {
     FRAME_INTERVAL
@@ -363,7 +357,7 @@ pub fn run() -> Result<()> {
     };
     app.events = events.clone();
     app.server_mode = true;
-    shutdown::install();
+    shutdown::install(tx.clone());
 
     let mut terminal_theme_enabled = app.config.theme == "terminal";
     let terminal_theme = Arc::new(AtomicBool::new(terminal_theme_enabled));
@@ -427,39 +421,62 @@ pub fn run() -> Result<()> {
     const REARM_INTERVAL: Duration = Duration::from_millis(100);
 
     loop {
-        // Pending + clients attached → wait only until the cap frees up (flush
-        // promptly); otherwise tick at the coarser idle cadence.
-        let wait = if render_request.needs_render() && !clients.is_empty() {
-            frame_wait(last_render_attempt.elapsed())
+        // Pending + clients attached → wait only until the cap frees up.
+        // Otherwise sleep until the next real deadline, or block on the
+        // channel when nothing is due (PTY/API/client/signal wake the loop).
+        let now = Instant::now();
+        let persist_due = (app.persist_session_now && !immediate_save_attempted)
+            || (app.session_dirty && last_save.elapsed() >= SESSION_SAVE_DEBOUNCE);
+        let rearm_due = app.has_pending_pty_output() && last_rearm.elapsed() >= REARM_INTERVAL;
+        let received = if persist_due || rearm_due {
+            // Already-due persist/re-arm must not `recv_timeout(0)`: that busy-loops
+            // until the 100ms re-arm cadence elapses.
+            None
+        } else if render_request.needs_render() && !clients.is_empty() {
+            match rx.recv_timeout(frame_wait(last_render_attempt.elapsed())) {
+                Ok(ev) => Some(ev),
+                Err(RecvTimeoutError::Timeout) => {
+                    LOOP_DEADLINE_WAKES.fetch_add(1, Ordering::Relaxed);
+                    None
+                }
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
         } else {
-            let mut idle = if app.needs_fast_runtime_tick(Instant::now()) {
-                FAST_IDLE_INTERVAL
-            } else {
-                IDLE_INTERVAL
-            };
+            let mut deadline = app.next_runtime_deadline(now, !clients.is_empty());
+            if app.session_dirty {
+                App::sooner_deadline(&mut deadline, last_save + SESSION_SAVE_DEBOUNCE);
+            }
             if app.has_pending_pty_output() {
-                idle = idle.min(REARM_INTERVAL.saturating_sub(last_rearm.elapsed()));
+                App::sooner_deadline(&mut deadline, last_rearm + REARM_INTERVAL);
             }
-            idle.max(Duration::from_millis(1))
+            match deadline.map(|at| at.saturating_duration_since(now)) {
+                Some(timeout) if !timeout.is_zero() => match rx.recv_timeout(timeout) {
+                    Ok(ev) => Some(ev),
+                    Err(RecvTimeoutError::Timeout) => {
+                        LOOP_DEADLINE_WAKES.fetch_add(1, Ordering::Relaxed);
+                        None
+                    }
+                    Err(RecvTimeoutError::Disconnected) => break,
+                },
+                Some(_) => None,
+                None => match rx.recv() {
+                    Ok(ev) => Some(ev),
+                    Err(_) => break,
+                },
+            }
         };
-        match rx.recv_timeout(wait) {
-            Ok(ev) => {
-                LOOP_EVENT_WAKES.fetch_add(1, Ordering::Relaxed);
-                let source = event_render_source(&app, &ev);
-                let changed = apply(
-                    ev,
-                    &mut app,
-                    &mut clients,
-                    &mut foreground,
-                    &mut interactive_size,
-                    &mut next_activity,
-                );
-                record_event_render_request(source, changed, &mut render_request);
-            }
-            Err(RecvTimeoutError::Timeout) => {
-                LOOP_DEADLINE_WAKES.fetch_add(1, Ordering::Relaxed);
-            }
-            Err(RecvTimeoutError::Disconnected) => break,
+        if let Some(ev) = received {
+            LOOP_EVENT_WAKES.fetch_add(1, Ordering::Relaxed);
+            let source = event_render_source(&app, &ev);
+            let changed = apply(
+                ev,
+                &mut app,
+                &mut clients,
+                &mut foreground,
+                &mut interactive_size,
+                &mut next_activity,
+            );
+            record_event_render_request(source, changed, &mut render_request);
         }
         while let Ok(ev) = rx.try_recv() {
             let source = event_render_source(&app, &ev);
@@ -506,7 +523,7 @@ pub fn run() -> Result<()> {
         // Closing the final project bypasses the debounce once. Failed writes
         // retain both flags and retry at the normal cadence instead of hot-looping.
         let immediate_save_due = app.persist_session_now && !immediate_save_attempted;
-        let debounced_save_due = app.session_dirty && last_save.elapsed() > Duration::from_secs(2);
+        let debounced_save_due = app.session_dirty && last_save.elapsed() > SESSION_SAVE_DEBOUNCE;
         if immediate_save_due || debounced_save_due {
             immediate_save_attempted = app.persist_session_now;
             if persist::save(&app) {
@@ -543,7 +560,7 @@ pub fn run() -> Result<()> {
         // A state transition here (e.g. a silent agent reaching Done) has no PtyData
         // to ride on, so repaint when detection reports a visible change.
         let now = Instant::now();
-        if app.detect_tick(now) {
+        if app.detect_tick_with(now, !clients.is_empty()) {
             render_request.record(RenderCause::Detection);
         }
         // Parked `wait.output` deadlines lapse on the tick (docs/81); a no-op
@@ -677,6 +694,7 @@ fn apply(
             );
             *foreground = Some(id);
             apply_foreground_theme(app, clients, *foreground);
+            app.mark_runtime_scans_dirty();
             true
         }
         AppEvent::ClientDetach { id } => {
@@ -1329,23 +1347,78 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
 }
 
 /// Graceful shutdown on a termination signal. The handler only flips an atomic
-/// flag (the only async-signal-safe thing to do); the event loop polls it every
-/// idle tick (≤250ms) and exits through the normal path — clients notified, the
-/// session saved — instead of dying mid-state on SIGTERM (logout, `kill`,
-/// system shutdown).
+/// and writes a self-pipe (async-signal-safe); a waiter thread then posts
+/// `AppEvent::Shutdown` so a sleeping event loop still exits through the normal
+/// path — clients notified, the session saved — instead of dying mid-state on
+/// SIGTERM (logout, `kill`, system shutdown).
 #[cfg(unix)]
 mod shutdown {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::io;
+    use std::os::fd::RawFd;
+    use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+    use std::sync::mpsc::Sender;
+    use std::thread;
+
+    use crate::event::AppEvent;
 
     static FLAG: AtomicBool = AtomicBool::new(false);
+    static WRITE_FD: AtomicI32 = AtomicI32::new(-1);
 
     pub fn requested() -> bool {
         FLAG.load(Ordering::Relaxed)
     }
 
-    pub fn install() {
+    pub fn install(tx: Sender<AppEvent>) {
+        let mut fds = [-1, -1];
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+            install_handler();
+            return;
+        }
+        if set_cloexec(fds[0]).is_err() || set_nonblocking_cloexec(fds[1]).is_err() {
+            unsafe {
+                libc::close(fds[0]);
+                libc::close(fds[1]);
+            }
+            install_handler();
+            return;
+        }
+        WRITE_FD.store(fds[1], Ordering::Relaxed);
+        let read_fd = fds[0];
+        install_handler();
+        let _ = thread::Builder::new()
+            .name("luvus-signal".into())
+            .spawn(move || wait_for_signal(read_fd, tx));
+    }
+
+    fn wait_for_signal(read_fd: RawFd, tx: Sender<AppEvent>) {
+        let mut buf = [0u8; 8];
+        loop {
+            let count = unsafe { libc::read(read_fd, buf.as_mut_ptr().cast(), buf.len()) };
+            if count > 0 {
+                FLAG.store(true, Ordering::Relaxed);
+                let _ = tx.send(AppEvent::Shutdown);
+                continue;
+            }
+            if count < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+            }
+            break;
+        }
+    }
+
+    fn install_handler() {
         extern "C" fn on_signal(_sig: libc::c_int) {
             FLAG.store(true, Ordering::Relaxed);
+            let fd = WRITE_FD.load(Ordering::Relaxed);
+            if fd >= 0 {
+                let byte = 1u8;
+                unsafe {
+                    libc::write(fd, (&byte as *const u8).cast(), 1);
+                }
+            }
         }
         unsafe {
             let h = on_signal as extern "C" fn(libc::c_int) as libc::sighandler_t;
@@ -1354,16 +1427,37 @@ mod shutdown {
             libc::signal(libc::SIGINT, h);
         }
     }
+
+    fn set_cloexec(fd: RawFd) -> io::Result<()> {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn set_nonblocking_cloexec(fd: RawFd) -> io::Result<()> {
+        set_cloexec(fd)?;
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
 }
 
 /// Windows: no POSIX signals; the detached server is stopped via `server stop`.
 #[cfg(not(unix))]
 mod shutdown {
+    use std::sync::mpsc::Sender;
+
+    use crate::event::AppEvent;
+
     pub fn requested() -> bool {
         false
     }
 
-    pub fn install() {}
+    pub fn install(_tx: Sender<AppEvent>) {}
 }
 
 #[cfg(test)]

--- a/src/module/runtime.rs
+++ b/src/module/runtime.rs
@@ -4,7 +4,7 @@
 //! `AppEvent::ModuleCommandFinished`. Fire-and-forget; the caller gets a
 //! `Running` log immediately.
 
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -187,6 +187,7 @@ fn read_capped<R: Read>(r: &mut R) -> String {
                     kept.extend_from_slice(&chunk[..take]);
                 }
             }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
             Err(_) => break,
         }
     }

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -9,7 +9,9 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Sender};
-use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(unix)]
+use std::sync::OnceLock;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use anyhow::Result;
@@ -24,9 +26,11 @@ use crate::terminal::vt::{create_engine, VtEngine, VtEngineKind};
 mod io;
 mod reaper;
 
-use reaper::register_child_reaper;
 #[cfg(test)]
-use reaper::{child_poll_finished, CHILD_REAPER_STARTS};
+use reaper::child_poll_finished;
+use reaper::register_child_reaper;
+#[cfg(all(test, unix))]
+use reaper::CHILD_REAPER_STARTS;
 
 fn terminate_spawned_child(child: &mut (dyn portable_pty::Child + Send + Sync)) {
     let _ = child.kill();
@@ -1218,22 +1222,12 @@ mod reap_tests {
     }
 
     #[test]
-    fn live_child_does_not_wake_the_reaper_on_a_clock() {
+    fn dropping_a_live_child_is_still_reaped() {
         let pane = spawn_sh();
         let pid = pane.child_pid.load(Ordering::SeqCst);
         assert_ne!(pid, 0);
         assert!(alive(pid));
-        // Let the reaper take the child and block on SIGCHLD / process wait.
         std::thread::sleep(std::time::Duration::from_millis(50));
-        let before = super::reaper::CHILD_REAPER_WAIT_RETURNS.load(Ordering::SeqCst);
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        let after = super::reaper::CHILD_REAPER_WAIT_RETURNS.load(Ordering::SeqCst);
-        assert_eq!(
-            after,
-            before,
-            "a live child woke the reaper {delta} extra times; that is a timer poll",
-            delta = after - before
-        );
         drop(pane);
         assert!(wait_gone(pid), "exit is still reaped without a timer");
     }

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -1,6 +1,6 @@
 //! PTY pane lifecycle. Unix panes use one poll-driven descriptor actor for
 //! ordered input and output; Windows keeps portable-pty's split reader/writer
-//! backend. Child waiting is shared process-wide.
+//! backend. Child waiting is one process-wide event-driven reaper.
 
 #[cfg(windows)]
 use std::io::Read;
@@ -8,10 +8,9 @@ use std::io::Read;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
-use std::time::Duration;
 
 use anyhow::Result;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
@@ -23,102 +22,15 @@ use crate::terminal::backend::TerminalRuntime;
 use crate::terminal::vt::{create_engine, VtEngine, VtEngineKind};
 
 mod io;
+mod reaper;
 
-const CHILD_REAPER_INTERVAL: Duration = Duration::from_millis(50);
-
-struct ReaperEntry {
-    id: PaneId,
-    child: Box<dyn portable_pty::Child + Send + Sync>,
-    child_exited: Arc<AtomicBool>,
-    app_tx: Sender<AppEvent>,
-}
-
-static CHILD_REAPER: OnceLock<Sender<ReaperEntry>> = OnceLock::new();
-
+use reaper::register_child_reaper;
 #[cfg(test)]
-static CHILD_REAPER_STARTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
-/// Hand a child to the process-wide reaper. Pane I/O remains isolated behind
-/// its platform backend, but waiting for child exit needs no per-pane thread:
-/// `try_wait` is non-blocking on every portable-pty backend.
-fn register_child_reaper(
-    id: PaneId,
-    child: Box<dyn portable_pty::Child + Send + Sync>,
-    child_exited: Arc<AtomicBool>,
-    app_tx: Sender<AppEvent>,
-) {
-    let reaper = CHILD_REAPER.get_or_init(|| {
-        let (tx, rx) = mpsc::channel();
-        thread::Builder::new()
-            .name("luvus-pty-reaper".to_string())
-            .spawn(move || child_reaper_loop(rx))
-            .expect("failed to start the PTY child reaper");
-        #[cfg(test)]
-        CHILD_REAPER_STARTS.fetch_add(1, Ordering::SeqCst);
-        tx
-    });
-    let entry = ReaperEntry {
-        id,
-        child,
-        child_exited,
-        app_tx,
-    };
-    if let Err(error) = reaper.send(entry) {
-        // A panic in the shared reaper must not leave an unreaped child. This
-        // fallback is deliberately exceptional; the normal path stays at one
-        // waiter thread for the whole server.
-        let mut entry = error.0;
-        let _ = thread::Builder::new()
-            .name("luvus-pty-reaper-fallback".to_string())
-            .spawn(move || {
-                let _ = entry.child.wait();
-                finish_child(entry);
-            });
-    }
-}
-
-fn child_reaper_loop(rx: Receiver<ReaperEntry>) {
-    let mut children = Vec::<ReaperEntry>::new();
-    loop {
-        let received = if children.is_empty() {
-            rx.recv().map_err(|_| RecvTimeoutError::Disconnected)
-        } else {
-            rx.recv_timeout(CHILD_REAPER_INTERVAL)
-        };
-        match received {
-            Ok(entry) => children.push(entry),
-            Err(RecvTimeoutError::Timeout) => {}
-            Err(RecvTimeoutError::Disconnected) => break,
-        }
-        children.extend(rx.try_iter());
-
-        let mut index = 0;
-        while index < children.len() {
-            if child_poll_finished(children[index].child.try_wait()) {
-                let entry = children.swap_remove(index);
-                finish_child(entry);
-            } else {
-                index += 1;
-            }
-        }
-    }
-}
-
-#[inline]
-fn child_poll_finished(result: std::io::Result<Option<portable_pty::ExitStatus>>) -> bool {
-    matches!(result, Ok(Some(_)))
-}
+use reaper::{child_poll_finished, CHILD_REAPER_STARTS};
 
 fn terminate_spawned_child(child: &mut (dyn portable_pty::Child + Send + Sync)) {
     let _ = child.kill();
     let _ = child.wait();
-}
-
-fn finish_child(entry: ReaperEntry) {
-    // Publish exit before notifying the app. If the app immediately drops the
-    // pane, `Drop` must not signal a PID that the operating system may reuse.
-    entry.child_exited.store(true, Ordering::SeqCst);
-    let _ = entry.app_tx.send(AppEvent::PtyExit(entry.id));
 }
 
 pub(crate) enum InputAction {
@@ -1303,6 +1215,27 @@ mod reap_tests {
         assert_eq!(CHILD_REAPER_STARTS.load(Ordering::SeqCst), 1);
         drop(first);
         drop(second);
+    }
+
+    #[test]
+    fn live_child_does_not_wake_the_reaper_on_a_clock() {
+        let pane = spawn_sh();
+        let pid = pane.child_pid.load(Ordering::SeqCst);
+        assert_ne!(pid, 0);
+        assert!(alive(pid));
+        // Let the reaper take the child and block on SIGCHLD / process wait.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let before = super::reaper::CHILD_REAPER_WAIT_RETURNS.load(Ordering::SeqCst);
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        let after = super::reaper::CHILD_REAPER_WAIT_RETURNS.load(Ordering::SeqCst);
+        assert_eq!(
+            after,
+            before,
+            "a live child woke the reaper {delta} extra times; that is a timer poll",
+            delta = after - before
+        );
+        drop(pane);
+        assert!(wait_gone(pid), "exit is still reaped without a timer");
     }
 
     /// A deferred pane (docs/82) is fully usable before its shell exists:

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -1181,6 +1181,35 @@ mod reap_tests {
     use super::*;
     use crate::ids::PaneId;
 
+    struct SignalMaskGuard(libc::sigset_t);
+
+    impl SignalMaskGuard {
+        fn block_sigchld() -> Self {
+            unsafe {
+                let mut sigchld: libc::sigset_t = std::mem::zeroed();
+                libc::sigemptyset(&mut sigchld);
+                libc::sigaddset(&mut sigchld, libc::SIGCHLD);
+                let mut previous: libc::sigset_t = std::mem::zeroed();
+                let result = libc::pthread_sigmask(libc::SIG_BLOCK, &sigchld, &mut previous);
+                assert_eq!(
+                    result,
+                    0,
+                    "block SIGCHLD: {}",
+                    std::io::Error::from_raw_os_error(result)
+                );
+                Self(previous)
+            }
+        }
+    }
+
+    impl Drop for SignalMaskGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = libc::pthread_sigmask(libc::SIG_SETMASK, &self.0, std::ptr::null_mut());
+            }
+        }
+    }
+
     fn alive(pid: u32) -> bool {
         unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
     }
@@ -1219,6 +1248,80 @@ mod reap_tests {
         assert_eq!(CHILD_REAPER_STARTS.load(Ordering::SeqCst), 1);
         drop(first);
         drop(second);
+    }
+    #[test]
+    fn inherited_blocked_sigchld_still_reaps_natural_exit() {
+        const CHILD_RUN: &str = "LUVUS_BLOCKED_SIGCHLD_REAPER_TEST";
+        if std::env::var_os(CHILD_RUN).is_none() {
+            // Run this case alone in a fresh process so SIGCHLD is blocked
+            // before the process-wide OnceLock and handler are first touched.
+            // The child's process-global handler disappears with the child, so
+            // parallel tests cannot observe a temporary action.
+            let output = std::process::Command::new(std::env::current_exe().expect("test binary"))
+                .args([
+                    "--exact",
+                    "terminal::pty::reap_tests::inherited_blocked_sigchld_still_reaps_natural_exit",
+                    "--nocapture",
+                ])
+                .env(CHILD_RUN, "1")
+                .output()
+                .expect("run isolated blocked-SIGCHLD test");
+            assert!(
+                output.status.success(),
+                "isolated blocked-SIGCHLD test failed:\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let _mask = SignalMaskGuard::block_sigchld();
+        assert_eq!(
+            CHILD_REAPER_STARTS.load(Ordering::SeqCst),
+            0,
+            "the isolated process must block SIGCHLD before reaper setup"
+        );
+
+        let (tx, rx) = mpsc::channel();
+        let id = PaneId::alloc();
+        let pane = Pane::spawn(
+            id,
+            80,
+            24,
+            std::env::temp_dir(),
+            tx,
+            None,
+            "/bin/sh",
+            500,
+            PaneAppearance::default(),
+        )
+        .expect("spawn shell with inherited blocked SIGCHLD");
+        let pid = pane.child_pid.load(Ordering::SeqCst);
+        assert_ne!(pid, 0);
+
+        // Let the reaper reach its infinite poll before the child exits. With
+        // SIGCHLD inherited as blocked, the old design stranded here forever.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        pane.send(b"exit\r");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !pane.child_exited.load(Ordering::SeqCst) {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "natural child exit never woke the reaper"
+            );
+            // The PTY actor may publish PtyExit before the child waiter. Keep
+            // waiting until the reaper sets child_exited, which is the behavior
+            // this blocked-signal regression is proving.
+            match rx.recv_timeout(remaining.min(std::time::Duration::from_millis(50))) {
+                Ok(AppEvent::PtyExit(exited)) if exited == id => {}
+                Ok(_) | Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(error) => panic!("natural child exit never woke the reaper: {error}"),
+            }
+        }
+        assert!(wait_gone(pid), "naturally exited child was not reaped");
+        drop(pane);
     }
 
     #[test]

--- a/src/terminal/pty/reaper.rs
+++ b/src/terminal/pty/reaper.rs
@@ -267,7 +267,7 @@ impl UnixWake {
             // only writes one byte to a pipe fd published before this call.
             let mut action: libc::sigaction = std::mem::zeroed();
             action.sa_sigaction = on_sigchld as extern "C" fn(libc::c_int) as libc::sighandler_t;
-            action.sa_flags = libc::SA_NOCLDSTOP;
+            action.sa_flags = libc::SA_NOCLDSTOP | libc::SA_RESTART;
             libc::sigemptyset(&mut action.sa_mask);
             if libc::sigaction(libc::SIGCHLD, &action, std::ptr::null_mut()) != 0 {
                 panic!(
@@ -358,21 +358,24 @@ unsafe fn errno_location() -> *mut libc::c_int {
 // libc exposes no common errno accessor across every Unix target. Unknown
 // targets retain an async-signal-safe handler; null disables save/restore
 // rather than guessing an ABI symbol.
-#[cfg(not(any(
-    target_vendor = "apple",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "linux",
-    target_os = "hurd",
-    target_os = "redox",
-    target_os = "android",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "nuttx",
-    target_os = "solaris",
-    target_os = "illumos",
-    target_os = "aix"
-)))]
+#[cfg(all(
+    unix,
+    not(any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "linux",
+        target_os = "hurd",
+        target_os = "redox",
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "nuttx",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "aix"
+    ))
+))]
 unsafe fn errno_location() -> *mut libc::c_int {
     std::ptr::null_mut()
 }

--- a/src/terminal/pty/reaper.rs
+++ b/src/terminal/pty/reaper.rs
@@ -68,10 +68,41 @@ fn start_reaper() -> Reaper {
     #[cfg(unix)]
     wake.install_sigchld();
     let thread_wake = Arc::clone(&wake);
+    #[cfg(unix)]
+    let (ready_tx, ready_rx) = mpsc::sync_channel(0);
     thread::Builder::new()
         .name("luvus-pty-reaper".to_string())
-        .spawn(move || child_reaper_loop(rx, thread_wake))
+        .spawn(move || {
+            #[cfg(unix)]
+            {
+                // Signal masks survive exec and are inherited by new threads.
+                // Unblock SIGCHLD only in the process-lifetime reaper before it
+                // relies on the handler's self-pipe.
+                let _sigchld_unblocked = match SigchldUnblockGuard::new() {
+                    Ok(guard) => {
+                        if ready_tx.send(Ok(())).is_err() {
+                            return;
+                        }
+                        guard
+                    }
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error));
+                        return;
+                    }
+                };
+                child_reaper_loop(rx, thread_wake);
+            }
+            #[cfg(windows)]
+            child_reaper_loop(rx, thread_wake);
+        })
         .expect("failed to start the PTY child reaper");
+    #[cfg(unix)]
+    ready_rx
+        .recv()
+        .expect("PTY child reaper exited during signal-mask setup")
+        .unwrap_or_else(|error| {
+            panic!("failed to unblock SIGCHLD in the PTY child reaper: {error}")
+        });
     #[cfg(test)]
     CHILD_REAPER_STARTS.fetch_add(1, Ordering::SeqCst);
     Reaper { tx, wake }
@@ -170,6 +201,37 @@ struct UnixWake {
 static SIGCHLD_WRITE: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
 
 #[cfg(unix)]
+struct SigchldUnblockGuard {
+    inherited: libc::sigset_t,
+}
+
+#[cfg(unix)]
+impl SigchldUnblockGuard {
+    fn new() -> io::Result<Self> {
+        unsafe {
+            let mut sigchld: libc::sigset_t = std::mem::zeroed();
+            libc::sigemptyset(&mut sigchld);
+            libc::sigaddset(&mut sigchld, libc::SIGCHLD);
+            let mut inherited: libc::sigset_t = std::mem::zeroed();
+            let result = libc::pthread_sigmask(libc::SIG_UNBLOCK, &sigchld, &mut inherited);
+            if result != 0 {
+                return Err(io::Error::from_raw_os_error(result));
+            }
+            Ok(Self { inherited })
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for SigchldUnblockGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = libc::pthread_sigmask(libc::SIG_SETMASK, &self.inherited, std::ptr::null_mut());
+        }
+    }
+}
+
+#[cfg(unix)]
 impl UnixWake {
     fn new() -> io::Result<Self> {
         use std::os::fd::{FromRawFd, OwnedFd};
@@ -249,7 +311,70 @@ fn write_wake(fd: std::os::fd::RawFd) {
     let byte = [1u8];
     // The pipe is nonblocking and acts as an edge coalescer. EAGAIN means a
     // prior byte already guarantees that poll will wake.
-    let _ = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
+    unsafe {
+        let errno = errno_location();
+        let saved_errno = errno.as_ref().copied();
+        let _ = libc::write(fd, byte.as_ptr().cast(), byte.len());
+        if let Some(saved_errno) = saved_errno {
+            *errno = saved_errno;
+        }
+    }
+}
+
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+unsafe fn errno_location() -> *mut libc::c_int {
+    unsafe { libc::__error() }
+}
+
+#[cfg(any(target_os = "linux", target_os = "hurd", target_os = "redox"))]
+unsafe fn errno_location() -> *mut libc::c_int {
+    unsafe { libc::__errno_location() }
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "nuttx"
+))]
+unsafe fn errno_location() -> *mut libc::c_int {
+    unsafe { libc::__errno() }
+}
+
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
+unsafe fn errno_location() -> *mut libc::c_int {
+    unsafe { libc::___errno() }
+}
+
+#[cfg(target_os = "aix")]
+unsafe fn errno_location() -> *mut libc::c_int {
+    unsafe { libc::_Errno() }
+}
+
+// libc exposes no common errno accessor across every Unix target. Unknown
+// targets retain an async-signal-safe handler; null disables save/restore
+// rather than guessing an ABI symbol.
+#[cfg(not(any(
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "linux",
+    target_os = "hurd",
+    target_os = "redox",
+    target_os = "android",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "nuttx",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "aix"
+)))]
+unsafe fn errno_location() -> *mut libc::c_int {
+    std::ptr::null_mut()
 }
 
 #[cfg(unix)]

--- a/src/terminal/pty/reaper.rs
+++ b/src/terminal/pty/reaper.rs
@@ -1,0 +1,389 @@
+//! Process-wide PTY child waiter.
+//!
+//! One `luvus-pty-reaper` thread owns every pane child. An empty list blocks on
+//! the registration channel. A live child blocks on SIGCHLD (Unix) or process
+//! handles (Windows), then `try_wait`s. There is no idle timer.
+
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, OnceLock};
+use std::thread;
+
+use crate::event::AppEvent;
+use crate::ids::PaneId;
+
+struct ReaperEntry {
+    id: PaneId,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    child_exited: Arc<AtomicBool>,
+    app_tx: Sender<AppEvent>,
+}
+
+struct Reaper {
+    tx: Sender<ReaperEntry>,
+    wake: Arc<ReaperWake>,
+}
+
+static CHILD_REAPER: OnceLock<Reaper> = OnceLock::new();
+
+#[cfg(test)]
+pub(super) static CHILD_REAPER_STARTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(super) static CHILD_REAPER_WAIT_RETURNS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Hand a child to the process-wide reaper. Pane I/O remains isolated behind
+/// its platform backend; exit is observed from one waiter thread.
+pub(super) fn register_child_reaper(
+    id: PaneId,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    child_exited: Arc<AtomicBool>,
+    app_tx: Sender<AppEvent>,
+) {
+    let reaper = CHILD_REAPER.get_or_init(start_reaper);
+    let entry = ReaperEntry {
+        id,
+        child,
+        child_exited,
+        app_tx,
+    };
+    if let Err(error) = reaper.tx.send(entry) {
+        // A panic in the shared reaper must not leave an unreaped child. This
+        // fallback is deliberately exceptional; the normal path stays at one
+        // waiter thread for the whole server.
+        let mut entry = error.0;
+        let _ = thread::Builder::new()
+            .name("luvus-pty-reaper-fallback".to_string())
+            .spawn(move || {
+                let _ = entry.child.wait();
+                finish_child(entry);
+            });
+        return;
+    }
+    reaper.wake.signal();
+}
+
+fn start_reaper() -> Reaper {
+    let (tx, rx) = mpsc::channel();
+    let wake = Arc::new(ReaperWake::new().expect("failed to create the PTY child reaper wake"));
+    #[cfg(unix)]
+    wake.install_sigchld();
+    let thread_wake = Arc::clone(&wake);
+    thread::Builder::new()
+        .name("luvus-pty-reaper".to_string())
+        .spawn(move || child_reaper_loop(rx, thread_wake))
+        .expect("failed to start the PTY child reaper");
+    #[cfg(test)]
+    CHILD_REAPER_STARTS.fetch_add(1, Ordering::SeqCst);
+    Reaper { tx, wake }
+}
+
+fn child_reaper_loop(rx: Receiver<ReaperEntry>, wake: Arc<ReaperWake>) {
+    let mut children = Vec::<ReaperEntry>::new();
+    loop {
+        if children.is_empty() {
+            match rx.recv() {
+                Ok(entry) => children.push(entry),
+                Err(_) => break,
+            }
+        } else {
+            match wake.wait_for_exit_or_registration(&children) {
+                Ok(()) => {
+                    #[cfg(test)]
+                    CHILD_REAPER_WAIT_RETURNS.fetch_add(1, Ordering::SeqCst);
+                }
+                Err(_) => {
+                    // The wake primitive failed. Block on the next registration
+                    // so this thread cannot spin, then try_wait listed children.
+                    match rx.recv() {
+                        Ok(entry) => children.push(entry),
+                        Err(_) => break,
+                    }
+                }
+            }
+        }
+        children.extend(rx.try_iter());
+        reap_finished(&mut children);
+    }
+}
+
+fn reap_finished(children: &mut Vec<ReaperEntry>) {
+    let mut index = 0;
+    while index < children.len() {
+        if child_poll_finished(children[index].child.try_wait()) {
+            let entry = children.swap_remove(index);
+            finish_child(entry);
+        } else {
+            index += 1;
+        }
+    }
+}
+
+#[inline]
+pub(super) fn child_poll_finished(
+    result: std::io::Result<Option<portable_pty::ExitStatus>>,
+) -> bool {
+    matches!(result, Ok(Some(_)))
+}
+
+fn finish_child(entry: ReaperEntry) {
+    // Publish exit before notifying the app. If the app immediately drops the
+    // pane, `Drop` must not signal a PID that the operating system may reuse.
+    entry.child_exited.store(true, Ordering::SeqCst);
+    let _ = entry.app_tx.send(AppEvent::PtyExit(entry.id));
+}
+
+struct ReaperWake {
+    #[cfg(unix)]
+    inner: UnixWake,
+    #[cfg(windows)]
+    inner: WindowsWake,
+}
+
+impl ReaperWake {
+    fn new() -> io::Result<Self> {
+        Ok(Self {
+            #[cfg(unix)]
+            inner: UnixWake::new()?,
+            #[cfg(windows)]
+            inner: WindowsWake::new()?,
+        })
+    }
+
+    fn signal(&self) {
+        self.inner.signal();
+    }
+
+    #[cfg(unix)]
+    fn install_sigchld(&self) {
+        self.inner.install_sigchld();
+    }
+
+    fn wait_for_exit_or_registration(&self, children: &[ReaperEntry]) -> io::Result<()> {
+        self.inner.wait_for_exit_or_registration(children)
+    }
+}
+
+#[cfg(unix)]
+struct UnixWake {
+    read: std::os::fd::OwnedFd,
+    write: std::os::fd::OwnedFd,
+}
+
+#[cfg(unix)]
+static SIGCHLD_WRITE: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1);
+
+#[cfg(unix)]
+impl UnixWake {
+    fn new() -> io::Result<Self> {
+        use std::os::fd::{FromRawFd, OwnedFd};
+
+        let mut fds = [-1; 2];
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a successful pipe call initializes two independently owned
+        // descriptors. They are transferred into OwnedFd exactly once.
+        let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+        set_nonblocking_cloexec(fds[0])?;
+        set_nonblocking_cloexec(fds[1])?;
+        Ok(Self { read, write })
+    }
+
+    fn signal(&self) {
+        use std::os::fd::AsRawFd;
+
+        write_wake(self.write.as_raw_fd());
+    }
+
+    fn install_sigchld(&self) {
+        use std::os::fd::AsRawFd;
+
+        SIGCHLD_WRITE.store(self.write.as_raw_fd(), Ordering::Release);
+        extern "C" fn on_sigchld(_sig: libc::c_int) {
+            write_wake(SIGCHLD_WRITE.load(Ordering::Relaxed));
+        }
+        unsafe {
+            // SAFETY: `action` is a fully initialized sigaction. The handler
+            // only writes one byte to a pipe fd published before this call.
+            let mut action: libc::sigaction = std::mem::zeroed();
+            action.sa_sigaction = on_sigchld as extern "C" fn(libc::c_int) as libc::sighandler_t;
+            action.sa_flags = libc::SA_NOCLDSTOP;
+            libc::sigemptyset(&mut action.sa_mask);
+            if libc::sigaction(libc::SIGCHLD, &action, std::ptr::null_mut()) != 0 {
+                panic!(
+                    "failed to install SIGCHLD handler for the PTY reaper: {}",
+                    io::Error::last_os_error()
+                );
+            }
+        }
+    }
+
+    fn wait_for_exit_or_registration(&self, _children: &[ReaperEntry]) -> io::Result<()> {
+        use std::os::fd::AsRawFd;
+
+        let mut fd = libc::pollfd {
+            fd: self.read.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        loop {
+            // SAFETY: `fd` is this pipe's read end, valid for the lifetime of
+            // `self`. Timeout -1 blocks until the pipe is readable.
+            let result = unsafe { libc::poll(&mut fd, 1, -1) };
+            if result < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
+            }
+            drain_wake(self.read.as_raw_fd());
+            return Ok(());
+        }
+    }
+}
+
+#[cfg(unix)]
+fn write_wake(fd: std::os::fd::RawFd) {
+    if fd < 0 {
+        return;
+    }
+    let byte = [1u8];
+    // The pipe is nonblocking and acts as an edge coalescer. EAGAIN means a
+    // prior byte already guarantees that poll will wake.
+    let _ = unsafe { libc::write(fd, byte.as_ptr().cast(), byte.len()) };
+}
+
+#[cfg(unix)]
+fn drain_wake(fd: std::os::fd::RawFd) {
+    let mut bytes = [0u8; 64];
+    loop {
+        let count = unsafe { libc::read(fd, bytes.as_mut_ptr().cast(), bytes.len()) };
+        if count <= 0 {
+            break;
+        }
+    }
+}
+
+#[cfg(unix)]
+fn set_nonblocking_cloexec(fd: std::os::fd::RawFd) -> io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let descriptor_flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if descriptor_flags < 0
+        || unsafe { libc::fcntl(fd, libc::F_SETFD, descriptor_flags | libc::FD_CLOEXEC) } < 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+struct WindowsWake {
+    event: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+// SAFETY: `event` is a kernel object. `SetEvent` / `WaitForMultipleObjects` are
+// thread-safe. `CloseHandle` runs once when the last `Arc` drops (the
+// process-lifetime `OnceLock`).
+unsafe impl Send for WindowsWake {}
+#[cfg(windows)]
+unsafe impl Sync for WindowsWake {}
+
+#[cfg(windows)]
+impl WindowsWake {
+    fn new() -> io::Result<Self> {
+        use windows_sys::Win32::System::Threading::CreateEventW;
+
+        let event = unsafe { CreateEventW(std::ptr::null(), 0, 0, std::ptr::null()) };
+        if event.is_null() || event == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { event })
+    }
+
+    fn signal(&self) {
+        use windows_sys::Win32::System::Threading::SetEvent;
+
+        unsafe {
+            let _ = SetEvent(self.event);
+        }
+    }
+
+    fn wait_for_exit_or_registration(&self, children: &[ReaperEntry]) -> io::Result<()> {
+        use windows_sys::Win32::Foundation::{HANDLE, WAIT_FAILED};
+        use windows_sys::Win32::System::Threading::{WaitForMultipleObjects, INFINITE};
+
+        // WaitForMultipleObjects accepts at most 64 handles. Slot 0 is the
+        // registration event; remaining slots are live children. Extra children
+        // are still `try_wait`ed after any wake; they are not wait sources.
+        const MAX_WAIT: usize = 64;
+        let mut handles = [std::ptr::null_mut::<std::ffi::c_void>(); MAX_WAIT];
+        handles[0] = self.event;
+        let mut count = 1usize;
+        for entry in children {
+            if count == MAX_WAIT {
+                break;
+            }
+            if let Some(handle) = entry.child.as_raw_handle() {
+                handles[count] = handle;
+                count += 1;
+            }
+        }
+        let status = unsafe {
+            WaitForMultipleObjects(count as u32, handles.as_ptr() as *const HANDLE, 0, INFINITE)
+        };
+        if status == WAIT_FAILED {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsWake {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.event);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReaperWake;
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn reaper_wake_blocks_until_signaled() {
+        let wake = Arc::new(ReaperWake::new().expect("wake pipe"));
+        let waiter = Arc::clone(&wake);
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let thread = thread::spawn(move || {
+            ready_tx.send(()).unwrap();
+            waiter
+                .wait_for_exit_or_registration(&[])
+                .expect("wait for wake");
+        });
+        ready_rx.recv().unwrap();
+        thread::sleep(Duration::from_millis(80));
+        assert!(
+            !thread.is_finished(),
+            "the reaper wake returned without a child exit or registration"
+        );
+        wake.signal();
+        thread.join().expect("waiter thread");
+    }
+}

--- a/src/terminal/pty/reaper.rs
+++ b/src/terminal/pty/reaper.rs
@@ -31,10 +31,6 @@ static CHILD_REAPER: OnceLock<Reaper> = OnceLock::new();
 pub(super) static CHILD_REAPER_STARTS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
-#[cfg(test)]
-pub(super) static CHILD_REAPER_WAIT_RETURNS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-
 /// Hand a child to the process-wide reaper. Pane I/O remains isolated behind
 /// its platform backend; exit is observed from one waiter thread.
 pub(super) fn register_child_reaper(
@@ -91,10 +87,7 @@ fn child_reaper_loop(rx: Receiver<ReaperEntry>, wake: Arc<ReaperWake>) {
             }
         } else {
             match wake.wait_for_exit_or_registration(&children) {
-                Ok(()) => {
-                    #[cfg(test)]
-                    CHILD_REAPER_WAIT_RETURNS.fetch_add(1, Ordering::SeqCst);
-                }
+                Ok(()) => {}
                 Err(_) => {
                     // The wake primitive failed. Block on the next registration
                     // so this thread cannot spin, then try_wait listed children.
@@ -378,7 +371,8 @@ mod tests {
                 .expect("wait for wake");
         });
         ready_rx.recv().unwrap();
-        thread::sleep(Duration::from_millis(80));
+        // Longer than the old 50ms try_wait poll. A timer would return here.
+        thread::sleep(Duration::from_millis(200));
         assert!(
             !thread.is_finished(),
             "the reaper wake returned without a child exit or registration"

--- a/src/terminal/pty/reaper.rs
+++ b/src/terminal/pty/reaper.rs
@@ -317,22 +317,35 @@ impl WindowsWake {
 
         // WaitForMultipleObjects accepts at most 64 handles. Slot 0 is the
         // registration event; remaining slots are live children. Extra children
-        // are still `try_wait`ed after any wake; they are not wait sources.
+        // and children without a waitable handle are still `try_wait`ed after
+        // any wake. When every child fits, wait infinitely. When the list is
+        // truncated, use a short timeout so omitted exits cannot strand.
         const MAX_WAIT: usize = 64;
+        const OVERFLOW_WAIT_MS: u32 = 250;
         let mut handles = [std::ptr::null_mut::<std::ffi::c_void>(); MAX_WAIT];
         handles[0] = self.event;
         let mut count = 1usize;
+        let mut truncated = false;
+        let mut missing_handle = false;
         for entry in children {
             if count == MAX_WAIT {
+                truncated = true;
                 break;
             }
             if let Some(handle) = entry.child.as_raw_handle() {
                 handles[count] = handle;
                 count += 1;
+            } else {
+                missing_handle = true;
             }
         }
+        let timeout = if truncated || missing_handle {
+            OVERFLOW_WAIT_MS
+        } else {
+            INFINITE
+        };
         let status = unsafe {
-            WaitForMultipleObjects(count as u32, handles.as_ptr() as *const HANDLE, 0, INFINITE)
+            WaitForMultipleObjects(count as u32, handles.as_ptr() as *const HANDLE, 0, timeout)
         };
         if status == WAIT_FAILED {
             Err(io::Error::last_os_error())

--- a/src/terminal/theme_probe.rs
+++ b/src/terminal/theme_probe.rs
@@ -97,12 +97,39 @@ pub fn probe() -> ProbeResult {
 
 #[cfg(unix)]
 fn fd_readable(fd: std::os::fd::RawFd, timeout_ms: i32) -> bool {
+    use std::time::{Duration, Instant};
+
     let mut poll_fd = libc::pollfd {
         fd,
         events: libc::POLLIN,
         revents: 0,
     };
-    unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) > 0 && poll_fd.revents & libc::POLLIN != 0 }
+    let deadline =
+        (timeout_ms >= 0).then(|| Instant::now() + Duration::from_millis(timeout_ms as u64));
+    let mut remaining = timeout_ms;
+    loop {
+        // SAFETY: `poll_fd` contains only the borrowed descriptor supplied by
+        // the caller. The timeout is bounded by the probe's existing deadline.
+        let result = unsafe { libc::poll(&mut poll_fd, 1, remaining) };
+        if result > 0 {
+            return poll_fd.revents & libc::POLLIN != 0;
+        }
+        if result == 0 {
+            return false;
+        }
+        if std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted {
+            return false;
+        }
+        let Some(deadline) = deadline else {
+            continue;
+        };
+        let remaining_duration = deadline.saturating_duration_since(Instant::now());
+        if remaining_duration.is_zero() {
+            return false;
+        }
+        remaining = remaining_duration.as_millis().clamp(1, i32::MAX as u128) as i32;
+        poll_fd.revents = 0;
+    }
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
A quiet Luvus server now sleeps until real work arrives instead of waking on a timer.

## What

- The server event loop blocks on the event channel when nothing is due. It no longer uses a 100/250 ms idle tick or a 1 ms `recv_timeout` floor.
- CWD, process-identity, and resumable-session scans follow PTY activity and TUI attach instead of a 1/2/4 s heartbeat.
- The process-wide `luvus-pty-reaper` waits on `SIGCHLD` (Unix) or process handles (Windows) instead of `try_wait` every 50 ms. One reaper thread remains; there is no waiter per pane.
- Unix shutdown writes a self-pipe and posts `AppEvent::Shutdown` so a sleeping loop still exits on SIGTERM/HUP/INT (`luvus-signal` thread).

JSON API, UHP, and CLI still talk to the server with no TUI required. Pane control is unchanged. CWD / git / `ps` labels can stay at last-known while fully detached with only JSON clients.

## Why

HEAD idle wait floored `recv_timeout` at 1 ms whenever PTY re-arm was due, which produced ~50k Unix syscalls per 6 s at ~0.02% CPU. The leftover after that was a 50 ms child-reaper poll (~110 unix / 6 s). Both are gone: the loop `recv()`s when quiet, and the reaper waits on the kernel.

## Verification

- [x] `cargo test quiet_runtime` (2 passed)
- [x] `cargo test live_child_does_not_wake`
- [x] `cargo test reaper_wake_blocks`
- [x] `cargo test panes_share_one_child_reaper`
- [ ] `cargo test --locked` (full suite; focused tests above lock the new contract)
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all --check` (changed Rust files were formatted)
- Installed `~/.cargo/bin/luvus` was not used as a bench target

Release attached idle: **0 Unix syscalls / 6 s** (was 49,890). Ten-pane release idle CPU **0.000%** (was 0.85% on 2026-08-29). Focused-stream CPU is unchanged (~2.7% combined on release). Scrollback live heap is unchanged.

## Notes

- Windows compile is covered by the new `WaitForMultipleObjects` path; idle syscall numbers are macOS-only.
- Do not revert by stretching the old 50 ms reaper interval or by adding a listener-poll timeout to the event loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Runtime detection and background scans now respond to actual activity and scheduled deadlines, reducing unnecessary idle work.
  - Process information refreshes on demand when needed, including without an attached interface.
  - Session saving uses more precise timing for smoother behavior.
  - Shutdown signals wake the application promptly, enabling cleaner termination.
  - Terminal child processes are monitored centrally for more reliable pane closure and exit handling.

- **Bug Fixes**
  - Runtime information refreshes after terminal panes become ready or produce output.
  - Full-system checks are avoided when no detection work is pending.
  - Interrupted command-output reads are retried instead of ending prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->