### PR TITLE
fix(orch): clarify context heartbeat semantics

### DIFF
--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -390,6 +390,16 @@ def valid_global_request(value, methods):
             return False
         if mode == "worktree" and "workspace_id" in params:
             return False
+    if value["method"] == "task.heartbeat":
+        params = value["params"]
+        context = params.get("context")
+        return (
+            set(params) == {"id", "context"}
+            and bounded_string(params["id"], 128, allow_empty=False)
+            and isinstance(context, (int, float))
+            and not isinstance(context, bool)
+            and 0 <= context <= 1
+        )
     return True
 
 

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -375,6 +375,10 @@ surface:
   retrying. Leases coordinate declared paths but do not sandbox a shared
   checkout. `task release` requeues an
   active task and releases its path leases; it does not stop the worker pane.
+  Report work progress only with `task update --note`. `task heartbeat
+  --context-used <0..1>` means the fraction of the model context window already
+  consumed, never task-completion progress; `0.6` means 60% consumed. Omit the
+  heartbeat when context-window usage is unknown.
 - Inspect module metadata, actions, settings, and logs before changing module
   state. Installation, uninstallation, and consequential setting changes need
   clear authorization.

--- a/protocol/uhp/v1/fixtures/invalid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/invalid/requests.jsonl
@@ -15,3 +15,4 @@
 {"id":"bad-session-extra","method":"session.start","params":{"name":"review","extra":true}}
 {"id":"bad-session-name","method":"session.start","params":{"name":"."}}
 {"id":"bad-integration-status","method":"integration.status","params":{"agent":"claude"}}
+{"id":"bad-task-heartbeat-progress","method":"task.heartbeat","params":{"id":"t1","context":1.1}}

--- a/protocol/uhp/v1/fixtures/manifest.json
+++ b/protocol/uhp/v1/fixtures/manifest.json
@@ -1,10 +1,10 @@
 {
   "protocol": { "name": "luvus-uhp", "major": 1, "minor": 0 },
   "files": [
-    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 36 },
+    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 37 },
     { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 5 },
     { "path": "valid/events.jsonl", "kind": "event", "expect": "valid", "count": 2 },
-    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 17 },
+    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 18 },
     { "path": "invalid/responses.jsonl", "kind": "response", "expect": "invalid", "count": 1 }
   ]
 }

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -34,3 +34,4 @@
 {"id":"34","method":"integration.status","params":{}}
 {"id":"35","method":"integration.install","params":{"agent":"claude","confirm":true}}
 {"id":"36","method":"integration.uninstall","params":{"agent":"claude","confirm":true}}
+{"id":"37","method":"task.heartbeat","params":{"id":"t1","context":0.6}}

--- a/protocol/uhp/v1/schema/event-catalog.schema.json
+++ b/protocol/uhp/v1/schema/event-catalog.schema.json
@@ -366,7 +366,10 @@
       "required": ["id", "context"],
       "properties": {
         "id": { "type": "string" },
-        "context": { "type": "number", "minimum": 0, "maximum": 1 }
+        "context": {
+          "type": "number", "minimum": 0, "maximum": 1,
+          "description": "Fraction of the model context window already consumed. This is not task-completion progress."
+        }
       }
     },
     "task_merge_started": {

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -140,6 +140,16 @@
         "mode": { "enum": ["worktree", "workspace"] },
         "workspace_id": { "type": "string", "minLength": 1, "maxLength": 128 }
       }
+    },
+    "taskHeartbeatParams": {
+      "type": "object", "additionalProperties": false, "required": ["id", "context"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "context": {
+          "type": "number", "minimum": 0, "maximum": 1,
+          "description": "Fraction of the model context window already consumed. This is not task-completion progress."
+        }
+      }
     }
   },
   "allOf": [
@@ -169,6 +179,8 @@
       "then": { "properties": { "params": { "$ref": "#/$defs/taskStartParams" } } } },
     { "if": { "properties": { "method": { "const": "task.next" } } },
       "then": { "properties": { "params": { "$ref": "#/$defs/taskNextParams" } } } },
+    { "if": { "properties": { "method": { "const": "task.heartbeat" } } },
+      "then": { "properties": { "params": { "$ref": "#/$defs/taskHeartbeatParams" } } } },
     { "if": { "properties": { "method": { "const": "terminal.backend.inventory" } } },
       "then": { "properties": { "params": { "$ref": "https://luvus.dev/protocol/uhp/v1/schema/terminal/methods/inventory.schema.json" } } } },
     { "if": { "properties": { "method": { "const": "terminal.backend.snapshot" } } },

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -375,6 +375,10 @@ surface:
   retrying. Leases coordinate declared paths but do not sandbox a shared
   checkout. `task release` requeues an
   active task and releases its path leases; it does not stop the worker pane.
+  Report work progress only with `task update --note`. `task heartbeat
+  --context-used <0..1>` means the fraction of the model context window already
+  consumed, never task-completion progress; `0.6` means 60% consumed. Omit the
+  heartbeat when context-window usage is unknown.
 - Inspect module metadata, actions, settings, and logs before changing module
   state. Installation, uninstallation, and consequential setting changes need
   clear authorization.

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -762,8 +762,8 @@ impl App {
                 return Err((
                     "needs_compaction".to_string(),
                     format!(
-                        "context at {:.0}% — run /compact (or hand off to a fresh agent) before finishing",
-                        ctx * 100.0
+                        "model context window at {:.0}% — compact in the agent if supported, hand off, or correct a mistaken report with `luvus task heartbeat {id} --context-used <0..1>` before finishing",
+                        ctx * 100.0,
                     ),
                 ));
             }
@@ -1440,8 +1440,11 @@ fn task_briefing(task: &crate::orch::Task, mode: TaskWorkerMode) -> String {
         )),
     }
     b.push_str(&format!(
-        " Report progress with `luvus task update {id} --note <text>` and context usage \
-         with `luvus task heartbeat {id} --context <0..1>`."
+        " Report work progress only with `luvus task update {id} --note <text>`. If you \
+         can estimate model context-window consumption, report it with `luvus task \
+         heartbeat {id} --context-used <0..1>`, where 0.6 means 60% of the model \
+         context window is consumed, not 60% task progress. Omit the heartbeat when \
+         context-window usage is unknown."
     ));
     b
 }
@@ -2335,6 +2338,9 @@ mod tests {
         assert!(line.contains("claude"));
         assert!(line.contains("luvus task done t1"));
         assert!(line.contains("cargo test auth"));
+        assert!(line.contains("--context-used <0..1>"));
+        assert!(line.contains("not 60% task progress"));
+        assert!(!line.contains("--context <0..1>"));
         if !cfg!(windows) {
             assert!(line.starts_with("LUVUS_TASK_ID=t1 "));
             // The apostrophe in the title survives POSIX single-quoting.
@@ -2734,7 +2740,10 @@ mod tests {
         app.orch.add_task("x".into(), vec![], vec![], None).unwrap();
         // Over the compaction threshold → done is refused.
         app.orch.heartbeat("t1", 0.92).unwrap();
-        assert_eq!(app.complete_task("t1").unwrap_err().0, "needs_compaction");
+        let error = app.complete_task("t1").unwrap_err();
+        assert_eq!(error.0, "needs_compaction");
+        assert!(error.1.contains("model context window"));
+        assert!(error.1.contains("--context-used"));
         assert_ne!(
             app.orch.task("t1").unwrap().status,
             crate::orch::TaskStatus::Done

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -938,6 +938,29 @@ mod socket_api_tests {
     }
 
     #[test]
+    fn task_heartbeat_rejects_invalid_context_without_mutation() {
+        let (_env, mut app) = app("socket-task-heartbeat-context");
+        app.orch
+            .add_task("heartbeat".into(), vec![], vec![], None)
+            .unwrap();
+
+        app.dispatch("task.heartbeat", &json!({"id":"t1","context":0.6}))
+            .unwrap();
+        assert_eq!(app.orch.task("t1").unwrap().context, Some(0.6));
+
+        for params in [
+            json!({"id":"t1"}),
+            json!({"id":"t1","context":"0.5"}),
+            json!({"id":"t1","context":-0.1}),
+            json!({"id":"t1","context":1.1}),
+        ] {
+            let error = app.dispatch("task.heartbeat", &params).unwrap_err();
+            assert_eq!(error.0, "invalid_request");
+            assert_eq!(app.orch.task("t1").unwrap().context, Some(0.6));
+        }
+    }
+
+    #[test]
     fn socket_mutations_support_optimistic_revision_guards() {
         let (_env, mut app) = app("socket-revision-guard");
         let (reply, _) = std::sync::mpsc::channel();
@@ -4865,6 +4888,12 @@ impl App {
                         "context (0..1) is required".to_string(),
                     )
                 })?;
+                if !ctx.is_finite() || !(0.0..=1.0).contains(&ctx) {
+                    return Err((
+                        "invalid_request".to_string(),
+                        "context must be a finite number from 0 to 1".to_string(),
+                    ));
+                }
                 let over = self.orch.heartbeat(&id, ctx).map_err(orch_err)?;
                 self.orch.save();
                 if over {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -277,7 +277,9 @@ orchestration (multiple agents on one project, docs/22):
                              claim the next ready task (--start creates a worker)
   task start <id> [--branch <b>] [--agent <cmd>] [--mode worktree|workspace]
                              start a worker (worktree default; workspace shares checkout)
-  task heartbeat <id> --context <0..1>   report context usage (blocks done at >85%)
+  task heartbeat <id> --context-used <0..1>
+                             report model context-window use, not task progress
+                             (>85% blocks done; --context remains accepted)
   task update <id> [--status <s>] [--output <o>] [--note <n>]
   task done <id>             mark done + release its leases
   task merge <id>            integrate the task's branch into luvus/integration
@@ -3495,7 +3497,13 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             if let Some(id) = arg0() {
                 obj.insert("id".into(), json!(id));
             }
-            if let Some(c) = flag(args, "--context").and_then(|s| s.parse::<f64>().ok()) {
+            // `--context` remains a compatibility alias. Keep the UHP field
+            // stable while making the CLI spelling explicit enough that an
+            // agent cannot reasonably confuse it with task progress.
+            if let Some(c) = flag(args, "--context-used")
+                .or_else(|| flag(args, "--context"))
+                .and_then(|s| s.parse::<f64>().ok())
+            {
                 obj.insert("context".into(), json!(c));
             }
             ("task.heartbeat".into(), Value::Object(obj))
@@ -4526,9 +4534,13 @@ mod tests {
 
         assert!(parse(&argv("luvus task start t1 --mode unsafe")).is_err());
 
-        let (m, p) = parse(&argv("luvus task heartbeat t1 --context 0.7")).unwrap();
+        let (m, p) = parse(&argv("luvus task heartbeat t1 --context-used 0.7")).unwrap();
         assert_eq!(m, "task.heartbeat");
         assert_eq!(p.get("context").and_then(|v| v.as_f64()), Some(0.7));
+
+        let (m, p) = parse(&argv("luvus task heartbeat t1 --context 0.4")).unwrap();
+        assert_eq!(m, "task.heartbeat");
+        assert_eq!(p.get("context").and_then(|v| v.as_f64()), Some(0.4));
 
         let (m, p) = parse(&argv("luvus task merge t1")).unwrap();
         assert_eq!(m, "task.merge");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3500,12 +3500,7 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             // `--context` remains a compatibility alias. Keep the UHP field
             // stable while making the CLI spelling explicit enough that an
             // agent cannot reasonably confuse it with task progress.
-            if let Some(c) = flag(args, "--context-used")
-                .or_else(|| flag(args, "--context"))
-                .and_then(|s| s.parse::<f64>().ok())
-            {
-                obj.insert("context".into(), json!(c));
-            }
+            obj.insert("context".into(), json!(heartbeat_context(args)?));
             ("task.heartbeat".into(), Value::Object(obj))
         }
         ("task", "start") => {
@@ -3613,6 +3608,22 @@ fn flag(args: &[String], name: &str) -> Option<String> {
     args.iter()
         .position(|a| a == name)
         .and_then(|i| args.get(i + 1).cloned())
+}
+
+/// Parse the model context-window fraction for `task heartbeat`. The explicit
+/// spelling wins whenever both aliases are present, including when its value is
+/// invalid, so a malformed primary flag cannot silently fall back to legacy
+/// input.
+fn heartbeat_context(args: &[String]) -> Result<f64> {
+    let flag_name = if args.iter().any(|arg| arg == "--context-used") {
+        "--context-used"
+    } else {
+        "--context"
+    };
+    flag(args, flag_name)
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite() && (0.0..=1.0).contains(value))
+        .ok_or_else(|| anyhow!("--context-used requires a finite number from 0 to 1"))
 }
 
 /// A module-setting value typed on the command line. `true`/`false` and whole
@@ -4541,6 +4552,28 @@ mod tests {
         let (m, p) = parse(&argv("luvus task heartbeat t1 --context 0.4")).unwrap();
         assert_eq!(m, "task.heartbeat");
         assert_eq!(p.get("context").and_then(|v| v.as_f64()), Some(0.4));
+
+        let (_, p) = parse(&argv(
+            "luvus task heartbeat t1 --context 0.4 --context-used 0.7",
+        ))
+        .unwrap();
+        assert_eq!(p.get("context").and_then(|v| v.as_f64()), Some(0.7));
+
+        for invalid in [
+            "luvus task heartbeat t1",
+            "luvus task heartbeat t1 --context-used",
+            "luvus task heartbeat t1 --context-used nope",
+            "luvus task heartbeat t1 --context-used NaN",
+            "luvus task heartbeat t1 --context-used inf",
+            "luvus task heartbeat t1 --context-used -0.1",
+            "luvus task heartbeat t1 --context-used 1.1",
+            "luvus task heartbeat t1 --context nope",
+            "luvus task heartbeat t1 --context -0.1",
+            "luvus task heartbeat t1 --context 1.1",
+            "luvus task heartbeat t1 --context 0.4 --context-used nope",
+        ] {
+            assert!(parse(&argv(invalid)).is_err(), "{invalid} must be rejected");
+        }
 
         let (m, p) = parse(&argv("luvus task merge t1")).unwrap();
         assert_eq!(m, "task.merge");

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -2180,15 +2180,26 @@ static HELP: &[Translation] = &[
         "워커 시작 (기본값 worktree, workspace는 체크아웃 공유)"
     ),
     tr!(
-        "report context usage (blocks done at >85%)",
-        "informar uso de contexto (bloquea finalizar por encima del 85%)",
-        "informar uso de contexto (bloqueia conclusão acima de 85%)",
-        "signaler l'usage du contexte (bloque la fin au-delà de 85 %)",
-        "Kontextnutzung melden (blockiert Abschluss über 85 %)",
-        "laporkan penggunaan konteks (blokir selesai di atas 85%)",
-        "报告上下文使用率（超过 85% 时阻止完成）",
-        "コンテキスト使用率を報告（85%超で完了を拒否）",
-        "컨텍스트 사용량 보고 (85% 초과 시 완료 차단)"
+        "report model context-window use, not task progress",
+        "informar uso de la ventana de contexto del modelo, no progreso de la tarea",
+        "informar uso da janela de contexto do modelo, não o progresso da tarefa",
+        "signaler l'utilisation de la fenêtre de contexte du modèle, pas la progression de la tâche",
+        "Nutzung des Modell-Kontextfensters melden, nicht den Aufgabenfortschritt",
+        "laporkan pemakaian jendela konteks model, bukan progres tugas",
+        "报告模型上下文窗口用量，而非任务进度",
+        "タスク進捗ではなくモデルのコンテキストウィンドウ使用量を報告",
+        "작업 진행률이 아닌 모델 컨텍스트 창 사용량 보고"
+    ),
+    tr!(
+        "(>85% blocks done; --context remains accepted)",
+        "(>85% bloquea finalizar; --context sigue aceptado)",
+        "(>85% bloqueia conclusão; --context continua aceito)",
+        "(>85 % bloque la fin ; --context reste accepté)",
+        "(>85 % blockiert Abschluss; --context bleibt gültig)",
+        "(>85% memblokir penyelesaian; --context tetap diterima)",
+        "（超过 85% 时阻止完成；仍接受 --context）",
+        "（85%超で完了を拒否、--context も引き続き使用可能）",
+        "(85% 초과 시 완료 차단, --context도 계속 허용)"
     ),
     tr!(
         "mark done + release its leases",

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -2791,6 +2791,8 @@ static TEXT: &[Translation] = &[
         "인자를 받지 않습니다"),
     tr!("unexpected", "inesperado", "inesperado", "inattendu", "unerwartet", "tidak diharapkan", "意外参数", "想定外",
         "예상치 못함"),
+    tr!("--context-used requires a finite number from 0 to 1", "--context-used requiere un número finito de 0 a 1", "--context-used requer um número finito de 0 a 1", "--context-used exige un nombre fini compris entre 0 et 1", "--context-used erfordert eine endliche Zahl von 0 bis 1", "--context-used memerlukan angka terbatas dari 0 hingga 1", "--context-used 需要一个 0 到 1 之间的有限数值", "--context-used には 0 から 1 までの有限数が必要です",
+        "--context-used에는 0에서 1 사이의 유한한 숫자가 필요합니다"),
 ];
 
 /// Translate a canonical help block without ever touching command syntax.

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -134,6 +134,11 @@ Branch-backed dependencies unblock only after they are merged into the shared
 integration history.
 `task release` requeues active work and releases its path leases, but it does
 not stop the worker pane or discard its worktree.
+Use `task update --note` for work progress. `task heartbeat --context-used
+<0..1>` reports only the fraction of the model context window already consumed,
+where `0.6` means 60% consumed, not 60% task progress. Omit the heartbeat when
+that measurement is unknown. The older `--context` spelling remains a CLI
+compatibility alias; UHP keeps the stable `context` field.
 `task start` checks path leases before creating a worker. Its default
 `mode=worktree` creates an isolated branch and checkout. Explicit
 `mode=workspace` creates a dedicated task tab in an existing shared checkout;

--- a/website/src/content/docs/docs/guides/orchestration.mdx
+++ b/website/src/content/docs/docs/guides/orchestration.mdx
@@ -119,7 +119,7 @@ luvus task next --start --agent "claude"   # claim + start the next ready task
 luvus task start t2 --mode workspace --agent "codex"
 
 # finish + merge
-luvus task heartbeat t1 --context 0.6      # context gate: >0.85 blocks `done`
+luvus task heartbeat t1 --context-used 0.6 # 60% of the model context window is used
 luvus task done t1                          # runs the quality gate
 luvus task merge t1
 
@@ -132,6 +132,10 @@ luvus events
 
 Inside a luvus pane, commands default to the calling pane via
 `$LUVUS_PANE_ID`, so a worker agent can `luvus task heartbeat` itself.
+`--context-used` is the fraction of the model's context window already consumed:
+`0.6` means 60% consumed. It is not task-completion progress. Use `task update
+--note` for work progress and omit the heartbeat when context-window usage is
+unknown. The older `--context` spelling remains accepted for compatibility.
 
 Events on the bus: `task.added` · `task.claimed` · `task.started` ·
 `task.ready` · `task.gate_running` · `task.gate_passed` · `task.gate_failed` ·
@@ -153,9 +157,10 @@ Events on the bus: `task.added` · `task.claimed` · `task.started` ·
 - **Two layers of isolation.** Leases prevent overlapping work from being
   *assigned*, and worktrees mean even a misbehaving agent's clash only surfaces
   (safely) at merge time.
-- **A context gate.** Workers report context usage via `heartbeat`. Above 85%,
-  `done` is blocked until the agent compacts, so there are no half-remembered
-  finishes.
+- **A context gate.** Workers may report model context-window consumption via
+  `heartbeat`. Above 85%, `done` is blocked until the agent compacts or hands
+  off, so there are no half-remembered finishes. This value is never work
+  progress.
 
 ## Troubleshooting
 
@@ -164,7 +169,7 @@ Events on the bus: `task.added` · `task.claimed` · `task.started` ·
 | `s` → *not a git repo* | Worktree mode needs Git. Select workspace mode to run a branchless worker in the current directory. |
 | `s` → *deps not done* | A dependency task isn't `done` yet. |
 | `s` → *lease conflict* | Another task owns an overlapping path. Finish or release that task before retrying. No worker was created. |
-| `d` → *needs compaction* | The worker's context is over 85%, so compact (e.g. `/compact`), then retry. |
+| `d` → *needs compaction* | The worker's model context window is over 85%. Compact if the agent supports it, hand off, or correct a mistaken report with `luvus task heartbeat <id> --context-used <0..1>`, then retry. |
 | Stuck at `review` | The gate failed. `luvus task get <id>` shows the output. Fix and `d` again. |
 | `blocked` after `m` | Merge conflict. Resolve in the task's worktree, then `m` again. |
 

--- a/website/src/content/docs/docs/guides/orchestration.mdx
+++ b/website/src/content/docs/docs/guides/orchestration.mdx
@@ -158,9 +158,9 @@ Events on the bus: `task.added` · `task.claimed` · `task.started` ·
   *assigned*, and worktrees mean even a misbehaving agent's clash only surfaces
   (safely) at merge time.
 - **A context gate.** Workers may report model context-window consumption via
-  `heartbeat`. Above 85%, `done` is blocked until the agent compacts or hands
-  off, so there are no half-remembered finishes. This value is never work
-  progress.
+  `heartbeat`. Above 85%, `done` is blocked until the agent compacts, hands off,
+  or corrects a mistaken heartbeat to 85% or below, so there are no
+  half-remembered finishes. This value is never work progress.
 
 ## Troubleshooting
 

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -218,7 +218,9 @@ orchestration (multiple agents on one project, docs/22):
                              claim the next ready task (--start creates a worker)
   task start <id> [--branch <b>] [--agent <cmd>] [--mode worktree|workspace]
                              start a worker (worktree default; workspace shares checkout)
-  task heartbeat <id> --context <0..1>   report context usage (blocks done at >85%)
+  task heartbeat <id> --context-used <0..1>
+                             report model context-window use, not task progress
+                             (>85% blocks done; --context remains accepted)
   task update <id> [--status <s>] [--output <o>] [--note <n>]
   task done <id>             mark done + release its leases
   task merge <id>            integrate the task's branch into luvus/integration

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -103,6 +103,12 @@ pane fails with `not_found`; malformed or out-of-range IDs fail with
 `invalid_request` before any mutation. Pane IDs accept an unsigned 32-bit JSON
 integer or its decimal string form.
 
+For `task.heartbeat`, the canonical UHP `context` field is the fraction of the
+model context window already consumed. `0.6` means 60% of that window has been
+used, not 60% task progress. Send work progress through the `note` field of
+`task.update` and omit the heartbeat when context-window usage is unknown. The
+CLI exposes the same field as the clearer `--context-used` flag.
+
 `pane.report_session` binds an exact built-in agent session to its owning pane.
 The identity-only form remains compatible with existing integrations:
 


### PR DESCRIPTION
## Summary

- make `--context-used <0..1>` the documented task heartbeat flag while retaining `--context` as a compatibility alias
- separate work progress from model context-window consumption in generated worker briefings, bundled agent guidance, CLI help, and public docs
- make `needs_compaction` errors portable across agents and include an exact recovery command for mistaken reports
- define and validate the stable UHP `task.heartbeat` `context` field, with conformance fixtures and consumer coverage
- preserve the existing 85% compaction gate and allow a corrected heartbeat to unblock completion

## Why

The previous `--context` spelling and worker prompt allowed agents to interpret `1.0` as 100% task progress. Luvus stores that value as model context-window consumption, so the mistaken report crossed the compaction threshold and prevented `task done`, indirectly preventing merge.

The new wording states that `0.6` means 60% of the model context window has been consumed, never 60% task completion. Agents are told to use `task update --note` for progress and omit heartbeat telemetry when the value is unknown.

## Compatibility

- existing CLI calls using `--context` continue to work
- the canonical UHP request field remains `context`
- no task state, threshold, event name, or persistence format changes
- behavior is platform-independent

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked` (1,388 passed, 1 ignored)
- `cargo build --release --locked`
- `cargo test --test cli_help -- --nocapture`
- focused CLI, worker-briefing, completion/recovery, localization, and docs-parity tests
- `python3 examples/uhp/consumer.py` (63 fixtures)
- `npm run build` in `website/` (48 pages)

Fixes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for `task.heartbeat` requests, requiring context-usage values from 0 to 1.
  * Added `--context-used` for reporting model context-window consumption; `--context` remains supported as a compatibility alias.

* **Improvements**
  * Clarified that heartbeat values represent context usage, not task-completion progress.
  * Progress updates should use `task update --note`; omit heartbeats when usage is unknown.

* **Documentation**
  * Updated CLI, orchestration, protocol, and agent guidance with revised terminology and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->