### PR TITLE
fix(backend): register terminals created by synchronous spawn

### DIFF
--- a/src/app/backend.rs
+++ b/src/app/backend.rs
@@ -49,7 +49,10 @@ impl App {
             return;
         };
         let terminal_event = match name {
-            "pane.created" => "terminal.created",
+            "pane.created" => {
+                self.register_backend_terminal(pane_id);
+                return;
+            }
             "pane.moved" => "terminal.moved",
             _ => return,
         };
@@ -1505,6 +1508,42 @@ fn backend_key_bytes(key: &str, application_cursor: bool) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
 
+    fn locator(app: &App, pane: PaneId) -> Value {
+        let runtime = app.panes[&pane].terminal_runtime().unwrap();
+        json!({
+            "server_generation":app.backend_server_generation,
+            "terminal_id":runtime.terminal_id,
+            "pane_id":pane.0.to_string(),
+        })
+    }
+
+    fn backend_events_after(app: &App, floor: u64, name: &str) -> Vec<Value> {
+        crate::ipc::api::replayed_events_after(&app.events, floor)
+            .into_iter()
+            .filter(|event| event["event"] == name)
+            .collect()
+    }
+
+    fn assert_capture_succeeds(app: &mut App, mut params: Value) {
+        params["mode"] = json!("visible");
+        params["lines"] = json!(24);
+        params["ansi"] = json!(false);
+        let (reply, response) = std::sync::mpsc::channel();
+        app.start_backend_capture(ApiRequest {
+            id: "capture-sync-pane".into(),
+            method: "terminal.backend.capture".into(),
+            params,
+            reply,
+        });
+        let response: Value = serde_json::from_str(
+            &response
+                .recv_timeout(Duration::from_secs(2))
+                .expect("capture worker replies"),
+        )
+        .unwrap();
+        assert_eq!(response["result"]["type"], "terminal_backend_capture");
+    }
+
     #[test]
     fn inventory_is_global_and_stable_across_a_pane_move() {
         let _env = crate::persist::test_env("backend-global-inventory");
@@ -1515,11 +1554,189 @@ mod tests {
         let before = app.backend_inventory(&json!({})).unwrap();
         assert_eq!(before["terminals"].as_array().unwrap().len(), 1);
         app.run_cmd(crate::app::keys::Cmd::NewTab);
+        let new_pane = app.layout().focus;
+        let original_locator = locator(&app, pane);
+        let new_locator = locator(&app, new_pane);
+        assert_eq!(
+            app.backend_validate(&original_locator).unwrap()["state"],
+            "alive"
+        );
+        assert_eq!(
+            app.backend_validate(&new_locator).unwrap()["state"],
+            "alive"
+        );
         app.workspaces[0].active_tab = 0;
         app.move_pane_to_tab(pane, MoveTarget::Tab(1)).unwrap();
         let after = app.backend_inventory(&json!({})).unwrap();
         assert_eq!(after["terminals"][0]["terminal_id"], runtime.terminal_id);
         assert_eq!(after["terminals"][0]["tab"]["index"], 1);
+        assert_eq!(
+            app.backend_validate(&original_locator).unwrap()["state"],
+            "alive"
+        );
+        assert_eq!(
+            app.backend_validate(&new_locator).unwrap()["state"],
+            "alive"
+        );
+    }
+
+    #[test]
+    fn synchronous_tab_terminal_supports_validate_capture_and_observe() {
+        let _env = crate::persist::test_env("backend-sync-tab");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let startup = app.layout().focus;
+        app.run_cmd(crate::app::keys::Cmd::NewTab);
+        let pane = app.layout().focus;
+        let target = locator(&app, pane);
+
+        assert_eq!(app.backend_validate(&target).unwrap()["state"], "alive");
+        assert_eq!(
+            app.prepare_backend_observe(&target).unwrap().pane_id,
+            pane.0.to_string()
+        );
+        assert_capture_succeeds(&mut app, target);
+        assert_eq!(
+            app.backend_validate(&locator(&app, startup)).unwrap()["state"],
+            "alive",
+            "the previously registered startup terminal stays addressable"
+        );
+    }
+
+    #[test]
+    fn workspace_open_and_resume_spawn_register_backend_terminals() {
+        let _env = crate::persist::test_env("backend-sync-workspace-resume");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let workspace = crate::persist::config_dir().join("opened-workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        app.dispatch(
+            "workspace.open",
+            &json!({"path":workspace.display().to_string()}),
+        )
+        .unwrap();
+        let opened = app.layout().focus;
+        assert_eq!(
+            app.backend_validate(&locator(&app, opened)).unwrap()["state"],
+            "alive"
+        );
+
+        let resumed = app
+            .spawn_resume_pane(workspace, "")
+            .expect("resume terminal spawns");
+        assert_eq!(
+            app.backend_validate(&locator(&app, resumed)).unwrap()["state"],
+            "alive"
+        );
+    }
+
+    #[test]
+    fn lifecycle_registration_handles_deferred_and_synchronous_panes_once() {
+        let _env = crate::persist::test_env("backend-lifecycle-registration");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let cwd = app.ws().cwd.clone();
+        let valid_shell = crate::platform::resolve_shell(&app.config.shell);
+        app.config.shell = "luvus-backend-test-shell-that-does-not-exist".into();
+        let before = app.backend_terminal_index.clone();
+        let floor = crate::ipc::api::current_sequence(&app.events);
+        let deferred = app
+            .spawn_into_deferred(cwd.clone(), &[])
+            .expect("deferred pane is allocated before spawn");
+        assert!(app.panes[&deferred].terminal_runtime().is_none());
+        assert_eq!(app.backend_terminal_index, before);
+        assert!(backend_events_after(&app, floor, "terminal.created").is_empty());
+
+        let ready = Pane::spawn(
+            deferred,
+            80,
+            24,
+            cwd.clone(),
+            app.app_tx.clone(),
+            None,
+            &valid_shell,
+            app.config.scrollback_bytes(),
+            app.pane_appearance,
+        )
+        .unwrap();
+        app.panes.insert(deferred, ready);
+        app.handle_event(AppEvent::PtyReady { id: deferred, cwd });
+        assert_eq!(
+            app.backend_terminal_index
+                .get(&app.panes[&deferred].terminal_runtime().unwrap().terminal_id),
+            Some(&deferred)
+        );
+        assert_eq!(
+            backend_events_after(&app, floor, "terminal.created").len(),
+            1
+        );
+
+        app.config.shell = valid_shell;
+        let synchronous = app.spawn_into(app.ws().cwd.clone()).unwrap();
+        assert_eq!(
+            app.backend_terminal_index.get(
+                &app.panes[&synchronous]
+                    .terminal_runtime()
+                    .unwrap()
+                    .terminal_id
+            ),
+            Some(&synchronous),
+            "the pane.created lifecycle is the synchronous registration choke point"
+        );
+    }
+
+    #[test]
+    fn missing_existing_and_closed_registration_paths_leave_consistent_state() {
+        let _env = crate::persist::test_env("backend-registration-edges");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let missing = PaneId::alloc();
+        let before = app.backend_terminal_index.clone();
+        let floor = crate::ipc::api::current_sequence(&app.events);
+        app.emit_backend_lifecycle_from_pane_event(
+            "pane.created",
+            &json!({"pane":missing.0.to_string()}),
+        );
+        assert_eq!(app.backend_terminal_index, before);
+        assert!(backend_events_after(&app, floor, "terminal.created").is_empty());
+
+        let existing = app.layout().focus;
+        let existing_runtime = app.panes[&existing].terminal_runtime().unwrap();
+        let before = app.backend_terminal_index.clone();
+        let floor = crate::ipc::api::current_sequence(&app.events);
+        app.emit_backend_lifecycle_from_pane_event(
+            "pane.created",
+            &json!({"pane":existing.0.to_string()}),
+        );
+        assert_eq!(app.backend_terminal_index, before);
+        assert_eq!(
+            app.backend_terminal_index
+                .get(&existing_runtime.terminal_id),
+            Some(&existing)
+        );
+        assert_eq!(
+            backend_events_after(&app, floor, "terminal.created").len(),
+            1
+        );
+
+        app.run_cmd(crate::app::keys::Cmd::NewTab);
+        let closing = app.layout().focus;
+        let closing_runtime = app.panes[&closing].terminal_runtime().unwrap();
+        assert_eq!(
+            app.backend_terminal_index.get(&closing_runtime.terminal_id),
+            Some(&closing)
+        );
+        let floor = crate::ipc::api::current_sequence(&app.events);
+        app.close_pane(closing);
+        assert!(!app.panes.contains_key(&closing));
+        assert!(!app
+            .backend_terminal_index
+            .contains_key(&closing_runtime.terminal_id));
+        assert_eq!(
+            backend_events_after(&app, floor, "terminal.closed").len(),
+            1
+        );
     }
 
     #[test]

--- a/src/app/backend.rs
+++ b/src/app/backend.rs
@@ -34,6 +34,9 @@ impl App {
         else {
             return;
         };
+        if self.backend_terminal_index.get(&runtime.terminal_id) == Some(&pane_id) {
+            return;
+        }
         self.backend_terminal_index
             .insert(runtime.terminal_id, pane_id);
         self.emit_backend_terminal_event(pane_id, "terminal.created", json!({}));
@@ -50,6 +53,8 @@ impl App {
         };
         let terminal_event = match name {
             "pane.created" => {
+                // Deferred panes normally have no runtime yet.
+                // They register after their worker reports `PtyReady`.
                 self.register_backend_terminal(pane_id);
                 return;
             }
@@ -868,8 +873,6 @@ impl App {
         let command = pane.command.clone();
         self.panes.insert(pane_id, pane);
         self.status.insert(pane_id, PaneStatus::new(command));
-        self.backend_terminal_index
-            .insert(runtime.terminal_id.clone(), pane_id);
         if let Some(label) = commit.label {
             self.backend_labels.insert(pane_id, label);
         }
@@ -884,6 +887,8 @@ impl App {
             "pane.created",
             json!({"pane":pane_id.0.to_string(),"terminal_id":runtime.terminal_id}),
         );
+        self.backend_terminal_index
+            .insert(runtime.terminal_id.clone(), pane_id);
         let placement_kind = match commit.placement {
             backend::CreatePlacement::Workspace => "workspace",
             backend::CreatePlacement::Sibling(_) => "sibling",
@@ -1673,6 +1678,7 @@ mod tests {
         );
 
         app.config.shell = valid_shell;
+        let floor = crate::ipc::api::current_sequence(&app.events);
         let synchronous = app.spawn_into(app.ws().cwd.clone()).unwrap();
         assert_eq!(
             app.backend_terminal_index.get(
@@ -1683,6 +1689,10 @@ mod tests {
             ),
             Some(&synchronous),
             "the pane.created lifecycle is the synchronous registration choke point"
+        );
+        assert_eq!(
+            backend_events_after(&app, floor, "terminal.created").len(),
+            1
         );
     }
 
@@ -1715,10 +1725,7 @@ mod tests {
                 .get(&existing_runtime.terminal_id),
             Some(&existing)
         );
-        assert_eq!(
-            backend_events_after(&app, floor, "terminal.created").len(),
-            1
-        );
+        assert!(backend_events_after(&app, floor, "terminal.created").is_empty());
 
         app.run_cmd(crate::app::keys::Cmd::NewTab);
         let closing = app.layout().focus;


### PR DESCRIPTION
Synchronous pane creation publishes `pane.created` through `App::emit_event` (`src/app/modules.rs:440-444`), but the backend adapter previously emitted `terminal.created` without inserting the runtime identity, while deferred `PtyReady` explicitly registered it (`src/app/input.rs:437-441`). Because inventory walks live panes while validate and capture resolve through `backend_terminal_index`, this asymmetry explains `stale_terminal` for tab and workspace-root panes in 0.13.4. The `pane.created` lifecycle arm now calls the existing registration helper (`src/app/backend.rs:29-39, 51-55`), leaving `pane.moved` and deferred no-runtime behavior unchanged.

## Tests

Test-first red on the initial `upstream/main` base `9dfdf397618bbe7bb95e7a16498b0d94675a564f` (the relevant backend code is unchanged at the final base `d964238b169f290d71bc40adad7fc995a5e1c3e8`):

```text
$ cargo test app::backend::tests -- --nocapture
test result: FAILED. 5 passed; 5 failed; 0 ignored; 0 measured; 1351 filtered out; finished in 0.11s
```

Focused green after the fix and final rebase:

```text
$ cargo test --locked app::backend::tests -- --nocapture
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 1353 filtered out; finished in 0.11s
```

Full suite green after running the Cargo-built test target from the main-tree CWD (the nested linked-worktree CWD makes six pre-existing workspace/UI assertions classify their fixture as a linked worktree):

```text
$ CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=target/run-luvus-tests-from-main-tree.sh cargo test --locked --target aarch64-unknown-linux-gnu
test result: ok. 1362 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 19.85s
```

The runner only changes to the main checkout root and executes Cargo's supplied test binary and arguments. Other checks:

```text
$ cargo clippy --locked --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.02s
$ cargo fmt --all -- --check
$ git diff upstream/main...HEAD --check
$ python3 examples/uhp/terminal/consumer.py --fixtures
validated 55 fixtures, all JSON schema documents, and snapshot replay
$ python3 examples/uhp/consumer.py
validated 61 UHP fixtures and all JSON schema documents
$ python3 examples/uhp/terminal/mock_conformance.py  # equivalent entry point with a shorter private runtime socket path
terminal-backend mock conformance passed
```

Live evidence used a debug build and an isolated home/session; no installed server endpoint was selected:

```bash
live_home=$(mktemp -d "$PWD/target/luvus-live.XXXXXX")
run_live() { env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION LUVUS_HOME="$live_home" "$PWD/target/debug/luvus" --session luvus-pr-test "$@"; }
run_live server start
run_live tab new
inventory=$(printf '%s\n' '{"id":"inventory","method":"terminal.backend.inventory","params":{}}' | run_live uhp proxy)
terminal=$(printf '%s\n' "$inventory" | jq -c '.result.terminals | max_by(.pane_id | tonumber)')
generation=$(printf '%s\n' "$inventory" | jq -r '.result.server_generation')
terminal_id=$(printf '%s\n' "$terminal" | jq -r '.terminal_id')
pane_id=$(printf '%s\n' "$terminal" | jq -r '.pane_id')
jq -cn --arg generation "$generation" --arg terminal_id "$terminal_id" --arg pane_id "$pane_id" '{id:"validate",method:"terminal.backend.validate",params:{server_generation:$generation,terminal_id:$terminal_id,pane_id:$pane_id}}' | run_live uhp proxy
jq -cn --arg generation "$generation" --arg terminal_id "$terminal_id" --arg pane_id "$pane_id" '{id:"capture",method:"terminal.backend.capture",params:{server_generation:$generation,terminal_id:$terminal_id,pane_id:$pane_id,mode:"visible",lines:20,ansi:false}}' | run_live uhp proxy
run_live server stop
```

Before (`upstream/main`):

```json
{"id":"validate","result":{"state":"gone","type":"terminal_backend_validation"}}
{"error":{"code":"stale_terminal","message":"terminal identity no longer exists"},"id":"capture"}
```

After (this branch):

```json
{"id":"validate","result":{"state":"alive","type":"terminal_backend_validation"}}
{"id":"capture","result":{"ansi":false,"bytes":19,"content_revision":0,"lines":20,"mode":"visible","text":"\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n","truncated":false,"type":"terminal_backend_capture"}}
```

## First-pass checklist

- R1 — Exact: no matching or parsing changed; same-pair registration is event-idempotent, while `terminal.backend.create` registers and emits once before its now-silent same-pair insert.
- R2 — Failure paths: missing pane, runtime `None`, already indexed, deferred readiness, and close cleanup each have state/event assertions; synchronous tab, workspace, resume, capture, observe, and move paths have regressions.
- R3 — CodeRabbit completed with “No actionable comments”; the inline-comment endpoint remained empty and no Greptile comment appeared during the bounded poll.
- R4 — The isolated before/after commands and JSON above prove `gone`/`stale_terminal` becomes `alive`/successful capture.
- R5 — Rebased onto `upstream/main` at `d964238b169f290d71bc40adad7fc995a5e1c3e8`; the existing terminal event schema/catalog already describe `terminal.created`, so no contract files change.
- R6 — N/A: no request or response meaning broadens.
- R7 — One concern: one three-line lifecycle change plus focused backend regressions; no drive-by code or formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157SP6ztLt1Lz91vWgXko8V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate terminal registration and duplicate terminal-created events when a pane is already registered.
  - Ensured backend-created panes follow the correct lifecycle sequence before terminal registration.
  - Improved handling of deferred pane registration after the terminal is ready.
  - Added coverage to verify that registration emits no duplicate events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->