### PR TITLE
perf(render): retain independent passive client baselines

### DIFF
--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1060,7 +1060,6 @@ fn render_client(
     }
 
     let may_patch = partial_pass
-        && interactive
         && client.retained_ready
         && !client.force_full
         && !client.behind
@@ -1091,8 +1090,8 @@ fn render_client(
                 .clone_from(&app.pane_content_rects);
             client.retained_ready = true;
         } else {
-            ui::render_projection(&mut target, app);
-            client.retained_ready = false;
+            client.retained_pane_content = ui::render_projection(&mut target, app);
+            client.retained_ready = true;
         }
         (target.cursor(), target.cursor_visible())
     };
@@ -1657,6 +1656,96 @@ mod tests {
         assert!(app.rearm_pty_notify_by_visibility().2);
         app.panes[&hidden].mark_data_pending_for_test();
         assert!(!app.rearm_pty_notify_by_visibility().2);
+    }
+
+    #[test]
+    fn passive_retained_frames_match_full_projection_at_each_client_size() {
+        use ratatui::{buffer::Buffer, layout::Rect};
+        let _env = crate::persist::test_env("passive-retained-frames");
+        let (tx, _rx) = mpsc::channel();
+        let mut app = App::new(100, 30, tx).unwrap();
+        app.server_mode = true;
+        let pane = app.layout().focus;
+        let (tx, _rx) = mpsc::channel();
+        let engine = create_engine(
+            VtEngineKind::Alacritty,
+            100,
+            30,
+            tx,
+            4 * 1024 * 1024,
+            PaneAppearance::default(),
+        );
+        app.panes.get_mut(&pane).unwrap().engine = engine.clone();
+        let mut clients = HashMap::new();
+        let mut receivers = Vec::new();
+        for (id, cols, rows) in [(1, 100, 30), (2, 100, 30), (3, 60, 20)] {
+            let (client, rx) = display_client(cols, rows, id);
+            clients.insert(id, client);
+            receivers.push(rx);
+        }
+        let mut foreground = Some(1);
+        let mut size = (100, 30);
+        let mut scratch = RenderScratch::default();
+        render_clients(
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut size,
+            false,
+            false,
+            &mut scratch,
+        );
+        for rx in &receivers {
+            rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        }
+        let geometry = app.pane_content_rects.clone();
+        let pty_size = app.panes[&pane].size();
+
+        for bytes in [
+            "界e\u{301} text",
+            "\rshort\x1b[K",
+            "\x1b]2;new title\x07!",
+            "\rnext",
+        ] {
+            for client in clients.values() {
+                client.sender.frame_pending.store(false, Ordering::Release);
+            }
+            engine.lock().unwrap().advance(bytes.as_bytes());
+            let partial_before = super::PARTIAL_TERMINAL_PROJECTIONS.load(Ordering::Relaxed);
+            render_clients(
+                &mut app,
+                &mut clients,
+                &mut foreground,
+                &mut size,
+                false,
+                true,
+                &mut scratch,
+            );
+            for rx in &receivers {
+                rx.recv_timeout(Duration::from_secs(1)).unwrap();
+            }
+            if !bytes.contains("\x1b]2;") {
+                assert!(
+                    super::PARTIAL_TERMINAL_PROJECTIONS.load(Ordering::Relaxed)
+                        >= partial_before + 3,
+                    "all three clients must patch their own retained geometry"
+                );
+            }
+            for client in clients.values() {
+                let area = Rect::new(0, 0, client.size.0, client.size.1);
+                let mut expected = Buffer::empty(area);
+                let mut target = crate::ui::RenderTarget::new(&mut expected, area);
+                crate::ui::render_projection(&mut target, &mut app);
+                let cursor = (target.cursor(), target.cursor_visible());
+                assert_eq!(client.render_buf, expected, "client size {:?}", client.size);
+                let frame = client.last_frame.as_ref().unwrap();
+                assert_eq!((frame.cursor, frame.cursor_visible), cursor);
+                assert!(client.retained_ready);
+            }
+            assert_eq!(app.pane_content_rects, geometry);
+            assert_eq!(app.panes[&pane].size(), pty_size);
+            assert_eq!(app.layout().focus, pane);
+        }
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -124,7 +124,9 @@ pub fn render_into(f: &mut RenderTarget, app: &mut App) {
 /// clamps a handful of scroll offsets as part of an ordinary interactive draw;
 /// preserve those values here so a passive projection cannot move the active
 /// client's cursor, scroll position, compact mode, or click targets.
-pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
+/// Return the passive client's content geometry before restoring all active
+/// hit-test state. Each client owns this baseline, never the shared App.
+pub(crate) fn render_projection(f: &mut RenderTarget, app: &mut App) -> Vec<(PaneId, Rect)> {
     let compact = app.compact;
     let last_main_area = app.last_main_area;
     let last_pane_area = app.last_pane_area;
@@ -294,7 +296,7 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
     app.file_tree.scroll = file_tree_scroll;
     app.menu_scroll = menu_scroll;
     app.pane_rects = pane_rects;
-    app.pane_content_rects = pane_content_rects;
+    let projected_content = std::mem::replace(&mut app.pane_content_rects, pane_content_rects);
     app.pane_title_rects = pane_title_rects;
     app.tab_rects = tab_rects;
     app.tab_close_rects = tab_close_rects;
@@ -398,9 +400,10 @@ pub fn render_projection(f: &mut RenderTarget, app: &mut App) {
             git.contributors_more_rect = contributors_more_rect;
         }
     }
+    projected_content
 }
 
-/// Whether a PTY-only frame may reuse the active client's complete UI buffer.
+/// Whether a PTY-only frame may reuse a client's complete UI buffer.
 /// Every state that draws over pane content or changes terminal styling forces
 /// the ordinary full renderer. Conservative false negatives cost one full
 /// frame; a false positive could corrupt visible output.

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -67,6 +67,12 @@ change schedules a presentation through the existing PTY notification path,
 including coalesced output. Unchanged titles and ordinary hidden output do not
 request a redraw just because title display is enabled.
 
+Each attached client retains its own buffer and projected pane rectangles,
+including passive clients at different sizes. All clients consume the same
+owned terminal damage before it is acknowledged. A passive display cannot
+change the active client's focus, PTY dimensions, scroll state, or hit targets.
+A client that falls behind receives a full repair frame.
+
 ## And the numbers
 
 Pure Rust, a single ~3 MB binary, single-digit-MB resident memory even with


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 5 of 15** · Base: #287 · Next: #289 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

Passive attached clients can now reuse terminal row projections at their own viewport sizes.

## What
- Capture each passive projection content geometry before restoring active App hit-test state.
- Reuse only a valid per-client baseline; preserve full rendering for resize, overlays, title invalidation, and backpressure repair.
- Keep damage acknowledgement after all client projections.
- Document active/passive geometry ownership. No new threads or protocol fields.

## Verification
- A new test compares complete buffers and cursor state against fresh full projections for one active and two passive clients, including different sizes, CJK/combining text, tail erasure, and title changes.
- Asserts all three clients use partial projection on eligible output and that active geometry, focus, and PTY dimensions stay unchanged.
- All nine server rendering tests passed, including resize, detach, clipboard, and repair frames.
- Projection tests passed on macOS. Other platforms remain subject to CI.

## Stack
Based on #287. No merge requested.