### PR TITLE
feat(agents): publish the stable workspace id on agent list rows

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2449,6 +2449,11 @@ impl App {
                                 "state_source":s.state_source,
                                 "session": session,
                                 "workspace": wi.to_string(), "workspace_name": ws.name,
+                                // The one selector that survives reordering:
+                                // `workspace` is a positional index that shifts
+                                // when an earlier workspace closes, and
+                                // `workspace_name` is user-editable.
+                                "workspace_id": ws.id,
                                 "project": ws.name, "cwd": cwd,
                                 "branch": branch, "repo": repo, "worktree": is_worktree,
                                 "tab": (ti + 1).to_string(), "focused": id == focus,
@@ -6952,6 +6957,72 @@ command = ["true"]
             .dispatch("agent.list", &json!({}))
             .expect("agent.list ok");
         assert_eq!(out["agents"][0]["session"], "sess-42");
+    }
+
+    /// Every `agent.list` row carries its workspace's stable id. `workspace` is a
+    /// positional index that moves when workspaces are reordered or an earlier one
+    /// closes, and `workspace_name` is user-editable, so the id is the only
+    /// selector a consumer can hold across those changes.
+    #[test]
+    fn agent_list_rows_carry_a_stable_workspace_id() {
+        let _env = crate::persist::test_env("agent-list-workspace-id");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+
+        let first_pane = app.layout().focus;
+        app.status.get_mut(&first_pane).unwrap().agent = "claude".into();
+        let first_id = app.workspaces[0].id.clone();
+
+        let second_root = crate::persist::config_dir().join("second-workspace");
+        std::fs::create_dir_all(&second_root).unwrap();
+        assert!(app.create_workspace_at(second_root));
+        let second_pane = app.layout().focus;
+        app.status.get_mut(&second_pane).unwrap().agent = "codex".into();
+        let second_id = app.workspaces[1].id.clone();
+        assert_ne!(first_id, second_id);
+
+        let row_for = |app: &mut App, pane: crate::app::PaneId| -> Value {
+            let out = app.dispatch("agent.list", &json!({})).expect("agent.list");
+            let wanted = pane.0.to_string();
+            out["agents"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|row| row["pane"].as_str() == Some(wanted.as_str()))
+                .expect("the agent is listed")
+                .clone()
+        };
+
+        // The id agrees with the one `workspace.get` publishes for that index, so
+        // a consumer can join the two surfaces without guessing.
+        let second_row = row_for(&mut app, second_pane);
+        assert_eq!(second_row["workspace"], "1");
+        assert_eq!(second_row["workspace_id"], second_id.as_str());
+        let published = app
+            .dispatch("workspace.get", &json!({"workspace": 1}))
+            .expect("workspace.get");
+        assert_eq!(published["workspace_id"], second_row["workspace_id"]);
+
+        // Reordering moves the index but not the id. This is the whole point of
+        // the field: an index captured before the move now names the other
+        // workspace, while the id still names this one.
+        app.dispatch("workspace.move", &json!({"workspace": 1, "to": 0}))
+            .expect("workspace.move");
+        let moved = row_for(&mut app, second_pane);
+        assert_eq!(
+            moved["workspace"], "0",
+            "the positional index followed the move"
+        );
+        assert_eq!(
+            moved["workspace_id"],
+            second_id.as_str(),
+            "the stable id survived the move"
+        );
+        assert_eq!(
+            row_for(&mut app, first_pane)["workspace_id"],
+            first_id.as_str(),
+            "the workspace that was displaced keeps its own id"
+        );
     }
 
     /// A live alias set by `agent.name` shows up in `agent.list` and resolves an

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -38,7 +38,7 @@ without resolving the notes.
 
 ### How to tell two of the same kind apart
 
-Run `luvus agent list` (each row has `pane`, `agent` kind, `name`, `cwd`, `workspace_name`). Two Claudes share the kind `claude` but differ by pane id and folder. Give each a name so you can mention it:
+Run `luvus agent list` (each row has `pane`, `agent` kind, `name`, `cwd`, `workspace_name`, and the stable `workspace_id`). Two Claudes share the kind `claude` but differ by pane id and folder. Give each a name so you can mention it:
 
 ```sh
 luvus agent name api --pane 1     # or run `luvus pane name api` inside that pane

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -116,6 +116,12 @@ pane owns that exact session.
 {"id":"usage","method":"pane.report_session","params":{"pane":"9","agent":"opencode","session_id":"ses_123","usage":{"model":"anthropic/claude-sonnet-4","tokens_in":1200,"tokens_out":340,"cache_read":800,"cache_write":40,"cost":0.42,"updated_at":1788330000000}}}
 ```
 
+`agent.list` rows identify their workspace three ways. `workspace` is a 0-based
+position that changes when workspaces are reordered or an earlier one closes,
+`workspace_name` is the user-editable label, and `workspace_id` is the stable id
+also published by `workspace.list` and `workspace.get`. Filter or correlate on
+`workspace_id` when the result has to survive those changes.
+
 `task.start` and `task.next` with `start: true` accept `mode: "worktree"` or
 `mode: "workspace"`; omitted mode means worktree. Workspace mode may include a
 stable `workspace_id` and creates a dedicated branchless task tab in that


### PR DESCRIPTION
`agent.list` rows now carry `workspace_id`, so a consumer can identify an agent's workspace with a selector that survives reordering.

## What

- Each `agent.list` row gains `workspace_id`, the same stable id `workspace.list` and `workspace.get` already publish.
- Purely additive: no new parameter, no schema constraint, no CLI flag, and no change to any existing field or to `pane.agent_status_changed`.

## Why

A row identified its workspace two ways, and neither is stable:

- `workspace` is a 0-based position into a `Vec`. Closing an earlier workspace goes through `Vec::remove`, so every later index shifts down.
- `workspace_name` is the user-editable label.

So a consumer wanting to correlate agents with one project across those changes had to call `workspace.list`, find the index for its id, then filter `agent.list` by that index — two round trips, with the index able to change in between.

This is the reduced form of #261, which I closed. That PR added a server-side `workspace` / `workspace_id` filter parameter to `agent.list`. A reviewer asked why `jq` was not sufficient, and working through it honestly: the convenience argument did not hold, the precedent I cited (`mission.snapshot`) scopes to limit expensive per-workspace usage work rather than to filter a cheap in-memory read, and UHP has no general filtering or pagination concept for list methods — so a one-off parameter on one of them would have frozen an awkward precedent into v1. The only genuine gap left was the missing stable key, which is this.

## Verification

- [x] `cargo test --locked` — 1,333 passed, 0 failed, 1 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Manual testing, if applicable

Also run: `python3 examples/uhp/consumer.py` (61 fixtures) and `python3 examples/uhp/terminal/consumer.py --fixtures` (55 fixtures), both unchanged since no wire contract was constrained.

New test `agent_list_rows_carry_a_stable_workspace_id` asserts the id matches what `workspace.get` publishes for the same index, then reorders with `workspace.move` and asserts the index followed the move while the id did not.

Live run against a debug server in an isolated home (`LUVUS_HOME=~/.luvus-dev`, dedicated session, inherited socket and session selectors cleared, stopped and cleaned up afterwards). Two workspaces, one reported agent each, then closing workspace 0:

```
before close
   pane 1 | ws 0 | luvus        | workspace_7cf78f06…
   pane 2 | ws 1 | luvus-wsid-b | workspace_2bbae2e7…

after close
   pane 2 | ws 0 | luvus-wsid-b | workspace_2bbae2e7…
```

The survivor's `workspace` shifted from `1` to `0` while its `workspace_id` did not move, which is the case the field exists for.

## Notes

Branched from `71f83d4` (#252), a few commits behind `main`. Nothing in those commits touches `agent.list`; happy to rebase.

`pane.agent_status_changed` is deliberately untouched: its payload is pinned by `event-catalog.schema.json` with `additionalProperties: false`, so adding a field there is a separate contract change and not needed for this.

Verified on macOS only. The change is one field in a JSON response with no platform-specific path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent listings now include a stable `workspace_id` for each agent, allowing reliable workspace identification even after reordering or renaming.

* **Documentation**
  * Updated agent messaging and UHP method documentation to explain workspace identifiers and recommend using `workspace_id` for persistent filtering and correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->