### PR TITLE
perf(runtime): scope cwd discovery to active tab evidence

### DIFF
--- a/src/app/cwd.rs
+++ b/src/app/cwd.rs
@@ -15,6 +15,53 @@ use crate::ids::PaneId;
 const CWD_REHOME_STABLE_SCANS: u8 = 2;
 
 impl App {
+    pub(super) fn invalidate_cwd_topology(&mut self, event: &str) {
+        if matches!(
+            event,
+            "pane.created"
+                | "pane.closed"
+                | "pane.forked"
+                | "pane.moved"
+                | "tab.created"
+                | "tab.closed"
+                | "tab.moved"
+                | "workspace.created"
+                | "workspace.closed"
+        ) {
+            self.runtime_cwd_dirty = true;
+            self.runtime_cwd_dirty_panes.clear();
+        }
+    }
+    /// Expand dirty panes to complete tabs: rehoming requires evidence for all
+    /// split siblings. Quiet unrelated tabs/workspaces need no CWD/Git probes.
+    pub(super) fn cwd_scan_scope(
+        &self,
+        dirty: &HashSet<PaneId>,
+        full: bool,
+    ) -> (HashSet<PaneId>, HashSet<String>) {
+        if full {
+            return (
+                self.panes.keys().copied().collect(),
+                self.workspaces.iter().map(|ws| ws.id.clone()).collect(),
+            );
+        }
+        let mut panes: HashSet<_> = dirty
+            .iter()
+            .copied()
+            .filter(|id| self.panes.contains_key(id))
+            .collect();
+        let mut workspaces = HashSet::new();
+        for ws in &self.workspaces {
+            for tab in &ws.tabs {
+                let leaves = tab.layout.leaves();
+                if leaves.iter().any(|id| dirty.contains(id)) {
+                    panes.extend(leaves.into_iter().filter(|id| self.panes.contains_key(id)));
+                    workspaces.insert(ws.id.clone());
+                }
+            }
+        }
+        (panes, workspaces)
+    }
     /// Track each pane's live process cwd (used for per-pane git / agent-session
     /// keying) and refresh each workspace's git branch from its **fixed** folder.
     /// A workspace is a **static workspace**: `cd`-ing inside a pane does not move the
@@ -61,8 +108,10 @@ impl App {
         workspace_candidates: Vec<crate::git::GitRootInfo>,
     ) -> bool {
         self.cwd_scan_inflight = false;
-        let live: HashSet<PaneId> = panes.iter().map(|(id, _)| *id).collect();
-        self.cwd_git_hits.retain(|id, _| live.contains(id));
+        // A scoped scan says nothing about unrelated live panes. Keep their
+        // consecutive evidence rather than treating absence as evidence loss.
+        self.cwd_git_hits
+            .retain(|id, _| self.panes.contains_key(id));
         let mut changed = false;
         let mut pane_git: HashMap<PaneId, Option<PathBuf>> = HashMap::new();
         for (id, evidence) in panes {
@@ -168,6 +217,9 @@ impl App {
         {
             let homes = self.workspace_homes();
             for (wi, leaves) in candidates {
+                if leaves.iter().any(|id| !pane_git.contains_key(id)) {
+                    continue;
+                }
                 let Some(dest) = tab_rehome_dest(&homes, wi, &leaves, |id| {
                     self.panes.get(&id).map(|pane| {
                         (
@@ -497,6 +549,34 @@ mod tests {
     use std::time::Duration;
     #[cfg(unix)]
     use std::time::Instant;
+
+    #[test]
+    fn scoped_cwd_scan_includes_split_siblings_but_preserves_quiet_workspaces() {
+        let _env = crate::persist::test_env("cwd-scoped-runtime");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let first = app.layout().focus;
+        let root = app.ws().id.clone();
+        app.split(crate::layout::Axis::Col);
+        let sibling = app.layout().focus;
+        let other = crate::persist::config_dir().join("quiet");
+        std::fs::create_dir_all(&other).unwrap();
+        assert!(app.create_workspace_at(other.clone()));
+        let quiet = app.layout().focus;
+        let quiet_ws = app.ws().id.clone();
+        let (panes, workspaces) = app.cwd_scan_scope(&HashSet::from([first]), false);
+        assert_eq!(panes, HashSet::from([first, sibling]));
+        assert_eq!(workspaces, HashSet::from([root.clone()]));
+        let (panes, workspaces) = app.cwd_scan_scope(&HashSet::new(), true);
+        assert_eq!(panes.len(), 3);
+        assert_eq!(workspaces, HashSet::from([root, quiet_ws.clone()]));
+        app.cwd_git_hits.insert(quiet, (other, 1));
+        // An absent pane in a partial result must neither lose its consecutive
+        // evidence nor be rehomed using another tab's incomplete evidence.
+        app.apply_cwd_scan(Vec::new(), Vec::new(), Vec::new());
+        assert_eq!(app.cwd_git_hits[&quiet].1, 1);
+        assert_eq!(app.ws().id, quiet_ws);
+    }
 
     // Live `cd` through Windows PowerShell does not reliably update the PEB
     // directory this reader uses. Windows coverage is process_cwd_matches_this_process

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1546,7 +1546,9 @@ impl App {
         }
 
         if clients_attached {
-            if self.runtime_cwd_dirty && !self.cwd_scan_inflight {
+            if (self.runtime_cwd_dirty || !self.runtime_cwd_dirty_panes.is_empty())
+                && !self.cwd_scan_inflight
+            {
                 consider(self.last_cwd_at + CWD_SCAN_INTERVAL, true);
             }
             if self.runtime_sessions_dirty && !self.sessions_scan_inflight {
@@ -1640,11 +1642,13 @@ impl App {
         }
         // CWD/git follow the user after PTY activity, throttled to 1s. Quiet
         // panes do not spawn a worker or walk process trees.
-        if self.runtime_cwd_dirty
+        if (self.runtime_cwd_dirty || !self.runtime_cwd_dirty_panes.is_empty())
             && !self.cwd_scan_inflight
             && now.duration_since(self.last_cwd_at) >= CWD_SCAN_INTERVAL
         {
-            self.runtime_cwd_dirty = false;
+            let full = std::mem::take(&mut self.runtime_cwd_dirty);
+            let dirty = std::mem::take(&mut self.runtime_cwd_dirty_panes);
+            let (cwd_scope, workspace_scope) = self.cwd_scan_scope(&dirty, full);
             self.last_cwd_at = now;
             self.cwd_scan_inflight = true;
             let include_processes = self.proc_scan_due(now, true);
@@ -1660,6 +1664,7 @@ impl App {
             let panes: Vec<(PaneId, u32)> = self
                 .panes
                 .iter()
+                .filter(|(id, _)| cwd_scope.contains(id))
                 .filter_map(|(id, p)| {
                     let pid = p.child_pid.load(std::sync::atomic::Ordering::SeqCst);
                     (pid != 0).then_some((*id, pid))
@@ -1668,15 +1673,29 @@ impl App {
             let workspaces: Vec<(String, PathBuf)> = self
                 .workspaces
                 .iter()
+                .filter(|ws| workspace_scope.contains(&ws.id))
                 .map(|ws| (ws.id.clone(), ws.cwd.clone()))
                 .collect();
             let homes = self.workspace_homes();
             let tabs = self.renameable_tab_leaves();
+            // Process identity demand remains fleet-wide. It shares this one
+            // OS snapshot without forcing unrelated CWD/Git resolution.
+            let process_roots: Vec<u32> = if include_processes {
+                self.panes
+                    .values()
+                    .map(|pane| pane.child_pid.load(std::sync::atomic::Ordering::SeqCst))
+                    .filter(|pid| *pid != 0)
+                    .collect()
+            } else {
+                Vec::new()
+            };
             let tx = self.app_tx.clone();
             std::thread::spawn(move || {
                 let pids: Vec<u32> = panes.iter().map(|(_, pid)| *pid).collect();
-                let (evidence, processes) =
-                    crate::platform::scan_pane_runtime(&pids, include_processes);
+                let (evidence, processes) = crate::platform::scan_pane_runtime_scoped(
+                    &pids,
+                    include_processes.then_some(process_roots.as_slice()),
+                );
                 let pane_results: Vec<(PaneId, crate::platform::PaneCwdEvidence)> = panes
                     .into_iter()
                     .zip(evidence)

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -696,7 +696,9 @@ impl App {
                     s.last_activity = Instant::now();
                 }
                 self.detection_dirty.insert(id);
-                self.runtime_cwd_dirty = true;
+                if self.panes.contains_key(&id) {
+                    self.runtime_cwd_dirty_panes.insert(id);
+                }
                 self.runtime_proc_dirty = true;
                 // A parked `wait.output` for this pane just got new output to
                 // test against — resolve it on the same wake (docs/81).
@@ -705,6 +707,7 @@ impl App {
                 true // the pane's screen advanced
             }
             AppEvent::PtyExit(id) => {
+                self.runtime_cwd_dirty_panes.remove(&id);
                 crate::logging::event(
                     crate::logging::EventKind::PtyExit,
                     &[

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2432,6 +2432,9 @@ pub struct App {
     last_proc_at: Instant,
     /// CWD/git follow-up is scheduled from PTY activity, not a 1s heartbeat.
     runtime_cwd_dirty: bool,
+    /// Ordinary output dirties its tab only. The boolean above remains the
+    /// full-invalidation path for attach, restore, and topology changes.
+    runtime_cwd_dirty_panes: HashSet<PaneId>,
     /// Attached PTY activity dirties process identity without creating a heartbeat.
     runtime_proc_dirty: bool,
     /// Resumable-session disk scans run on attach/demand, not a 4s walk.
@@ -2943,6 +2946,7 @@ impl App {
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
             runtime_cwd_dirty: false,
+            runtime_cwd_dirty_panes: HashSet::new(),
             runtime_proc_dirty: false,
             runtime_sessions_dirty: false,
             last_detect_at: Instant::now()
@@ -3586,6 +3590,7 @@ impl App {
             usage_scan_inflight: false,
             last_proc_at: Instant::now(),
             runtime_cwd_dirty: false,
+            runtime_cwd_dirty_panes: HashSet::new(),
             runtime_proc_dirty: false,
             runtime_sessions_dirty: false,
             last_detect_at: Instant::now()

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -438,6 +438,7 @@ impl App {
     /// any enabled module's matching `[[events]]` hook (MOD-3). The payload is
     /// passed to hooks as `LUVUS_MODULE_EVENT_JSON`.
     pub fn emit_event(&mut self, name: &str, data: serde_json::Value) {
+        self.invalidate_cwd_topology(name);
         let event_json = data.to_string();
         let backend_data = data.clone();
         api::publish_event(&self.events, name, data);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -788,13 +788,28 @@ pub struct PaneCwdEvidence {
 /// Resolve CWD evidence and, optionally, process identities from one platform
 /// snapshot. The optional command projection is used only when the independent
 /// agent-detection deadline coincides with this CWD scan.
+#[cfg(test)]
 pub fn scan_pane_runtime(
     roots: &[u32],
     include_commands: bool,
 ) -> (Vec<PaneCwdEvidence>, Option<ProcessCommands>) {
+    scan_pane_runtime_scoped(roots, include_commands.then_some(roots))
+}
+
+/// One OS snapshot, with independent CWD and command-projection demands.
+pub fn scan_pane_runtime_scoped(
+    cwd_roots: &[u32],
+    command_roots: Option<&[u32]>,
+) -> (Vec<PaneCwdEvidence>, Option<ProcessCommands>) {
+    let mut roots = cwd_roots.to_vec();
+    if let Some(commands) = command_roots {
+        roots.extend_from_slice(commands);
+        roots.sort_unstable();
+        roots.dedup();
+    }
     let mut cache = std::collections::HashMap::new();
-    let (trees, commands) = pane_process_snapshot(roots, true, include_commands);
-    let evidence = roots
+    let (trees, commands) = pane_process_snapshot(&roots, true, command_roots.is_some());
+    let evidence = cwd_roots
         .iter()
         .map(|&root| {
             let nodes = trees.get(&root).map(Vec::as_slice).unwrap_or(&[]);
@@ -1079,6 +1094,15 @@ mod tests {
         let (cwd_only, commands) = super::scan_pane_runtime(&[pid], false);
         assert_eq!(cwd_only.len(), 1);
         assert!(commands.is_none(), "command projection is demand-driven");
+        let (no_cwds, commands) = super::scan_pane_runtime_scoped(&[], Some(&[pid]));
+        assert!(
+            no_cwds.is_empty(),
+            "unrequested CWDs do not receive Git probes"
+        );
+        assert!(
+            commands.unwrap().contains_key(&pid),
+            "independent process demand remains represented"
+        );
     }
 
     #[cfg(unix)]

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -79,6 +79,12 @@ Scrolling updates the reported offset without traversing retained rows. The
 reported byte fields remain allocation estimates, not process RSS or an exact
 byte-enforced history limit.
 
+Ordinary pane output schedules CWD and workspace-branch inspection for its tab,
+including split siblings needed for safe rehoming. Attach, restore, and topology
+changes retain full invalidation. Process-identity demand remains independent
+and shares the OS process snapshot when deadlines coincide. This reduces
+unrelated Git probes; it does not eliminate platform-wide process enumeration.
+
 ## And the numbers
 
 Pure Rust, a single ~3 MB binary, single-digit-MB resident memory even with


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 8 of 15** · Base: #290 · Next: #292 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

Ordinary pane output no longer asks unrelated workspaces for fresh CWD/Git evidence.

## What
- Track bounded dirty pane identities and expand them to complete tabs so split rehoming remains evidence-based.
- Retain full invalidation on startup/attach and structural pane/tab/workspace events.
- Preserve unrelated consecutive CWD evidence when applying a partial scan; never rehome a tab using incomplete sibling evidence.
- Keep process-identity demand independent, using one shared platform snapshot when deadlines coincide.
- Preserve existing deadlines, in-flight guards, and detached demand behavior. No new polling or thread type.

## Verification
- New scope test selects both split siblings while excluding a quiet workspace, then verifies full invalidation and preserved quiet evidence.
- Platform test verifies process demand without requesting unrelated CWD/Git evidence.
- Existing CWD rehome/split/zoom tests and runtime/detached/deadline tests passed.
- macOS locked suite: 1519 unit tests and 15 integration tests passed, two benchmarks ignored. Strict all-target Clippy passed.
- This reduces selected Git probes; it does not claim elimination of OS-wide process enumeration or a measured percentage CPU reduction.

## Stack
Based on #290, including its Windows test-import correction. No merge requested.