### PR TITLE
fix(input): keep mouse copy highlight for 1.4s

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -163,6 +163,7 @@ fn finish_selected_text(mut out: String) -> Option<String> {
 /// A second left click within this of the first, on the same cell (±1), is a
 /// double-click. Terminals emit no native double-click, so luvus times it.
 const DOUBLE_CLICK: Duration = Duration::from_millis(400);
+const COPY_HIGHLIGHT_DURATION: Duration = Duration::from_millis(1400);
 
 /// A run of grid cells on one row: `(row, start_col, end_col)`, `end_col`
 /// exclusive — the same shape as [`crate::links::Link::spans`].
@@ -1875,6 +1876,7 @@ impl App {
                 }
                 // Begin a selection only inside a pane's content; otherwise drop
                 // any old one. Falls through to normal click handling (focus/etc).
+                self.selection_clear_at = None;
                 self.selection = self
                     .pane_content_at(m.column, m.row)
                     .map(|(pane, content)| {
@@ -1943,11 +1945,11 @@ impl App {
                 return;
             }
             MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Up(MouseButton::Middle) => {
-                // A double-click already copied on its press; clear its highlight on
-                // release so it behaves like a drag copy (toast is the feedback).
+                // A double-click already copied on its press; keep its highlight
+                // briefly on release, like a drag copy (toast is the feedback).
                 if self.dbl_click_release {
                     self.dbl_click_release = false;
-                    self.selection = None;
+                    self.schedule_copy_highlight_clear();
                     return;
                 }
                 if let Some(p) = self.link_press.take() {
@@ -1983,16 +1985,16 @@ impl App {
                 }
                 // A real drag copies its text + flashes a toast; a plain click
                 // clears the (1-cell) selection so nothing stays highlighted.
-                // After a successful copy the highlight is also cleared immediately
-                // — the toast is the feedback, not a lingering selection.
+                // After a successful copy the highlight lingers briefly so you can
+                // see what was copied; the toast times out on the same cadence.
                 match self.selection_text() {
                     Some(text) => {
                         self.pending_clipboard = Some(text);
                         let msg = self.catalog.copied;
                         self.show_toast(msg);
-                        self.selection = None;
+                        self.schedule_copy_highlight_clear();
                     }
-                    None => self.selection = None,
+                    None => self.clear_selection(),
                 }
                 return;
             }
@@ -2645,7 +2647,7 @@ impl App {
             return false;
         };
         let (offset, history) = pane.scroll_state();
-        self.selection = None;
+        self.clear_selection();
         self.scroll_pane = None;
         self.copy_mode = Some(CopyMode {
             pane: id,
@@ -3064,8 +3066,8 @@ impl App {
         // Highlight exactly the copied cells: from the first covered cell to the
         // last, which for a rejoined soft-wrapped path runs through the full rows
         // between them (the same reading-order rule `Selection` copies with). The
-        // highlight is transient (screen coordinates, cleared on the next click),
-        // so it carries no retained-history span.
+        // highlight is transient (screen coordinates, cleared after copy or the
+        // next click), so it carries no retained-history span.
         if let (Some(first), Some(last)) = (spans.first(), spans.last()) {
             self.selection = Some(Selection {
                 pane,
@@ -3255,7 +3257,27 @@ impl App {
     }
 
     pub fn show_toast(&mut self, text: impl Into<String>) {
-        self.toast = Some((text.into(), Instant::now() + Duration::from_millis(1400)));
+        self.toast = Some((text.into(), Instant::now() + COPY_HIGHLIGHT_DURATION));
+    }
+
+    fn schedule_copy_highlight_clear(&mut self) {
+        self.selection_clear_at = Some(Instant::now() + COPY_HIGHLIGHT_DURATION);
+    }
+
+    fn clear_selection(&mut self) {
+        self.selection = None;
+        self.selection_clear_at = None;
+    }
+
+    /// Clear an expired copied-selection highlight; returns true when it changed
+    /// so the loop repaints once to remove it, since idle frames aren't rendered.
+    pub fn tick_copy_highlight(&mut self, now: Instant) -> bool {
+        if self.selection_clear_at.is_some_and(|at| now >= at) {
+            self.clear_selection();
+            true
+        } else {
+            false
+        }
     }
 
     /// Clear an expired toast; returns true when it changed (so the loop redraws
@@ -5789,6 +5811,20 @@ mod link_click_tests {
                 " Morning arrives without ceremony,\n a thin gold line on the edge of the glass.\n The kettle speaks in its private language,"
             )
         );
+        assert!(
+            app.selection.is_some(),
+            "the copied drag keeps its highlight briefly"
+        );
+        assert!(
+            !app.tick_copy_highlight(Instant::now()),
+            "the highlight stays until the toast cadence elapses"
+        );
+        assert!(app.selection.is_some());
+        assert!(
+            app.tick_copy_highlight(Instant::now() + COPY_HIGHLIGHT_DURATION),
+            "the highlight clears once the timer expires"
+        );
+        assert!(app.selection.is_none());
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1313,6 +1313,13 @@ impl App {
 
     fn apply_mouse(&mut self, m: ratatui::crossterm::event::MouseEvent) {
         use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+        // A new primary-button gesture replaces any copied mouse selection,
+        // even when a modal, menu, resize handle, or child TUI claims the press
+        // below. This keeps the delayed highlight from surviving an unrelated
+        // click through one of those early-return paths.
+        if matches!(m.kind, MouseEventKind::Down(MouseButton::Left)) {
+            self.clear_selection();
+        }
         // Track the cursor for hover affordances (e.g. the session delete ✕).
         self.hover = Some((m.column, m.row));
         if let MouseEventKind::Down(_) = m.kind {
@@ -1876,7 +1883,6 @@ impl App {
                 }
                 // Begin a selection only inside a pane's content; otherwise drop
                 // any old one. Falls through to normal click handling (focus/etc).
-                self.selection_clear_at = None;
                 self.selection = self
                     .pane_content_at(m.column, m.row)
                     .map(|(pane, content)| {
@@ -1945,11 +1951,10 @@ impl App {
                 return;
             }
             MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Up(MouseButton::Middle) => {
-                // A double-click already copied on its press; keep its highlight
-                // briefly on release, like a drag copy (toast is the feedback).
+                // A double-click already copied and scheduled its highlight
+                // expiry on press. Its release only closes the gesture.
                 if self.dbl_click_release {
                     self.dbl_click_release = false;
-                    self.schedule_copy_highlight_clear();
                     return;
                 }
                 if let Some(p) = self.link_press.take() {
@@ -3082,6 +3087,7 @@ impl App {
         self.pending_clipboard = Some(text);
         let msg = self.catalog.copied;
         self.show_toast(msg);
+        self.schedule_copy_highlight_clear();
         true
     }
 
@@ -6020,6 +6026,66 @@ mod link_click_tests {
             "the second press copies the whitespace word"
         );
         assert!(app.selection.is_some(), "and highlights it");
+        let clear_at = app
+            .selection_clear_at
+            .expect("the second press schedules highlight expiry");
+
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        assert!(!app.dbl_click_release, "release closes the gesture");
+        assert_eq!(
+            app.selection_clear_at,
+            Some(clear_at),
+            "release does not restart the press-time expiry"
+        );
+        assert!(app.tick_copy_highlight(clear_at));
+        assert!(app.selection.is_none(), "the press-time deadline clears it");
+    }
+
+    #[test]
+    fn a_new_left_press_clears_a_copied_highlight_before_overlay_handling() {
+        let _env = crate::persist::test_env("copy-highlight-overlay-click");
+        let (mut app, _t, at) = fixture_showing("hello world", 6);
+        let end = (at.0 + 4, at.1);
+
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            at,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            end,
+            KeyModifiers::NONE,
+        ));
+        app.handle_event(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            end,
+            KeyModifiers::NONE,
+        ));
+        assert!(app.selection.is_some(), "the copied drag is highlighted");
+        assert!(
+            app.selection_clear_at.is_some(),
+            "the copied drag has a pending expiry"
+        );
+
+        // The help overlay returns near the start of `apply_mouse`. Its click
+        // must still replace the delayed terminal highlight immediately.
+        app.help_open = true;
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            (0, 0),
+            KeyModifiers::NONE,
+        ));
+        assert!(!app.help_open, "the overlay handled the click");
+        assert!(app.selection.is_none(), "the old highlight cleared first");
+        assert!(
+            app.selection_clear_at.is_none(),
+            "its obsolete timer cleared with it"
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1825,6 +1825,8 @@ pub struct App {
     /// Active mouse text selection in a pane (drag to select). Cleared on a new
     /// click; on release its text is queued to `pending_clipboard`.
     pub selection: Option<Selection>,
+    /// When set, a copied mouse selection stays highlighted until this instant.
+    selection_clear_at: Option<Instant>,
     /// Keyboard copy selection. This deliberately owns navigation keys so they
     /// cannot reach the child while text is being selected.
     pub copy_mode: Option<CopyMode>,
@@ -2338,6 +2340,7 @@ impl App {
             pending_notify: Vec::new(),
             pending_sound: None,
             selection: None,
+            selection_clear_at: None,
             copy_mode: None,
             mouse_grab: None,
             pending_clipboard: None,
@@ -2957,6 +2960,7 @@ impl App {
             pending_notify: Vec::new(),
             pending_sound: None,
             selection: None,
+            selection_clear_at: None,
             copy_mode: None,
             mouse_grab: None,
             pending_clipboard: None,

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -569,6 +569,9 @@ pub fn run() -> Result<()> {
         if app.tick_toast(Instant::now()) {
             render_request.record(RenderCause::Metadata);
         }
+        if app.tick_copy_highlight(Instant::now()) {
+            render_request.record(RenderCause::Metadata);
+        }
         // Likewise for an expired search-jump flash (docs/63).
         if app.tick_search_flash(Instant::now()) {
             render_request.record(RenderCause::Metadata);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1365,6 +1365,7 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
             emit_clipboard(&text);
         }
         app.tick_toast(Instant::now());
+        app.tick_copy_highlight(Instant::now());
         app.tick_search_flash(Instant::now());
         app.tick_bar_notifications(Instant::now());
         // A forced redraw (resize / regained focus) wipes the terminal so the next


### PR DESCRIPTION
## Summary
- After drag or double-click copy, keep the selection highlight visible for 1.4s (same cadence as the "Copied" toast)
- Plain clicks and new selections still clear the highlight immediately
- Follow-up to #233: avoids indefinite stale selection while giving visible confirmation of what was copied

## Test plan
- [x] `cargo test --locked --bin luvus mouse_drag_copy_preserves_selected_terminal_cells`
- [x] `cargo test --locked --bin luvus stationary_click_stays_empty_when_output_advances_history`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual: drag-select copy — highlight stays ~1.4s, toast matches
- [ ] Manual: double-click word copy — highlight visible briefly after release
- [ ] Manual: plain click — no lingering highlight


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Copied text remains visibly highlighted for approximately 1.4 seconds, making it easier to confirm what was copied.
  * The highlight now clears automatically after the display period across supported copy interactions.
* **Bug Fixes**
  * Improved selection-highlight consistency for drag, double-click, and copy-mode interactions.
  * Clicking elsewhere now clears lingering copied-text highlighting immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->