### PR TITLE
perf(terminal): accelerate bulk scrollback ingestion

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2471,6 +2471,12 @@ impl App {
                             "history_cache_bytes": history.and_then(|m| m.cache_bytes),
                             "history_compacted_rows": history.and_then(|m| m.compacted_rows),
                             "history_allocated_cells": history.and_then(|m| m.allocated_cells),
+                            "history_packed_blocks": history.and_then(|m| m.packed_blocks),
+                            "history_packed_bytes": history.and_then(|m| m.packed_bytes),
+                            "history_packed_rows": history.and_then(|m| m.packed_rows),
+                            "history_dense_row_bytes": history.and_then(|m| m.dense_row_bytes),
+                            "history_row_descriptor_bytes": history.and_then(|m| m.row_descriptor_bytes),
+                            "history_allocation_count": history.and_then(|m| m.allocation_count),
                             "history_exact": history.map(|m| m.exact_bytes).unwrap_or(false),
                             "history_bytes_kind": if history.is_some_and(|m| m.exact_bytes) { "exact" } else { "estimated" },
                         })
@@ -2644,6 +2650,12 @@ impl App {
                     "history_cache_bytes": history.and_then(|m| m.cache_bytes),
                     "history_compacted_rows": history.and_then(|m| m.compacted_rows),
                     "history_allocated_cells": history.and_then(|m| m.allocated_cells),
+                    "history_packed_blocks": history.and_then(|m| m.packed_blocks),
+                    "history_packed_bytes": history.and_then(|m| m.packed_bytes),
+                    "history_packed_rows": history.and_then(|m| m.packed_rows),
+                    "history_dense_row_bytes": history.and_then(|m| m.dense_row_bytes),
+                    "history_row_descriptor_bytes": history.and_then(|m| m.row_descriptor_bytes),
+                    "history_allocation_count": history.and_then(|m| m.allocation_count),
                     "history_exact": history.map(|m| m.exact_bytes).unwrap_or(false),
                     "history_bytes_kind": if history.is_some_and(|m| m.exact_bytes) { "exact" } else { "estimated" },
                 }))
@@ -10230,9 +10242,10 @@ command = ["true"]
         let pane = app.layout().focus;
         if let Some(p) = app.panes.get(&pane) {
             if let Ok(mut engine) = p.engine.lock() {
-                for i in 0..40 {
+                for i in 0..300 {
                     engine.advance(format!("line {i}\r\n").as_bytes());
                 }
+                engine.finish_output_batch();
             }
         }
         let out = app
@@ -10246,6 +10259,13 @@ command = ["true"]
         assert!(out.get("history_cache_bytes").is_some());
         assert!(out["history_compacted_rows"].as_u64().is_some());
         assert!(out["history_allocated_cells"].as_u64().is_some());
+        assert!(out["history_packed_blocks"].as_u64().is_some());
+        assert!(out["history_packed_bytes"].as_u64().is_some());
+        assert!(out["history_packed_rows"].as_u64().is_some());
+        assert!(out["history_packed_rows"].as_u64().unwrap_or(0) > 0);
+        assert!(out["history_dense_row_bytes"].as_u64().is_some());
+        assert!(out["history_row_descriptor_bytes"].as_u64().is_some());
+        assert!(out["history_allocation_count"].as_u64().is_some());
         assert_eq!(out["history_bytes_kind"], "estimated");
         assert_eq!(out["history_exact"], false, "Alacritty reports an estimate");
 
@@ -10274,6 +10294,12 @@ command = ["true"]
         assert!(row.get("history_cache_bytes").is_some());
         assert!(row.get("history_compacted_rows").is_some());
         assert!(row.get("history_allocated_cells").is_some());
+        assert!(row.get("history_packed_blocks").is_some());
+        assert!(row.get("history_packed_bytes").is_some());
+        assert!(row.get("history_packed_rows").is_some());
+        assert!(row.get("history_dense_row_bytes").is_some());
+        assert!(row.get("history_row_descriptor_bytes").is_some());
+        assert!(row.get("history_allocation_count").is_some());
         assert_eq!(row["history_bytes_kind"], "estimated");
     }
 

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -27,6 +27,10 @@ use crate::terminal::vt::{create_engine, VtEngine, VtEngineKind};
 mod io;
 mod reaper;
 
+/// Keep each pane's read working set small. Unix amortizes synchronization by
+/// draining several of these chunks under one bounded engine lock.
+const PTY_READ_BUFFER_BYTES: usize = 8 * 1024;
+
 #[cfg(test)]
 use reaper::child_poll_finished;
 use reaper::register_child_reaper;
@@ -731,6 +735,12 @@ impl Pane {
         let pending = self
             .data_pending
             .swap(false, std::sync::atomic::Ordering::AcqRel);
+        // Unix compacts on a bounded deadline in its existing descriptor
+        // actor. Doing it here would repeatedly pack and re-inflate rows while
+        // one large output stream is still being consumed. The blocking
+        // Windows reader has no such event-loop deadline, so retain its
+        // coalesced app-boundary maintenance.
+        #[cfg(windows)]
         if pending {
             if let Ok(mut engine) = self.engine.lock() {
                 engine.finish_output_batch();
@@ -962,6 +972,12 @@ impl Pane {
                 cache_bytes: None,
                 compacted_rows: None,
                 allocated_cells: None,
+                packed_blocks: None,
+                packed_bytes: None,
+                packed_rows: None,
+                dense_row_bytes: None,
+                row_descriptor_bytes: None,
+                allocation_count: None,
                 exact_bytes: false,
             },
         )
@@ -1176,7 +1192,7 @@ fn read_loop(
     data_pending: Arc<AtomicBool>,
     content_revision: Arc<AtomicU64>,
 ) {
-    let mut buf = [0u8; 8192];
+    let mut buf = [0u8; PTY_READ_BUFFER_BYTES];
     loop {
         match reader.read(&mut buf) {
             Ok(0) | Err(_) => {

--- a/src/terminal/pty/io/unix_actor.rs
+++ b/src/terminal/pty/io/unix_actor.rs
@@ -13,9 +13,13 @@ use crate::event::AppEvent;
 use crate::ids::PaneId;
 use crate::terminal::vt::VtEngine;
 
-use super::super::InputAction;
+use super::super::{InputAction, PTY_READ_BUFFER_BYTES};
 
+// Drain enough output per readiness edge to amortize parser locking and app
+// wakeups during bulk output, while retaining a hard fairness bound for input.
 const IO_BUDGET: usize = 64 * 1024;
+const HISTORY_COMPACTION_QUIET: Duration = Duration::from_millis(100);
+const HISTORY_COMPACTION_MAX_DEFER: Duration = Duration::from_millis(500);
 
 pub(crate) struct WakePipe {
     read: OwnedFd,
@@ -157,7 +161,9 @@ fn actor_loop(
     cancelled: Arc<AtomicBool>,
 ) {
     let mut pending = VecDeque::new();
-    let mut read_buffer = [0u8; 8192];
+    let mut read_buffer = [0u8; PTY_READ_BUFFER_BYTES];
+    let mut history_compaction_started = None;
+    let mut history_compaction_deadline = None;
     loop {
         wake.drain();
         drain_input(&input, &mut pending);
@@ -168,7 +174,7 @@ fn actor_loop(
         let now = Instant::now();
         arm_or_finish_submit_delay(&mut pending, now);
         let wants_write = matches!(pending.front(), Some(PendingWrite::Bytes { .. }));
-        let timeout = poll_timeout(&pending, now);
+        let timeout = poll_timeout(&pending, history_compaction_deadline, now);
         let mut fds = [
             libc::pollfd {
                 fd: master.as_raw_fd(),
@@ -212,6 +218,12 @@ fn actor_loop(
                 &content_revision,
             ) {
                 Ok(ReadState::Data) => {
+                    let now = Instant::now();
+                    let started = *history_compaction_started.get_or_insert(now);
+                    history_compaction_deadline = Some(
+                        (now + HISTORY_COMPACTION_QUIET)
+                            .min(started + HISTORY_COMPACTION_MAX_DEFER),
+                    );
                     if !data_pending.swap(true, Ordering::AcqRel)
                         && app_tx.send(AppEvent::PtyData(id)).is_err()
                     {
@@ -224,6 +236,20 @@ fn actor_loop(
         }
         if terminal_events & (libc::POLLERR | libc::POLLNVAL) != 0 {
             break;
+        }
+        if history_compaction_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            if let Ok(mut terminal) = engine.lock() {
+                terminal.finish_output_batch();
+            }
+            history_compaction_deadline = None;
+            history_compaction_started = None;
+        }
+    }
+    // Preserve bounded memory when a pane exits or is cancelled before its
+    // quiet-period deadline fires.
+    if history_compaction_deadline.is_some() {
+        if let Ok(mut terminal) = engine.lock() {
+            terminal.finish_output_batch();
         }
     }
     let _ = app_tx.send(AppEvent::PtyExit(id));
@@ -264,8 +290,12 @@ fn arm_or_finish_submit_delay(pending: &mut VecDeque<PendingWrite>, now: Instant
     }
 }
 
-fn poll_timeout(pending: &VecDeque<PendingWrite>, now: Instant) -> libc::c_int {
-    match pending.front() {
+fn poll_timeout(
+    pending: &VecDeque<PendingWrite>,
+    history_compaction_deadline: Option<Instant>,
+    now: Instant,
+) -> libc::c_int {
+    let input_timeout = match pending.front() {
         Some(PendingWrite::SubmitDelay {
             deadline: Some(deadline),
             ..
@@ -277,6 +307,17 @@ fn poll_timeout(pending: &VecDeque<PendingWrite>, now: Instant) -> libc::c_int {
         Some(PendingWrite::SubmitDelay { deadline: None, .. }) => 0,
         Some(PendingWrite::Bytes { .. }) => -1,
         None => -1,
+    };
+    let history_timeout = history_compaction_deadline.map_or(-1, |deadline| {
+        deadline
+            .saturating_duration_since(now)
+            .as_millis()
+            .max(1)
+            .min(libc::c_int::MAX as u128) as libc::c_int
+    });
+    match (input_timeout, history_timeout) {
+        (-1, timeout) | (timeout, -1) => timeout,
+        (input, history) => input.min(history),
     }
 }
 
@@ -329,14 +370,21 @@ fn read_available(
 ) -> io::Result<ReadState> {
     let mut budget = IO_BUDGET;
     let mut read_any = false;
+    let mut advanced_any = false;
+    let mut state = ReadState::Data;
+    // One actor exclusively advances this engine. Hold its lock across the
+    // bounded nonblocking drain so a burst does not pay one mutex round trip
+    // and one revision update per kernel read.
+    let mut terminal = engine.lock().ok();
     while budget > 0 {
         let count = unsafe { libc::read(fd, buffer.as_mut_ptr().cast(), buffer.len().min(budget)) };
         if count == 0 {
-            return Ok(if read_any {
+            state = if read_any {
                 ReadState::Data
             } else {
                 ReadState::Eof
-            });
+            };
+            break;
         }
         if count < 0 {
             let error = io::Error::last_os_error();
@@ -344,27 +392,30 @@ fn read_available(
                 continue;
             }
             if error.kind() == io::ErrorKind::WouldBlock {
-                return Ok(if read_any {
+                state = if read_any {
                     ReadState::Data
                 } else {
                     ReadState::WouldBlock
-                });
+                };
+                break;
             }
-            return if read_any {
-                Ok(ReadState::Data)
-            } else {
-                Err(error)
-            };
+            if read_any {
+                break;
+            }
+            return Err(error);
         }
         let count = count as usize;
-        if let Ok(mut engine) = engine.lock() {
-            engine.advance(&buffer[..count]);
-            content_revision.fetch_add(1, Ordering::Release);
+        if let Some(terminal) = terminal.as_deref_mut() {
+            terminal.advance(&buffer[..count]);
+            advanced_any = true;
         }
         read_any = true;
         budget -= count;
     }
-    Ok(ReadState::Data)
+    if advanced_any {
+        content_revision.fetch_add(1, Ordering::Release);
+    }
+    Ok(state)
 }
 
 #[cfg(test)]
@@ -399,6 +450,17 @@ mod tests {
             pending.front(),
             Some(PendingWrite::Bytes { bytes, .. }) if bytes == b"\r"
         ));
+    }
+
+    #[test]
+    fn history_maintenance_deadline_only_arms_poll_while_pending() {
+        let pending = VecDeque::new();
+        let now = Instant::now();
+        assert_eq!(poll_timeout(&pending, None, now), -1);
+        assert_eq!(
+            poll_timeout(&pending, Some(now + HISTORY_COMPACTION_QUIET), now),
+            HISTORY_COMPACTION_QUIET.as_millis() as libc::c_int
+        );
     }
 
     #[test]

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -468,7 +468,6 @@ impl VtEngine for AlacrittyEngine {
     }
 
     fn damage_snapshot(&mut self) -> DamageSnapshot {
-        self.term.finish_output_batch();
         self.damage_line_indices.clear();
         let kind = match self.term.damage() {
             TermDamage::Full => DamageKind::Full,
@@ -891,15 +890,22 @@ impl VtEngine for AlacrittyEngine {
         let retained_rows = self.history_len();
         let retained_bytes =
             retained_rows.saturating_mul(estimated_row_bytes(self.term.grid().columns()));
+        let storage = self.term.history_storage_metrics();
         HistoryMetrics {
             offset: self.scroll_offset(),
             retained_rows,
             budget_bytes: self.history_budget_bytes,
             retained_bytes,
-            estimated_grid_bytes: self.term.estimated_grid_bytes(),
-            cache_bytes: Some(self.term.history_cache_bytes()),
+            estimated_grid_bytes: storage.estimated_bytes,
+            cache_bytes: Some(storage.cache_bytes),
             compacted_rows: Some(self.term.compacted_history_rows()),
-            allocated_cells: Some(self.term.allocated_cell_capacity()),
+            allocated_cells: Some(storage.allocated_cells),
+            packed_blocks: Some(storage.packed_blocks),
+            packed_bytes: Some(storage.packed_block_bytes),
+            packed_rows: Some(storage.packed_rows),
+            dense_row_bytes: Some(storage.dense_cell_bytes),
+            row_descriptor_bytes: Some(storage.row_descriptor_bytes),
+            allocation_count: Some(storage.allocations),
             exact_bytes: false,
         }
     }
@@ -1372,14 +1378,24 @@ mod tests {
     #[test]
     fn cold_history_compacts_losslessly_and_survives_reflow() {
         let (tx, _rx) = channel();
-        let mut e = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 500));
+        // Size the budget for the wider post-reflow grid so width-dependent
+        // history accounting does not intentionally evict the oldest rows.
+        let mut e = AlacrittyEngine::new(40, 5, tx, budget_for_rows(80, 500));
         e.advance(b"\x1b[38;2;12;200;155mCOLOR\x1b[0m cafe\xcc\x81 \x1b]8;;https://luvus.dev\x1b\\LINK\x1b]8;;\x1b\\\r\n");
         assert!(e.detection_text(100).contains("cafe\u{301}"));
-        feed_lines(&mut e, 80);
+        feed_lines(&mut e, 300);
+        e.finish_output_batch();
 
         let before = e.history_metrics();
         assert!(before.compacted_rows.unwrap_or(0) > 0);
         assert!(before.allocated_cells.unwrap_or(0) > 0);
+        assert!(before.packed_blocks.unwrap_or(0) > 0);
+        assert!(before.packed_rows.unwrap_or(0) >= 64);
+        assert!(before.packed_bytes.unwrap_or(usize::MAX) < before.estimated_grid_bytes);
+        assert!(
+            before.allocation_count.unwrap_or(usize::MAX) <= before.retained_rows + 16,
+            "bounded reusable row buffers may retain one allocation per row plus block metadata"
+        );
 
         e.scroll_to_top();
         let mut rendered = Vec::new();
@@ -1398,12 +1414,86 @@ mod tests {
             .expect("oldest feature row remains readable");
         assert!(retained.contains("cafe\u{301}"));
 
-        e.resize(80, 8);
+        // Exercise width reflow without changing the viewport height. Growing
+        // the viewport intentionally consumes the oldest history rows in
+        // Alacritty, which is a separate terminal semantic from reflow.
+        e.resize(80, 5);
         e.scroll_to_top();
         let after = e.history_metrics();
         assert!(after.compacted_rows.unwrap_or(0) > 0);
-        assert!(e.visible_rows().join("\n").contains("COLOR"));
-        assert!(e.visible_rows().join("\n").contains("LINK"));
+        assert!(after.packed_blocks.unwrap_or(0) > 0);
+        let mut retained = String::new();
+        e.for_each_retained_row(&mut |_row, text| {
+            retained.push_str(text);
+            retained.push('\n');
+        });
+        assert!(retained.contains("COLOR"));
+        assert!(retained.contains("LINK"));
+    }
+
+    #[test]
+    fn dense_history_width_reflow_preserves_oldest_feature_row() {
+        let (tx, _rx) = channel();
+        let mut e = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 500));
+        e.advance(b"OLDEST FEATURE\r\n");
+        // Stay below the cold-packing threshold so this remains the dense
+        // representation control for the packed-history test above.
+        feed_lines(&mut e, 150);
+        e.resize(80, 5);
+
+        let mut retained = String::new();
+        e.for_each_retained_row(&mut |_row, text| {
+            retained.push_str(text);
+            retained.push('\n');
+        });
+        assert!(retained.contains("OLDEST FEATURE"));
+    }
+
+    #[test]
+    fn selection_and_capture_cross_packed_and_hot_history() {
+        let (tx, _rx) = channel();
+        let mut e = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 1_000));
+        e.advance(b"PACKED START\r\n");
+        feed_lines(&mut e, 300);
+        e.advance(b"HOT END\r\n");
+        e.finish_output_batch();
+        assert!(e.history_metrics().packed_rows.unwrap_or(0) > 0);
+
+        let mut start = None;
+        let mut end = None;
+        e.for_each_retained_row(&mut |row, text| {
+            if text == "PACKED START" {
+                start = Some(row);
+            }
+            if text == "HOT END" {
+                end = Some(row);
+            }
+        });
+        let (start, end) = (start.expect("packed row"), end.expect("hot row"));
+        let selected = e
+            .retained_selection_text(((start, 0), (end, 6)))
+            .expect("cross-boundary selection");
+        assert!(selected.starts_with("PACKED START\nline0"));
+        assert!(selected.ends_with("HOT END"));
+
+        let capture = e.backend_capture(CaptureMode::RecentUnwrapped, 400, false, 64 * 1024);
+        assert!(capture.text.contains("PACKED START"));
+        assert!(capture.text.contains("HOT END"));
+    }
+
+    #[test]
+    fn shrinking_history_releases_packed_blocks() {
+        let (tx, _rx) = channel();
+        let mut e = AlacrittyEngine::new(40, 5, tx, budget_for_rows(40, 1_000));
+        feed_lines(&mut e, 300);
+        e.finish_output_batch();
+        assert!(e.history_metrics().packed_blocks.unwrap_or(0) > 0);
+
+        e.set_history_budget(budget_for_rows(40, 20));
+        let metrics = e.history_metrics();
+        assert_eq!(e.history_len(), 20);
+        assert_eq!(metrics.packed_blocks, Some(0));
+        assert_eq!(metrics.packed_rows, Some(0));
     }
 
     #[test]
@@ -1823,6 +1913,22 @@ mod tests {
             0,
             "alternate history is reclaimed instead of leaking into the primary screen"
         );
+    }
+
+    #[test]
+    fn packed_alternate_history_is_reclaimed_on_exit() {
+        let (tx, _rx) = channel();
+        let mut e = AlacrittyEngine::new(20, 5, tx, budget_for_rows(20, 500));
+        e.advance(b"\x1b[?1049h");
+        feed_lines(&mut e, 300);
+        e.finish_output_batch();
+        assert!(e.history_metrics().packed_blocks.unwrap_or(0) > 0);
+
+        e.advance(b"\x1b[?1049l");
+        e.finish_output_batch();
+        let metrics = e.history_metrics();
+        assert_eq!(metrics.packed_blocks, Some(0));
+        assert_eq!(metrics.packed_rows, Some(0));
     }
 
     #[test]

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -266,6 +266,18 @@ pub struct HistoryMetrics {
     pub compacted_rows: Option<usize>,
     /// Physical cell slots allocated by the engine, excluding logical repeats.
     pub allocated_cells: Option<usize>,
+    /// Cold-history blocks shared by packed rows.
+    pub packed_blocks: Option<usize>,
+    /// Shallow bytes owned by packed cold-history blocks.
+    pub packed_bytes: Option<usize>,
+    /// Rows backed by packed cold-history blocks.
+    pub packed_rows: Option<usize>,
+    /// Shallow bytes owned by ordinary dense row cell vectors.
+    pub dense_row_bytes: Option<usize>,
+    /// Bytes reserved by the outer row descriptor vectors.
+    pub row_descriptor_bytes: Option<usize>,
+    /// Approximate number of outer, row, and block allocations.
+    pub allocation_count: Option<usize>,
     pub exact_bytes: bool,
 }
 
@@ -306,9 +318,9 @@ pub trait VtEngine: Send {
     /// Feed child output. Must never panic on arbitrary bytes.
     fn advance(&mut self, bytes: &[u8]);
 
-    /// Finish allocation maintenance deferred while parsing the latest output
-    /// burst. Called at the app's coalesced frame boundary, outside the PTY
-    /// reader path.
+    /// Finish allocation maintenance deferred while parsing recent output.
+    /// Unix calls this from its existing descriptor actor after a bounded
+    /// activity window; Windows uses the app's coalesced output boundary.
     fn finish_output_batch(&mut self);
 
     /// Monotonic generation of successfully parsed terminal output.

--- a/vendor/alacritty_terminal/src/grid/mod.rs
+++ b/vendor/alacritty_terminal/src/grid/mod.rs
@@ -1,6 +1,7 @@
 //! A specialized 2D grid implementation optimized for use in a terminal.
 
 use std::cmp::{max, min};
+use std::hash::Hash;
 use std::ops::{Bound, Deref, Index, IndexMut, Range, RangeBounds};
 
 #[cfg(feature = "serde")]
@@ -18,6 +19,7 @@ mod tests;
 
 pub use self::row::Row;
 use self::storage::Storage;
+use self::storage::StorageMetrics;
 
 pub trait GridCell: Sized + Clone {
     /// Check if the cell contains any content.
@@ -328,7 +330,7 @@ impl<T: GridCell + Default + PartialEq> Grid<T> {
 
         // Ensure all new lines are fully cleared.
         for i in (region.end.0 - positions as i32..region.end.0).map(Line::from) {
-            self.raw[i].reset(&self.cursor.template);
+            self.raw.reset_row(i, &self.cursor.template);
         }
     }
 
@@ -427,6 +429,11 @@ impl<T> Grid<T> {
         self.raw.cache_bytes()
     }
 
+    #[inline]
+    pub(crate) fn storage_metrics(&self) -> StorageMetrics {
+        self.raw.storage_metrics()
+    }
+
     /// Estimated shallow allocation for the grid's row and cell vectors.
     #[inline]
     pub fn estimated_storage_bytes(&self) -> usize {
@@ -510,6 +517,23 @@ impl<T> Grid<T> {
     {
         let point = self.cursor.point;
         &mut self[point.line][point.column]
+    }
+}
+
+impl<T> Grid<T>
+where
+    T: GridCell + Default + Eq + Hash,
+{
+    /// Pack newly cold history without touching the active or recent rows.
+    #[inline]
+    pub fn pack_cold_history(&mut self) -> usize {
+        self.raw.pack_cold_history()
+    }
+
+    /// Repack every dense cold-history run after a structural mutation.
+    #[inline]
+    pub fn pack_all_cold_history(&mut self) -> usize {
+        self.raw.pack_all_cold_history()
     }
 }
 

--- a/vendor/alacritty_terminal/src/grid/row.rs
+++ b/vendor/alacritty_terminal/src/grid/row.rs
@@ -220,6 +220,9 @@ impl<T: Default> Row<T> {
         }
 
         self.inflate();
+        // Growth introduces a default suffix which may differ from the old
+        // template. Preserve the entire old row when compacting after reflow.
+        self.occ = self.columns;
         self.dense_mut().resize_with(columns, T::default);
         self.columns = u32::try_from(columns).expect("terminal row width exceeds u32");
     }
@@ -855,6 +858,30 @@ mod tests {
         assert!(row.compact_trailing());
         assert_eq!(row.dense(), &['x', '-']);
         assert_eq!(row.into_iter().copied().collect::<String>(), "x-----");
+    }
+
+    #[test]
+    fn growing_template_row_preserves_suffix_metadata_on_compaction() {
+        let mut fill = Cell::default();
+        fill.flags.insert(crate::term::cell::Flags::BOLD);
+        fill.push_zerowidth('\u{301}');
+        for compact_first in [false, true] {
+            let mut row = Row::new_uniform(6, Arc::new(fill.clone()));
+            row[Column(0)].c = 'x';
+            if compact_first {
+                row.compact_trailing();
+            }
+            row.grow(10);
+            row.grow(12);
+            row.compact_trailing();
+            for column in 1..6 {
+                assert_eq!(row[Column(column)], fill);
+            }
+            for column in 6..12 {
+                assert_eq!(row[Column(column)], Cell::default());
+            }
+            assert_eq!(row[Column(0)].c, 'x');
+        }
     }
 
     #[test]

--- a/vendor/alacritty_terminal/src/grid/row.rs
+++ b/vendor/alacritty_terminal/src/grid/row.rs
@@ -1,8 +1,9 @@
 //! Defines the Row type which makes up lines in the grid.
 
 use std::cmp::{max, min};
+use std::sync::Arc;
 use std::ops::{Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive};
-use std::{ptr, slice};
+use std::slice;
 
 #[cfg(feature = "serde")]
 use serde::de::Deserializer;
@@ -15,6 +16,97 @@ use crate::grid::GridCell;
 use crate::index::Column;
 use crate::term::cell::ResetDiscriminant;
 
+/// A small completed-row allocation is cheaper to reuse than to return to the
+/// allocator and recreate for the next line. The retained space is bounded by
+/// the hot-history frontier and included in storage metrics.
+const COMPACT_ROW_REUSE_CELLS: usize = 16;
+
+/// Dictionary-compressed cell storage shared by a bounded group of cold rows.
+///
+/// Every logical row keeps its own range into `indices`; repeated cell values
+/// are retained once in `values`. Returning a cell still produces an ordinary
+/// `&T`, so packing does not leak through Alacritty's grid API.
+#[derive(Debug)]
+pub(crate) struct PackedBlock<T> {
+    cells: PackedCells<T>,
+}
+
+#[derive(Debug)]
+enum PackedCells<T> {
+    Direct(Vec<T>),
+    Indexed8 { values: Vec<T>, indices: Vec<u8> },
+    Indexed16 { values: Vec<T>, indices: Vec<u16> },
+}
+
+impl<T> PackedBlock<T> {
+    #[inline]
+    fn cell(&self, index: usize) -> &T {
+        match &self.cells {
+            PackedCells::Direct(cells) => &cells[index],
+            PackedCells::Indexed8 { values, indices } => &values[indices[index] as usize],
+            PackedCells::Indexed16 { values, indices } => &values[indices[index] as usize],
+        }
+    }
+
+    #[inline]
+    pub(crate) fn heap_bytes(&self) -> usize {
+        let allocation = std::mem::size_of::<Self>()
+            .saturating_add(2usize.saturating_mul(std::mem::size_of::<usize>()));
+        allocation.saturating_add(match &self.cells {
+            PackedCells::Direct(cells) => {
+                cells.capacity().saturating_mul(std::mem::size_of::<T>())
+            },
+            PackedCells::Indexed8 { values, indices } => values
+                .capacity()
+                .saturating_mul(std::mem::size_of::<T>())
+                .saturating_add(indices.capacity()),
+            PackedCells::Indexed16 { values, indices } => values
+                .capacity()
+                .saturating_mul(std::mem::size_of::<T>())
+                .saturating_add(
+                    indices
+                        .capacity()
+                        .saturating_mul(std::mem::size_of::<u16>()),
+                ),
+        })
+    }
+
+    #[inline]
+    pub(crate) fn value_capacity(&self) -> usize {
+        match &self.cells {
+            PackedCells::Direct(cells) => cells.capacity(),
+            PackedCells::Indexed8 { values, .. } | PackedCells::Indexed16 { values, .. } => {
+                values.capacity()
+            },
+        }
+    }
+
+    #[inline]
+    pub(crate) fn allocation_count(&self) -> usize {
+        match self.cells {
+            PackedCells::Direct(_) => 2,
+            PackedCells::Indexed8 { .. } | PackedCells::Indexed16 { .. } => 3,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum RowStorage<T> {
+    Dense(Vec<T>),
+    Uniform(Arc<T>),
+    Packed {
+        block: Arc<PackedBlock<T>>,
+        start: u32,
+        len: u32,
+    },
+}
+
+impl<T> Default for RowStorage<T> {
+    fn default() -> Self {
+        Self::Dense(Vec::new())
+    }
+}
+
 /// A row in the grid.
 #[derive(Default, Clone, Debug)]
 pub struct Row<T> {
@@ -24,20 +116,16 @@ pub struct Row<T> {
     /// Keeping one copy of that suffix preserves exact cell contents while
     /// avoiding a full-width allocation for cold history. Active writes thaw
     /// the row before returning mutable access.
-    inner: Vec<T>,
+    inner: RowStorage<T>,
 
     /// Maximum number of occupied entries.
     ///
     /// This is the upper bound on the number of elements in the row, which have been modified
     /// since the last reset. All cells after this point are guaranteed to be equal.
-    pub(crate) occ: usize,
+    pub(crate) occ: u32,
 
     /// Logical column count. This differs from `inner.len()` while compacted.
-    columns: usize,
-
-    /// Whether `inner.last()` represents every logical cell after the stored
-    /// prefix rather than one physical column.
-    compacted: bool,
+    columns: u32,
 }
 
 // Keep Alacritty's established `{ inner, occ }` wire shape. The compact form
@@ -56,7 +144,7 @@ impl<T: Serialize> Serialize for Row<T> {
             where
                 S: Serializer,
             {
-                let mut sequence = serializer.serialize_seq(Some(self.0.columns))?;
+                let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
                 for cell in self.0 {
                     sequence.serialize_element(cell)?;
                 }
@@ -66,7 +154,7 @@ impl<T: Serialize> Serialize for Row<T> {
 
         let mut row = serializer.serialize_struct("Row", 2)?;
         row.serialize_field("inner", &LogicalCells(self))?;
-        row.serialize_field("occ", &self.occ)?;
+        row.serialize_field("occ", &usize::try_from(self.occ).unwrap_or(usize::MAX))?;
         row.end()
     }
 }
@@ -100,23 +188,25 @@ impl<T: Default> Row<T> {
     /// Ideally the `template` should be `Copy` in all performance sensitive scenarios.
     pub fn new(columns: usize) -> Row<T> {
         debug_assert!(columns >= 1);
+        let mut inner = Vec::with_capacity(columns.min(COMPACT_ROW_REUSE_CELLS));
+        inner.push(T::default());
 
-        let mut inner: Vec<T> = Vec::with_capacity(columns);
-
-        // This is a slightly optimized version of `std::vec::Vec::resize`.
-        unsafe {
-            let mut ptr = inner.as_mut_ptr();
-
-            for _ in 1..columns {
-                ptr::write(ptr, T::default());
-                ptr = ptr.offset(1);
-            }
-            ptr::write(ptr, T::default());
-
-            inner.set_len(columns);
+        Row {
+            inner: RowStorage::Dense(inner),
+            occ: 0,
+            columns: u32::try_from(columns).expect("terminal row width exceeds u32"),
         }
+    }
 
-        Row { inner, occ: 0, columns, compacted: false }
+    /// Create a logically blank row sharing one immutable template allocation.
+    #[inline]
+    pub(crate) fn new_uniform(columns: usize, fill: Arc<T>) -> Row<T> {
+        debug_assert!(columns >= 1);
+        Row {
+            inner: RowStorage::Uniform(fill),
+            occ: 0,
+            columns: u32::try_from(columns).expect("terminal row width exceeds u32"),
+        }
     }
 
     /// Increase the number of columns in the row.
@@ -125,13 +215,13 @@ impl<T: Default> Row<T> {
     where
         T: Clone,
     {
-        if self.columns >= columns {
+        if self.len() >= columns {
             return;
         }
 
         self.inflate();
-        self.inner.resize_with(columns, T::default);
-        self.columns = columns;
+        self.dense_mut().resize_with(columns, T::default);
+        self.columns = u32::try_from(columns).expect("terminal row width exceeds u32");
     }
 
     /// Reduce the number of columns in the row.
@@ -141,19 +231,19 @@ impl<T: Default> Row<T> {
     where
         T: Clone + GridCell,
     {
-        if self.columns <= columns {
+        if self.len() <= columns {
             return None;
         }
 
         self.inflate();
 
         // Split off cells for a new row.
-        let mut new_row = self.inner.split_off(columns);
+        let mut new_row = self.dense_mut().split_off(columns);
         let index = new_row.iter().rposition(|c| !c.is_empty()).map_or(0, |i| i + 1);
         new_row.truncate(index);
 
-        self.occ = min(self.occ, columns);
-        self.columns = columns;
+        self.occ = min(self.occ as usize, columns) as u32;
+        self.columns = u32::try_from(columns).expect("terminal row width exceeds u32");
 
         if new_row.is_empty() { None } else { Some(new_row) }
     }
@@ -165,20 +255,57 @@ impl<T: Default> Row<T> {
         T: Clone + ResetDiscriminant<D> + GridCell,
         D: PartialEq,
     {
+        self.reset_reusing(template, &mut Vec::new());
+    }
+
+    pub(crate) fn reset_reusing<D>(&mut self, template: &T, reusable: &mut Vec<Vec<T>>)
+    where
+        T: Clone + ResetDiscriminant<D> + GridCell,
+        D: PartialEq,
+    {
         debug_assert!(self.columns != 0);
-        self.inflate();
+        let occupied = self.occ as usize;
+        let mut fill = self.last().expect("terminal row must contain a cell").clone();
+        fill.reset(template);
+        let reusable_prefix = min(
+            self.len(),
+            (self.occ as usize + 1).min(COMPACT_ROW_REUSE_CELLS),
+        )
+        .max(1);
 
-        // Mark all cells as dirty if template cell changed.
-        let len = self.inner.len();
-        if self.inner[len - 1].discriminant() != template.discriminant() {
-            self.occ = len;
+        if let RowStorage::Dense(dense) = &mut self.inner {
+            let reset_all = dense
+                .last()
+                .is_some_and(|suffix| suffix.discriminant() != template.discriminant());
+            dense.truncate(reusable_prefix);
+            let reset_len = if reset_all {
+                dense.len()
+            } else {
+                occupied.min(dense.len())
+            };
+            for cell in &mut dense[..reset_len] {
+                cell.reset(template);
+            }
+            if dense.len() < reusable_prefix {
+                dense.resize(reusable_prefix, fill);
+            }
+            self.occ = 0;
+            return;
         }
 
-        // Reset every dirty cell in the row.
-        for item in &mut self.inner[0..self.occ] {
-            item.reset(template);
-        }
-
+        // A reset row is logically uniform. Preserve an existing allocation
+        // for reuse, but do not inflate packed history back to a full-width
+        // vector merely to clear it. Ordinary cell writes grow this compact
+        // prefix only as far as the column being changed.
+        let mut dense = match std::mem::take(&mut self.inner) {
+            RowStorage::Dense(dense) => dense,
+            RowStorage::Uniform(_) | RowStorage::Packed { .. } => reusable
+                .pop()
+                .unwrap_or_else(|| Vec::with_capacity(self.len().min(COMPACT_ROW_REUSE_CELLS))),
+        };
+        dense.clear();
+        dense.resize(reusable_prefix, fill);
+        self.inner = RowStorage::Dense(dense);
         self.occ = 0;
     }
 }
@@ -188,50 +315,232 @@ impl<T> Row<T> {
     #[inline]
     pub fn from_vec(vec: Vec<T>, occ: usize) -> Row<T> {
         let columns = vec.len();
-        Row { inner: vec, occ, columns, compacted: false }
+        Row {
+            inner: RowStorage::Dense(vec),
+            occ: u32::try_from(occ.min(columns)).expect("terminal row occupancy exceeds u32"),
+            columns: u32::try_from(columns).expect("terminal row width exceeds u32"),
+        }
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.columns
+        self.columns as usize
     }
 
     /// Whether this row uses a single retained cell for its repeated suffix.
     #[inline]
     pub(crate) fn is_compacted(&self) -> bool {
-        self.compacted
+        self.is_packed() || self.physical_len() < self.len()
     }
 
     /// Heap allocation owned by this row's cell vector. Dynamically allocated
     /// data inside individual cells is intentionally not included.
     #[inline]
     pub(crate) fn heap_storage_bytes(&self) -> usize {
-        self.inner.capacity().saturating_mul(std::mem::size_of::<T>())
+        match &self.inner {
+            RowStorage::Dense(inner) => {
+                inner.capacity().saturating_mul(std::mem::size_of::<T>())
+            },
+            RowStorage::Uniform(_) | RowStorage::Packed { .. } => 0,
+        }
     }
 
     #[inline]
     pub fn last(&self) -> Option<&T> {
-        self.inner.last()
+        let len = self.physical_len();
+        (len != 0).then(|| self.physical_cell(len - 1))
     }
 
     /// Return the physical cell capacity retained by this row.
     #[inline]
     pub(crate) fn allocated_cells(&self) -> usize {
-        self.inner.capacity()
+        match &self.inner {
+            RowStorage::Dense(inner) => inner.capacity(),
+            RowStorage::Uniform(_) | RowStorage::Packed { .. } => 0,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_packed(&self) -> bool {
+        matches!(self.inner, RowStorage::Packed { .. })
+    }
+
+    #[inline]
+    pub(crate) fn is_uniform(&self) -> bool {
+        matches!(self.inner, RowStorage::Uniform(_))
+    }
+
+    #[inline]
+    pub(crate) fn physical_len(&self) -> usize {
+        match &self.inner {
+            RowStorage::Dense(inner) => inner.len(),
+            RowStorage::Uniform(_) => 1,
+            RowStorage::Packed { len, .. } => *len as usize,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn physical_cell(&self, index: usize) -> &T {
+        match &self.inner {
+            RowStorage::Dense(inner) => &inner[index],
+            RowStorage::Uniform(fill) => {
+                debug_assert_eq!(index, 0);
+                fill
+            },
+            RowStorage::Packed { block, start, len } => {
+                debug_assert!(index < *len as usize);
+                block.cell(*start as usize + index)
+            },
+        }
+    }
+
+    #[inline]
+    pub(crate) fn packed_block(&self) -> Option<&Arc<PackedBlock<T>>> {
+        match &self.inner {
+            RowStorage::Packed { block, .. } => Some(block),
+            RowStorage::Dense(_) | RowStorage::Uniform(_) => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn uniform_fill(&self) -> Option<&Arc<T>> {
+        match &self.inner {
+            RowStorage::Uniform(fill) => Some(fill),
+            RowStorage::Dense(_) | RowStorage::Packed { .. } => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn install_packed(
+        &mut self,
+        block: Arc<PackedBlock<T>>,
+        start: usize,
+        len: usize,
+    ) -> Option<Vec<T>> {
+        debug_assert!(!self.is_packed());
+        let previous = std::mem::replace(&mut self.inner, RowStorage::Packed {
+            block,
+            start: u32::try_from(start).expect("packed block offset exceeds u32"),
+            len: u32::try_from(len).expect("packed row length exceeds u32"),
+        });
+        match previous {
+            RowStorage::Dense(mut dense) if dense.capacity() <= COMPACT_ROW_REUSE_CELLS => {
+                dense.clear();
+                Some(dense)
+            },
+            RowStorage::Dense(_) | RowStorage::Uniform(_) | RowStorage::Packed { .. } => None,
+        }
+    }
+
+    pub(crate) fn new_direct_block(cells: Vec<T>) -> Arc<PackedBlock<T>> {
+        Arc::new(PackedBlock { cells: PackedCells::Direct(cells) })
+    }
+
+    pub(crate) fn new_indexed8_block(
+        values: Vec<T>,
+        indices: Vec<u8>,
+    ) -> Arc<PackedBlock<T>> {
+        Arc::new(PackedBlock { cells: PackedCells::Indexed8 { values, indices } })
+    }
+
+    pub(crate) fn new_indexed16_block(
+        values: Vec<T>,
+        indices: Vec<u16>,
+    ) -> Arc<PackedBlock<T>> {
+        Arc::new(PackedBlock { cells: PackedCells::Indexed16 { values, indices } })
+    }
+
+    #[inline]
+    fn dense(&self) -> &[T] {
+        match &self.inner {
+            RowStorage::Dense(inner) => inner,
+            RowStorage::Uniform(_) | RowStorage::Packed { .. } => {
+                panic!("compact row requires logical indexing")
+            },
+        }
+    }
+
+    #[inline]
+    fn dense_mut(&mut self) -> &mut Vec<T> {
+        match &mut self.inner {
+            RowStorage::Dense(inner) => inner,
+            RowStorage::Uniform(_) | RowStorage::Packed { .. } => {
+                unreachable!("compact row must be inflated before mutation")
+            },
+        }
     }
 }
 
 impl<T: Clone> Row<T> {
+    /// Materialize only enough of a compact row for one mutable cell.
+    #[inline]
+    fn inflate_to(&mut self, index: usize) {
+        let columns = self.len();
+        debug_assert!(index < columns);
+        let target_len = (index + 2).min(columns);
+        let dense = match &mut self.inner {
+            RowStorage::Dense(inner) if inner.len() < target_len => {
+                let fill = inner.last().expect("compacted row must have a suffix cell").clone();
+                inner.resize(target_len, fill);
+                return;
+            },
+            RowStorage::Dense(_) => return,
+            RowStorage::Uniform(fill) => {
+                let capacity = columns.min(COMPACT_ROW_REUSE_CELLS).max(target_len);
+                let mut dense = Vec::with_capacity(capacity);
+                dense.resize(target_len, fill.as_ref().clone());
+                dense
+            },
+            RowStorage::Packed { block, start, len } => {
+                let start = *start as usize;
+                let suffix = (*len as usize).saturating_sub(1);
+                let capacity = columns.min(COMPACT_ROW_REUSE_CELLS).max(target_len);
+                let mut dense = Vec::with_capacity(capacity);
+                for offset in 0..target_len {
+                    dense.push(block.cell(start + offset.min(suffix)).clone());
+                }
+                dense
+            },
+        };
+        self.inner = RowStorage::Dense(dense);
+    }
+
     /// Restore a compact scrollback row to ordinary dense Alacritty storage.
     #[inline]
     fn inflate(&mut self) {
-        if !self.compacted {
-            return;
-        }
+        let columns = self.len();
+        let dense = match &mut self.inner {
+            RowStorage::Dense(inner) if inner.len() < columns => {
+                let fill = inner.pop().expect("compacted row must have a suffix cell");
+                inner.resize(columns, fill);
+                return;
+            },
+            RowStorage::Dense(_) => return,
+            RowStorage::Uniform(fill) => vec![fill.as_ref().clone(); columns],
+            RowStorage::Packed { block, start, len } => {
+                let start = *start as usize;
+                let suffix = (*len as usize).saturating_sub(1);
+                let mut dense = Vec::with_capacity(columns);
+                for index in 0..columns {
+                    dense.push(block.cell(start + index.min(suffix)).clone());
+                }
+                dense
+            },
+        };
+        self.inner = RowStorage::Dense(dense);
+    }
 
-        let fill = self.inner.pop().expect("compacted row must have a suffix cell");
-        self.inner.resize(self.columns, fill);
-        self.compacted = false;
+    /// Return a mutable contiguous cell range while retaining a compact suffix.
+    ///
+    /// Terminal text runs can use this to thaw a row once per run instead of
+    /// repeating the compact-storage dispatch for every character.
+    #[inline]
+    pub(crate) fn cells_mut(&mut self, range: Range<usize>) -> &mut [T] {
+        debug_assert!(range.start < range.end);
+        debug_assert!(range.end <= self.len());
+        self.inflate_to(range.end - 1);
+        self.occ = max(self.occ, range.end as u32);
+        &mut self.dense_mut()[range]
     }
 
     /// Collapse an identical trailing run into a single cell.
@@ -243,26 +552,38 @@ impl<T: Clone> Row<T> {
     where
         T: PartialEq,
     {
-        if self.compacted || self.columns <= 1 {
+        if self.is_packed() || self.is_uniform() || self.columns <= 1 {
             return false;
         }
 
-        debug_assert_eq!(self.inner.len(), self.columns);
-        let fill = self.inner[self.columns - 1].clone();
-        let prefix_len = self.inner[..self.columns - 1]
+        if self.physical_len() < self.len() {
+            return false;
+        }
+
+        let columns = self.len();
+        // `occ` is the upper bound of cells which may differ from the row's
+        // repeated suffix. Avoid comparing the untouched remainder of every
+        // completed line; wide terminals otherwise turn line archival into a
+        // full-width scan even when only a short prompt or counter was drawn.
+        let occupied = min(self.occ as usize, columns - 1);
+        let inner = self.dense_mut();
+        debug_assert_eq!(inner.len(), columns);
+        let fill = inner[columns - 1].clone();
+        let prefix_len = inner[..occupied]
             .iter()
             .rposition(|cell| cell != &fill)
             .map_or(0, |index| index + 1);
 
         // A one-cell suffix cannot save storage.
-        if prefix_len + 1 >= self.columns {
+        if prefix_len + 1 >= columns {
             return false;
         }
 
-        self.inner.truncate(prefix_len);
-        self.inner.push(fill);
-        self.inner.shrink_to_fit();
-        self.compacted = true;
+        inner.truncate(prefix_len);
+        inner.push(fill);
+        // Keep the small active-row allocation until block packing takes
+        // ownership of this cold row. Shrinking every completed line would
+        // add an allocator round trip to the terminal parser's hottest path.
         true
     }
 
@@ -270,7 +591,7 @@ impl<T: Clone> Row<T> {
     pub fn last_mut(&mut self) -> Option<&mut T> {
         self.inflate();
         self.occ = self.columns;
-        self.inner.last_mut()
+        self.dense_mut().last_mut()
     }
 
     #[inline]
@@ -279,19 +600,19 @@ impl<T: Clone> Row<T> {
         T: GridCell,
     {
         self.inflate();
-        self.occ += vec.len();
-        self.inner.append(vec);
-        self.columns = self.inner.len();
+        self.occ = self.occ.saturating_add(vec.len() as u32);
+        self.dense_mut().append(vec);
+        self.columns = self.physical_len() as u32;
     }
 
     #[inline]
     pub fn append_front(&mut self, mut vec: Vec<T>) {
         self.inflate();
-        self.occ += vec.len();
+        self.occ = self.occ.saturating_add(vec.len() as u32);
 
-        vec.append(&mut self.inner);
-        self.inner = vec;
-        self.columns = self.inner.len();
+        vec.append(self.dense_mut());
+        self.columns = vec.len() as u32;
+        self.inner = RowStorage::Dense(vec);
     }
 
     /// Check if all cells in the row are empty.
@@ -306,11 +627,11 @@ impl<T: Clone> Row<T> {
     #[inline]
     pub fn front_split_off(&mut self, at: usize) -> Vec<T> {
         self.inflate();
-        self.occ = self.occ.saturating_sub(at);
+        self.occ = self.occ.saturating_sub(at as u32);
 
-        let mut split = self.inner.split_off(at);
-        std::mem::swap(&mut split, &mut self.inner);
-        self.columns = self.inner.len();
+        let mut split = self.dense_mut().split_off(at);
+        std::mem::swap(&mut split, self.dense_mut());
+        self.columns = self.physical_len() as u32;
         split
     }
 }
@@ -361,7 +682,7 @@ impl<'a, T> IntoIterator for &'a Row<T> {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        RowIter { row: self, front: 0, back: self.columns }
+        RowIter { row: self, front: 0, back: self.len() }
     }
 }
 
@@ -373,7 +694,7 @@ impl<'a, T: Clone> IntoIterator for &'a mut Row<T> {
     fn into_iter(self) -> slice::IterMut<'a, T> {
         self.inflate();
         self.occ = self.columns;
-        self.inner.iter_mut()
+        self.dense_mut().iter_mut()
     }
 }
 
@@ -382,22 +703,18 @@ impl<T> Index<Column> for Row<T> {
 
     #[inline]
     fn index(&self, index: Column) -> &T {
-        debug_assert!(index.0 < self.columns);
-        if self.compacted {
-            let prefix_len = self.inner.len() - 1;
-            &self.inner[index.0.min(prefix_len)]
-        } else {
-            &self.inner[index.0]
-        }
+        debug_assert!(index.0 < self.len());
+        let prefix_len = self.physical_len() - 1;
+        self.physical_cell(index.0.min(prefix_len))
     }
 }
 
 impl<T: Clone> IndexMut<Column> for Row<T> {
     #[inline]
     fn index_mut(&mut self, index: Column) -> &mut T {
-        self.inflate();
-        self.occ = max(self.occ, *index + 1);
-        &mut self.inner[index.0]
+        self.inflate_to(index.0);
+        self.occ = max(self.occ, (*index + 1) as u32);
+        &mut self.dense_mut()[index.0]
     }
 }
 
@@ -406,8 +723,8 @@ impl<T> Index<Range<Column>> for Row<T> {
 
     #[inline]
     fn index(&self, index: Range<Column>) -> &[T] {
-        assert!(!self.compacted, "range indexing requires a dense row");
-        &self.inner[(index.start.0)..(index.end.0)]
+        assert!(!self.is_compacted(), "range indexing requires a dense row");
+        &self.dense()[(index.start.0)..(index.end.0)]
     }
 }
 
@@ -415,8 +732,8 @@ impl<T: Clone> IndexMut<Range<Column>> for Row<T> {
     #[inline]
     fn index_mut(&mut self, index: Range<Column>) -> &mut [T] {
         self.inflate();
-        self.occ = max(self.occ, *index.end);
-        &mut self.inner[(index.start.0)..(index.end.0)]
+        self.occ = max(self.occ, *index.end as u32);
+        &mut self.dense_mut()[(index.start.0)..(index.end.0)]
     }
 }
 
@@ -425,8 +742,8 @@ impl<T> Index<RangeTo<Column>> for Row<T> {
 
     #[inline]
     fn index(&self, index: RangeTo<Column>) -> &[T] {
-        assert!(!self.compacted, "range indexing requires a dense row");
-        &self.inner[..(index.end.0)]
+        assert!(!self.is_compacted(), "range indexing requires a dense row");
+        &self.dense()[..(index.end.0)]
     }
 }
 
@@ -434,8 +751,8 @@ impl<T: Clone> IndexMut<RangeTo<Column>> for Row<T> {
     #[inline]
     fn index_mut(&mut self, index: RangeTo<Column>) -> &mut [T] {
         self.inflate();
-        self.occ = max(self.occ, *index.end);
-        &mut self.inner[..(index.end.0)]
+        self.occ = max(self.occ, *index.end as u32);
+        &mut self.dense_mut()[..(index.end.0)]
     }
 }
 
@@ -444,8 +761,8 @@ impl<T> Index<RangeFrom<Column>> for Row<T> {
 
     #[inline]
     fn index(&self, index: RangeFrom<Column>) -> &[T] {
-        assert!(!self.compacted, "range indexing requires a dense row");
-        &self.inner[(index.start.0)..]
+        assert!(!self.is_compacted(), "range indexing requires a dense row");
+        &self.dense()[(index.start.0)..]
     }
 }
 
@@ -454,7 +771,7 @@ impl<T: Clone> IndexMut<RangeFrom<Column>> for Row<T> {
     fn index_mut(&mut self, index: RangeFrom<Column>) -> &mut [T] {
         self.inflate();
         self.occ = self.columns;
-        &mut self.inner[(index.start.0)..]
+        &mut self.dense_mut()[(index.start.0)..]
     }
 }
 
@@ -463,8 +780,8 @@ impl<T> Index<RangeFull> for Row<T> {
 
     #[inline]
     fn index(&self, _: RangeFull) -> &[T] {
-        assert!(!self.compacted, "range indexing requires a dense row");
-        &self.inner[..]
+        assert!(!self.is_compacted(), "range indexing requires a dense row");
+        self.dense()
     }
 }
 
@@ -473,7 +790,7 @@ impl<T: Clone> IndexMut<RangeFull> for Row<T> {
     fn index_mut(&mut self, _: RangeFull) -> &mut [T] {
         self.inflate();
         self.occ = self.columns;
-        &mut self.inner[..]
+        self.dense_mut()
     }
 }
 
@@ -482,8 +799,8 @@ impl<T> Index<RangeToInclusive<Column>> for Row<T> {
 
     #[inline]
     fn index(&self, index: RangeToInclusive<Column>) -> &[T] {
-        assert!(!self.compacted, "range indexing requires a dense row");
-        &self.inner[..=(index.end.0)]
+        assert!(!self.is_compacted(), "range indexing requires a dense row");
+        &self.dense()[..=(index.end.0)]
     }
 }
 
@@ -491,14 +808,20 @@ impl<T: Clone> IndexMut<RangeToInclusive<Column>> for Row<T> {
     #[inline]
     fn index_mut(&mut self, index: RangeToInclusive<Column>) -> &mut [T] {
         self.inflate();
-        self.occ = max(self.occ, *index.end + 1);
-        &mut self.inner[..=(index.end.0)]
+        self.occ = max(self.occ, (*index.end + 1) as u32);
+        &mut self.dense_mut()[..=(index.end.0)]
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::term::cell::Cell;
+
+    #[test]
+    fn row_descriptor_stays_compact() {
+        assert!(std::mem::size_of::<Row<char>>() <= 32);
+    }
 
     #[test]
     fn compact_suffix_is_transparent_and_mutation_inflates() {
@@ -506,17 +829,17 @@ mod tests {
         row[Column(0)] = 'a';
         row[Column(1)] = 'b';
 
-        assert!(row.compact_trailing());
+        row.compact_trailing();
         assert!(row.is_compacted());
         assert_eq!(row.len(), 8);
-        assert_eq!(row.inner, vec!['a', 'b', '\0']);
+        assert_eq!(row.dense(), &['a', 'b', '\0']);
         assert_eq!(row[Column(0)], 'a');
         assert_eq!(row[Column(7)], '\0');
         assert_eq!(row.into_iter().copied().collect::<Vec<_>>(), vec!['a', 'b', '\0', '\0', '\0', '\0', '\0', '\0']);
 
         row[Column(7)] = 'z';
         assert!(!row.is_compacted());
-        assert_eq!(row.inner.len(), 8);
+        assert_eq!(row.dense().len(), 8);
         assert_eq!(row[Column(0)], 'a');
         assert_eq!(row[Column(7)], 'z');
     }
@@ -530,7 +853,78 @@ mod tests {
         row[Column(0)] = 'x';
 
         assert!(row.compact_trailing());
-        assert_eq!(row.inner, vec!['x', '-']);
+        assert_eq!(row.dense(), &['x', '-']);
         assert_eq!(row.into_iter().copied().collect::<String>(), "x-----");
+    }
+
+    #[test]
+    fn resetting_packed_history_materializes_only_the_written_prefix() {
+        let mut row = Row::<Cell>::new(80);
+        row[Column(0)].c = 'x';
+        row.compact_trailing();
+        let block = Row::new_direct_block(
+            (0..row.physical_len())
+                .map(|index| row.physical_cell(index).clone())
+                .collect(),
+        );
+        let _ = row.install_packed(block, 0, row.physical_len());
+
+        row.reset(&Cell::default());
+        assert_eq!(row.physical_len(), 2);
+        row[Column(5)].c = 'z';
+
+        assert_eq!(row.physical_len(), 7);
+        assert_eq!(row[Column(5)].c, 'z');
+        assert_eq!(row[Column(79)], Cell::default());
+    }
+
+    #[test]
+    fn reset_reuses_the_previous_written_prefix() {
+        let mut row = Row::<Cell>::new(80);
+        for column in 0..8 {
+            row[Column(column)].c = 'x';
+        }
+
+        row.reset(&Cell::default());
+
+        assert_eq!(row.physical_len(), 9);
+        assert!(row.allocated_cells() >= COMPACT_ROW_REUSE_CELLS);
+        for column in 0..8 {
+            row[Column(column)].c = 'y';
+        }
+        assert_eq!(row.physical_len(), 9);
+        assert_eq!(row[Column(79)], Cell::default());
+    }
+
+    #[test]
+    fn first_uniform_write_reserves_the_reusable_prefix() {
+        let fill = Arc::new(Cell::default());
+        let mut row = Row::new_uniform(80, fill);
+
+        row[Column(5)].c = 'z';
+
+        assert_eq!(row.physical_len(), 7);
+        assert!(row.allocated_cells() >= COMPACT_ROW_REUSE_CELLS);
+        assert_eq!(row[Column(5)].c, 'z');
+        assert_eq!(row[Column(79)], Cell::default());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn packed_row_keeps_the_dense_wire_format() {
+        let mut row = Row::<char>::new(8);
+        row[Column(0)] = 'a';
+        row.compact_trailing();
+        let block = Row::new_indexed8_block(vec!['a', '\0'], vec![0, 1]);
+        let _ = row.install_packed(block, 0, 2);
+
+        let serialized = serde_json::to_string(&row).expect("serialize packed row");
+        let restored: Row<char> = serde_json::from_str(&serialized).expect("restore packed row");
+
+        assert_eq!(restored, row);
+        assert!(!restored.is_packed());
+        assert_eq!(restored.len(), 8);
+        assert_eq!(restored[Column(0)], 'a');
+        assert_eq!(restored[Column(7)], '\0');
     }
 }

--- a/vendor/alacritty_terminal/src/grid/storage.rs
+++ b/vendor/alacritty_terminal/src/grid/storage.rs
@@ -1,6 +1,9 @@
 use std::cmp::max;
+use std::collections::{HashMap, HashSet};
+use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::mem;
 use std::ops::{Index, IndexMut};
+use std::sync::Arc;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -14,10 +17,113 @@ use crate::index::Line;
 /// vector, that makes the spare allocation grow linearly with terminal width.
 /// A byte target keeps the reuse benefit without retaining multiple megabytes
 /// per wide terminal.
-const MAX_CACHE_BYTES: usize = 256 * 1024;
+const MAX_CACHE_BYTES: usize = 64 * 1024;
 
 /// Keep a few rows ready so ordinary short bursts do not allocate line by line.
 const MIN_CACHE_ROWS: usize = 8;
+const MAX_REUSABLE_ROW_BUFFERS: usize = 256;
+
+/// Recent history remains as ordinary mutable rows. Older completed rows can
+/// share dictionary-compressed blocks without affecting the active parser.
+const HOT_HISTORY_ROWS: usize = 128;
+
+/// Bound packing work and block fan-out. This also bounds the memory retained
+/// when only part of the oldest block remains inside the history limit.
+const PACKED_BLOCK_MAX_ROWS: usize = 512;
+const PACKED_BLOCK_TARGET_BYTES: usize = 128 * 1024;
+const MIN_PACKED_BLOCK_ROWS: usize = 32;
+const LINEAR_DICTIONARY_CELLS: usize = 16;
+
+/// Fast bounded fingerprinting for transient block construction.
+///
+/// This is never used as an authority boundary: a collision rejects the
+/// dictionary and falls back to a lossless direct block. The input is capped
+/// by `PACKED_BLOCK_TARGET_BYTES`, so it cannot create unbounded work.
+struct FingerprintHasher(u64);
+
+impl Default for FingerprintHasher {
+    fn default() -> Self {
+        Self(0xcbf2_9ce4_8422_2325)
+    }
+}
+
+impl Hasher for FingerprintHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.0 ^= u64::from(*byte);
+            self.0 = self.0.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+}
+
+/// The cell fingerprint is already a complete hash, so hashing that `u64`
+/// again inside `HashMap` only burns CPU on completed terminal history.
+#[derive(Default)]
+struct FingerprintMapHasher(u64);
+
+impl Hasher for FingerprintMapHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut fingerprint = FingerprintHasher::default();
+        fingerprint.write(bytes);
+        self.0 = fingerprint.finish();
+    }
+
+    #[inline]
+    fn write_u64(&mut self, value: u64) {
+        self.0 = value;
+    }
+}
+
+type FingerprintMap = HashMap<u64, u16, BuildHasherDefault<FingerprintMapHasher>>;
+
+fn fingerprint<T: Hash>(value: &T) -> u64 {
+    let mut hasher = FingerprintHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn fingerprint_map<T: Eq + Hash>(values: &[T]) -> Option<FingerprintMap> {
+    let mut dictionary = FingerprintMap::with_capacity_and_hasher(
+        values.len().saturating_mul(2),
+        BuildHasherDefault::default(),
+    );
+    for (index, value) in values.iter().enumerate() {
+        let index = u16::try_from(index).ok()?;
+        let key = fingerprint(value);
+        if let Some(previous) = dictionary.insert(key, index) {
+            if values[previous as usize] != *value {
+                return None;
+            }
+        }
+    }
+    Some(dictionary)
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct StorageMetrics {
+    pub(crate) estimated_bytes: usize,
+    pub(crate) cache_bytes: usize,
+    pub(crate) row_descriptor_bytes: usize,
+    pub(crate) dense_cell_bytes: usize,
+    pub(crate) packed_block_bytes: usize,
+    pub(crate) packed_blocks: usize,
+    pub(crate) dense_rows: usize,
+    pub(crate) packed_rows: usize,
+    pub(crate) allocated_cells: usize,
+    pub(crate) allocations: usize,
+}
 
 fn cache_row_limit<T>(columns: usize) -> usize {
     let row_bytes = mem::size_of::<Row<T>>()
@@ -46,6 +152,11 @@ fn cache_row_limit<T>(columns: usize) -> usize {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Storage<T> {
     inner: Vec<Row<T>>,
+
+    /// Small cell vectors recycled between packed history and the live row.
+    /// This is bounded independently from scrollback and never serialized.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    reusable_rows: Vec<Vec<T>>,
 
     /// Starting point for the storage of rows.
     ///
@@ -84,9 +195,16 @@ impl<T> Storage<T> {
     {
         // Initialize visible lines; the scrollback buffer is initialized dynamically.
         let mut inner = Vec::with_capacity(visible_lines);
-        inner.resize_with(visible_lines, || Row::new(columns));
+        let fill = Arc::new(T::default());
+        inner.resize_with(visible_lines, || Row::new_uniform(columns, fill.clone()));
 
-        Storage { inner, zero: 0, visible_lines, len: visible_lines }
+        Storage {
+            inner,
+            reusable_rows: Vec::new(),
+            zero: 0,
+            visible_lines,
+            len: visible_lines,
+        }
     }
 
     /// Increase the number of lines in the buffer.
@@ -144,6 +262,8 @@ impl<T> Storage<T> {
     pub fn compact(&mut self) {
         self.truncate();
         self.inner.shrink_to_fit();
+        self.reusable_rows.clear();
+        self.reusable_rows.shrink_to_fit();
     }
 
     /// Dynamically grow the storage buffer at runtime.
@@ -157,7 +277,9 @@ impl<T> Storage<T> {
 
             let cache_rows = cache_row_limit::<T>(columns);
             let realloc_size = self.inner.len() + max(additional_rows, cache_rows);
-            self.inner.resize_with(realloc_size, || Row::new(columns));
+            let fill = Arc::new(T::default());
+            self.inner
+                .resize_with(realloc_size, || Row::new_uniform(columns, fill.clone()));
         }
 
         self.len += additional_rows;
@@ -177,25 +299,351 @@ impl<T> Storage<T> {
         let cached_rows = self.inner.len().saturating_sub(self.len);
         let outer_spare = self.inner.capacity().saturating_sub(self.inner.len())
             .saturating_mul(mem::size_of::<Row<T>>());
-        cached_rows.saturating_mul(row_bytes).saturating_add(outer_spare)
+        let reusable_bytes = self
+            .reusable_rows
+            .capacity()
+            .saturating_mul(mem::size_of::<Vec<T>>())
+            .saturating_add(
+                self.reusable_rows
+                    .iter()
+                    .map(|row| row.capacity().saturating_mul(mem::size_of::<T>()))
+                    .sum::<usize>(),
+            );
+        cached_rows
+            .saturating_mul(row_bytes)
+            .saturating_add(outer_spare)
+            .saturating_add(reusable_bytes)
     }
 
     /// Shallow storage owned by all allocated rows and the outer vector.
     #[inline]
     pub fn estimated_storage_bytes(&self) -> usize {
-        self.inner.capacity().saturating_mul(mem::size_of::<Row<T>>())
-            .saturating_add(self.inner.iter().map(Row::heap_storage_bytes).sum::<usize>())
+        self.storage_metrics().estimated_bytes
     }
 
     /// Physical cell slots allocated by active, historical, and cached rows.
     #[inline]
     pub fn allocated_cell_capacity(&self) -> usize {
-        self.inner.iter().map(Row::allocated_cells).sum()
+        self.storage_metrics().allocated_cells
+    }
+
+    pub(crate) fn storage_metrics(&self) -> StorageMetrics {
+        let row_descriptor_bytes = self.inner.capacity().saturating_mul(mem::size_of::<Row<T>>());
+        let mut metrics = StorageMetrics {
+            row_descriptor_bytes,
+            cache_bytes: self.cache_bytes(),
+            allocations: usize::from(self.inner.capacity() != 0),
+            ..StorageMetrics::default()
+        };
+        let mut packed = HashSet::new();
+        let mut uniform = HashSet::new();
+
+        for row in &self.inner {
+            if let Some(block) = row.packed_block() {
+                metrics.packed_rows += 1;
+                let pointer = Arc::as_ptr(block) as usize;
+                if packed.insert(pointer) {
+                    metrics.packed_blocks += 1;
+                    metrics.packed_block_bytes = metrics
+                        .packed_block_bytes
+                        .saturating_add(block.heap_bytes());
+                    metrics.allocated_cells = metrics
+                        .allocated_cells
+                        .saturating_add(block.value_capacity());
+                    metrics.allocations = metrics
+                        .allocations
+                        .saturating_add(block.allocation_count());
+                }
+            } else if let Some(fill) = row.uniform_fill() {
+                metrics.dense_rows += 1;
+                let pointer = Arc::as_ptr(fill) as usize;
+                if uniform.insert(pointer) {
+                    metrics.dense_cell_bytes = metrics.dense_cell_bytes.saturating_add(
+                        mem::size_of::<T>()
+                            .saturating_add(2usize.saturating_mul(mem::size_of::<usize>())),
+                    );
+                    metrics.allocated_cells = metrics.allocated_cells.saturating_add(1);
+                    metrics.allocations = metrics.allocations.saturating_add(1);
+                }
+            } else {
+                metrics.dense_rows += 1;
+                metrics.dense_cell_bytes = metrics
+                    .dense_cell_bytes
+                    .saturating_add(row.heap_storage_bytes());
+                metrics.allocated_cells = metrics
+                    .allocated_cells
+                    .saturating_add(row.allocated_cells());
+                metrics.allocations = metrics
+                    .allocations
+                    .saturating_add(usize::from(row.allocated_cells() != 0));
+            }
+        }
+
+        metrics.dense_cell_bytes = metrics.dense_cell_bytes.saturating_add(
+            self.reusable_rows
+                .iter()
+                .map(|row| row.capacity().saturating_mul(mem::size_of::<T>()))
+                .sum::<usize>()
+                .saturating_add(
+                    self.reusable_rows
+                        .capacity()
+                        .saturating_mul(mem::size_of::<Vec<T>>()),
+                ),
+        );
+        metrics.allocated_cells = metrics.allocated_cells.saturating_add(
+            self.reusable_rows.iter().map(Vec::capacity).sum::<usize>(),
+        );
+        metrics.allocations = metrics.allocations.saturating_add(self.reusable_rows.len());
+
+        metrics.estimated_bytes = row_descriptor_bytes
+            .saturating_add(metrics.dense_cell_bytes)
+            .saturating_add(metrics.packed_block_bytes);
+        metrics
     }
 
     #[inline]
     fn columns(&self) -> usize {
         self.inner.first().map(Row::len).unwrap_or(1)
+    }
+
+    /// Pack newly cold rows at the mutable/immutable boundary.
+    ///
+    /// Normal output leaves at most `HOT_HISTORY_ROWS` plus
+    /// `MIN_PACKED_BLOCK_ROWS - 1` dense history rows. The first call for an
+    /// already populated terminal packs the complete cold run in bounded
+    /// blocks; later calls inspect only the new dense frontier.
+    pub(crate) fn pack_cold_history(&mut self) -> usize
+    where
+        T: Clone + Eq + Hash,
+    {
+        let history_rows = self.len.saturating_sub(self.visible_lines);
+        if history_rows < HOT_HISTORY_ROWS + MIN_PACKED_BLOCK_ROWS {
+            return 0;
+        }
+
+        let first_age = HOT_HISTORY_ROWS;
+        let first = self.compute_index(Line(-((first_age + 1) as i32)));
+        if self.inner[first].is_packed() {
+            return 0;
+        }
+
+        let mut dense_run = 0;
+        for age in first_age..history_rows {
+            let index = self.compute_index(Line(-((age + 1) as i32)));
+            if self.inner[index].is_packed() {
+                break;
+            }
+            dense_run += 1;
+        }
+
+        if dense_run < MIN_PACKED_BLOCK_ROWS {
+            return 0;
+        }
+
+        let mut packed_rows = 0;
+        while packed_rows < dense_run {
+            let remaining = dense_run - packed_rows;
+            let mut rows = Vec::with_capacity(remaining.min(PACKED_BLOCK_MAX_ROWS));
+            let mut shallow_bytes = 0usize;
+            for age in first_age + packed_rows..first_age + dense_run {
+                let index = self.compute_index(Line(-((age + 1) as i32)));
+                let row_bytes = self.inner[index]
+                    .physical_len()
+                    .saturating_mul(mem::size_of::<T>());
+                if !rows.is_empty()
+                    && (rows.len() == PACKED_BLOCK_MAX_ROWS
+                        || shallow_bytes.saturating_add(row_bytes)
+                            > PACKED_BLOCK_TARGET_BYTES)
+                {
+                    break;
+                }
+                rows.push(index);
+                shallow_bytes = shallow_bytes.saturating_add(row_bytes);
+            }
+            self.pack_rows(&rows);
+            packed_rows += rows.len();
+        }
+        packed_rows
+    }
+
+    /// Repack every dense cold run after operations such as width reflow.
+    pub(crate) fn pack_all_cold_history(&mut self) -> usize
+    where
+        T: Clone + Eq + Hash,
+    {
+        let history_rows = self.len.saturating_sub(self.visible_lines);
+        if history_rows < HOT_HISTORY_ROWS + MIN_PACKED_BLOCK_ROWS {
+            return 0;
+        }
+
+        let mut packed_rows = 0;
+        let mut age = HOT_HISTORY_ROWS;
+        while age < history_rows {
+            let index = self.compute_index(Line(-((age + 1) as i32)));
+            if self.inner[index].is_packed() {
+                age += 1;
+                continue;
+            }
+
+            let start = age;
+            let mut shallow_bytes = 0usize;
+            while age < history_rows {
+                let index = self.compute_index(Line(-((age + 1) as i32)));
+                if self.inner[index].is_packed() || age - start == PACKED_BLOCK_MAX_ROWS {
+                    break;
+                }
+                let row_bytes = self.inner[index]
+                    .physical_len()
+                    .saturating_mul(mem::size_of::<T>());
+                if age != start
+                    && shallow_bytes.saturating_add(row_bytes) > PACKED_BLOCK_TARGET_BYTES
+                {
+                    break;
+                }
+                shallow_bytes = shallow_bytes.saturating_add(row_bytes);
+                age += 1;
+            }
+
+            let count = age - start;
+            if count == 0 {
+                continue;
+            }
+            let mut rows = Vec::with_capacity(count);
+            for row_age in start..age {
+                rows.push(self.compute_index(Line(-((row_age + 1) as i32))));
+            }
+            self.pack_rows(&rows);
+            packed_rows += count;
+        }
+        packed_rows
+    }
+
+    fn pack_rows(&mut self, rows: &[usize])
+    where
+        T: Clone + Eq + Hash,
+    {
+        debug_assert!(!rows.is_empty());
+        debug_assert!(rows.iter().all(|index| !self.inner[*index].is_packed()));
+
+        let total_cells = rows
+            .iter()
+            .map(|index| self.inner[*index].physical_len())
+            .sum::<usize>();
+        let mut values = Vec::new();
+        let mut dictionary: Option<FingerprintMap> = None;
+        let mut narrow_indices = Vec::with_capacity(total_cells);
+        let mut wide_indices = None::<Vec<u16>>;
+        let mut dictionary_complete = true;
+
+        'rows: for index in rows {
+            let row = &self.inner[*index];
+            for cell_index in 0..row.physical_len() {
+                let cell = row.physical_cell(cell_index);
+                let dictionary_index = match dictionary.as_mut() {
+                    Some(dictionary) => {
+                        let fingerprint = fingerprint(cell);
+                        match dictionary.get(&fingerprint) {
+                            Some(index) if values[*index as usize] == *cell => *index,
+                            Some(_) => {
+                                dictionary_complete = false;
+                                break 'rows;
+                            },
+                            None => {
+                                let Ok(index) = u16::try_from(values.len()) else {
+                                    dictionary_complete = false;
+                                    break 'rows;
+                                };
+                                values.push(cell.clone());
+                                dictionary.insert(fingerprint, index);
+                                index
+                            },
+                        }
+                    },
+                    None => match values.iter().position(|value| value == cell) {
+                        Some(index) => index as u16,
+                        None => {
+                            // Small terminal dictionaries (plain text, ANSI
+                            // palettes, prompts) are faster as a linear scan:
+                            // most failed comparisons stop after the glyph.
+                            // Promote to hashed lookup before this can become
+                            // quadratic for high-entropy content.
+                            let Ok(index) = u16::try_from(values.len()) else {
+                                dictionary_complete = false;
+                                break 'rows;
+                            };
+                            values.push(cell.clone());
+                            if values.len() == LINEAR_DICTIONARY_CELLS {
+                                let Some(promoted) = fingerprint_map(&values) else {
+                                    dictionary_complete = false;
+                                    break 'rows;
+                                };
+                                dictionary = Some(promoted);
+                            }
+                            index
+                        },
+                    },
+                };
+                match wide_indices.as_mut() {
+                    Some(indices) => indices.push(dictionary_index),
+                    None => match u8::try_from(dictionary_index) {
+                        Ok(index) => narrow_indices.push(index),
+                        Err(_) => {
+                            let mut indices = Vec::with_capacity(total_cells);
+                            indices.extend(narrow_indices.drain(..).map(u16::from));
+                            indices.push(dictionary_index);
+                            wide_indices = Some(indices);
+                        },
+                    },
+                }
+            }
+        }
+
+        let indexed_width = if wide_indices.is_some() { 2 } else { 1 };
+        let indices_len = wide_indices
+            .as_ref()
+            .map_or(narrow_indices.len(), Vec::len);
+        let indexed_bytes = values
+            .len()
+            .saturating_mul(mem::size_of::<T>())
+            .saturating_add(total_cells.saturating_mul(indexed_width));
+        let direct_bytes = total_cells.saturating_mul(mem::size_of::<T>());
+
+        let block = if dictionary_complete
+            && indices_len == total_cells
+            && indexed_bytes < direct_bytes
+        {
+            match wide_indices {
+                Some(indices) => Row::new_indexed16_block(values, indices),
+                None => Row::new_indexed8_block(values, narrow_indices),
+            }
+        } else {
+            let mut cells = Vec::with_capacity(total_cells);
+            for index in rows {
+                let row = &self.inner[*index];
+                cells.extend((0..row.physical_len()).map(|cell| row.physical_cell(cell).clone()));
+            }
+            Row::new_direct_block(cells)
+        };
+
+        let mut start = 0;
+        for index in rows {
+            let len = self.inner[*index].physical_len();
+            if let Some(reusable) = self.inner[*index].install_packed(block.clone(), start, len) {
+                if self.reusable_rows.len() < MAX_REUSABLE_ROW_BUFFERS {
+                    self.reusable_rows.push(reusable);
+                }
+            }
+            start += len;
+        }
+    }
+
+    pub(crate) fn reset_row<D>(&mut self, line: Line, template: &T)
+    where
+        T: Clone + Default + super::GridCell + crate::term::cell::ResetDiscriminant<D>,
+        D: PartialEq,
+    {
+        let index = self.compute_index(line);
+        self.inner[index].reset_reusing(template, &mut self.reusable_rows);
     }
 
     /// Swap two rows while respecting the ring buffer's logical indexing.
@@ -323,7 +771,9 @@ mod tests {
 
     use crate::grid::GridCell;
     use crate::grid::row::Row;
-    use crate::grid::storage::{MAX_CACHE_BYTES, MIN_CACHE_ROWS, Storage, cache_row_limit};
+    use crate::grid::storage::{
+        MAX_CACHE_BYTES, MAX_REUSABLE_ROW_BUFFERS, MIN_CACHE_ROWS, Storage, cache_row_limit,
+    };
     use crate::index::{Column, Line};
     use crate::term::cell::Flags;
 
@@ -407,6 +857,7 @@ mod tests {
         // Setup storage area.
         let mut storage: Storage<char> = Storage {
             inner: vec![filled_row('0'), filled_row('1'), filled_row('-')],
+            reusable_rows: Vec::new(),
             zero: 0,
             visible_lines: 3,
             len: 3,
@@ -418,6 +869,7 @@ mod tests {
         // Make sure the result is correct.
         let mut expected = Storage {
             inner: vec![filled_row('0'), filled_row('1'), filled_row('-')],
+            reusable_rows: Vec::new(),
             zero: 0,
             visible_lines: 4,
             len: 4,
@@ -448,6 +900,7 @@ mod tests {
         // Setup storage area.
         let mut storage: Storage<char> = Storage {
             inner: vec![filled_row('-'), filled_row('0'), filled_row('1')],
+            reusable_rows: Vec::new(),
             zero: 1,
             visible_lines: 3,
             len: 3,
@@ -459,6 +912,7 @@ mod tests {
         // Make sure the result is correct.
         let mut expected = Storage {
             inner: vec![filled_row('0'), filled_row('1'), filled_row('-')],
+            reusable_rows: Vec::new(),
             zero: 0,
             visible_lines: 4,
             len: 4,
@@ -486,6 +940,7 @@ mod tests {
         // Setup storage area.
         let mut storage: Storage<char> = Storage {
             inner: vec![filled_row('2'), filled_row('0'), filled_row('1')],
+            reusable_rows: Vec::new(),
             zero: 1,
             visible_lines: 3,
             len: 3,
@@ -497,6 +952,7 @@ mod tests {
         // Make sure the result is correct.
         let expected = Storage {
             inner: vec![filled_row('2'), filled_row('0'), filled_row('1')],
+            reusable_rows: Vec::new(),
             zero: 1,
             visible_lines: 2,
             len: 2,
@@ -522,6 +978,7 @@ mod tests {
         // Setup storage area.
         let mut storage: Storage<char> = Storage {
             inner: vec![filled_row('0'), filled_row('1'), filled_row('2')],
+            reusable_rows: Vec::new(),
             zero: 0,
             visible_lines: 3,
             len: 3,
@@ -533,6 +990,7 @@ mod tests {
         // Make sure the result is correct.
         let expected = Storage {
             inner: vec![filled_row('0'), filled_row('1'), filled_row('2')],
+            reusable_rows: Vec::new(),
             zero: 0,
             visible_lines: 2,
             len: 2,
@@ -571,6 +1029,7 @@ mod tests {
                 filled_row('2'),
                 filled_row('3'),
             ],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 6,
             len: 6,
@@ -589,6 +1048,7 @@ mod tests {
                 filled_row('2'),
                 filled_row('3'),
             ],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 2,
             len: 2,
@@ -623,6 +1083,7 @@ mod tests {
                 filled_row('2'),
                 filled_row('3'),
             ],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 1,
             len: 2,
@@ -634,6 +1095,7 @@ mod tests {
         // Make sure the result is correct.
         let expected = Storage {
             inner: vec![filled_row('0'), filled_row('1')],
+            reusable_rows: Vec::new(),
             zero: 0,
             visible_lines: 1,
             len: 2,
@@ -658,6 +1120,7 @@ mod tests {
         // Setup storage area.
         let mut storage: Storage<char> = Storage {
             inner: vec![filled_row('1'), filled_row('2'), filled_row('0')],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 1,
             len: 2,
@@ -669,6 +1132,7 @@ mod tests {
         // Make sure the result is correct.
         let expected = Storage {
             inner: vec![filled_row('0'), filled_row('1')],
+            reusable_rows: Vec::new(),
             zero: 0,
             visible_lines: 1,
             len: 2,
@@ -715,6 +1179,7 @@ mod tests {
                 filled_row('2'),
                 filled_row('3'),
             ],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 0,
             len: 6,
@@ -733,6 +1198,7 @@ mod tests {
                 filled_row('2'),
                 filled_row('3'),
             ],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 0,
             len: 3,
@@ -754,6 +1220,7 @@ mod tests {
                 filled_row('2'),
                 filled_row('3'),
             ],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 0,
             len: 4,
@@ -776,6 +1243,7 @@ mod tests {
                 filled_row('2'),
                 filled_row('3'),
             ],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 0,
             len: 6,
@@ -796,7 +1264,13 @@ mod tests {
         ];
         let expected_init_size = std::cmp::max(init_size, cache_row_limit::<char>(1));
         expected_inner.append(&mut vec![filled_row('\0'); expected_init_size]);
-        let expected_storage = Storage { inner: expected_inner, zero: 0, visible_lines: 0, len: 9 };
+        let expected_storage = Storage {
+            inner: expected_inner,
+            reusable_rows: Vec::new(),
+            zero: 0,
+            visible_lines: 0,
+            len: 9,
+        };
 
         assert_eq!(storage.len, expected_storage.len);
         assert_eq!(storage.zero, expected_storage.zero);
@@ -807,6 +1281,7 @@ mod tests {
     fn rotate_wrap_zero() {
         let mut storage: Storage<char> = Storage {
             inner: vec![filled_row('-'), filled_row('-'), filled_row('-')],
+            reusable_rows: Vec::new(),
             zero: 2,
             visible_lines: 0,
             len: 3,
@@ -847,7 +1322,13 @@ mod tests {
     fn compact_releases_cached_rows_and_outer_capacity() {
         let mut inner = Vec::with_capacity(64);
         inner.extend((0..32).map(|_| filled_row('x')));
-        let mut storage = Storage { inner, zero: 7, visible_lines: 3, len: 3 };
+        let mut storage = Storage {
+            inner,
+            reusable_rows: Vec::new(),
+            zero: 7,
+            visible_lines: 3,
+            len: 3,
+        };
 
         storage.compact();
 
@@ -855,6 +1336,84 @@ mod tests {
         assert_eq!(storage.inner.capacity(), 3);
         assert_eq!(storage.zero, 0);
         assert_eq!(storage.cache_bytes(), 0);
+    }
+
+    #[test]
+    fn cold_history_shares_dictionary_blocks_and_mutation_inflates_one_row() {
+        let columns = 80;
+        let mut storage = Storage::<char>::with_capacity(3, columns);
+        storage.initialize(256, columns);
+        for age in 0..256 {
+            storage[Line(-((age + 1) as i32))][Column(0)] = 'x';
+        }
+
+        let before = storage.storage_metrics();
+        assert_eq!(storage.pack_cold_history(), 128);
+        let packed = storage.storage_metrics();
+
+        assert_eq!(packed.packed_rows, 128);
+        assert_eq!(packed.packed_blocks, 1);
+        assert!(packed.packed_block_bytes < before.dense_cell_bytes / 4);
+        assert_eq!(storage[Line(-200)][Column(79)], '\0');
+
+        let reusable = storage.reusable_rows.len();
+        assert!(reusable > 0);
+        assert!(reusable <= MAX_REUSABLE_ROW_BUFFERS);
+        storage.reset_row(Line(-200), &'\0');
+        assert_eq!(storage.reusable_rows.len(), reusable - 1);
+        assert!(!storage[Line(-200)].is_packed());
+
+        storage[Line(-200)][Column(0)] = 'y';
+        assert_eq!(storage[Line(-200)][Column(0)], 'y');
+        assert_eq!(storage[Line(-201)][Column(0)], 'x');
+        assert_eq!(storage.storage_metrics().packed_rows, 127);
+    }
+
+    #[test]
+    fn high_entropy_blocks_stay_inside_the_shallow_byte_target() {
+        let columns = 80;
+        let history_rows = 240;
+        let mut storage = Storage::<[u8; 32]>::with_capacity(3, columns);
+        storage.initialize(history_rows, columns);
+
+        for age in 0..history_rows {
+            for column in 0..columns {
+                let mut value = [0; 32];
+                value[..8]
+                    .copy_from_slice(&((age * columns + column) as u64).to_le_bytes());
+                storage[Line(-((age + 1) as i32))][Column(column)] = value;
+            }
+        }
+
+        let packed_rows = history_rows - super::HOT_HISTORY_ROWS;
+        assert_eq!(storage.pack_cold_history(), packed_rows);
+        let metrics = storage.storage_metrics();
+        assert!(metrics.packed_blocks > 1);
+        assert_eq!(metrics.packed_rows, packed_rows);
+        let direct_cell_bytes = packed_rows * columns * mem::size_of::<[u8; 32]>();
+        assert!(metrics.packed_block_bytes >= direct_cell_bytes);
+        assert!(
+            metrics.packed_block_bytes
+                <= direct_cell_bytes.saturating_add(metrics.packed_blocks * 128)
+        );
+        assert!(
+            metrics.packed_block_bytes
+                <= metrics.packed_blocks * (super::PACKED_BLOCK_TARGET_BYTES + 128)
+        );
+    }
+
+    #[test]
+    fn cold_history_packing_is_idempotent_and_keeps_hot_rows_dense() {
+        let columns = 20;
+        let mut storage = Storage::<char>::with_capacity(4, columns);
+        storage.initialize(320, columns);
+
+        assert_eq!(storage.pack_cold_history(), 192);
+        assert_eq!(storage.pack_cold_history(), 0);
+        assert!(!storage[Line(-1)].is_packed());
+        assert!(!storage[Line(-128)].is_packed());
+        assert!(storage[Line(-129)].is_packed());
+        assert!(storage[Line(-320)].is_packed());
     }
 
     fn filled_row(content: char) -> Row<char> {

--- a/vendor/alacritty_terminal/src/term/cell.rs
+++ b/vendor/alacritty_terminal/src/term/cell.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::hash::{Hash, Hasher};
 
 use arrayvec::ArrayVec;
 use bitflags::bitflags;
@@ -135,6 +136,14 @@ pub struct CellExtra {
     hyperlink: Option<Hyperlink>,
 }
 
+impl Hash for CellExtra {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.zerowidth.hash(state);
+        hash_color_option(self.underline_color, state);
+        self.hyperlink.hash(state);
+    }
+}
+
 /// Content and attributes of a single cell in the terminal grid.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -144,6 +153,45 @@ pub struct Cell {
     pub bg: Color,
     pub flags: Flags,
     pub extra: Option<Arc<CellExtra>>,
+}
+
+impl Hash for Cell {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.c.hash(state);
+        hash_color(self.fg, state);
+        hash_color(self.bg, state);
+        self.flags.hash(state);
+        self.extra.hash(state);
+    }
+}
+
+fn hash_color<H: Hasher>(color: Color, state: &mut H) {
+    match color {
+        Color::Named(color) => {
+            0u8.hash(state);
+            (color as u16).hash(state);
+        },
+        Color::Spec(color) => {
+            1u8.hash(state);
+            color.r.hash(state);
+            color.g.hash(state);
+            color.b.hash(state);
+        },
+        Color::Indexed(color) => {
+            2u8.hash(state);
+            color.hash(state);
+        },
+    }
+}
+
+fn hash_color_option<H: Hasher>(color: Option<Color>, state: &mut H) {
+    match color {
+        Some(color) => {
+            true.hash(state);
+            hash_color(color, state);
+        },
+        None => false.hash(state),
+    }
 }
 
 impl Default for Cell {

--- a/vendor/alacritty_terminal/src/term/mod.rs
+++ b/vendor/alacritty_terminal/src/term/mod.rs
@@ -335,6 +335,24 @@ pub struct Term<T> {
     config: Config,
 }
 
+/// Shallow allocation diagnostics for both terminal grids.
+///
+/// Dynamically allocated cell extras such as hyperlink strings are excluded,
+/// so callers must describe `estimated_bytes` as an estimate rather than an
+/// allocator-exact total.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct HistoryStorageMetrics {
+    pub estimated_bytes: usize,
+    pub cache_bytes: usize,
+    pub row_descriptor_bytes: usize,
+    pub dense_cell_bytes: usize,
+    pub packed_block_bytes: usize,
+    pub packed_blocks: usize,
+    pub packed_rows: usize,
+    pub allocated_cells: usize,
+    pub allocations: usize,
+}
+
 /// Configuration options for the [`Term`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
@@ -494,14 +512,19 @@ impl<T> Term<T> {
 
     /// Resets the terminal damage information.
     pub fn reset_damage(&mut self) {
-        self.finish_output_batch();
+        self.trim_history_cache_if_dirty();
         self.damage.reset(self.columns());
     }
 
     /// Complete deferred allocation maintenance after a parsed output batch.
-    /// Consumers which do not use damage tracking can call this at their own
-    /// frame boundary.
+    /// Consumers can call this at a bounded activity or frame boundary.
     pub fn finish_output_batch(&mut self) {
+        self.trim_history_cache_if_dirty();
+        self.grid.pack_cold_history();
+        self.inactive_grid.pack_cold_history();
+    }
+
+    fn trim_history_cache_if_dirty(&mut self) {
         if mem::take(&mut self.history_cache_dirty) {
             self.grid.trim_history_cache();
             self.inactive_grid.trim_history_cache();
@@ -679,6 +702,27 @@ impl<T> Term<T> {
         self.inactive_grid.compact_history();
     }
 
+    /// Collect all shallow allocation counters in one traversal per grid.
+    pub fn history_storage_metrics(&self) -> HistoryStorageMetrics {
+        let active = self.grid.storage_metrics();
+        let inactive = self.inactive_grid.storage_metrics();
+        HistoryStorageMetrics {
+            estimated_bytes: active.estimated_bytes.saturating_add(inactive.estimated_bytes),
+            cache_bytes: active.cache_bytes.saturating_add(inactive.cache_bytes),
+            row_descriptor_bytes: active
+                .row_descriptor_bytes
+                .saturating_add(inactive.row_descriptor_bytes),
+            dense_cell_bytes: active.dense_cell_bytes.saturating_add(inactive.dense_cell_bytes),
+            packed_block_bytes: active
+                .packed_block_bytes
+                .saturating_add(inactive.packed_block_bytes),
+            packed_blocks: active.packed_blocks.saturating_add(inactive.packed_blocks),
+            packed_rows: active.packed_rows.saturating_add(inactive.packed_rows),
+            allocated_cells: active.allocated_cells.saturating_add(inactive.allocated_cells),
+            allocations: active.allocations.saturating_add(inactive.allocations),
+        }
+    }
+
     /// Estimated shallow allocation held by cached rows in both grids.
     pub fn history_cache_bytes(&self) -> usize {
         self.grid.history_cache_bytes().saturating_add(self.inactive_grid.history_cache_bytes())
@@ -727,6 +771,8 @@ impl<T> Term<T> {
         if is_alt {
             self.rebalance_alt_history();
         }
+        self.grid.pack_all_cold_history();
+        self.inactive_grid.pack_all_cold_history();
 
         // Invalidate selection and tabs only when necessary.
         if old_cols != num_cols {
@@ -1222,6 +1268,82 @@ impl<T: EventListener> Handler for Term<T> {
             self.grid.cursor.point.column += 1;
         } else {
             self.grid.cursor.input_needs_wrap = true;
+        }
+    }
+
+    #[inline]
+    fn input_ascii(&mut self, bytes: &[u8]) {
+        if self.grid.cursor.charsets[self.active_charset] != StandardCharset::Ascii
+            || self.mode.contains(TermMode::INSERT)
+        {
+            for byte in bytes {
+                self.input(char::from(*byte));
+            }
+            return;
+        }
+
+        let columns = self.columns();
+        let mut offset = 0;
+        while offset < bytes.len() {
+            if self.grid.cursor.input_needs_wrap {
+                self.wrapline();
+            }
+
+            let point = self.grid.cursor.point;
+            let start = point.column.0;
+            let count = (columns - start).min(bytes.len() - offset);
+            let end = start + count;
+            let fresh_template_row = {
+                let row = &self.grid[point.line];
+                row.occ == 0
+                    && row
+                        .last()
+                        .is_some_and(|cell| cell == &self.grid.cursor.template)
+            };
+            let wide = !fresh_template_row
+                && (start..end).any(|column| {
+                    self.grid[point.line][Column(column)]
+                        .flags
+                        .intersects(Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER)
+                });
+            if wide {
+                for byte in &bytes[offset..] {
+                    self.input(char::from(*byte));
+                }
+                return;
+            }
+
+            let style = (!fresh_template_row).then(|| {
+                (
+                    self.grid.cursor.template.fg,
+                    self.grid.cursor.template.bg,
+                    self.grid.cursor.template.flags,
+                    self.grid.cursor.template.extra.clone(),
+                )
+            });
+            let cells = self.grid[point.line].cells_mut(start..end);
+            if fresh_template_row {
+                for (cell, byte) in cells.iter_mut().zip(&bytes[offset..offset + count]) {
+                    cell.c = char::from(*byte);
+                }
+            } else {
+                let (fg, bg, flags, extra) = style.expect("non-template row style");
+                for (cell, byte) in cells.iter_mut().zip(&bytes[offset..offset + count]) {
+                    cell.c = char::from(*byte);
+                    cell.fg = fg;
+                    cell.bg = bg;
+                    cell.flags = flags;
+                    cell.extra.clone_from(&extra);
+                }
+            }
+
+            offset += count;
+            if end < columns {
+                self.grid.cursor.point.column = Column(end);
+            } else {
+                self.grid.cursor.point.column = Column(columns - 1);
+                self.grid.cursor.input_needs_wrap = true;
+            }
         }
     }
 

--- a/vendor/vte/src/ansi.rs
+++ b/vendor/vte/src/ansi.rs
@@ -508,6 +508,13 @@ pub trait Handler {
     /// A character to be displayed.
     fn input(&mut self, _c: char) {}
 
+    /// A contiguous run of printable ASCII characters.
+    fn input_ascii(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.input(char::from(*byte));
+        }
+    }
+
     /// Set cursor to position.
     fn goto(&mut self, _line: i32, _col: usize) {}
 
@@ -1299,6 +1306,12 @@ where
     fn print(&mut self, c: char) {
         self.handler.input(c);
         self.state.preceding_char = Some(c);
+    }
+
+    #[inline]
+    fn print_ascii(&mut self, bytes: &[u8]) {
+        self.handler.input_ascii(bytes);
+        self.state.preceding_char = bytes.last().copied().map(char::from);
     }
 
     #[inline]

--- a/vendor/vte/src/ansi.rs
+++ b/vendor/vte/src/ansi.rs
@@ -1315,6 +1315,13 @@ where
     }
 
     #[inline]
+    fn ascii_print_never_terminates(&self) -> bool {
+        // Only escape/control dispatch changes this performer's termination
+        // state; Handler::input_ascii has no access to that state.
+        true
+    }
+
+    #[inline]
     fn execute(&mut self, byte: u8) {
         match byte {
             C0::HT => self.handler.put_tab(1),

--- a/vendor/vte/src/ansi.rs
+++ b/vendor/vte/src/ansi.rs
@@ -1367,7 +1367,7 @@ where
                 }
                 buf.push_str("],");
             }
-            debug!("[unhandled osc_dispatch]: [{}] at line {}", &buf, line!());
+            debug!("[unhandled osc_dispatch]: [{}] at line {}", buf, line!());
         }
 
         if params.is_empty() || params[0].is_empty() {

--- a/vendor/vte/src/lib.rs
+++ b/vendor/vte/src/lib.rs
@@ -144,14 +144,15 @@ impl<const OSC_RAW_BUF_SIZE: usize> Parser<OSC_RAW_BUF_SIZE> {
     ) -> usize {
         let mut i = 0;
 
-        // Handle partial codepoints from previous calls to `advance`.
-        if self.partial_utf8_len != 0 {
-            i += self.advance_partial_utf8(performer, bytes);
-        }
-
         while i != bytes.len() && !performer.terminated() {
+            if self.partial_utf8_len != 0 {
+                i += self.advance_partial_utf8(performer, &bytes[i..i + 1]);
+                continue;
+            }
             match self.state {
-                State::Ground => i += self.advance_ground(performer, &bytes[i..]),
+                // A performer may terminate on any printed character or
+                // control byte. Do not consume the remainder of a text run.
+                State::Ground => i += self.advance_ground(performer, &bytes[i..i + 1]),
                 _ => {
                     // Inlining it results in worse codegen.
                     let byte = bytes[i];
@@ -862,6 +863,31 @@ mod tests {
     use std::vec::Vec;
 
     use super::*;
+
+    #[test]
+    fn termination_preserves_unconsumed_text() {
+        struct StopOn {
+            stop: char,
+            text: std::string::String,
+        }
+        impl Perform for StopOn {
+            fn print(&mut self, c: char) {
+                self.text.push(c);
+            }
+            fn terminated(&self) -> bool {
+                self.text.ends_with(self.stop)
+            }
+        }
+        for (input, stop, expected) in [("abcdef", 'c', "abc"), ("aé終z", '終', "aé終")] {
+            let mut parser = Parser::new();
+            let mut performer = StopOn { stop, text: std::string::String::new() };
+            let consumed = parser.advance_until_terminated(&mut performer, input.as_bytes());
+            assert_eq!(consumed, expected.len());
+            assert_eq!(performer.text, expected);
+            parser.advance(&mut performer, &input.as_bytes()[consumed..]);
+            assert_eq!(performer.text, input);
+        }
+    }
 
     const OSC_BYTES: &[u8] = &[
         0x1B, 0x5D, // Begin OSC

--- a/vendor/vte/src/lib.rs
+++ b/vendor/vte/src/lib.rs
@@ -720,11 +720,28 @@ impl<const OSC_RAW_BUF_SIZE: usize> Parser<OSC_RAW_BUF_SIZE> {
     /// Handle ground dispatch of print/execute for all characters in a string.
     #[inline]
     fn ground_dispatch<P: Perform>(performer: &mut P, text: &str) {
-        for c in text.chars() {
+        let bytes = text.as_bytes();
+        let mut index = 0;
+        while index < bytes.len() {
+            if matches!(bytes[index], b' '..=b'~') {
+                let start = index;
+                index += 1;
+                while index < bytes.len() && matches!(bytes[index], b' '..=b'~') {
+                    index += 1;
+                }
+                performer.print_ascii(&bytes[start..index]);
+                continue;
+            }
+
+            let c = text[index..]
+                .chars()
+                .next()
+                .expect("ground text index remains on a character boundary");
             match c {
                 '\x00'..='\x1f' | '\u{80}'..='\u{9f}' => performer.execute(c as u8),
                 _ => performer.print(c),
             }
+            index += c.len_utf8();
         }
     }
 }
@@ -761,6 +778,17 @@ enum State {
 pub trait Perform {
     /// Draw a character to the screen and update states.
     fn print(&mut self, _c: char) {}
+
+    /// Draw a contiguous run of printable ASCII characters.
+    ///
+    /// The default retains the exact per-character contract. Terminal
+    /// implementations can override this to avoid repeating UTF-8 and width
+    /// classification for the overwhelmingly common shell-output path.
+    fn print_ascii(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.print(char::from(*byte));
+        }
+    }
 
     /// Execute a C0 or C1 control function.
     fn execute(&mut self, _byte: u8) {}

--- a/vendor/vte/src/lib.rs
+++ b/vendor/vte/src/lib.rs
@@ -150,6 +150,15 @@ impl<const OSC_RAW_BUF_SIZE: usize> Parser<OSC_RAW_BUF_SIZE> {
                 continue;
             }
             match self.state {
+                State::Ground if performer.ascii_print_never_terminates()
+                    && matches!(bytes[i], b' '..=b'~') =>
+                {
+                    let start = i;
+                    while i < bytes.len() && matches!(bytes[i], b' '..=b'~') {
+                        i += 1;
+                    }
+                    performer.print_ascii(&bytes[start..i]);
+                },
                 // A performer may terminate on any printed character or
                 // control byte. Do not consume the remainder of a text run.
                 State::Ground => i += self.advance_ground(performer, &bytes[i..i + 1]),
@@ -791,6 +800,13 @@ pub trait Perform {
         }
     }
 
+    /// Opt into ASCII batching in the terminating parser only when printing
+    /// printable ASCII can never change `terminated()` from false to true.
+    /// Control characters and escape sequences still check termination.
+    fn ascii_print_never_terminates(&self) -> bool {
+        false
+    }
+
     /// Execute a C0 or C1 control function.
     fn execute(&mut self, _byte: u8) {}
 
@@ -887,6 +903,25 @@ mod tests {
             parser.advance(&mut performer, &input.as_bytes()[consumed..]);
             assert_eq!(performer.text, input);
         }
+    }
+
+    #[test]
+    fn terminating_parser_batches_opted_in_ascii_but_stops_at_control() {
+        #[derive(Default)]
+        struct Batch {
+            runs: Vec<Vec<u8>>,
+            stopped: bool,
+        }
+        impl Perform for Batch {
+            fn ascii_print_never_terminates(&self) -> bool { true }
+            fn print_ascii(&mut self, bytes: &[u8]) { self.runs.push(bytes.to_vec()); }
+            fn execute(&mut self, _: u8) { self.stopped = true; }
+            fn terminated(&self) -> bool { self.stopped }
+        }
+        let mut parser = Parser::new();
+        let mut performer = Batch::default();
+        assert_eq!(parser.advance_until_terminated(&mut performer, b"abc\ndef"), 4);
+        assert_eq!(performer.runs, vec![b"abc".to_vec()]);
     }
 
     const OSC_BYTES: &[u8] = &[

--- a/website/src/content/docs/docs/guides/scrollback.mdx
+++ b/website/src/content/docs/docs/guides/scrollback.mdx
@@ -16,6 +16,14 @@ memory predictably but reports retained bytes as an estimate rather than an
 exact allocator measurement. Reducing the setting trims existing history
 immediately; increasing it applies to subsequent output.
 
+Completed rows stay fully lossless but cold history is packed into bounded,
+shared blocks. Repeated cells use a block-local dictionary, while high-entropy
+content falls back to direct packed cells. The visible screen and recent 128
+history rows stay in the normal mutable representation. Unix schedules packing
+on a bounded activity deadline inside the existing PTY descriptor actor;
+Windows uses its coalesced output boundary. This adds no thread or idle polling,
+and reading old history does not inflate the complete transcript.
+
 **Keyboard scroll mode:** press **`Shift+↑`** (no prefix needed, so it works
 even where macOS eats `Ctrl+Space`). The status bar switches to SCROLL and
 plain keys navigate without reaching the program in the pane:

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -598,6 +598,17 @@ read-only history fields to their existing result rows:
   "history_rows": 1830,
   "history_budget_bytes": 10485760,
   "history_bytes": 7340032,
+  "history_estimated_grid_bytes": 524288,
+  "history_cache_bytes": 65536,
+  "history_compacted_rows": 1700,
+  "history_allocated_cells": 4200,
+  "history_packed_blocks": 4,
+  "history_packed_bytes": 98304,
+  "history_packed_rows": 1536,
+  "history_dense_row_bytes": 204800,
+  "history_row_descriptor_bytes": 65536,
+  "history_allocation_count": 310,
+  "history_bytes_kind": "estimated",
   "history_exact": false
 }
 ```
@@ -609,6 +620,15 @@ reading; `history_exact` tells consumers whether that number is exact. With the
 current Alacritty adapter it is a conservative estimate (`false`), because the
 underlying terminal engine limits rows rather than allocation bytes. These
 fields observe state only; they do not grant remote control of a pane viewport.
+
+The additive `history_estimated_grid_bytes`, `history_cache_bytes`,
+`history_dense_row_bytes`, `history_row_descriptor_bytes`, and
+`history_packed_bytes` fields attribute shallow terminal storage. Packed block
+and row counts, allocated cell capacity, and the approximate allocation count
+support repeatable diagnostics without exposing pane content. Dynamic cell
+extras and allocator metadata are not fully measurable, so
+`history_bytes_kind` remains `estimated` and consumers must not present these
+fields as exact process memory.
 
 ### Runtime performance counters
 


### PR DESCRIPTION
Bulk output previously repeated small row allocations, parser synchronization, and render-boundary history compaction. This change packs cold scrollback losslessly and reduces ingestion overhead while preserving existing terminal behavior and memory settings.

## What

- Keep the active screen and recent history mutable; store cold rows in bounded shared dictionary or direct-cell blocks.
- Reuse bounded small row buffers and batch Unix PTY reads under one bounded terminal lock.
- Schedule history packing through the existing Unix descriptor actor with quiet and maximum-defer deadlines. Windows retains its output-boundary maintenance path.
- Add printable-ASCII batching with a conservative parser contract: general terminating performers stop at the exact character, while the ANSI performer explicitly opts into batching because printable text cannot terminate it.
- Preserve template attributes and grapheme data when growing and recompacting rows during reflow.
- Add estimated history-storage diagnostics to pane inspection and document their limits.
- Add no dependency, operating-system thread, watcher, or idle polling loop.

## Measurement

Three development measurements of the original performance commit used macOS Apple Silicon, a 160x40 viewport, 20 panes, and 50,000 input lines per pane. Release server ingestion CPU was 2.64, 2.76, and 2.27 seconds, with a 2.64-second median. Median loaded physical footprint was 29 MiB and allocator-reported live heap was 8.79 MiB under the configured retention bound.

These are measurements of the original candidate, not a fresh benchmark of the subsequent parser/reflow review fixes. Correctness coverage verifies that the ANSI batching path remains active.

## Verification

- Local: formatting, 80 Luvus terminal tests, 151 vendored terminal unit tests, 45 terminal reference fixtures, and the vendored terminal doctest passed after the initial review fixes.
- Latest parser: 57 tests with the ANSI feature enabled and strict standalone Clippy passed, including exact termination and explicit ASCII-batch opt-in regressions.
- UHP: 55 terminal fixtures, 92 general fixtures, schema validation, snapshot replay, and mock conformance passed locally.
- The local full suite recorded two environment-sensitive failures: customized-shell CWD detection and scratch-server palette startup. A subsequent root build was interrupted after profiling confirmed a macOS directory-enumeration stall in the existing build cache. No production server or build cache was removed.
- GitHub CI results are required for the final commit, including Linux/macOS tests, Windows protocol/ConPTY, UHP live/failure conformance, packageability, binary size, audit, and Nix builds.

## Notes

History metrics remain estimates and the existing width-aware row limit remains in use. This change does not claim allocator-exact byte-budget enforcement. Platform runtime evidence is limited to the local and CI environments actually exercised.
