### PR TITLE
test(ipc): isolate and bound lifecycle fixtures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,13 @@ PTYs without requiring an interactive terminal. Test visible changes manually,
 measure performance changes before and after, and test platform-specific code on
 the affected platform when available.
 
+Lifecycle tests must isolate the state home and clear inherited socket/session
+selectors before spawning a server. Use an explicit shell when testing process
+behavior rather than shell integration. Bound startup and socket waits, check
+early child exits, retain a bounded excerpt of failure diagnostics, and use a
+child-handle cleanup guard. Tests that change process-global configuration must
+hold `persist::test_env(...)` for their entire lifetime.
+
 ## Adding agent support
 
 Use a detection manifest when an agent only needs identity and live-state

--- a/src/app/cwd.rs
+++ b/src/app/cwd.rs
@@ -505,6 +505,11 @@ mod tests {
     #[test]
     fn pane_cwd_follows_cd_without_moving_its_workspace() {
         let _env = crate::persist::test_env("pane-cwd-follows-cd");
+        // Exercise CWD tracking, not the developer's interactive shell plugins.
+        crate::config::save(&crate::config::Config {
+            shell: "/bin/sh".into(),
+            ..Default::default()
+        });
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         let id = app.layout().focus;
@@ -521,11 +526,17 @@ mod tests {
             std::thread::sleep(Duration::from_millis(100));
             app.refresh_cwds();
             got = app.panes.get(&id).unwrap().cwd.display().to_string();
-            if got.contains("tmp") {
+            if std::path::Path::new(&got).canonicalize().ok()
+                == std::path::Path::new("/tmp").canonicalize().ok()
+            {
                 break;
             }
         }
-        assert!(got.contains("tmp"), "cwd did not follow cd: got '{got}'");
+        assert_eq!(
+            std::path::Path::new(&got).canonicalize().unwrap(),
+            std::path::Path::new("/tmp").canonicalize().unwrap(),
+            "cwd did not follow cd"
+        );
         assert_eq!(
             app.ws().cwd,
             workspace_cwd,

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -842,6 +842,7 @@ mod tests {
         std::fs::create_dir_all(&home).unwrap();
         let config = crate::config::Config {
             theme: "terminal".into(),
+            shell: "/bin/sh".into(),
             ..Default::default()
         };
         std::fs::write(
@@ -850,6 +851,9 @@ mod tests {
         )
         .unwrap();
 
+        // Keep startup diagnostics out of pipes, which can fill and block the
+        // child. Only a bounded excerpt is read if startup fails.
+        let diagnostics = std::fs::File::create(home.join("startup.log")).unwrap();
         // A real server on a scratch home.
         let server = Command::new(&bin)
             .args([
@@ -863,9 +867,12 @@ mod tests {
             // An agent pane inherits the live session's socket. The scratch
             // server and its cleanup must never escape this test home.
             .env_remove("LUVUS_SOCKET_PATH")
+            .env_remove("LUVUS_SESSION")
+            .env_remove("LUVUS_PANE_ID")
+            .env_remove("LUVUS_TASK_ID")
             .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stdout(diagnostics.try_clone().unwrap())
+            .stderr(diagnostics)
             .spawn()
             .unwrap();
         struct ScratchServer {
@@ -879,7 +886,7 @@ mod tests {
                 let _ = std::fs::remove_dir_all(&self.home);
             }
         }
-        let _server = ScratchServer {
+        let mut server = ScratchServer {
             child: server,
             home: home.clone(),
         };
@@ -888,11 +895,26 @@ mod tests {
             if sock.exists() {
                 break;
             }
+            if server.child.try_wait().unwrap().is_some() {
+                break;
+            }
             thread::sleep(std::time::Duration::from_millis(100));
         }
-        assert!(sock.exists(), "server never created its client socket");
+        if !sock.exists() {
+            let mut diagnostics = String::new();
+            std::io::Read::take(std::fs::File::open(home.join("startup.log")).unwrap(), 8192)
+                .read_to_string(&mut diagnostics)
+                .unwrap();
+            panic!("server never created its client socket: {diagnostics}");
+        }
 
         let conn = crate::ipc::transport::connect(&sock).unwrap();
+        assert_eq!(
+            conn.set_timeouts(std::time::Duration::from_secs(5))
+                .unwrap(),
+            crate::ipc::transport::TimeoutMode::Kernel,
+            "Unix lifecycle tests require bounded blocking reads and writes"
+        );
         let mut writer = conn.clone();
         let mut reader = std::io::BufReader::new(conn);
 
@@ -954,7 +976,7 @@ mod tests {
             "the server returned a real frame after palette negotiation"
         );
 
-        // `_server` kills only the child handle spawned above, even if an
+        // `server` kills only the child handle spawned above, even if an
         // assertion panics. It never addresses an inherited production socket.
     }
 


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 1 of 15** · Base: `main` · Next: #285 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |
<!-- luvus-audit-stack:end -->

## What
- Clear inherited session, socket, pane, and task selectors in the scratch palette server.
- Use an explicit test shell for palette and CWD lifecycle checks.
- Bound socket reads/writes, detect early child exit, and include a capped startup diagnostic excerpt.
- Document lifecycle-test isolation in CONTRIBUTING.md. No production runtime behavior changes.

## Verification
- Reproduced the original palette startup failure with an inherited LUVUS_SESSION.
- Fixed test passes with the same inherited selector.
- CWD test passes with an invalid inherited SHELL.
- Focused macOS tests, formatting, diff checks, and strict all-target Clippy passed.
- Linux and Windows execution remains subject to CI.

## Stack
First independent foundation of the runtime audit follow-ups. No merge requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded contributor guidance for writing reliable lifecycle tests, including state isolation, bounded waits, diagnostics, and cleanup practices.

- **Tests**
  - Improved coverage for pane working-directory behavior after changing directories.
  - Strengthened terminal palette connection testing with explicit shell configuration, startup diagnostics, early failure detection, and timeout-mode validation.
  - Test checks now use canonicalized paths for more accurate working-directory verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->