### PR TITLE
perf(render): invalidate retained frames only when titles change

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4385,7 +4385,7 @@ impl App {
     /// active tab from output owned by another tab or workspace. The server
     /// uses this to keep focused rendering responsive without repeatedly
     /// diffing an unchanged UI for background-only bursts.
-    pub fn rearm_pty_notify_by_visibility(&self) -> (bool, bool) {
+    pub fn rearm_pty_notify_by_visibility(&self) -> (bool, bool, bool) {
         let layout = self.workspaces.get(self.active_ws).and_then(|workspace| {
             workspace
                 .tabs
@@ -4394,6 +4394,7 @@ impl App {
         });
         let mut visible = false;
         let mut background = false;
+        let mut title_changed = false;
         for (id, pane) in &self.panes {
             if !pane.take_data_pending() {
                 continue;
@@ -4402,9 +4403,19 @@ impl App {
                 visible = true;
             } else {
                 background = true;
+                title_changed |= self.hidden_title_changed(*id);
             }
         }
-        (visible, background)
+        (visible, background, title_changed)
+    }
+
+    pub(crate) fn hidden_title_changed(&self, id: PaneId) -> bool {
+        self.config.layout.agent_title
+            && self.is_agent_pane(id)
+            && self
+                .panes
+                .get(&id)
+                .is_some_and(|pane| pane.take_title_change())
     }
 
     /// Whether any PTY reader is currently coalescing an output notification.

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1609,6 +1609,7 @@ mod tests {
         let (app_tx, _app_rx) = mpsc::channel();
         let mut app = App::new(100, 30, app_tx).expect("app starts");
         app.server_mode = true;
+        app.config.layout.agent_title = true;
         let focus = app.layout().focus;
         let (response_tx, _response_rx) = mpsc::channel();
         let engine = create_engine(

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -612,7 +612,10 @@ pub fn run() -> Result<()> {
         // flag still set here means un-rendered output → schedule a frame.
         if last_rearm.elapsed() >= REARM_INTERVAL {
             last_rearm = Instant::now();
-            let (visible, background) = app.rearm_pty_notify_by_visibility();
+            let (visible, background, title_changed) = app.rearm_pty_notify_by_visibility();
+            if title_changed {
+                render_request.record(RenderCause::Metadata);
+            }
             if visible {
                 render_request.record_visible_pty();
             }
@@ -651,7 +654,10 @@ pub fn run() -> Result<()> {
             // Re-arm the PTY readers now that their output is on screen. A flag
             // set during this frame = more output already waiting → stay dirty
             // so the burst keeps rendering at the frame cap, tail included.
-            let (visible, background) = app.rearm_pty_notify_by_visibility();
+            let (visible, background, title_changed) = app.rearm_pty_notify_by_visibility();
+            if title_changed {
+                render_request.record(RenderCause::Metadata);
+            }
             if visible {
                 render_request.record_visible_pty();
             }
@@ -823,6 +829,9 @@ enum EventRenderSource {
 fn event_render_source(app: &App, event: &AppEvent) -> EventRenderSource {
     match event {
         AppEvent::PtyData(id) if app.pane_is_visible(*id) => EventRenderSource::VisiblePty,
+        AppEvent::PtyData(id) if app.hidden_title_changed(*id) => {
+            EventRenderSource::Cause(RenderCause::Metadata)
+        }
         AppEvent::PtyData(_) => EventRenderSource::HiddenPty,
         AppEvent::ClientConnected { .. }
         | AppEvent::ClientInput {
@@ -1601,6 +1610,53 @@ mod tests {
             ServerMessage::FrameDiff(frame) => (frame.width, frame.height),
             _ => panic!("expected rendered frame"),
         }
+    }
+
+    #[test]
+    fn hidden_agent_titles_present_once_including_coalesced_output() {
+        let _env = crate::persist::test_env("hidden-agent-title");
+        let (tx, _rx) = mpsc::channel();
+        let mut app = App::new(100, 30, tx).unwrap();
+        let hidden = app.layout().focus;
+        app.status.get_mut(&hidden).unwrap().agent = "claude".into();
+        let (tx, _rx) = mpsc::channel();
+        let engine = create_engine(
+            VtEngineKind::Alacritty,
+            100,
+            30,
+            tx,
+            4 * 1024 * 1024,
+            PaneAppearance::default(),
+        );
+        app.panes.get_mut(&hidden).unwrap().engine = engine.clone();
+        app.dispatch("tab.new", &serde_json::json!({})).unwrap();
+        assert!(!app.pane_is_visible(hidden));
+        app.config.layout.agent_title = true;
+
+        engine.lock().unwrap().advance(b"\x1b]2;reviewing\x07");
+        let source = super::event_render_source(&app, &AppEvent::PtyData(hidden));
+        let mut request = RenderRequest::default();
+        record_event_render_request(source, true, &mut request);
+        assert!(request.needs_render());
+        assert!(matches!(
+            source,
+            EventRenderSource::Cause(RenderCause::Metadata)
+        ));
+        engine
+            .lock()
+            .unwrap()
+            .advance(b"ordinary output\x1b]2;reviewing\x07");
+        assert!(matches!(
+            super::event_render_source(&app, &AppEvent::PtyData(hidden)),
+            EventRenderSource::HiddenPty
+        ));
+
+        // Output may arrive while the reader's notification is already set.
+        engine.lock().unwrap().advance(b"\x1b]2;finished\x07");
+        app.panes[&hidden].mark_data_pending_for_test();
+        assert!(app.rearm_pty_notify_by_visibility().2);
+        app.panes[&hidden].mark_data_pending_for_test();
+        assert!(!app.rearm_pty_notify_by_visibility().2);
     }
 
     #[test]

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -149,6 +149,7 @@ pub struct Pane {
     /// it while holding the VT lock, so capture can return a revision that
     /// exactly matches the screen snapshot it serialized.
     content_revision: Arc<AtomicU64>,
+    observed_title_generation: AtomicU64,
     /// `PtyData` coalescing: set by the reader when it announces new output,
     /// cleared by the app loop when it consumes the event. While set, further
     /// reads skip the send — a saturated PTY (thousands of 8 KB reads/s) wakes
@@ -511,6 +512,7 @@ impl Pane {
             child_pid: Arc::new(AtomicU32::new(child_pid)),
             terminal_runtime: Arc::new(Mutex::new(Some(terminal_runtime))),
             content_revision,
+            observed_title_generation: AtomicU64::new(0),
             master: Arc::new(Mutex::new(Some(pair.master))),
             input_tx,
             cwd,
@@ -717,6 +719,7 @@ impl Pane {
             child_pid,
             terminal_runtime,
             content_revision,
+            observed_title_generation: AtomicU64::new(0),
             master,
             input_tx,
             cwd,
@@ -754,6 +757,22 @@ impl Pane {
     /// a pane actually has pending bytes, instead of waking forever when idle.
     pub fn has_data_pending(&self) -> bool {
         self.data_pending.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Coalesce title-only presentation with the existing PTY output wake.
+    pub(crate) fn take_title_change(&self) -> bool {
+        let Ok(engine) = self.engine.lock() else {
+            return false;
+        };
+        let generation = engine.title_generation();
+        self.observed_title_generation
+            .swap(generation, Ordering::AcqRel)
+            != generation
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mark_data_pending_for_test(&self) {
+        self.data_pending.store(true, Ordering::Release);
     }
 
     /// Clear the pending-output coalescing flag so the reader's next

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -19,7 +19,15 @@ use crate::terminal::appearance::PaneAppearance;
 use crate::terminal::backend::{CaptureMode, CaptureResult};
 use crate::terminal::pty::{InputAction, InputSender};
 
-type TitleSlot = Arc<Mutex<Option<String>>>;
+#[derive(Default)]
+struct TitleState {
+    value: Option<String>,
+    // Title chrome must be fully projected before terminal-only patching can
+    // resume. Cleared only by a generation-matched damage acknowledgement.
+    changed: bool,
+}
+
+type TitleSlot = Arc<Mutex<TitleState>>;
 
 /// Receives terminal-generated responses (cursor reports, device attributes,
 /// etc.) and forwards them back to the child via the shared write channel.
@@ -56,12 +64,17 @@ impl EventListener for EventProxy {
             }
             Event::Title(t) => {
                 if let Ok(mut g) = self.title.lock() {
-                    *g = Some(t);
+                    if g.value.as_ref() != Some(&t) {
+                        g.value = Some(t);
+                        g.changed = true;
+                    }
                 }
             }
             Event::ResetTitle => {
                 if let Ok(mut g) = self.title.lock() {
-                    *g = None;
+                    if g.value.take().is_some() {
+                        g.changed = true;
+                    }
                 }
             }
             _ => {}
@@ -132,7 +145,7 @@ impl AlacrittyEngine {
             cols: cols.max(1) as usize,
             rows: rows.max(1) as usize,
         };
-        let title: TitleSlot = Arc::new(Mutex::new(None));
+        let title: TitleSlot = Arc::new(Mutex::new(TitleState::default()));
         let appearance = Arc::new(Mutex::new(initial_appearance));
         let proxy = EventProxy {
             tx: resp_tx.clone(),
@@ -469,7 +482,7 @@ impl VtEngine for AlacrittyEngine {
 
     fn damage_snapshot(&mut self) -> DamageSnapshot {
         self.damage_line_indices.clear();
-        let kind = match self.term.damage() {
+        let mut kind = match self.term.damage() {
             TermDamage::Full => DamageKind::Full,
             TermDamage::Partial(lines) => {
                 self.damage_line_indices
@@ -477,6 +490,9 @@ impl VtEngine for AlacrittyEngine {
                 DamageKind::Partial
             }
         };
+        if self.title.lock().map_or(true, |title| title.changed) {
+            kind = DamageKind::Full;
+        }
 
         let cursor = self.cursor();
         let composer_region = self.codex_composer_region();
@@ -563,6 +579,9 @@ impl VtEngine for AlacrittyEngine {
             return false;
         }
         self.term.reset_damage();
+        if let Ok(mut title) = self.title.lock() {
+            title.changed = false;
+        }
         true
     }
 
@@ -844,7 +863,7 @@ impl VtEngine for AlacrittyEngine {
     }
 
     fn title(&self) -> Option<String> {
-        self.title.lock().ok().and_then(|g| g.clone())
+        self.title.lock().ok().and_then(|g| g.value.clone())
     }
 
     fn set_history_budget(&mut self, bytes: usize) {
@@ -1204,6 +1223,25 @@ mod tests {
 
     fn budget_for_rows(cols: usize, rows: usize) -> usize {
         estimated_row_bytes(cols).saturating_mul(rows)
+    }
+
+    #[test]
+    fn title_changes_force_full_damage_until_matching_acknowledgement() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(24, 4, tx, budget_for_rows(24, 20));
+        assert!(engine.acknowledge_damage(engine.output_generation()));
+        engine.advance(b"\x1b[22;0t\x1b]2;review\x07");
+        let changed = engine.damage_snapshot();
+        assert_eq!(changed.kind, DamageKind::Full);
+        engine.advance(b"ordinary output");
+        assert!(!engine.acknowledge_damage(changed.generation));
+        assert_eq!(engine.damage_snapshot().kind, DamageKind::Full);
+        assert!(engine.acknowledge_damage(engine.output_generation()));
+        engine.advance(b"\x1b]2;review\x07!");
+        assert_eq!(engine.damage_snapshot().kind, DamageKind::Partial);
+        engine.advance(b"\x1b[23;0t");
+        assert_eq!(engine.damage_snapshot().kind, DamageKind::Full);
+        assert!(engine.title().is_none());
     }
 
     #[test]

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -25,6 +25,7 @@ struct TitleState {
     // Title chrome must be fully projected before terminal-only patching can
     // resume. Cleared only by a generation-matched damage acknowledgement.
     changed: bool,
+    generation: u64,
 }
 
 type TitleSlot = Arc<Mutex<TitleState>>;
@@ -67,6 +68,7 @@ impl EventListener for EventProxy {
                     if g.value.as_ref() != Some(&t) {
                         g.value = Some(t);
                         g.changed = true;
+                        g.generation = g.generation.wrapping_add(1);
                     }
                 }
             }
@@ -74,6 +76,7 @@ impl EventListener for EventProxy {
                 if let Ok(mut g) = self.title.lock() {
                     if g.value.take().is_some() {
                         g.changed = true;
+                        g.generation = g.generation.wrapping_add(1);
                     }
                 }
             }
@@ -864,6 +867,10 @@ impl VtEngine for AlacrittyEngine {
 
     fn title(&self) -> Option<String> {
         self.title.lock().ok().and_then(|g| g.value.clone())
+    }
+
+    fn title_generation(&self) -> u64 {
+        self.title.lock().map_or(0, |title| title.generation)
     }
 
     fn set_history_budget(&mut self, bytes: usize) {

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -344,6 +344,8 @@ pub trait VtEngine: Send {
 
     /// Capture owned visible rows affected since the last acknowledged render.
     /// Implementations may conservatively return [`DamageKind::Full`].
+    /// Title changes must return Full until acknowledged: titles can also
+    /// affect chrome outside terminal rows, including agent sidebar labels.
     fn damage_snapshot(&mut self) -> DamageSnapshot;
 
     /// Forget damage through `generation` only when no newer output exists.

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -394,6 +394,12 @@ pub trait VtEngine: Send {
     /// Latest window title set by the child via OSC 0/2, if any.
     fn title(&self) -> Option<String>;
 
+    /// Changes only when title chrome changes, including reset. Engines with
+    /// mutable titles must override this for hidden-pane presentation.
+    fn title_generation(&self) -> u64 {
+        0
+    }
+
     /// Scroll the viewport `delta` lines through scrollback: **positive scrolls
     /// up into history**, negative back toward the live bottom. Clamped to the
     /// retained history. No-op while on the alternate screen.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -406,10 +406,8 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
 /// frame; a false positive could corrupt visible output.
 pub(crate) fn retained_pty_eligible(app: &App) -> bool {
     app.mode == Mode::Normal
-        // OSC title changes arrive with PTY output and can alter an agent row
-        // outside the pane. Until retained chrome has its own invalidation,
-        // keep that optional projection on the full path.
-        && !app.config.layout.agent_title
+        // The VT damage contract forces a full projection when title chrome
+        // changes. Enabling titles alone need not disable retained rendering.
         && app.selection.is_none()
         && app.copy_mode.is_none()
         && app.hover_link.is_none()

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -56,6 +56,12 @@ full 40-character line ~100 bytes. This is what makes
 [remote attach](/docs/guides/remote/) over plain SSH feel local, and keeps the
 local render path around a millisecond per frame.
 
+For ordinary terminal-only updates, the server can also reuse its rendered
+buffer and repaint only damaged rows. Agent titles do not disable this path:
+a changed title invalidates the full projection until that output generation
+is acknowledged. Repeated identical titles keep the row-only path available.
+Overlays, resize, and backpressure recovery retain conservative full rendering.
+
 ## And the numbers
 
 Pure Rust, a single ~3 MB binary, single-digit-MB resident memory even with

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -62,6 +62,11 @@ a changed title invalidates the full projection until that output generation
 is acknowledged. Repeated identical titles keep the row-only path available.
 Overlays, resize, and backpressure recovery retain conservative full rendering.
 
+A hidden agent's changed title can still update a visible sidebar label. That
+change schedules a presentation through the existing PTY notification path,
+including coalesced output. Unchanged titles and ordinary hidden output do not
+request a redraw just because title display is enabled.
+
 ## And the numbers
 
 Pure Rust, a single ~3 MB binary, single-digit-MB resident memory even with


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 4 of 15** · Base: #286 · Next: #288 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

Agent titles no longer disable terminal row patching for every output update.

## What
- Track actual title changes behind the existing title lock.
- Force full damage until a generation-matched acknowledgement, including title reset.
- Repeated identical titles keep partial damage available.
- Document the VT chrome invalidation contract and public rendering behavior.
- No new thread, timer, dependency, or public API field.

## Verification
Focused macOS tests cover changed and unchanged OSC titles, reset through the title stack, stale acknowledgements, and a title-enabled client using retained rows with backpressure recovery. This establishes the avoided full-projection path, not a percentage CPU claim. Formatting and diff checks passed. Full stack validation and CI remain required.

## Stack
Based on #286. No merge requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal title updates so visual changes reliably refresh the full display when needed.
  * Prevented unnecessary full redraws when the title remains unchanged.
  * Ensured hidden agent title changes update their visible labels, including when output is coalesced.
  * Retained efficient partial rendering when the agent title layout is enabled.

* **Documentation**
  * Clarified how terminal updates, title changes, overlays, resizing, and recovery affect screen rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->