### PR TITLE
fix(pty): submit agent prompts atomically

### DIFF
--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -1545,8 +1545,7 @@ impl App {
             .panes
             .get(&target)
             .ok_or_else(|| "target pane closed before delivery".to_string())?;
-        pane.try_send_paste(&message)?;
-        pane.send_after(b"\r".to_vec(), std::time::Duration::from_millis(45));
+        pane.try_submit_text_with_settle(&message, std::time::Duration::from_millis(45))?;
         let delivered_at = crate::diff::notes::now_ms();
         for selected_note in &selected {
             if let Some(index) = self

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -1545,7 +1545,7 @@ impl App {
             .panes
             .get(&target)
             .ok_or_else(|| "target pane closed before delivery".to_string())?;
-        pane.try_submit_text_with_settle(&message, std::time::Duration::from_millis(45))?;
+        pane.try_submit_text_with_settle(&message, super::AGENT_MESSAGE_SETTLE)?;
         let delivered_at = crate::diff::notes::now_ms();
         for selected_note in &selected {
             if let Some(index) = self

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -3603,10 +3603,14 @@ impl App {
                         "agent send text must not be empty".to_string(),
                     ));
                 }
-                if let Some(pane) = self.panes.get(&id) {
-                    pane.send_paste(text);
-                    pane.send_after(b"\r".to_vec(), std::time::Duration::from_millis(45));
-                }
+                let pane = self.panes.get(&id).ok_or_else(|| {
+                    (
+                        "send_failed".to_string(),
+                        "target pane closed before input was queued".to_string(),
+                    )
+                })?;
+                pane.try_submit_text_with_settle(text, std::time::Duration::from_millis(45))
+                    .map_err(|message| ("send_failed".to_string(), message))?;
                 let (agent, status) = self
                     .status
                     .get(&id)
@@ -9049,6 +9053,48 @@ command = ["true"]
                 .0,
             "not_found"
         );
+    }
+
+    #[test]
+    fn agent_send_admits_one_ordered_submission_and_reports_closed_queue() {
+        let _env = crate::persist::test_env("agent-send-atomic");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).unwrap().agent = "claude".into();
+        app.panes[&pane]
+            .engine
+            .lock()
+            .unwrap()
+            .advance(b"\x1b[?2004h");
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
+        for text in ["first\nsecond", "next"] {
+            app.dispatch(
+                "agent.send",
+                &json!({"target": pane.0.to_string(), "text": text}),
+            )
+            .unwrap();
+            let crate::terminal::pty::InputAction::Submit { paste, settle } =
+                input_rx.try_recv().unwrap()
+            else {
+                panic!("paste and Enter must be a single action")
+            };
+            assert_eq!(paste, format!("\x1b[200~{text}\x1b[201~").as_bytes());
+            assert_eq!(settle, std::time::Duration::from_millis(45));
+            assert!(input_rx.try_recv().is_err());
+        }
+        drop(input_rx);
+        let error = app
+            .dispatch(
+                "agent.send",
+                &json!({"target": pane.0.to_string(), "text": "closed"}),
+            )
+            .unwrap_err();
+        assert_eq!(error.0, "send_failed");
     }
 
     #[test]

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -3609,7 +3609,7 @@ impl App {
                         "target pane closed before input was queued".to_string(),
                     )
                 })?;
-                pane.try_submit_text_with_settle(text, std::time::Duration::from_millis(45))
+                pane.try_submit_text_with_settle(text, AGENT_MESSAGE_SETTLE)
                     .map_err(|message| ("send_failed".to_string(), message))?;
                 let (agent, status) = self
                     .status

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -57,6 +57,9 @@ pub use settings::{
 /// How recently a pane must have produced PTY output to read as *raw* Working.
 const ACTIVITY_WINDOW: Duration = Duration::from_millis(700);
 
+/// Shared paste-to-Enter settling policy for direct and DIFF agent messages.
+const AGENT_MESSAGE_SETTLE: Duration = Duration::from_millis(45);
+
 /// Anti-jitter dwell: how long a pane must stay *quiet* before its published
 /// status is allowed to fall back to Idle/Done. Agents stream in bursts — a
 /// single turn has natural gaps (thinking, tool calls, API latency) far longer

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -788,6 +788,15 @@ impl Pane {
     /// success is dispatch evidence only; it does not claim the child consumed
     /// or acted on the bytes.
     pub fn try_submit_text(&self, text: &str) -> Result<(), String> {
+        self.try_submit_text_with_settle(text, std::time::Duration::from_millis(30))
+    }
+
+    /// Admit paste and Enter together, preserving the caller's settle policy.
+    pub(crate) fn try_submit_text_with_settle(
+        &self,
+        text: &str,
+        settle: std::time::Duration,
+    ) -> Result<(), String> {
         let bracketed = self
             .engine
             .lock()
@@ -801,7 +810,7 @@ impl Pane {
                 } else {
                     wrap_paste(text, bracketed)
                 },
-                settle: std::time::Duration::from_millis(30),
+                settle,
             })
             .map_err(|_| "target pane closed before input was queued".to_string())
     }
@@ -823,19 +832,6 @@ impl Pane {
 
     pub fn child_exited(&self) -> bool {
         self.child_exited.load(Ordering::SeqCst)
-    }
-
-    /// Enqueue `bytes` after `delay`, off-thread. Used to follow a pasted prompt
-    /// with a submit key once the child has ingested the paste: an agent's input
-    /// widget needs the paste to land before the Enter, or the Enter is swallowed
-    /// into the paste. The cloned input channel keeps the writer alive for exactly
-    /// this one deferred send.
-    pub fn send_after(&self, bytes: Vec<u8>, delay: std::time::Duration) {
-        let tx = self.input_tx.clone();
-        std::thread::spawn(move || {
-            std::thread::sleep(delay);
-            let _ = tx.send(InputAction::Bytes(bytes));
-        });
     }
 
     /// Apply a new per-pane history memory budget (Settings → Layout). Shrinks
@@ -1045,12 +1041,7 @@ impl Pane {
     /// dropped file's path as literal text instead of attaching the file, and
     /// vim auto-indents pasted code. Re-wrapping restores the distinction.
     pub fn send_paste(&self, text: &str) {
-        let bracketed = self
-            .engine
-            .lock()
-            .map(|e| e.bracketed_paste())
-            .unwrap_or(false);
-        self.send(&wrap_paste(text, bracketed));
+        let _ = self.try_send_paste(text);
     }
 
     pub fn try_send_paste(&self, text: &str) -> Result<(), String> {

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -37,6 +37,13 @@ validates every entry before it queues one ordered byte sequence, so a
 mixed-type or unknown-key batch sends no prefix. A closed PTY input queue
 returns `send_failed` instead of reporting delivery.
 
+Prompt text and its final Enter are queued as one ordered submission, including
+direct `agent.send` requests and DIFF note handoffs. Other queued input cannot
+interleave between that paste and Enter. A successful send means the queue
+accepted the submission, not that the agent completed it. A closed queue fails
+without recording a successful handoff. Submission uses the existing PTY writer
+and does not create a delayed-send thread.
+
 For line-specific feedback, the native [DIFF review](/docs/guides/diff/) uses
 the same target validation. It groups selected local notes into one bounded
 message, quotes source context as untrusted review data, and records delivery


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 3 of 15** · Base: #285 · Next: #287 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

Direct agent.send and DIFF note handoffs now admit paste and Enter as one ordered action.

## What
- Reuse the existing Unix actor and Windows writer Submit action, retaining the existing 45 ms settle policy.
- Remove the per-submission delayed Enter thread.
- Return send_failed for a closed direct-send queue, and record DIFF delivery only after admission succeeds.
- Preserve ordinary paste and all DIFF UI/review behavior.
- Document that admission is not agent completion.

## Verification
- New dispatch regression covers bracketed multiline text, subsequent submissions, exact settle delay, and closed queues.
- Existing writer and Unix FIFO tests passed.
- macOS locked suite: 1509 unit tests passed, one ignored benchmark; all 15 integration tests passed.
- Strict all-target Clippy, formatting, and diff checks passed.
- Other platforms remain subject to CI; no live provider invocation was required.

## Stack
Based on #285. No merge requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Agent messages and handoff notes are now submitted as a single ordered action, reducing the risk of input interleaving.
  * Custom submission timing improves compatibility with terminal prompt handling.
  * Closed or unavailable agent panes now report send failures instead of indicating successful delivery.

* **Documentation**
  * Updated agent-messaging guidance explains submission ordering, delivery acknowledgment limits, and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->