### PR TITLE
fix(input): keep pane title clicks focused

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2486,18 +2486,6 @@ impl App {
             self.zoomed = !self.zoomed;
             return;
         }
-        // Clicking a pane's title strip opens the running-command overlay — the
-        // full argv from the OS, since an agent's on-screen `Bash(… …)` is
-        // elided before it ever reaches us.
-        if let Some((id, _)) = self
-            .pane_title_rects
-            .iter()
-            .find(|(_, rect)| hit(*rect))
-            .map(|(id, r)| (*id, *r))
-        {
-            self.open_cmd_inspect(id);
-            return;
-        }
         // Tab-bar scroll arrows: step to the previous / next tab.
         if self.tab_prev_rect.is_some_and(hit) {
             let a = self.ws().active_tab;
@@ -6507,10 +6495,9 @@ mod link_click_tests {
             KeyModifiers::NONE,
         ));
         assert!(
-            app.cmd_inspect.is_some(),
-            "the title click opened the command overlay (setup sanity)"
+            app.cmd_inspect.is_none(),
+            "the title click did not open the command overlay"
         );
-        app.close_cmd_inspect();
         // Reset focus *after* the title click, so only the body click can move it.
         app.layout_mut().focus = top;
         app.handle_event(mouse(

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -6498,6 +6498,11 @@ mod link_click_tests {
             app.cmd_inspect.is_none(),
             "the title click did not open the command overlay"
         );
+        assert_eq!(
+            app.layout().focus,
+            bottom,
+            "the title click focused the pane"
+        );
         // Reset focus *after* the title click, so only the body click can move it.
         app.layout_mut().focus = top;
         app.handle_event(mouse(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6790,13 +6790,12 @@ impl App {
     /// which for a stacked pane lands exactly on the horizontal divider. Resize
     /// must yield there, or the divider grab zone swallows every click on the ✕
     /// and the pane can't be closed by mouse.
-    /// True if `(c, r)` lands on a pane's interactive **border chrome**: a title
-    /// strip (the command-inspector button), the ⤢/⤡ zoom toggle, or the ✕ close
-    /// button. These live on the top border row — exactly the cells a resize grab
-    /// band would otherwise swallow — so every resize path (grab, Ctrl-grab, hover
-    /// highlight) excludes them: the seam between panes stays grabbable, but a
-    /// click on a title or button always wins. On a stacked split this matters
-    /// most, since the divider line *is* the lower pane's top border.
+    /// True if `(c, r)` lands on pane **border chrome**: a title strip, the ⤢/⤡
+    /// zoom toggle, or the ✕ close button. These live on the top border row,
+    /// exactly where a resize grab band would otherwise claim the press, so every
+    /// resize path excludes them. A title click can then focus its pane without
+    /// unexpectedly starting a resize. On a stacked split this matters most,
+    /// since the divider line is the lower pane's top border.
     fn on_pane_chrome(&self, c: u16, r: u16) -> bool {
         fn hit(rc: Rect, c: u16, r: u16) -> bool {
             c >= rc.x && c < rc.right() && r >= rc.y && r < rc.bottom()
@@ -6808,10 +6807,8 @@ impl App {
 
     pub fn begin_resize(&mut self, c: u16, r: u16) -> bool {
         // Pane border chrome (title, ⤢ zoom, ✕ close) always wins the click, even
-        // though it sits on the seam a resize would otherwise grab — see
-        // `on_pane_chrome`. This is what makes those buttons and the title
-        // clickable on a stacked split, where the divider line lands on the lower
-        // pane's top border row.
+        // though it sits on the seam a resize would otherwise grab. This keeps
+        // title focus and the two buttons reliable on stacked splits.
         if self.active_is_git() || self.active_is_orch() || self.on_pane_chrome(c, r) {
             return false;
         }
@@ -10424,9 +10421,9 @@ mod tests {
     }
 
     /// End-to-end through the real mouse pipeline (`handle_event`), the user's
-    /// exact report: on a stacked split, clicking the bottom pane's title opens
-    /// its command overlay, clicking its ⤢ zoom toggles zoom, and clicking its
-    /// content focuses it — none of them get eaten by a divider resize.
+    /// exact report: on a stacked split, clicking the bottom pane's title focuses
+    /// it, clicking its ⤢ zoom toggles zoom, and clicking its content focuses it.
+    /// None of them get eaten by a divider resize.
     #[test]
     fn stacked_bottom_pane_title_zoom_and_body_are_all_clickable() {
         let _env = crate::persist::test_env("stacked-clickable");
@@ -10463,19 +10460,17 @@ mod tests {
         app.zoomed = false;
         render(&mut app, &mut term);
 
-        // 2. The title strip opens the running-command overlay.
+        // 2. The title strip focuses its pane without opening an overlay.
         let (_, title) = *app
             .pane_title_rects
             .iter()
             .max_by_key(|(_, rc)| rc.y)
             .expect("bottom pane has a title strip");
+        app.layout_mut().focus = top;
         click(&mut app, title.x + 1, title.y);
-        assert!(
-            app.cmd_inspect.is_some(),
-            "clicking the title opened the command overlay"
-        );
+        assert_eq!(app.layout().focus, bottom, "title click focused its pane");
+        assert!(app.cmd_inspect.is_none(), "title click opened no overlay");
         assert!(app.resize_drag.is_none(), "title did not start a resize");
-        app.close_cmd_inspect();
         render(&mut app, &mut term);
 
         // 3. Focus the top pane, then a click in the bottom pane's *body* focuses
@@ -12751,19 +12746,18 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
-    // Clicking a pane's title opens the running-command overlay. The point is
-    // that the command comes from the OS, not the screen: an agent's own UI
-    // elides long commands and those characters never reach luvus at all.
+    // The pane context menu keeps the running-command overlay available. The
+    // command comes from the OS, not the screen, because an agent's own UI can
+    // elide characters before they ever reach luvus.
     #[test]
-    fn clicking_a_pane_title_shows_the_real_command() {
-        use ratatui::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    fn pane_menu_shows_the_real_running_command() {
         use ratatui::{backend::TestBackend, Terminal};
         let _env = crate::persist::test_env("cmd-inspect");
         let (tx, rx) = std::sync::mpsc::channel();
         let mut app = App::new(120, 40, tx).unwrap();
 
-        // Titles (and borders) only render on split panes, so split first — the
-        // single-pane case is covered by the pane context menu instead.
+        // Split first so this continues to exercise the same live child process
+        // setup as the pane-title regression tests.
         app.split(Axis::Col);
         let id = app.layout().focus;
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
@@ -12779,22 +12773,16 @@ mod tests {
                 Err(error) => panic!("the split pane never became ready: {error}"),
             }
         }
-        // Render once so the title strips are registered as click targets.
+        // The right-click menu action remains the explicit path to inspection.
         let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
-        let (_, title) = *app
-            .pane_title_rects
-            .iter()
-            .find(|(pid, _)| *pid == id)
-            .expect("the focused pane has a clickable title");
-
         assert!(app.cmd_inspect.is_none());
-        app.handle_event(AppEvent::Mouse(MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Left),
-            column: title.x + 1,
-            row: title.y,
-            modifiers: KeyModifiers::NONE,
-        }));
+        app.open_pane_menu(id, 1, 1);
+        assert!(
+            app.pane_menu_items().contains(&PaneMenuItem::RunningCmd),
+            "the pane menu offers running-command inspection"
+        );
+        app.pane_menu_action(PaneMenuItem::RunningCmd);
         let c = app.cmd_inspect.as_ref().expect("the overlay opened");
         assert_eq!(c.pane, id);
         // The pane's own shell is the root of the tree, with its real argv.

--- a/src/ui/cmdinfo.rs
+++ b/src/ui/cmdinfo.rs
@@ -1,4 +1,4 @@
-//! The "what's actually running in this pane?" overlay — click a pane's title.
+//! The "what's actually running in this pane?" overlay from its context menu.
 //!
 //! Agent CLIs elide long tool commands on screen (`Bash(cargo test …)`), and the
 //! elided characters are never sent to the terminal, so luvus cannot expand what

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -837,7 +837,7 @@ fn render_into_mode(f: &mut RenderTarget, app: &mut App, resize_panes: bool) {
         app.changelog_link_rects.clear();
         app.changelog_copy_rects.clear();
     }
-    // The running-command overlay (click a pane title) draws above that.
+    // The running-command overlay from the pane context menu draws above that.
     if let Some(c) = app.cmd_inspect.as_ref() {
         cmdinfo::draw(f, area, c, &t);
     }

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -109,7 +109,8 @@ pub(super) fn draw_pane_titles(
         ]);
         let title_rect = Rect::new(rect.x + 1, rect.y, text_w, 1);
         f.render_widget(Paragraph::new(title), title_rect);
-        // Clicking the title opens the running-command overlay.
+        // Keep the title geometry so clicks focus the pane and never become an
+        // accidental divider resize on a stacked layout.
         title_rects.push((*id, title_rect));
         draw_title_buttons(f, *rect, focused, app.zoomed, title_w, bg, t);
     }


### PR DESCRIPTION
Clicking a pane title now focuses that pane without opening the running-command inspector.

## What

- remove the direct left-click shortcut from pane titles to the running-command overlay
- keep pane-title hit geometry so stacked-pane titles cannot accidentally start divider resizing
- preserve normal pane focus when a title is clicked
- keep **Running Command** available through the pane right-click menu
- update focused tests for title clicks, resize protection, double-click isolation, and context-menu inspection

## Why

The title shortcut could open the command overlay while the user was trying to focus a pane or interact near the tab row. The pane context menu already provides an explicit Running Command action, so the title no longer needs a second competing behavior.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] focused title-click and command-menu regressions
  - `a_title_click_then_a_body_click_focuses_the_pane_not_a_double_click`
  - `stacked_bottom_pane_title_zoom_and_body_are_all_clickable`
  - `pane_menu_shows_the_real_running_command`
- [ ] `cargo test --locked`

The complete locked suite was attempted locally. All tests related to this change passed, but the run stopped on the unrelated `app::cwd::tests::pane_cwd_follows_cd_without_moving_its_workspace` test, which also failed when rerun alone because its child CWD remained at the repository root. A second run with only that test skipped reached the unrelated real-server test and failed because its test socket was not created. Neither failure touches files changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clicking a pane title now focuses the pane without opening the running-command inspection overlay.
  - Pane title clicks no longer trigger unintended divider resizing in stacked layouts.
  - Zoom controls and pane body clicks continue to work without starting a resize operation.

- **Improvements**
  - Running-command inspection is now accessed through the pane’s context menu, providing a clear and consistent interaction path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->