### PR TITLE
fix(terminal): preserve live-screen snapshot fidelity

### DIFF
--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -1062,51 +1062,47 @@ impl VtEngine for AlacrittyEngine {
         if rows == 0 || cols == 0 {
             return String::new();
         }
-        let default = (' ', Color::Reset, Color::Reset, Modifier::empty());
-        let mut cells = vec![vec![default; cols]; rows];
-        for indexed in grid.display_iter() {
-            let r = indexed.point.line.0;
-            let c = indexed.point.column.0;
-            if r < 0 || r as usize >= rows || c >= cols {
-                continue;
-            }
-            let cell = indexed.cell;
-            if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-                continue;
-            }
-            let ch = if cell.c == '\0' { ' ' } else { cell.c };
-            cells[r as usize][c] = (
-                ch,
-                map_color(cell.fg),
-                map_color(cell.bg),
-                map_flags(cell.flags),
-            );
-        }
-
-        // Trim trailing blank rows so replaying into any-size engine doesn't
-        // scroll the content off-screen.
-        let last_row = match cells
-            .iter()
-            .rposition(|row| row.iter().any(|c| *c != default))
-        {
-            Some(r) => r,
-            None => return String::from("\x1b[2J\x1b[H"),
-        };
+        // Logical nonnegative rows are the live screen, irrespective of the
+        // user's scroll offset. Do not change that viewport to take a snapshot,
+        // or allocate another grid just to serialize this bounded screen.
         let mut out = String::from("\x1b[2J\x1b[H");
-        for (ri, row) in cells.iter().take(last_row + 1).enumerate() {
-            let last = row.iter().rposition(|c| *c != default).map_or(0, |i| i + 1);
+        for ri in 0..rows {
+            let row = &grid[Line(ri as i32)];
+            let last = (0..cols).rfind(|&ci| {
+                let cell = &row[Column(ci)];
+                !cell.flags.contains(Flags::WIDE_CHAR_SPACER)
+                    && (cell.c != ' ' && cell.c != '\0'
+                        || cell.zerowidth().is_some_and(|chars| !chars.is_empty())
+                        || map_color(cell.fg) != Color::Reset
+                        || map_color(cell.bg) != Color::Reset
+                        || !map_flags(cell.flags).is_empty())
+            });
+            let Some(last) = last else { continue };
+            // Absolute rows avoid a pending autowrap at the right edge causing
+            // the next row to scroll. Empty trailing rows need no replay bytes.
+            out.push_str(&format!("\x1b[{};1H", ri + 1));
             let mut cur = (Color::Reset, Color::Reset, Modifier::empty());
-            for (ch, fg, bg, m) in &row[..last] {
-                if (*fg, *bg, *m) != cur {
-                    out.push_str(&sgr(*fg, *bg, *m));
-                    cur = (*fg, *bg, *m);
+            for ci in 0..=last {
+                let cell = &row[Column(ci)];
+                // The preceding wide character already advances two cells.
+                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                    continue;
                 }
-                out.push(*ch);
+                let style = (
+                    map_color(cell.fg),
+                    map_color(cell.bg),
+                    map_flags(cell.flags),
+                );
+                if style != cur {
+                    out.push_str(&sgr(style.0, style.1, style.2));
+                    cur = style;
+                }
+                out.push(if cell.c == '\0' { ' ' } else { cell.c });
+                if let Some(chars) = cell.zerowidth() {
+                    out.extend(chars);
+                }
             }
             out.push_str("\x1b[0m");
-            if ri < last_row {
-                out.push_str("\r\n");
-            }
         }
         out
     }
@@ -1202,6 +1198,56 @@ mod tests {
 
     fn budget_for_rows(cols: usize, rows: usize) -> usize {
         estimated_row_bytes(cols).saturating_mul(rows)
+    }
+
+    #[test]
+    fn snapshot_replays_live_unicode_cells_independent_of_scroll() {
+        for cols in [8, 24] {
+            let (tx, _rx) = channel();
+            let mut source = AlacrittyEngine::new(cols, 4, tx, budget_for_rows(cols as usize, 40));
+            feed_lines(&mut source, 15);
+            source.advance("\x1b[2J\x1b[H界Aé e\u{301}\r\n♥\u{fe0f}X\r\n👩\u{200d}💻Z\r\n\x1b[1;3;4;38;2;2;3;4;48;5;12m界B\x1b[0m".as_bytes());
+            let snapshot = source.snapshot_ansi();
+            source.scroll(8);
+            let offset = source.term.grid().display_offset();
+            let cursor = source.term.grid().cursor.point;
+            assert!(offset > 0);
+            assert_eq!(source.snapshot_ansi(), snapshot);
+            assert_eq!(source.term.grid().display_offset(), offset);
+            assert_eq!(source.term.grid().cursor.point, cursor);
+            assert!(!snapshot.contains("line"), "history must not be serialized");
+
+            let (tx, _rx) = channel();
+            let mut replay = AlacrittyEngine::new(cols, 4, tx, budget_for_rows(cols as usize, 40));
+            replay.advance(snapshot.as_bytes());
+            for line in 0..4 {
+                for col in 0..cols {
+                    let point = Point::new(Line(line), Column(col as usize));
+                    let expected = &source.term.grid()[point];
+                    let actual = &replay.term.grid()[point];
+                    assert_eq!(actual.c, expected.c, "{cols}: {point:?}");
+                    assert_eq!(actual.zerowidth(), expected.zerowidth());
+                    assert_eq!(map_color(actual.fg), map_color(expected.fg));
+                    assert_eq!(map_color(actual.bg), map_color(expected.bg));
+                    assert_eq!(map_flags(actual.flags), map_flags(expected.flags));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn snapshot_preserves_right_edge_and_blank_rows_after_resize() {
+        let (tx, _rx) = channel();
+        let mut source = AlacrittyEngine::new(8, 4, tx, budget_for_rows(8, 20));
+        source.advance("123456界\r\n\r\nlast".as_bytes());
+        source.resize(12, 4);
+        let snapshot = source.snapshot_ansi();
+        let (tx, _rx) = channel();
+        let mut replay = AlacrittyEngine::new(12, 4, tx, budget_for_rows(12, 20));
+        replay.advance(snapshot.as_bytes());
+        assert_eq!(replay.snapshot_ansi(), snapshot);
+        // ED2 retains the initial blank cursor row; replay adds no scrolling.
+        assert_eq!(replay.term.grid().history_size(), 1);
     }
 
     #[test]

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -1125,6 +1125,12 @@ fn sgr(fg: Color, bg: Color, m: Modifier) -> String {
     if m.contains(Modifier::REVERSED) {
         s.push_str(";7");
     }
+    if m.contains(Modifier::HIDDEN) {
+        s.push_str(";8");
+    }
+    if m.contains(Modifier::CROSSED_OUT) {
+        s.push_str(";9");
+    }
     push_color(&mut s, fg, 38);
     push_color(&mut s, bg, 48);
     s.push('m');
@@ -1206,7 +1212,7 @@ mod tests {
             let (tx, _rx) = channel();
             let mut source = AlacrittyEngine::new(cols, 4, tx, budget_for_rows(cols as usize, 40));
             feed_lines(&mut source, 15);
-            source.advance("\x1b[2J\x1b[H界Aé e\u{301}\r\n♥\u{fe0f}X\r\n👩\u{200d}💻Z\r\n\x1b[1;3;4;38;2;2;3;4;48;5;12m界B\x1b[0m".as_bytes());
+            source.advance("\x1b[2J\x1b[H界Aé e\u{301}\r\n♥\u{fe0f}X\r\n👩\u{200d}💻Z\r\n\x1b[1;3;4;8;9;38;2;2;3;4;48;5;12m界B\x1b[0m".as_bytes());
             let snapshot = source.snapshot_ansi();
             source.scroll(8);
             let offset = source.term.grid().display_offset();

--- a/website/src/content/docs/docs/getting-started/first-session.mdx
+++ b/website/src/content/docs/docs/getting-started/first-session.mdx
@@ -72,6 +72,12 @@ tabs, and layouts. It also **resumes each agent's own conversation** via its
 native session store. A Claude Code pane comes back *as the same Claude Code
 conversation*, no `--resume` flags to remember.
 
+The saved terminal image is a bounded copy of the live screen, not the portion
+of history you happen to be viewing. Scrolling before a save does not change
+that image. Wide characters, combining marks, and text styling are preserved
+when replayed at the same terminal size. This cosmetic image is separate from
+the agent's native conversation store and is not a backup of all scrollback.
+
 ## Where next
 
 - [Core Concepts](/docs/getting-started/concepts/): the 2-minute mental model


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 2 of 15** · Base: #284 · Next: #286 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

Session snapshots now serialize the live screen independently of scroll position and retain complex Unicode text.

## What
- Read bounded live logical rows without mutating viewport or cursor.
- Preserve combining sequences and omit redundant wide-character spacer output.
- Preserve styling and blank-row positions with absolute row positioning.
- Avoid allocating a second full cell grid during serialization.
- Document the difference between cosmetic screen snapshots and native agent session recovery.

## Verification
82 focused terminal tests passed on macOS, including new round trips for CJK, combining accents, variation selectors, ZWJ sequences, styles, scrolled screens, right-edge characters, and resize. Formatting and diff checks passed. No copy/selection behavior changed. Same-size fidelity is tested; a differently sized terminal still uses bounded ANSI replay, not a full history backup.

## Stack
Based on #284. Review this branch against fix/lifecycle-test-isolation. No merge requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal snapshots now remain consistent regardless of scroll position.
  * Snapshots better preserve right-edge content, blank rows, and terminal formatting after resizing.
  * Replaying a saved snapshot reproduces the displayed screen more reliably.

* **Documentation**
  * Clarified that saved terminal images capture the visible screen at its current size and do not include scrollback or conversation history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->