### PR TITLE
perf(files): execute confirmed mutations off the app loop

### DIFF
--- a/src/app/file_jobs.rs
+++ b/src/app/file_jobs.rs
@@ -1,7 +1,101 @@
 //! Bounded metadata refresh with path/read-generation fenced completions.
 use super::*;
 
+pub(super) enum FileMutation {
+    CreateFile(PathBuf),
+    CreateFolder(PathBuf),
+    Rename {
+        source: PathBuf,
+        destination: PathBuf,
+    },
+    Delete(PathBuf),
+}
+
+impl FileMutation {
+    fn path(&self) -> &std::path::Path {
+        match self {
+            Self::CreateFile(path) | Self::CreateFolder(path) | Self::Delete(path) => path,
+            Self::Rename { destination, .. } => destination,
+        }
+    }
+
+    fn execute(&self) -> std::io::Result<&'static str> {
+        match self {
+            Self::CreateFile(path) => {
+                // Atomic create, including dangling symlinks: never truncate an
+                // entry that appeared after the user opened the prompt.
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(path)?;
+                Ok("created")
+            }
+            Self::CreateFolder(path) => {
+                std::fs::create_dir(path)?;
+                Ok("created")
+            }
+            Self::Rename {
+                source,
+                destination,
+            } => {
+                std::fs::symlink_metadata(source)?;
+                std::fs::rename(source, destination)?;
+                Ok("renamed")
+            }
+            Self::Delete(path) => {
+                // Remove the selected link itself, not a linked directory tree.
+                let metadata = std::fs::symlink_metadata(path)?;
+                #[cfg(windows)]
+                {
+                    use std::os::windows::fs::FileTypeExt;
+                    if metadata.file_type().is_symlink_dir() {
+                        std::fs::remove_dir(path)?;
+                        return Ok("deleted");
+                    }
+                }
+                if metadata.is_dir() {
+                    std::fs::remove_dir_all(path)?;
+                } else {
+                    std::fs::remove_file(path)?;
+                }
+                Ok("deleted")
+            }
+        }
+    }
+}
+
 impl App {
+    pub(super) fn schedule_file_mutation(
+        &mut self,
+        operation: FileMutation,
+    ) -> Result<(), &'static str> {
+        if self.file_mutation_inflight {
+            return Err("a file operation is already pending");
+        }
+        let root = self.file_tree.root().to_path_buf();
+        self.io_jobs.submit(self.app_tx.clone(), move || {
+            let result = operation.execute().map_err(|e| e.to_string());
+            Box::new(move |app| {
+                app.file_mutation_inflight = false;
+                match result {
+                    Ok(message) => {
+                        // A workspace switch must not reveal an old path in the
+                        // new workspace's tree or alter another open prompt.
+                        if app.file_tree.root() == root {
+                            app.after_fs_change(operation.path());
+                        }
+                        app.show_toast(message);
+                    }
+                    Err(error) => app.show_toast(format!("file operation failed: {error}")),
+                }
+                true
+            })
+        })?;
+        self.file_mutation_inflight = true;
+        self.show_toast("file operation pending");
+        Ok(())
+    }
+
     pub(super) fn schedule_file_metadata(&mut self) {
         if self.file_metadata_inflight || self.views.is_empty() {
             return;
@@ -85,6 +179,37 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn create_never_truncates_existing_content() {
+        let _env = crate::persist::test_env("file-create-collision");
+        let path = crate::persist::config_dir().join("keep.txt");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"keep this").unwrap();
+        assert_eq!(
+            FileMutation::CreateFile(path.clone())
+                .execute()
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
+        assert_eq!(std::fs::read(path).unwrap(), b"keep this");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delete_directory_link_preserves_target() {
+        let _env = crate::persist::test_env("file-delete-symlink");
+        let root = crate::persist::config_dir();
+        let target = root.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("keep"), b"keep").unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        FileMutation::Delete(link.clone()).execute().unwrap();
+        assert!(std::fs::symlink_metadata(link).is_err());
+        assert!(target.join("keep").exists());
+    }
 
     #[test]
     fn metadata_completion_rejects_replaced_read_and_closed_view() {

--- a/src/app/file_jobs.rs
+++ b/src/app/file_jobs.rs
@@ -79,9 +79,15 @@ impl App {
                 app.file_mutation_inflight = false;
                 match result {
                     Ok(message) => {
-                        // A workspace switch must not reveal an old path in the
-                        // new workspace's tree or alter another open prompt.
-                        if app.file_tree.root() == root {
+                        // The tree can retain its old root after a workspace
+                        // switch or failed replacement-shell startup. Refresh
+                        // only while its owning workspace is still active.
+                        if app.file_tree.root() == root
+                            && app
+                                .workspaces
+                                .get(app.active_ws)
+                                .is_some_and(|ws| crate::platform::same_path(&ws.cwd, &root))
+                        {
                             app.after_fs_change(operation.path());
                         }
                         app.show_toast(message);
@@ -179,6 +185,46 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mutation_completion_skips_closed_or_replaced_workspace() {
+        let _env = crate::persist::test_env("file-mutation-workspace");
+        let root = crate::persist::config_dir();
+        std::fs::create_dir_all(&root).unwrap();
+        for scenario in ["closed", "workspace-switched", "tree-replaced"] {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let mut app = App::new(80, 24, tx).unwrap();
+            app.workspaces[app.active_ws].cwd = root.clone();
+            app.file_tree.set_root(root.clone());
+            let path = root.join(scenario);
+            app.schedule_file_mutation(FileMutation::CreateFile(path.clone()))
+                .unwrap();
+            let completion = loop {
+                let event = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+                if let AppEvent::IoCompleted(completion) = event {
+                    break completion;
+                }
+            };
+            match scenario {
+                "closed" => app.workspaces.clear(),
+                "workspace-switched" => {
+                    app.workspaces[app.active_ws].cwd = root.join("other");
+                }
+                "tree-replaced" => app.file_tree.set_root(root.join("other")),
+                _ => unreachable!(),
+            }
+            let last_git_status_at = app.last_git_status_at;
+            assert!(app.handle_event(AppEvent::IoCompleted(completion)));
+            assert!(path.exists(), "accepted mutation must still complete");
+            assert!(!app.file_mutation_inflight);
+            assert_eq!(app.last_git_status_at, last_git_status_at);
+            assert_eq!(
+                app.toast.as_ref().map(|(message, _)| message.as_str()),
+                Some("created")
+            );
+            app.drain_io_jobs();
+        }
+    }
 
     #[test]
     fn create_never_truncates_existing_content() {

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -915,28 +915,21 @@ impl App {
         }
         let dest = p.dir.join(&name);
         let (kind, target) = (p.kind, p.target.clone());
-        let result = match kind {
-            FilePromptKind::NewFile => {
-                if dest.exists() {
-                    Err(std::io::Error::new(
-                        std::io::ErrorKind::AlreadyExists,
-                        "already exists",
-                    ))
-                } else {
-                    std::fs::write(&dest, b"")
+        use super::file_jobs::FileMutation;
+        let operation = match kind {
+            FilePromptKind::NewFile => FileMutation::CreateFile(dest),
+            FilePromptKind::NewFolder => FileMutation::CreateFolder(dest),
+            FilePromptKind::Rename => {
+                let Some(source) = target else { return };
+                FileMutation::Rename {
+                    source,
+                    destination: dest,
                 }
             }
-            FilePromptKind::NewFolder => std::fs::create_dir(&dest),
-            FilePromptKind::Rename => std::fs::rename(target.as_ref().unwrap(), &dest),
         };
-        match result {
+        match self.schedule_file_mutation(operation) {
             Ok(()) => {
                 self.file_prompt = None;
-                self.after_fs_change(&dest);
-                self.show_toast(match kind {
-                    FilePromptKind::Rename => "renamed",
-                    _ => "created",
-                });
             }
             Err(e) => {
                 if let Some(pr) = self.file_prompt.as_mut() {
@@ -958,22 +951,16 @@ impl App {
         let Some(path) = self.file_delete.take() else {
             return;
         };
-        let result = if path.is_dir() {
-            std::fs::remove_dir_all(&path)
-        } else {
-            std::fs::remove_file(&path)
-        };
-        match result {
-            Ok(()) => {
-                self.after_fs_change(&path);
-                self.show_toast("deleted");
-            }
-            Err(e) => self.show_toast(format!("delete failed: {e}")),
+        if let Err(error) =
+            self.schedule_file_mutation(super::file_jobs::FileMutation::Delete(path.clone()))
+        {
+            self.file_delete = Some(path);
+            self.show_toast(error);
         }
     }
 
     /// After a create/rename/delete: re-read the tree, reveal the path, re-tint.
-    fn after_fs_change(&mut self, path: &Path) {
+    pub(super) fn after_fs_change(&mut self, path: &Path) {
         self.file_tree.invalidate();
         self.load_pending_dirs();
         self.file_tree.reveal(path);
@@ -3492,6 +3479,7 @@ mod tests {
         app.file_menu_action_pub(crate::app::FileMenuItem::NewFile);
         typ(&mut app, "created.rs");
         app.file_prompt_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        pump_file_mutation(&rx, &mut app);
         assert!(
             root.join("src/created.rs").exists(),
             "new file created on disk"
@@ -3515,6 +3503,7 @@ mod tests {
         }
         typ(&mut app, "new.rs");
         app.file_prompt_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        pump_file_mutation(&rx, &mut app);
         assert!(
             root.join("src/new.rs").exists() && !root.join("src/old.rs").exists(),
             "renamed"
@@ -3533,6 +3522,7 @@ mod tests {
         app.open_file_menu(c_idx, 5, 7);
         app.file_menu_action_pub(crate::app::FileMenuItem::Delete);
         app.file_delete_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        pump_file_mutation(&rx, &mut app);
         assert!(!root.join("src/created.rs").exists(), "deleted");
 
         let _ = std::fs::remove_dir_all(&root);
@@ -3584,9 +3574,21 @@ mod tests {
         app.open_file_menu(idx, 5, 5);
         app.file_menu_action_pub(crate::app::FileMenuItem::Delete);
         app.file_delete_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        pump_file_mutation(&rx, &mut app);
         assert!(!file.exists(), "confirmed delete removes it");
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn pump_file_mutation(rx: &std::sync::mpsc::Receiver<AppEvent>, app: &mut App) {
+        use std::time::{Duration, Instant};
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while app.file_mutation_inflight {
+            let event = rx
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .expect("file mutation completion");
+            app.handle_event(event);
+        }
     }
 
     // ── Insert Path (docs/38 FILE-6) ─────────────────────────────────────────

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2147,6 +2147,7 @@ pub struct App {
     io_jobs: io_jobs::IoJobs,
     file_metadata_inflight: bool,
     file_metadata_cursor: usize,
+    file_mutation_inflight: bool,
     /// Active `key → Cmd` map for prefix mode (defaults + config overrides).
     pub keymap: std::collections::HashMap<String, Cmd>,
     /// Explicit normal-mode shortcuts. Empty by default so pane input remains
@@ -2836,6 +2837,7 @@ impl App {
             io_jobs: io_jobs::IoJobs::default(),
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
+            file_mutation_inflight: false,
             keymap,
             direct_keymap,
             prefix,
@@ -3483,6 +3485,7 @@ impl App {
             io_jobs: io_jobs::IoJobs::default(),
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
+            file_mutation_inflight: false,
             keymap,
             direct_keymap,
             prefix,

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -37,6 +37,15 @@ pane, show up on their own within a couple of seconds.
 New Folder, Rename, Copy Path, Insert Path, Open as Workspace (folders), and
 Delete (Delete always asks first).
 
+Create, rename, and confirmed delete run on the shared filesystem worker. The
+prompt closes after admission and a pending message appears; completion or failure
+is reported afterward. Only one mutation is admitted at a time. If the queue is
+busy, the prompt remains available to retry. Confirmation is the cancellation
+boundary: an admitted operation is not cancelled by switching workspace or closing
+a modal. Its result never closes a newer prompt or reveals a path in a different
+workspace. New-file creation cannot truncate an existing entry, and deleting a
+directory symlink removes the link rather than its target.
+
 | Key | FILES tree action |
 |---|---|
 | `j` / `k`, `↓` / `↑` | next / previous row |


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 11 of 15** · Base: #293 · Next: #295 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

## Summary
Moves file-tree create, rename, and confirmed deletion onto the bounded shared I/O worker. One mutation can be outstanding. Admission, pending, completion, and errors remain distinct. A workspace switch cannot apply an old reveal to the current tree or dismiss a newer prompt.

## Safety
Atomic create_new avoids truncating existing files. Deletion uses symlink metadata and removes directory links themselves, including the Windows directory-link API. Existing rename semantics are retained. Confirmation remains required; admitted OS work cannot be cancelled by closing UI. Busy admission preserves the prompt for retry. Guide documents these semantics.

## Verification
61 focused file tests passed, covering CRUD, confirmation, live refresh, stale metadata, create collisions, symlink deletion, native views, and editor routing. Formatting and strict all-target Clippy passed on macOS. Windows compilation and targeted CI remain required.

## Stack
Based on #293. No merge requested.