### PR TITLE
perf(files): offload metadata to a bounded shared worker

### DIFF
--- a/src/app/file_jobs.rs
+++ b/src/app/file_jobs.rs
@@ -1,0 +1,127 @@
+//! Bounded metadata refresh with path/read-generation fenced completions.
+use super::*;
+
+impl App {
+    pub(super) fn schedule_file_metadata(&mut self) {
+        if self.file_metadata_inflight || self.views.is_empty() {
+            return;
+        }
+        // Stable order gives every view service without an unbounded job input.
+        let mut ids: Vec<_> = self.views.keys().copied().collect();
+        ids.sort_by_key(|id| id.0);
+        let start = self.file_metadata_cursor % ids.len();
+        let count = ids.len().min(128);
+        let inputs: Vec<_> = ids
+            .iter()
+            .cycle()
+            .skip(start)
+            .take(count)
+            .filter_map(|id| match self.views.get(id)? {
+                ViewKind::File(v) => Some((*id, v.path.clone(), v.read_token, v.mtime, false)),
+                ViewKind::Preview(v) => Some((*id, v.path.clone(), v.read_token, v.mtime, true)),
+                ViewKind::Diff(_) => None,
+            })
+            .collect();
+        if inputs.is_empty() {
+            self.file_metadata_cursor = start + count;
+            return;
+        }
+        if self
+            .io_jobs
+            .submit(self.app_tx.clone(), move || {
+                let changed: Vec<_> = inputs
+                    .into_iter()
+                    .filter_map(|(id, path, token, previous, preview)| {
+                        let disk = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+                        (disk.is_some() && disk != previous)
+                            .then_some((id, path, token, previous, disk, preview))
+                    })
+                    .collect();
+                Box::new(move |app| {
+                    app.file_metadata_inflight = false;
+                    let mut refreshed = false;
+                    for (id, path, token, previous, disk, preview) in changed {
+                        let valid = match app.views.get_mut(&id) {
+                            Some(ViewKind::File(v))
+                                if !preview
+                                    && v.path == path
+                                    && v.read_token == token
+                                    && v.mtime == previous =>
+                            {
+                                v.mtime = disk;
+                                true
+                            }
+                            Some(ViewKind::Preview(v))
+                                if preview
+                                    && v.path == path
+                                    && v.read_token == token
+                                    && v.mtime == previous =>
+                            {
+                                v.mtime = disk;
+                                true
+                            }
+                            _ => false,
+                        };
+                        if valid {
+                            refreshed = true;
+                            if preview {
+                                app.schedule_preview_read(id, path);
+                            } else {
+                                app.schedule_file_read(id, path);
+                            }
+                        }
+                    }
+                    refreshed
+                })
+            })
+            .is_ok()
+        {
+            self.file_metadata_cursor = start + count;
+            self.file_metadata_inflight = true;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_completion_rejects_replaced_read_and_closed_view() {
+        let _env = crate::persist::test_env("metadata-generation");
+        let path = crate::persist::config_dir().join("example.txt");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"changed").unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let id = PaneId(10000);
+        for close in [false, true] {
+            let mut view = crate::files::FileView::new(path.clone());
+            view.read_token = 10;
+            app.views.insert(id, ViewKind::File(view));
+            app.ensure_file_views();
+            assert!(app.file_metadata_inflight);
+            let completion = loop {
+                let ev = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+                if let AppEvent::IoCompleted(completion) = ev {
+                    break completion;
+                }
+            };
+            if close {
+                app.views.remove(&id);
+            } else if let Some(ViewKind::File(v)) = app.views.get_mut(&id) {
+                v.read_token = 11;
+            }
+            completion.apply(&mut app);
+            assert!(!app.file_metadata_inflight);
+            if !close {
+                let Some(ViewKind::File(v)) = app.views.get(&id) else {
+                    panic!("missing view")
+                };
+                assert_eq!(v.read_token, 11);
+                assert_eq!(v.mtime, None);
+            }
+        }
+        app.drain_io_jobs();
+    }
+}

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -221,44 +221,10 @@ impl App {
         }
     }
 
-    /// Live refresh (docs/38 FILE-5): re-read any open file view whose file
-    /// changed on disk since we last read it. One `stat` per open view, ~1s —
-    /// cheap (there are rarely more than a couple). Called from `detect_tick`.
+    /// Live refresh uses one bounded metadata job, never filesystem calls on
+    /// the app loop. Results are fenced by path and read token.
     pub fn ensure_file_views(&mut self) {
-        if self.views.is_empty() {
-            return;
-        }
-        let mut stale_files = Vec::new();
-        let mut stale_previews = Vec::new();
-        for (id, view) in self.views.iter() {
-            match view {
-                ViewKind::File(v) => {
-                    let disk = std::fs::metadata(&v.path).and_then(|m| m.modified()).ok();
-                    if disk.is_some() && disk != v.mtime {
-                        stale_files.push((*id, v.path.clone(), disk));
-                    }
-                }
-                ViewKind::Preview(v) => {
-                    let disk = std::fs::metadata(&v.path).and_then(|m| m.modified()).ok();
-                    if disk.is_some() && disk != v.mtime {
-                        stale_previews.push((*id, v.path.clone(), disk));
-                    }
-                }
-                ViewKind::Diff(_) => {}
-            }
-        }
-        for (id, path, mtime) in stale_files {
-            if let Some(ViewKind::File(v)) = self.views.get_mut(&id) {
-                v.mtime = mtime; // record now so we don't reschedule until it changes again
-            }
-            self.schedule_file_read(id, path);
-        }
-        for (id, path, mtime) in stale_previews {
-            if let Some(ViewKind::Preview(v)) = self.views.get_mut(&id) {
-                v.mtime = mtime;
-            }
-            self.schedule_preview_read(id, path);
-        }
+        self.schedule_file_metadata();
     }
 
     /// Give normal-mode keyboard input to the FILES tree. The dock is mounted
@@ -1198,7 +1164,7 @@ impl App {
         self.recent_files.truncate(RECENT_FILE_CAP);
     }
 
-    fn schedule_file_read(&mut self, id: PaneId, path: PathBuf) {
+    pub(super) fn schedule_file_read(&mut self, id: PaneId, path: PathBuf) {
         // Claim the next token for this view and record the mtime now, so live
         // refresh (FILE-5) only re-reads on a real change rather than
         // immediately after this read. No view means nothing could apply the

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -420,6 +420,9 @@ impl App {
         // off-loop. Apply its completed registry before the empty-workspace guard
         // so the single writer always observes the result.
         let ev = match ev {
+            AppEvent::IoCompleted(completion) => {
+                return completion.apply(self);
+            }
             AppEvent::BackendCreateReady {
                 id,
                 reply,
@@ -1063,7 +1066,8 @@ impl App {
             | AppEvent::ClientInput { .. }
             | AppEvent::Shutdown => false,
             // Consumed by the pre-dispatch worker-result branch above.
-            AppEvent::ThemeUninstalled { .. }
+            AppEvent::IoCompleted(_)
+            | AppEvent::ThemeUninstalled { .. }
             | AppEvent::ConfigReloaded { .. }
             | AppEvent::ManifestsReloaded { .. }
             | AppEvent::BackendCreateReady { .. }

--- a/src/app/io_jobs.rs
+++ b/src/app/io_jobs.rs
@@ -1,0 +1,174 @@
+//! One lazy, bounded executor for app-owned filesystem work.
+//!
+//! Jobs own immutable inputs. Only their completions may mutate `App`, on its
+//! existing event loop. Capacity includes completed but unapplied results.
+
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
+
+use super::App;
+use crate::event::AppEvent;
+
+const MAX_JOBS: usize = 8;
+type Apply = Box<dyn FnOnce(&mut App) -> bool + Send>;
+type Work = Box<dyn FnOnce() -> Apply + Send>;
+
+#[derive(Default)]
+struct Budget {
+    used: Mutex<usize>,
+}
+
+struct Permit(Arc<Budget>);
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        *self.0.used.lock().unwrap_or_else(|e| e.into_inner()) -= 1;
+    }
+}
+
+pub(crate) struct Completion {
+    apply: Apply,
+    _permit: Permit,
+}
+
+impl Completion {
+    pub(super) fn apply(self, app: &mut App) -> bool {
+        let Self { apply, _permit } = self;
+        drop(_permit);
+        apply(app)
+    }
+}
+
+enum Message {
+    Job(Work, Permit),
+    Drain(mpsc::Sender<()>),
+}
+
+#[derive(Default)]
+pub(super) struct IoJobs {
+    sender: Option<mpsc::Sender<Message>>,
+    budget: Arc<Budget>,
+    closing: bool,
+}
+
+impl IoJobs {
+    /// Nonblocking admission. Callers retain dirty/pending intent on rejection.
+    /// Each caller must bound its input and admit at most one large snapshot.
+    pub(super) fn submit(
+        &mut self,
+        events: mpsc::Sender<AppEvent>,
+        work: impl FnOnce() -> Apply + Send + 'static,
+    ) -> Result<(), &'static str> {
+        if self.closing {
+            return Err("filesystem worker is shutting down");
+        }
+        let mut used = self.budget.used.lock().unwrap_or_else(|e| e.into_inner());
+        if *used >= MAX_JOBS {
+            return Err("filesystem work queue is full");
+        }
+        if self.sender.is_none() {
+            let (sender, receiver) = mpsc::channel();
+            std::thread::Builder::new()
+                .name("luvus-io".into())
+                .spawn(move || {
+                    while let Ok(message) = receiver.recv() {
+                        match message {
+                            Message::Job(work, permit) => {
+                                // A failed job must not strand unrelated admitted work.
+                                let apply =
+                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(work))
+                                        .unwrap_or_else(|_| {
+                                            Box::new(|app: &mut App| {
+                                                app.show_toast(
+                                                    "filesystem job failed unexpectedly",
+                                                );
+                                                true
+                                            })
+                                        });
+                                let _ = events.send(AppEvent::IoCompleted(Completion {
+                                    apply,
+                                    _permit: permit,
+                                }));
+                            }
+                            Message::Drain(reply) => {
+                                let _ = reply.send(());
+                                break;
+                            }
+                        }
+                    }
+                })
+                .map_err(|_| "could not start filesystem worker")?;
+            self.sender = Some(sender);
+        }
+        *used += 1;
+        drop(used);
+        self.sender
+            .as_ref()
+            .expect("worker installed")
+            .send(Message::Job(Box::new(work), Permit(self.budget.clone())))
+            .map_err(|_| "filesystem worker unavailable")
+    }
+
+    /// Shutdown-only FIFO barrier. Never wait on storage in the interactive loop.
+    /// OS filesystem calls cannot safely be cancelled; timeout reports uncertainty.
+    pub(super) fn drain(&mut self, timeout: Duration) -> bool {
+        self.closing = true;
+        let Some(sender) = self.sender.take() else {
+            return true;
+        };
+        let (tx, rx) = mpsc::channel();
+        sender.send(Message::Drain(tx)).is_ok() && rx.recv_timeout(timeout).is_ok()
+    }
+}
+
+impl App {
+    pub(crate) fn drain_io_jobs(&mut self) {
+        if !self.io_jobs.drain(Duration::from_secs(2)) {
+            eprintln!("Luvus: filesystem work did not finish within the shutdown deadline");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capacity_includes_unapplied_completions_and_drain_is_fifo() {
+        let (tx, rx) = mpsc::channel();
+        let mut jobs = IoJobs::default();
+        let order = Arc::new(Mutex::new(Vec::new()));
+        for i in 0..MAX_JOBS {
+            let order = order.clone();
+            jobs.submit(tx.clone(), move || {
+                order.lock().unwrap().push(i);
+                Box::new(|_| false)
+            })
+            .unwrap();
+        }
+        assert!(jobs.submit(tx.clone(), || Box::new(|_| false)).is_err());
+        let completion = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(jobs.submit(tx.clone(), || Box::new(|_| false)).is_err());
+        drop(completion);
+        jobs.submit(tx, || Box::new(|_| false)).unwrap();
+        assert!(jobs.drain(Duration::from_secs(2)));
+        assert_eq!(*order.lock().unwrap(), (0..MAX_JOBS).collect::<Vec<_>>());
+        assert!(jobs.sender.is_none());
+    }
+
+    #[test]
+    fn blocked_job_does_not_block_admission_or_bounded_shutdown() {
+        let (tx, _rx) = mpsc::channel();
+        let (release, wait) = mpsc::channel();
+        let mut jobs = IoJobs::default();
+        jobs.submit(tx.clone(), move || {
+            let _ = wait.recv();
+            Box::new(|_| false)
+        })
+        .unwrap();
+        jobs.submit(tx.clone(), || Box::new(|_| false)).unwrap();
+        assert!(!jobs.drain(Duration::from_millis(10)));
+        assert!(jobs.submit(tx, || Box::new(|_| false)).is_err());
+        release.send(()).unwrap();
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -31,9 +31,11 @@ pub use board::{
 };
 pub(crate) mod diff;
 mod dispatch;
+mod file_jobs;
 pub(crate) mod files;
 mod git;
 mod input;
+pub(crate) mod io_jobs;
 mod keys;
 mod mission;
 mod modules;
@@ -2142,6 +2144,9 @@ pub struct App {
     /// This server's last local config snapshot. Persistence diffs against this
     /// snapshot so another named server's newer, unrelated fields survive.
     config_baseline: crate::config::Config,
+    io_jobs: io_jobs::IoJobs,
+    file_metadata_inflight: bool,
+    file_metadata_cursor: usize,
     /// Active `key → Cmd` map for prefix mode (defaults + config overrides).
     pub keymap: std::collections::HashMap<String, Cmd>,
     /// Explicit normal-mode shortcuts. Empty by default so pane input remains
@@ -2828,6 +2833,9 @@ impl App {
             catalog,
             config,
             config_baseline,
+            io_jobs: io_jobs::IoJobs::default(),
+            file_metadata_inflight: false,
+            file_metadata_cursor: 0,
             keymap,
             direct_keymap,
             prefix,
@@ -3472,6 +3480,9 @@ impl App {
             catalog,
             config,
             config_baseline,
+            io_jobs: io_jobs::IoJobs::default(),
+            file_metadata_inflight: false,
+            file_metadata_cursor: 0,
             keymap,
             direct_keymap,
             prefix,

--- a/src/event.rs
+++ b/src/event.rs
@@ -22,6 +22,7 @@ pub enum ClientInput {
 }
 
 pub enum AppEvent {
+    IoCompleted(crate::app::io_jobs::Completion),
     Key(KeyEvent),
     Mouse(MouseEvent),
     Paste(String),

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -667,6 +667,7 @@ pub fn run() -> Result<()> {
         }
     }
 
+    app.drain_io_jobs();
     persist::save(&app);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1390,6 +1390,7 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
     }
 
     let detached = app.detach_requested;
+    app.drain_io_jobs();
     persist::save(&app);
     Ok(detached)
 }

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -3,6 +3,20 @@ title: Architecture
 description: Why luvus is fast and why sessions survive, thanks to the server/client split, one event loop, and frame diffs.
 ---
 
+## Shared filesystem work
+
+Native file and document-preview refresh checks use one lazily started `luvus-io`
+worker per server. It sleeps on a channel when idle. Admission is nonblocking and
+limited to eight outstanding jobs, including completed results not yet applied.
+Metadata refresh admits only one batch at a time, covering at most 128 views.
+Results return to the app loop and must match the view path and read generation.
+A closed or replaced view cannot receive a stale refresh.
+
+Shutdown allows two seconds for admitted work to finish and reports a timeout.
+An operating-system filesystem call cannot be forcibly cancelled safely, so a
+timeout is not a successful completion guarantee. This worker adds no per-pane
+thread and does not change PTY ownership or public API acknowledgement semantics.
+
 Three design decisions explain most of luvus's behavior.
 
 ## A headless server, a thin client


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 10 of 15** · Base: #292 · Next: #294 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

## Summary
Adds one approved lazy shared filesystem worker per server, with nonblocking admission capped at eight jobs including unapplied completions. Metadata refresh runs in batches of at most 128 views, with one batch in flight, and path/read-token fenced results applied by the app loop. Unchanged results do not force rendering.

## Safety and lifecycle
No per-pane or per-save thread. Idle worker sleeps on its channel. Shutdown has a two-second FIFO drain deadline and reports uncertainty on timeout rather than claiming cancellation of operating-system I/O. Public API and automation durability semantics are unchanged.

## Verification
Focused worker saturation, unapplied-result accounting, blocked-job/shutdown, stale-generation, closed-view, and live file-refresh tests passed on macOS. Formatting and strict all-target Clippy passed. Public architecture documentation included. Broader stack validation follows subsequent consumers.

## Stack
Based on #292. No merge requested. Persistence and file mutation consumers are separate follow-ups.