### PR TITLE
feat(sidebar): add persistent path visibility controls

### DIFF
--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1708,9 +1708,10 @@ mod tests {
         );
         app.handle_agent_menu_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
         app.handle_agent_menu_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        app.handle_agent_menu_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
         assert_eq!(
             app.agent_menu.as_ref().and_then(|menu| menu.selected),
-            Some(3),
+            Some(4),
             "keyboard navigation skips the divider"
         );
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -557,6 +557,8 @@ pub struct WsMenu {
 pub enum WsMenuItem {
     Pin,
     Unpin,
+    /// Toggle the persisted cwd line for every WORKSPACES row.
+    TogglePath,
     Close,
     Rename,
     /// Delete a **linked worktree** and its files (git worktree remove + folder).
@@ -991,6 +993,8 @@ pub enum AgentMenuItem {
     /// Pin a live agent to the top of the AGENTS list (per-session).
     Pin,
     Unpin,
+    /// Toggle the persisted path/detail line for every AGENTS row.
+    TogglePath,
     Divider,
     /// The `i`-th module action declaring `contexts = ["agent"]` (docs/13 §3.8).
     Module(usize),
@@ -5329,7 +5333,12 @@ impl App {
         } else {
             WsMenuItem::Pin
         };
-        let mut items = vec![WsMenuItem::Close, WsMenuItem::Rename, pin];
+        let mut items = vec![
+            WsMenuItem::Close,
+            WsMenuItem::Rename,
+            pin,
+            WsMenuItem::TogglePath,
+        ];
         if is_worktree {
             items.push(WsMenuItem::DeleteWorktree);
         }
@@ -5419,6 +5428,7 @@ impl App {
                 AgentMenuItem::Pin
             });
         }
+        items.push(AgentMenuItem::TogglePath);
         items.push(AgentMenuItem::Divider);
         items.push(AgentMenuItem::ToggleWorkspaceScope);
         let extras = self
@@ -5471,6 +5481,10 @@ impl App {
             // (docs), persisted across restarts.
             WsMenuItem::Pin | WsMenuItem::Unpin => {
                 let _ = self.set_workspace_pinned(index, item == WsMenuItem::Pin);
+            }
+            WsMenuItem::TogglePath => {
+                self.config.layout.workspace_paths = !self.config.layout.workspace_paths;
+                self.persist_config();
             }
             // The right-clicked node, which needn't be the focused one.
             WsMenuItem::Module(i) => {
@@ -6173,6 +6187,10 @@ impl App {
         match (item, target) {
             (AgentMenuItem::ToggleWorkspaceScope, _) => {
                 self.set_agents_scope(!self.agents_this_workspace);
+            }
+            (AgentMenuItem::TogglePath, _) => {
+                self.config.layout.agent_paths = !self.config.layout.agent_paths;
+                self.persist_config();
             }
             (AgentMenuItem::Resume, AgentTarget::Session(i)) => self.resume_session(i),
             (AgentMenuItem::Close, AgentTarget::Session(i)) => self.dismiss_session(i),
@@ -8827,6 +8845,39 @@ mod tests {
             app.workspace_display_order(),
             vec![(1, false), (2, true), (0, false)]
         );
+    }
+
+    #[test]
+    fn sidebar_path_toggles_persist_independently() {
+        let _env = crate::persist::test_env("sidebar-path-toggles");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+
+        assert!(app.config.layout.workspace_paths);
+        assert!(app.config.layout.agent_paths);
+        assert!(app.ws_menu_items(0).contains(&WsMenuItem::TogglePath));
+        assert!(app
+            .agent_menu_items(AgentTarget::Live(pane))
+            .contains(&AgentMenuItem::TogglePath));
+
+        app.open_ws_menu(0, 0, 0);
+        app.ws_menu_action(WsMenuItem::TogglePath);
+        let stored = crate::config::load();
+        assert!(!stored.layout.workspace_paths);
+        assert!(stored.layout.agent_paths);
+
+        app.open_agent_menu(AgentTarget::Live(pane), 0, 0);
+        app.agent_menu_action(AgentMenuItem::TogglePath);
+        let stored = crate::config::load();
+        assert!(!stored.layout.workspace_paths);
+        assert!(!stored.layout.agent_paths);
+
+        drop(app);
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let restarted = App::new(80, 24, tx).unwrap();
+        assert!(!restarted.config.layout.workspace_paths);
+        assert!(!restarted.config.layout.agent_paths);
     }
 
     #[test]
@@ -12161,12 +12212,13 @@ mod tests {
         let items = &app.agent_menu.as_ref().unwrap().items;
         assert_eq!(
             items.len(),
-            4,
-            "session menu has Resume + Close + divider + workspace scope"
+            5,
+            "session menu has Resume + Close + path + divider + workspace scope"
         );
         assert_eq!(items[0].0, AgentMenuItem::Resume);
-        assert_eq!(items[2].0, AgentMenuItem::Divider);
-        assert_eq!(items[3].0, AgentMenuItem::ToggleWorkspaceScope);
+        assert_eq!(items[2].0, AgentMenuItem::TogglePath);
+        assert_eq!(items[3].0, AgentMenuItem::Divider);
+        assert_eq!(items[4].0, AgentMenuItem::ToggleWorkspaceScope);
         let rendered = |term: &Terminal<TestBackend>| {
             term.backend()
                 .buffer()
@@ -12179,7 +12231,7 @@ mod tests {
 
         // The scope row describes the action that will be taken. Clicking it
         // persists the choice; reopening any AGENTS row offers the inverse.
-        let scope = items[3].1;
+        let scope = items[4].1;
         app.handle_event(AppEvent::Mouse(MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
             column: scope.x + 1,

--- a/src/config.rs
+++ b/src/config.rs
@@ -218,6 +218,15 @@ pub struct LayoutConfig {
     /// useful title.
     #[serde(default)]
     pub agent_title: bool,
+    /// Show the cwd line beneath each WORKSPACES entry. On by default to retain
+    /// the established two-row presentation; the row context menu persists the
+    /// compact one-row preference when this is disabled.
+    #[serde(default = "yes")]
+    pub workspace_paths: bool,
+    /// Show the workspace/path detail line beneath each AGENTS entry. On by
+    /// default; the row context menu can hide it for a denser one-row list.
+    #[serde(default = "yes")]
+    pub agent_paths: bool,
     /// Resume a session into its own workspace (else a new tab in the current one).
     #[serde(default = "yes", alias = "resume_in_new_node")]
     pub resume_in_new_workspace: bool,
@@ -485,6 +494,8 @@ impl Default for LayoutConfig {
             show_titles: true,
             pane_title_path: false,
             agent_title: false,
+            workspace_paths: true,
+            agent_paths: true,
             resume_in_new_workspace: true,
             new_pane_to_workspace_root: false,
             file_open: default_file_open(),
@@ -788,12 +799,16 @@ mod tests {
         let c = Config::default();
         assert_eq!(c.theme, "quattro-rally");
         assert!(c.layout.show_titles);
+        assert!(c.layout.workspace_paths);
+        assert!(c.layout.agent_paths);
         assert_eq!(c.layout.col_gap, 1);
         assert_eq!(c.layout.mobile_width, crate::app::MOBILE_WIDTH);
         // Empty object → all defaults (forward/back compat).
         let from_empty: Config = serde_json::from_str("{}").unwrap();
         assert_eq!(from_empty.theme, "quattro-rally");
         assert_eq!(from_empty.sidebar_width, SIDEBAR_WIDTH_DEFAULT);
+        assert!(from_empty.layout.workspace_paths);
+        assert!(from_empty.layout.agent_paths);
         assert!(
             from_empty.direct_keybindings.is_empty(),
             "existing configs do not gain input-stealing direct shortcuts"

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -407,6 +407,8 @@ pub struct Catalog {
     pub menu_resume: &'static str,
     pub menu_show_workspace_only: &'static str,
     pub menu_show_all_workspaces: &'static str,
+    pub menu_show_path: &'static str,
+    pub menu_hide_path: &'static str,
     pub menu_split_vertical: &'static str,
     pub menu_move_to_tab: &'static str,
     pub menu_new_tab: &'static str,
@@ -800,6 +802,8 @@ pub static EN: Catalog = Catalog {
     menu_resume: "Resume",
     menu_show_workspace_only: "Show Workspace Only",
     menu_show_all_workspaces: "Show All Workspaces",
+    menu_show_path: "Show Path",
+    menu_hide_path: "Hide Path",
     menu_split_vertical: "Split Vertical",
     menu_move_to_tab: "Move to Tab",
     menu_new_tab: "New Tab",
@@ -1192,6 +1196,8 @@ static ES: Catalog = Catalog {
     menu_resume: "Reanudar",
     menu_show_workspace_only: "Mostrar solo este espacio",
     menu_show_all_workspaces: "Mostrar todos los espacios",
+    menu_show_path: "Mostrar ruta",
+    menu_hide_path: "Ocultar ruta",
     menu_split_vertical: "Dividir vertical",
     menu_move_to_tab: "Mover a pestaña",
     menu_new_tab: "Nueva pestaña",
@@ -1584,6 +1590,8 @@ static PT: Catalog = Catalog {
     menu_resume: "Retomar",
     menu_show_workspace_only: "Mostrar somente este espaço",
     menu_show_all_workspaces: "Mostrar todos os espaços",
+    menu_show_path: "Mostrar caminho",
+    menu_hide_path: "Ocultar caminho",
     menu_split_vertical: "Dividir vertical",
     menu_move_to_tab: "Mover para aba",
     menu_new_tab: "Nova aba",
@@ -1976,6 +1984,8 @@ static FR: Catalog = Catalog {
     menu_resume: "Reprendre",
     menu_show_workspace_only: "Afficher uniquement cet espace",
     menu_show_all_workspaces: "Afficher tous les espaces",
+    menu_show_path: "Afficher le chemin",
+    menu_hide_path: "Masquer le chemin",
     menu_split_vertical: "Diviser verticalement",
     menu_move_to_tab: "Déplacer vers un onglet",
     menu_new_tab: "Nouvel onglet",
@@ -2368,6 +2378,8 @@ static DE: Catalog = Catalog {
     menu_resume: "Fortsetzen",
     menu_show_workspace_only: "Nur diesen Arbeitsbereich anzeigen",
     menu_show_all_workspaces: "Alle Arbeitsbereiche anzeigen",
+    menu_show_path: "Pfad anzeigen",
+    menu_hide_path: "Pfad ausblenden",
     menu_split_vertical: "Vertikal teilen",
     menu_move_to_tab: "In Tab verschieben",
     menu_new_tab: "Neuer Tab",
@@ -2760,6 +2772,8 @@ static ID: Catalog = Catalog {
     menu_resume: "Lanjutkan",
     menu_show_workspace_only: "Tampilkan ruang kerja ini saja",
     menu_show_all_workspaces: "Tampilkan semua ruang kerja",
+    menu_show_path: "Tampilkan path",
+    menu_hide_path: "Sembunyikan path",
     menu_split_vertical: "Bagi vertikal",
     menu_move_to_tab: "Pindah ke tab",
     menu_new_tab: "Tab baru",
@@ -3152,6 +3166,8 @@ static ZH: Catalog = Catalog {
     menu_resume: "恢复",
     menu_show_workspace_only: "仅显示本工作区",
     menu_show_all_workspaces: "显示所有工作区",
+    menu_show_path: "显示路径",
+    menu_hide_path: "隐藏路径",
     menu_split_vertical: "垂直拆分",
     menu_move_to_tab: "移动到标签页",
     menu_new_tab: "新标签页",
@@ -3544,6 +3560,8 @@ static JA: Catalog = Catalog {
     menu_resume: "再開",
     menu_show_workspace_only: "このワークスペースのみ表示",
     menu_show_all_workspaces: "すべてのワークスペースを表示",
+    menu_show_path: "パスを表示",
+    menu_hide_path: "パスを隠す",
     menu_split_vertical: "垂直分割",
     menu_move_to_tab: "タブへ移動",
     menu_new_tab: "新しいタブ",
@@ -3936,6 +3954,8 @@ static KO: Catalog = Catalog {
     menu_resume: "재개",
     menu_show_workspace_only: "이 작업 공간만 표시",
     menu_show_all_workspaces: "모든 작업 공간 표시",
+    menu_show_path: "경로 표시",
+    menu_hide_path: "경로 숨기기",
     menu_split_vertical: "세로 분할",
     menu_move_to_tab: "탭으로 이동",
     menu_new_tab: "새 탭",
@@ -4023,6 +4043,14 @@ mod tests {
             assert!(
                 !catalog.menu_show_all_workspaces.trim().is_empty(),
                 "{code} has an unscoped action"
+            );
+            assert!(
+                !catalog.menu_show_path.trim().is_empty(),
+                "{code} has a show-path action"
+            );
+            assert!(
+                !catalog.menu_hide_path.trim().is_empty(),
+                "{code} has a hide-path action"
             );
             assert_eq!(
                 catalog.blocked_elsewhere.matches("{n}").count(),

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -195,7 +195,7 @@ pub(super) fn draw_ws_menu(
     let rows: Vec<MenuRow> = items
         .iter()
         .map(|it| MenuRow {
-            text: ws_label(*it, cat, &extras),
+            text: ws_label(*it, cat, &extras, app.config.layout.workspace_paths),
             divider: matches!(it, WsMenuItem::Divider),
             destructive: matches!(it, WsMenuItem::Close | WsMenuItem::DeleteWorktree),
         })
@@ -461,7 +461,7 @@ pub(super) fn draw_agent_menu(
     let rows: Vec<MenuRow> = items
         .iter()
         .map(|it| MenuRow {
-            text: agent_label(*it, cat, &extras, scoped),
+            text: agent_label(*it, cat, &extras, scoped, app.config.layout.agent_paths),
             divider: matches!(it, AgentMenuItem::Divider),
             destructive: matches!(it, AgentMenuItem::Close),
         })
@@ -490,6 +490,7 @@ fn agent_label(
     cat: &Catalog,
     extras: &[ModuleMenuAction],
     scoped: bool,
+    paths_visible: bool,
 ) -> String {
     match it {
         AgentMenuItem::ToggleWorkspaceScope => if scoped {
@@ -502,6 +503,12 @@ fn agent_label(
         AgentMenuItem::RenamePane => cat.menu_rename.to_string(),
         AgentMenuItem::Pin => cat.menu_pin.to_string(),
         AgentMenuItem::Unpin => cat.menu_unpin.to_string(),
+        AgentMenuItem::TogglePath => if paths_visible {
+            cat.menu_hide_path
+        } else {
+            cat.menu_show_path
+        }
+        .to_string(),
         AgentMenuItem::Close => cap_first(cat.act_close),
         AgentMenuItem::Divider => String::new(),
         AgentMenuItem::Module(i) => module_label(extras, i),
@@ -543,10 +550,21 @@ pub(super) fn draw_session_menu(
     }
 }
 
-fn ws_label(it: WsMenuItem, cat: &Catalog, extras: &[ModuleMenuAction]) -> String {
+fn ws_label(
+    it: WsMenuItem,
+    cat: &Catalog,
+    extras: &[ModuleMenuAction],
+    paths_visible: bool,
+) -> String {
     match it {
         WsMenuItem::Pin => cat.menu_pin.to_string(),
         WsMenuItem::Unpin => cat.menu_unpin.to_string(),
+        WsMenuItem::TogglePath => if paths_visible {
+            cat.menu_hide_path
+        } else {
+            cat.menu_show_path
+        }
+        .to_string(),
         WsMenuItem::Close => cap_first(cat.act_close),
         WsMenuItem::Rename => cat.menu_rename.to_string(),
         WsMenuItem::DeleteWorktree => cat.menu_delete_worktree.to_string(),
@@ -872,6 +890,7 @@ mod label_case_tests {
         for it in [
             WsMenuItem::Close,
             WsMenuItem::Rename,
+            WsMenuItem::TogglePath,
             WsMenuItem::DeleteWorktree,
             WsMenuItem::NewWorktree,
             WsMenuItem::OpenWorktree,
@@ -879,7 +898,7 @@ mod label_case_tests {
             WsMenuItem::OpenOrch,
             WsMenuItem::OpenMission,
         ] {
-            rows.push(ws_label(it, cat, none));
+            rows.push(ws_label(it, cat, none, true));
         }
         for it in PaneMenuItem::ALL.iter().copied() {
             rows.push(pane_label(it, cat, none));
@@ -896,8 +915,12 @@ mod label_case_tests {
         // user content, but the trailing "New Tab" is ours (`move_targets` in
         // `app/mod.rs`).
         rows.push(cat.menu_new_tab.to_string());
-        for it in [AgentMenuItem::Resume, AgentMenuItem::Close] {
-            rows.push(agent_label(it, cat, none, false));
+        for it in [
+            AgentMenuItem::Resume,
+            AgentMenuItem::TogglePath,
+            AgentMenuItem::Close,
+        ] {
+            rows.push(agent_label(it, cat, none, false, true));
         }
         for it in [
             OrchMenuItem::Start,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -53,12 +53,20 @@ type AgentHits = (Vec<(PaneId, Rect)>, Vec<(String, Rect)>, Vec<(usize, Rect)>);
 /// during a divider drag, starts this many rows below the sidebar origin.
 pub(crate) const SIDEBAR_CHROME_ROWS: u16 = 2;
 
-/// Rows each list item occupies: two content rows, drawn back-to-back.
-const ROW_STRIDE: u16 = 2;
+/// Rows an expanded list item occupies: two content rows, drawn back-to-back.
+const EXPANDED_ROW_STRIDE: u16 = 2;
 
-/// How many items fit in a list `rows` tall.
-fn list_capacity(rows: u16) -> usize {
-    (rows / ROW_STRIDE) as usize
+fn dock_row_stride(paths_visible: bool) -> u16 {
+    if paths_visible {
+        EXPANDED_ROW_STRIDE
+    } else {
+        1
+    }
+}
+
+/// How many items fit in a list `rows` tall at its current row height.
+fn list_capacity(rows: u16, row_stride: u16) -> usize {
+    (rows / row_stride) as usize
 }
 
 /// A scrollbar on the sidebar's right edge, shown only when the list overflows
@@ -423,7 +431,9 @@ fn draw_workspaces_dock(
     };
     let nlist_top = area.y + 1;
     let nrows = area.height.saturating_sub(1);
-    let ncap = list_capacity(nrows);
+    let paths_visible = app.config.layout.workspace_paths;
+    let row_stride = dock_row_stride(paths_visible);
+    let ncap = list_capacity(nrows, row_stride);
     let ntotal = app.workspaces.len();
     // Draw order groups each worktree under the node it branched from (docs/18
     // WT-4), so scroll positions index into this order, not raw creation order.
@@ -454,10 +464,10 @@ fn draw_workspaces_dock(
     app.workspaces_area = Rect::new(area.x, nlist_top, area.width, nrows);
     let nscroll = app.workspaces_scroll;
     for (vi, (i, is_member)) in order.into_iter().skip(nscroll).take(ncap).enumerate() {
-        let y = nlist_top + vi as u16 * ROW_STRIDE;
+        let y = nlist_top + vi as u16 * row_stride;
         let active = i == app.active_ws;
         let selected = keyboard_focused && nscroll + vi == app.workspace_cursor;
-        ws_rects.push((i, Rect::new(area.x, y, area.width, 2)));
+        ws_rects.push((i, Rect::new(area.x, y, area.width, row_stride)));
         let st = rollup(app, i);
         let ws = &app.workspaces[i];
         let terminal_cwd = app.workspace_terminal_cwd(i).unwrap_or(&ws.cwd);
@@ -510,29 +520,31 @@ fn draw_workspaces_dock(
             ));
         }
         line_at(f, y, Line::from(line1));
-        // Row 2: the project path, indented under the name (extra for members).
-        let pad = 2 + indent as usize;
-        line_at(
-            f,
-            y + 1,
-            Line::from(Span::styled(
-                format!(
-                    "{}{}",
-                    " ".repeat(pad),
-                    short_path(terminal_cwd, cw.saturating_sub(pad as u16))
-                ),
-                Style::new().fg(if selected {
-                    t.accent
-                } else if active {
-                    t.subtext0
-                } else {
-                    t.overlay0
-                }),
-            )),
-        );
+        if paths_visible {
+            // Row 2: the project path, indented under the name (extra for members).
+            let pad = 2 + indent as usize;
+            line_at(
+                f,
+                y + 1,
+                Line::from(Span::styled(
+                    format!(
+                        "{}{}",
+                        " ".repeat(pad),
+                        short_path(terminal_cwd, cw.saturating_sub(pad as u16))
+                    ),
+                    Style::new().fg(if selected {
+                        t.accent
+                    } else if active {
+                        t.subtext0
+                    } else {
+                        t.overlay0
+                    }),
+                )),
+            );
+        }
         if active || selected {
             let buf = f.buffer_mut();
-            for row in [y, y + 1] {
+            for row in y..y + row_stride {
                 for x in area.x..area.right().saturating_sub(1) {
                     buf[(x, row)].set_bg(if selected { t.surface1 } else { t.sel_bg });
                 }
@@ -602,6 +614,8 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
     let scoped = app.agents_scope_active();
     let alist_top = aheader + 1;
     let arows = area.bottom().saturating_sub(alist_top);
+    let paths_visible = app.config.layout.agent_paths;
+    let row_stride = dock_row_stride(paths_visible);
     app.agents_area = Rect::new(area.x, alist_top, area.width, arows);
 
     let focus = app.layout().focus;
@@ -732,7 +746,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
     let keyboard_total = atotal + usize::from(has_elsewhere);
     app.agent_cursor = app.agent_cursor.min(keyboard_total.saturating_sub(1));
     app.agents_elsewhere_rect = None;
-    let acap = list_capacity(arows.saturating_sub(u16::from(has_elsewhere)));
+    let acap = list_capacity(arows.saturating_sub(u16::from(has_elsewhere)), row_stride);
     if keyboard_focused && app.agent_cursor < atotal {
         if app.agent_cursor < app.agents_scroll {
             app.agents_scroll = app.agent_cursor;
@@ -758,7 +772,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
         );
     } else {
         for (vi, k) in (ascroll..atotal).take(acap).enumerate() {
-            let y = alist_top + vi as u16 * ROW_STRIDE;
+            let y = alist_top + vi as u16 * row_stride;
             let selected = keyboard_focused && app.agent_cursor == k;
             if let Some((id, wsname)) = live.get(k) {
                 // A live agent: runtime status + which workspace it runs in.
@@ -775,7 +789,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                 } else {
                     Style::new().fg(t.subtext1)
                 };
-                agent_rects.push((id, Rect::new(area.x, y, area.width, 2)));
+                agent_rects.push((id, Rect::new(area.x, y, area.width, row_stride)));
                 // Working stays visually prominent without scheduling animation
                 // frames while the agent is busy.
                 let dot = st.dot();
@@ -791,39 +805,36 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                         Span::styled(agent, name_style),
                     ]),
                 );
-                // Row 2: project · tab · how to mention this pane, styled exactly
-                // like a workspace's path row. It was pinned to `overlay0`, which
-                // lands on `sel_bg` for the focused row and is then all but
-                // unreadable — the same reason the workspaces dock brightens its
-                // path when active. The trailing token is the pane's live alias
-                // (`=name`, set by `agent name`) or its pane id (`=3`), so the
-                // reader can paste the token directly into a delegation line.
-                let mention = app
-                    .agent_name_for(id)
-                    .map(|n| format!("={n}"))
-                    .unwrap_or_else(|| format!("={}", id.0));
-                // When enabled, show the agent's live session title (its OSC
-                // title, e.g. "Ship the desktop release…") in place of the meta
-                // line; fall back to it when the agent set no useful title.
-                let meta = app
-                    .config
-                    .layout
-                    .agent_title
-                    .then(|| app.pane_title(id))
-                    .flatten()
-                    .map(|ttl| format!("  {ttl}"))
-                    .unwrap_or_else(|| format!("  {wsname} · {mention}"));
-                line_at(
-                    f,
-                    y + 1,
-                    Line::from(Span::styled(
-                        crate::ui::truncate(&meta, cw as usize),
-                        Style::new().fg(if focused { t.subtext0 } else { t.overlay0 }),
-                    )),
-                );
+                if paths_visible {
+                    // Row 2: project + how to mention this pane, styled exactly
+                    // like a workspace's path row. The trailing token is the
+                    // pane's live alias (`=name`) or its pane id (`=3`).
+                    let mention = app
+                        .agent_name_for(id)
+                        .map(|n| format!("={n}"))
+                        .unwrap_or_else(|| format!("={}", id.0));
+                    // When enabled, show the live OSC title in place of the meta
+                    // line; fall back when the agent set no useful title.
+                    let meta = app
+                        .config
+                        .layout
+                        .agent_title
+                        .then(|| app.pane_title(id))
+                        .flatten()
+                        .map(|ttl| format!("  {ttl}"))
+                        .unwrap_or_else(|| format!("  {wsname} · {mention}"));
+                    line_at(
+                        f,
+                        y + 1,
+                        Line::from(Span::styled(
+                            crate::ui::truncate(&meta, cw as usize),
+                            Style::new().fg(if focused { t.subtext0 } else { t.overlay0 }),
+                        )),
+                    );
+                }
                 if focused {
                     let buf = f.buffer_mut();
-                    for row in [y, y + 1] {
+                    for row in y..y + row_stride {
                         for x in area.x..area.right().saturating_sub(1) {
                             buf[(x, row)].set_bg(t.sel_bg);
                         }
@@ -834,7 +845,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
             {
                 automation_rects.push((
                     automation.clone(),
-                    Rect::new(area.x, y, area.width, ROW_STRIDE),
+                    Rect::new(area.x, y, area.width, row_stride),
                 ));
                 let label = format!(
                     " {}  ",
@@ -857,17 +868,19 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                         ),
                     ]),
                 );
-                line_at(
-                    f,
-                    y + 1,
-                    Line::from(Span::styled(
-                        crate::ui::truncate(
-                            &format!("  {workspace} · UTC {}", super::format_utc(*deadline)),
-                            cw as usize,
-                        ),
-                        Style::new().fg(t.overlay0),
-                    )),
-                );
+                if paths_visible {
+                    line_at(
+                        f,
+                        y + 1,
+                        Line::from(Span::styled(
+                            crate::ui::truncate(
+                                &format!("  {workspace} · UTC {}", super::format_utc(*deadline)),
+                                cw as usize,
+                            ),
+                            Style::new().fg(t.overlay0),
+                        )),
+                    );
+                }
             } else {
                 // A resumable session discovered on disk — click to reopen.
                 let visible_index = k - live.len() - scheduled.len();
@@ -877,12 +890,7 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                     visible_index
                 };
                 let s = &app.resumable[si];
-                let proj = s
-                    .cwd
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("project");
-                let row = Rect::new(area.x, y, area.width, 2);
+                let row = Rect::new(area.x, y, area.width, row_stride);
                 session_rects.push((si, row));
                 let label = " resume  ";
                 let prefix_w = 1 + crate::ui::display_width(label);
@@ -896,20 +904,27 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                         Span::styled(name, Style::new().fg(t.subtext0)),
                     ]),
                 );
-                line_at(
-                    f,
-                    y + 1,
-                    Line::from(Span::styled(
-                        crate::ui::truncate(&format!("  {proj}"), cw as usize),
-                        Style::new().fg(t.overlay0),
-                    )),
-                );
+                if paths_visible {
+                    let proj = s
+                        .cwd
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("project");
+                    line_at(
+                        f,
+                        y + 1,
+                        Line::from(Span::styled(
+                            crate::ui::truncate(&format!("  {proj}"), cw as usize),
+                            Style::new().fg(t.overlay0),
+                        )),
+                    );
+                }
                 // Removing / reopening a session is on the row's right-click menu
                 // (docs/28) — no per-row ✕ button.
             }
             if selected {
                 f.buffer_mut().set_style(
-                    Rect::new(area.x, y, area.width.saturating_sub(1), ROW_STRIDE),
+                    Rect::new(area.x, y, area.width.saturating_sub(1), row_stride),
                     Style::new().fg(t.accent).bg(t.surface1),
                 );
             }
@@ -1198,6 +1213,32 @@ mod tests {
                 .bg,
             app.theme.surface1
         );
+    }
+
+    #[test]
+    fn hidden_sidebar_paths_compact_workspace_and_agent_rows() {
+        let _env = crate::persist::test_env("sidebar-path-row-height");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        app.resumable.push(crate::agent::SessionInfo {
+            agent: "claude".into(),
+            session_id: "sidebar-path-row".into(),
+            cwd: std::env::current_dir().unwrap(),
+            updated: std::time::SystemTime::now(),
+        });
+
+        term.draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+        assert_eq!(app.ws_rects[0].1.height, 2);
+        assert_eq!(app.session_rects[0].1.height, 2);
+
+        app.config.layout.workspace_paths = false;
+        app.config.layout.agent_paths = false;
+        term.draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+        assert_eq!(app.ws_rects[0].1.height, 1);
+        assert_eq!(app.session_rects[0].1.height, 1);
     }
 
     /// The column each agent row's state label starts at, for every row drawn.

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -30,7 +30,9 @@ keyboard navigation, press `Ctrl+Space a` to focus AGENTS, move with arrows or
 `j` / `k`, and press `Enter` to open the selected live or resumable agent. Press
 `a` for the selected row's right-click actions, `f` to switch All / Active, `s`
 to switch all workspaces / this workspace, and `Esc` or `q` to return input to
-the pane.
+the pane. Choose **Hide Path** in any agent row's menu for a compact one-row
+list, then **Show Path** to restore the workspace and session detail rows. The
+choice persists across restarts.
 
 States are **debounced**: an agent that pauses mid-turn (thinking, tool calls,
 API latency) holds at *working* instead of flickering. You get one clean

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -118,6 +118,9 @@ Right-click any workspace row for its menu:
   disk)
 - **Pin** / **Unpin** it at the top of the list. A linked worktree stays with
   its parent, so pinning either one moves the complete group.
+- **Hide Path** switches WORKSPACES to compact one-row entries. Right-click
+  again and choose **Show Path** to restore the cwd rows. Luvus remembers this
+  choice across restarts.
 - **New Git Worktree** / **Open Worktree** (for git repos)
 - **Open Git Tab** · **Open Task Board** · **Open Mission Control**
 

--- a/website/src/content/docs/docs/reference/configuration.mdx
+++ b/website/src/content/docs/docs/reference/configuration.mdx
@@ -33,6 +33,8 @@ cleanly across versions because unknown fields get defaults.
 | `layout.resume_in_new_workspace` | resume a session into its own workspace instead of a new tab |
 | `layout.file_open` | which viewer opens a file: `readonly` (default) or an editor command such as `vim` (see [Browsing & Opening Files](/docs/guides/files/)) |
 | `layout.file_click` | what a plain click in the FILES dock does: `preview` (default) reuses one read-only preview pane, `tab` opens a whole tab through `layout.file_open`. Only `tab` can launch an editor. |
+| `layout.workspace_paths` | show the cwd line beneath WORKSPACES rows; defaults to `true` and can be toggled from any workspace row menu |
+| `layout.agent_paths` | show the workspace/path detail line beneath AGENTS rows; defaults to `true` and can be toggled from any agent row menu |
 | `layout.diff_layout` | default native DIFF layout: `auto`, `split`, or `stack` |
 | `layout.diff_wrap` | wrap long diff rows instead of using horizontal navigation |
 | `layout.diff_context_lines` | unchanged Git context lines per hunk, from `0` to `20` |

--- a/website/src/content/docs/docs/reference/keybindings.mdx
+++ b/website/src/content/docs/docs/reference/keybindings.mdx
@@ -127,8 +127,9 @@ After `Enter` opens a file view, `x` closes that view. An opened DIFF review
 closes with `q` or `Esc`.
 
 **Right-click menus** (no key needed): a **tab** to rename it, a **workspace** row
-for its menu (rename / close / worktrees / git / board), a **pane** to split or
-close it, an **agent** row for quick actions, or a **FILES** row to open it
+for its menu (rename / close / path visibility / worktrees / git / board), a
+**pane** to split or close it, an **agent** row for quick actions and path
+visibility, or a **FILES** row to open it
 read-only or in an editor, explicitly preview Markdown/Mermaid, or manage the
 entry (new / rename / delete). See
 [Panes, Tabs & Workspaces](/docs/guides/layout/) and


### PR DESCRIPTION
## Summary

- add dynamic Show Path and Hide Path actions to WORKSPACES and AGENTS row menus
- compact hidden path entries from two rows to one and update scrolling, hit targets, and selection rendering
- persist workspace and agent path visibility independently across restarts
- localize the menu actions across all supported UI languages
- document the controls and configuration fields

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --release --locked`
- `bun run build` in `website`

The locked Rust suite passed with 1,486 tests, plus the CLI, named session, and theme integration tests. One existing retained render benchmark remains ignored.

## Safety

- existing configurations retain visible paths by default
- WORKSPACES and AGENTS visibility preferences are independent
- no production Luvus server was started, stopped, or modified