### PR TITLE
perf(terminal): cache storage-aware history accounting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,17 @@ early child exits, retain a bounded excerpt of failure diagnostics, and use a
 child-handle cleanup guard. Tests that change process-global configuration must
 hold `persist::test_env(...)` for their entire lifetime.
 
+Detailed terminal-history inspection has an opt-in, in-process benchmark:
+
+```bash
+cargo test --locked history_inspection_benchmark -- --ignored --nocapture
+```
+
+It reports three warmed trials for 1, 20, and 50 engines with 10,000 retained
+rows each. These are engine-accounting timings, not end-to-end API latency or
+process memory measurements. Record the commit and build profile when comparing
+runs. Ordinary test runs do not execute this workload.
+
 ## Adding agent support
 
 Use a detection manifest when an agent only needs identity and live-state

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -1,5 +1,6 @@
 //! `alacritty_terminal` implementation of `VtEngine`. Pure Rust — no Zig, no FFI.
 
+use std::cell::Cell;
 use std::sync::{Arc, Mutex};
 
 use alacritty_terminal::event::{Event, EventListener};
@@ -112,6 +113,9 @@ pub struct AlacrittyEngine {
     appearance: Arc<Mutex<PaneAppearance>>,
     history_budget_bytes: usize,
     output_generation: u64,
+    // One bounded summary, invalidated at every storage mutation boundary.
+    // Output generation alone is insufficient: quiet packing changes storage.
+    history_metrics_cache: Cell<Option<HistoryMetrics>>,
     damage_line_indices: Vec<u16>,
     damage_rows: Vec<DamageRow>,
 }
@@ -173,12 +177,14 @@ impl AlacrittyEngine {
             appearance,
             history_budget_bytes,
             output_generation: 0,
+            history_metrics_cache: Cell::new(None),
             damage_line_indices: Vec::new(),
             damage_rows: Vec::new(),
         }
     }
 
     fn apply_history_budget(&mut self) {
+        self.history_metrics_cache.set(None);
         self.term.set_options(Config {
             scrolling_history: history_rows_for_budget(
                 self.history_budget_bytes,
@@ -358,11 +364,13 @@ fn history_rows_for_budget(bytes: usize, cols: u16) -> usize {
 
 impl VtEngine for AlacrittyEngine {
     fn advance(&mut self, bytes: &[u8]) {
+        self.history_metrics_cache.set(None);
         self.parser.advance(&mut self.term, bytes);
         self.output_generation = self.output_generation.wrapping_add(1);
     }
 
     fn finish_output_batch(&mut self) {
+        self.history_metrics_cache.set(None);
         self.term.finish_output_batch();
     }
 
@@ -913,11 +921,17 @@ impl VtEngine for AlacrittyEngine {
     }
 
     fn history_metrics(&self) -> HistoryMetrics {
+        if let Some(mut metrics) = self.history_metrics_cache.get() {
+            // Viewport movement changes no allocation. Keep it live without
+            // traversing history or invalidating the storage summary.
+            metrics.offset = self.scroll_offset();
+            return metrics;
+        }
         let retained_rows = self.history_len();
         let retained_bytes =
             retained_rows.saturating_mul(estimated_row_bytes(self.term.grid().columns()));
         let storage = self.term.history_storage_metrics();
-        HistoryMetrics {
+        let metrics = HistoryMetrics {
             offset: self.scroll_offset(),
             retained_rows,
             budget_bytes: self.history_budget_bytes,
@@ -933,7 +947,9 @@ impl VtEngine for AlacrittyEngine {
             row_descriptor_bytes: Some(storage.row_descriptor_bytes),
             allocation_count: Some(storage.allocations),
             exact_bytes: false,
-        }
+        };
+        self.history_metrics_cache.set(Some(metrics));
+        metrics
     }
 
     fn retained_row_count(&self) -> usize {
@@ -1230,6 +1246,73 @@ mod tests {
 
     fn budget_for_rows(cols: usize, rows: usize) -> usize {
         estimated_row_bytes(cols).saturating_mul(rows)
+    }
+
+    #[test]
+    fn history_metrics_cache_tracks_storage_changes_and_live_scroll() {
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(80, 24, tx, budget_for_rows(80, 1000));
+        feed_lines(&mut engine, 800);
+        let dense = engine.history_metrics();
+        assert_eq!(engine.history_metrics_cache.get(), Some(dense));
+        let output_generation = engine.output_generation();
+        engine.finish_output_batch();
+        assert!(engine.history_metrics_cache.get().is_none());
+        assert_eq!(engine.output_generation(), output_generation);
+        let packed = engine.history_metrics();
+        assert!(packed.packed_rows > dense.packed_rows);
+        engine.scroll(10);
+        let scrolled = engine.history_metrics();
+        assert_eq!(scrolled.offset, 10);
+        assert_eq!(scrolled.estimated_grid_bytes, packed.estimated_grid_bytes);
+        assert_eq!(engine.history_metrics_cache.get(), Some(packed));
+        engine.advance(b"\x1b[?1049hhello");
+        assert!(engine.history_metrics_cache.get().is_none());
+        assert_eq!(engine.history_metrics().retained_rows, 0);
+        engine.advance(b"\x1b[?1049l");
+        assert_eq!(engine.history_metrics().retained_rows, packed.retained_rows);
+        engine.resize(40, 12);
+        assert!(engine.history_metrics_cache.get().is_none());
+        engine.history_metrics();
+        engine.set_history_budget(budget_for_rows(40, 30));
+        assert!(engine.history_metrics_cache.get().is_none());
+        let small = engine.history_metrics();
+        assert!(small.retained_rows <= 30);
+        // Compare against a forced fresh computation, not another cache hit.
+        engine.history_metrics_cache.set(None);
+        assert_eq!(engine.history_metrics(), small);
+    }
+
+    /// Opt-in inspection benchmark. No child processes or production sessions.
+    #[test]
+    #[ignore]
+    fn history_inspection_benchmark() {
+        use std::{hint::black_box, time::Instant};
+        for count in [1, 20, 50] {
+            let mut engines = Vec::new();
+            for _ in 0..count {
+                let (tx, _rx) = channel();
+                let mut engine = AlacrittyEngine::new(80, 24, tx, budget_for_rows(80, 10_000));
+                feed_lines(&mut engine, 10_024);
+                engine.finish_output_batch();
+                engines.push(engine);
+            }
+            for trial in 1..=3 {
+                for engine in &engines {
+                    black_box(engine.history_metrics());
+                }
+                let start = Instant::now();
+                for _ in 0..100 {
+                    for engine in &engines {
+                        black_box(engine.history_metrics());
+                    }
+                }
+                eprintln!(
+                    "history_inspection panes={count} rows=10000 trial={trial} us_per_fleet={:.3}",
+                    start.elapsed().as_secs_f64() * 1_000_000.0 / 100.0
+                );
+            }
+        }
     }
 
     #[test]

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -73,6 +73,12 @@ owned terminal damage before it is acknowledged. A passive display cannot
 change the active client's focus, PTY dimensions, scroll state, or hit targets.
 A client that falls behind receives a full repair frame.
 
+Detailed history accounting is cached once per terminal storage state. Output,
+resize, budget changes, and quiet history packing invalidate the summary.
+Scrolling updates the reported offset without traversing retained rows. The
+reported byte fields remain allocation estimates, not process RSS or an exact
+byte-enforced history limit.
+
 ## And the numbers
 
 Pure Rust, a single ~3 MB binary, single-digit-MB resident memory even with


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 6 of 15** · Base: #288 · Next: #290 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

Repeated inspection of quiet terminal histories now reuses one bounded accounting summary per engine.

## What
- Invalidate on output, resize, budget changes, and quiet packing, not merely visible output revision.
- Keep scroll offset live without traversing history.
- Preserve all existing fields and their estimate semantics.
- Add an opt-in 1/20/50-engine benchmark and document its scope and invocation.

## Verification
- Regression covers packing without new output, scroll, alternate-screen transitions, resize, and budget reduction, including forced fresh recomputation.
- 84 terminal tests passed on macOS; one benchmark ignored by ordinary tests.
- Strict all-target Clippy, formatting, and diff checks passed.
- Three debug-profile benchmark trials at 10000 rows per engine: 50-engine warm inspection before 90731–91090 microseconds per pass, after 1.128–1.325 microseconds. This isolates cached engine accounting and excludes API/JSON/lock contention overhead. Cold inspection after mutation still computes a fresh summary; this is not an end-to-end CPU or memory claim.

## Stack
Based on #288. No merge requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved terminal history metric queries during scrolling by reusing previously calculated information, reducing unnecessary work.
  - Metrics now refresh appropriately after terminal output, resizing, history budget changes, and related storage updates.

- **Documentation**
  - Clarified how terminal history accounting works, including cache refresh behavior and the meaning of reported byte estimates.
  - Added guidance for an opt-in terminal-history inspection benchmark, which is excluded from ordinary test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->