### PR TITLE
perf(persist): serialize session saves off the app loop

### DIFF
--- a/src/app/io_jobs.rs
+++ b/src/app/io_jobs.rs
@@ -41,7 +41,7 @@ impl Completion {
 
 enum Message {
     Job(Work, Permit),
-    Drain(mpsc::Sender<()>),
+    Drain(Box<dyn FnOnce() -> bool + Send>, mpsc::Sender<bool>),
 }
 
 #[derive(Default)]
@@ -90,8 +90,8 @@ impl IoJobs {
                                     _permit: permit,
                                 }));
                             }
-                            Message::Drain(reply) => {
-                                let _ = reply.send(());
+                            Message::Drain(final_work, reply) => {
+                                let _ = reply.send(final_work());
                                 break;
                             }
                         }
@@ -111,17 +111,30 @@ impl IoJobs {
 
     /// Shutdown-only FIFO barrier. Never wait on storage in the interactive loop.
     /// OS filesystem calls cannot safely be cancelled; timeout reports uncertainty.
+    #[cfg(test)]
     pub(super) fn drain(&mut self, timeout: Duration) -> bool {
+        self.finish(timeout, || true)
+    }
+
+    pub(super) fn finish(
+        &mut self,
+        timeout: Duration,
+        final_work: impl FnOnce() -> bool + Send + 'static,
+    ) -> bool {
         self.closing = true;
         let Some(sender) = self.sender.take() else {
-            return true;
+            return false;
         };
         let (tx, rx) = mpsc::channel();
-        sender.send(Message::Drain(tx)).is_ok() && rx.recv_timeout(timeout).is_ok()
+        sender
+            .send(Message::Drain(Box::new(final_work), tx))
+            .is_ok()
+            && rx.recv_timeout(timeout).unwrap_or(false)
     }
 }
 
 impl App {
+    #[cfg(test)]
     pub(crate) fn drain_io_jobs(&mut self) {
         if !self.io_jobs.drain(Duration::from_secs(2)) {
             eprintln!("Luvus: filesystem work did not finish within the shutdown deadline");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod io_jobs;
 mod keys;
 mod mission;
 mod modules;
+mod persistence;
 mod picker;
 mod preview;
 mod search;
@@ -2148,6 +2149,7 @@ pub struct App {
     file_metadata_inflight: bool,
     file_metadata_cursor: usize,
     file_mutation_inflight: bool,
+    pub(crate) session_save_inflight: bool,
     /// Active `key → Cmd` map for prefix mode (defaults + config overrides).
     pub keymap: std::collections::HashMap<String, Cmd>,
     /// Explicit normal-mode shortcuts. Empty by default so pane input remains
@@ -2838,6 +2840,7 @@ impl App {
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
             file_mutation_inflight: false,
+            session_save_inflight: false,
             keymap,
             direct_keymap,
             prefix,
@@ -3486,6 +3489,7 @@ impl App {
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
             file_mutation_inflight: false,
+            session_save_inflight: false,
             keymap,
             direct_keymap,
             prefix,

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -1,0 +1,119 @@
+//! Session save admission and completion, owned by the app event loop.
+use super::*;
+
+impl App {
+    /// At most one captured session waits for I/O. Clearing dirty at admission
+    /// separates later mutations from this snapshot; acknowledgement never clears
+    /// a newer dirty flag. Failure restores the retry intent.
+    pub(crate) fn schedule_session_save(&mut self) {
+        if self.session_save_inflight {
+            return;
+        }
+        let capture = persist::capture_session(self);
+        let accepted = self.io_jobs.submit(self.app_tx.clone(), move || {
+            let saved = capture.write();
+            Box::new(move |app| {
+                app.session_save_inflight = false;
+                if !saved {
+                    app.session_dirty = true;
+                    app.show_toast("session save failed; changes will be retried");
+                }
+                !saved
+            })
+        });
+        if accepted.is_ok() {
+            self.session_save_inflight = true;
+            self.session_dirty = false;
+            self.persist_session_now = false;
+        }
+    }
+
+    /// The final capture follows every earlier accepted write on the same worker.
+    /// No synchronous fallback can race an old delayed write after a timeout.
+    pub(crate) fn finish_session_persistence(&mut self) {
+        // Start the lazy worker if needed. A full queue still has a live worker;
+        // its reserved shutdown slot remains available.
+        let _ = self
+            .io_jobs
+            .submit(self.app_tx.clone(), || Box::new(|_| false));
+        let capture = persist::capture_session(self);
+        if !self
+            .io_jobs
+            .finish(Duration::from_secs(2), move || capture.write())
+        {
+            eprintln!("Luvus: final session save failed or exceeded the shutdown deadline");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    fn completion(rx: &mpsc::Receiver<AppEvent>, app: &mut App) {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            let ev = rx
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .expect("save completion");
+            if let AppEvent::IoCompleted(done) = ev {
+                done.apply(app);
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn session_ack_preserves_newer_dirty_state_and_final_write_is_last() {
+        let _env = persist::test_env("session-save-order");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.workspaces[0].name = "first".into();
+        app.schedule_session_save();
+        assert!(app.session_save_inflight);
+        assert!(!app.session_dirty);
+        app.workspaces[0].name = "latest".into();
+        app.session_dirty = true;
+        completion(&rx, &mut app);
+        assert!(app.session_dirty, "old ack cannot clear new changes");
+        assert!(!app.session_save_inflight);
+        app.schedule_session_save();
+        app.workspaces[0].name = "final".into();
+        app.finish_session_persistence();
+        assert_eq!(persist::load().unwrap().workspaces[0].name, "final");
+    }
+
+    #[test]
+    fn failed_session_write_keeps_retry_intent_without_immediate_retry_loop() {
+        let _env = persist::test_env("session-save-failure");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        std::fs::create_dir_all(persist::session_dir().join("session.json")).unwrap();
+        app.persist_session_now = true;
+        app.schedule_session_save();
+        completion(&rx, &mut app);
+        assert!(app.session_dirty);
+        assert!(
+            !app.persist_session_now,
+            "failed write retries at debounce cadence"
+        );
+        assert!(!app.session_save_inflight);
+        app.drain_io_jobs();
+    }
+
+    #[test]
+    fn empty_session_capture_preserves_explicit_closed_workspaces() {
+        let _env = persist::test_env("session-save-empty");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.workspaces.clear();
+        app.closed_workspace_paths
+            .push(PathBuf::from("/closed/project"));
+        app.schedule_session_save();
+        completion(&rx, &mut app);
+        let snapshot = persist::load().unwrap();
+        assert_eq!(snapshot.closed_workspace_paths, app.closed_workspace_paths);
+        app.drain_io_jobs();
+    }
+}

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -426,8 +426,9 @@ pub fn run() -> Result<()> {
         // Otherwise sleep until the next real deadline, or block on the
         // channel when nothing is due (PTY/API/client/signal wake the loop).
         let now = Instant::now();
-        let persist_due = (app.persist_session_now && !immediate_save_attempted)
-            || (app.session_dirty && last_save.elapsed() >= SESSION_SAVE_DEBOUNCE);
+        let persist_due = !app.session_save_inflight
+            && ((app.persist_session_now && !immediate_save_attempted)
+                || (app.session_dirty && last_save.elapsed() >= SESSION_SAVE_DEBOUNCE));
         let rearm_due = app.has_pending_pty_output() && last_rearm.elapsed() >= REARM_INTERVAL;
         let received = if persist_due || rearm_due {
             // Already-due persist/re-arm must not `recv_timeout(0)`: that busy-loops
@@ -444,7 +445,7 @@ pub fn run() -> Result<()> {
             }
         } else {
             let mut deadline = app.next_runtime_deadline(now, !clients.is_empty());
-            if app.session_dirty {
+            if app.session_dirty && !app.session_save_inflight {
                 App::sooner_deadline(&mut deadline, last_save + SESSION_SAVE_DEBOUNCE);
             }
             if app.has_pending_pty_output() {
@@ -533,13 +534,9 @@ pub fn run() -> Result<()> {
         // retain both flags and retry at the normal cadence instead of hot-looping.
         let immediate_save_due = app.persist_session_now && !immediate_save_attempted;
         let debounced_save_due = app.session_dirty && last_save.elapsed() >= SESSION_SAVE_DEBOUNCE;
-        if immediate_save_due || debounced_save_due {
+        if !app.session_save_inflight && (immediate_save_due || debounced_save_due) {
             immediate_save_attempted = app.persist_session_now;
-            if persist::save(&app) {
-                app.persist_session_now = false;
-                app.session_dirty = false;
-                immediate_save_attempted = false;
-            }
+            app.schedule_session_save();
             last_save = Instant::now();
         }
         if app.detach_requested {
@@ -667,8 +664,7 @@ pub fn run() -> Result<()> {
         }
     }
 
-    app.drain_io_jobs();
-    persist::save(&app);
+    app.finish_session_persistence();
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1343,13 +1343,9 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
         // retain both flags and retry at the normal cadence instead of hot-looping.
         let immediate_save_due = app.persist_session_now && !immediate_save_attempted;
         let debounced_save_due = app.session_dirty && last_save.elapsed() > Duration::from_secs(2);
-        if immediate_save_due || debounced_save_due {
+        if !app.session_save_inflight && (immediate_save_due || debounced_save_due) {
             immediate_save_attempted = app.persist_session_now;
-            if persist::save(&app) {
-                app.persist_session_now = false;
-                app.session_dirty = false;
-                immediate_save_attempted = false;
-            }
+            app.schedule_session_save();
             last_save = Instant::now();
         }
 
@@ -1390,8 +1386,7 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
     }
 
     let detached = app.detach_requested;
-    app.drain_io_jobs();
-    persist::save(&app);
+    app.finish_session_persistence();
     Ok(detached)
 }
 

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -304,6 +304,7 @@ mod server_pid_file_tests {
 
 /// Create the selected runtime directory with the same owner-only protection as
 /// the global root. This is the startup-lock namespace for one server only.
+#[cfg(test)]
 pub fn ensure_session_dir() -> PathBuf {
     let dir = session_dir();
     ensure_private_dir(&dir);
@@ -499,7 +500,13 @@ pub fn client_socket_path() -> PathBuf {
 /// between tabs on restart. When discovery cannot prove ownership, the pane
 /// restores as a shell instead. That is recoverable and safe; resuming the wrong
 /// conversation is neither.
-fn resolve_pane_sessions(app: &App) -> HashMap<PaneId, Option<(String, String)>> {
+struct SessionEvidence {
+    out: HashMap<PaneId, Option<(String, String)>>,
+    claimed: HashSet<(String, String)>,
+    unbound: HashMap<(String, PathBuf), Vec<PaneId>>,
+}
+
+fn capture_session_evidence(app: &App) -> SessionEvidence {
     let mut out: HashMap<PaneId, Option<(String, String)>> = HashMap::new();
     let mut claimed: HashSet<(String, String)> = HashSet::new();
     let mut ids: Vec<PaneId> = app.status.keys().copied().collect();
@@ -550,6 +557,19 @@ fn resolve_pane_sessions(app: &App) -> HashMap<PaneId, Option<(String, String)>>
                 .push(id);
         }
     }
+    SessionEvidence {
+        out,
+        claimed,
+        unbound,
+    }
+}
+
+fn resolve_pane_sessions(evidence: SessionEvidence) -> HashMap<PaneId, Option<(String, String)>> {
+    let SessionEvidence {
+        mut out,
+        mut claimed,
+        unbound,
+    } = evidence;
     for ((agent, cwd), pane_ids) in unbound {
         let sessions: Vec<String> = crate::agent::sessions_for(&agent, &cwd)
             .into_iter()
@@ -586,8 +606,82 @@ fn snapshot_agent(
         .unwrap_or_else(|| fallback.to_string())
 }
 
+/// Immutable layout and native-identity evidence captured by the app owner.
+/// Native store discovery and JSON/file work happen only in `write`.
+pub(crate) struct SessionCapture {
+    snapshot: SessionSnapshot,
+    evidence: SessionEvidence,
+    launch_args: HashMap<PaneId, Vec<String>>,
+    path: PathBuf,
+}
+
+impl SessionCapture {
+    fn finish(mut self) -> SessionSnapshot {
+        let sessions = resolve_pane_sessions(self.evidence);
+        for workspace in &mut self.snapshot.workspaces {
+            for tab in &mut workspace.tabs {
+                for (id, pane) in &mut tab.panes {
+                    let id = PaneId(*id);
+                    pane.agent_session = sessions.get(&id).cloned().flatten();
+                    if pane.agent_session.is_some() {
+                        pane.agent_launch = self.launch_args.remove(&id);
+                    }
+                }
+            }
+        }
+        self.snapshot
+    }
+
+    pub(crate) fn write(self) -> bool {
+        let path = self.path.clone();
+        write_snapshot(&self.finish(), &path)
+    }
+}
+
+pub(crate) fn capture_session(app: &App) -> SessionCapture {
+    let evidence = capture_session_evidence(app);
+    let mut launch_args = HashMap::new();
+    for (id, status) in &app.status {
+        let agent = evidence
+            .out
+            .get(id)
+            .and_then(Option::as_ref)
+            .map(|(agent, _)| agent.clone())
+            .unwrap_or_else(|| {
+                snapshot_agent(
+                    &app.manifests,
+                    app.proc_commands.get(id).map(Vec::as_slice),
+                    &status.agent,
+                )
+            });
+        if app.manifests.is_agent(&agent) {
+            if let Some(args) = app
+                .proc_commands
+                .get(id)
+                .and_then(|cmds| app.manifests.launch_args_for(cmds, &agent))
+                .filter(|v| !v.is_empty())
+            {
+                launch_args.insert(*id, args);
+            }
+        }
+    }
+    SessionCapture {
+        snapshot: snapshot_layout(app, &evidence.out),
+        evidence,
+        launch_args,
+        path: session_path(),
+    }
+}
+
+#[cfg(test)]
 pub fn snapshot(app: &App) -> SessionSnapshot {
-    let sessions = resolve_pane_sessions(app);
+    capture_session(app).finish()
+}
+
+fn snapshot_layout(
+    app: &App,
+    sessions: &HashMap<PaneId, Option<(String, String)>>,
+) -> SessionSnapshot {
     let mut workspaces = Vec::new();
     for ws in &app.workspaces {
         let mut tabs = Vec::new();
@@ -786,10 +880,14 @@ pub fn snapshot(app: &App) -> SessionSnapshot {
 /// Save the app's session atomically. A truly empty session can only remain after
 /// restore or shell startup failure; clear its stale snapshot so the next start
 /// cannot resurrect panes the user already closed.
+#[cfg(test)]
 pub fn save(app: &App) -> bool {
-    let snap = snapshot(app);
-    if snap.workspaces.is_empty() {
-        if let Err(error) = fs::remove_file(session_path()) {
+    capture_session(app).write()
+}
+
+fn write_snapshot(snap: &SessionSnapshot, path: &std::path::Path) -> bool {
+    if snap.workspaces.is_empty() && snap.closed_workspace_paths.is_empty() {
+        if let Err(error) = fs::remove_file(path) {
             if error.kind() != std::io::ErrorKind::NotFound {
                 log_persist_failure("persist_clear");
                 return false;
@@ -801,7 +899,10 @@ pub fn save(app: &App) -> bool {
         );
         return true;
     }
-    let dir = ensure_session_dir();
+    let Some(dir) = path.parent() else {
+        return false;
+    };
+    ensure_private_dir(dir);
     if !dir.is_dir() {
         log_persist_failure("persist_dir");
         return false;
@@ -810,7 +911,6 @@ pub fn save(app: &App) -> bool {
         log_persist_failure("persist_serialize");
         return false;
     };
-    let path = session_path();
     let tmp = path.with_extension("json.tmp");
     let Ok(mut file) = fs::File::create(&tmp) else {
         log_persist_failure("persist_create");
@@ -824,7 +924,7 @@ pub fn save(app: &App) -> bool {
         log_persist_failure("persist_flush");
         return false;
     }
-    if fs::rename(&tmp, &path).is_err() {
+    if crate::platform::atomic_replace_file(&tmp, path).is_err() {
         log_persist_failure("persist_rename");
         return false;
     }

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -880,7 +880,7 @@ fn snapshot_layout(
 /// Save the app's session atomically. A truly empty session can only remain after
 /// restore or shell startup failure; clear its stale snapshot so the next start
 /// cannot resurrect panes the user already closed.
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub fn save(app: &App) -> bool {
     capture_session(app).write()
 }

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -17,6 +17,20 @@ An operating-system filesystem call cannot be forcibly cancelled safely, so a
 timeout is not a successful completion guarantee. This worker adds no per-pane
 thread and does not change PTY ownership or public API acknowledgement semantics.
 
+Session persistence captures immutable layout and identity evidence on the app
+loop, then discovers native sessions, serializes, and atomically replaces the
+selected session file on this worker. Only one ordinary capture is outstanding.
+An acknowledgement cannot clear changes made after admission; failed writes
+retain retry intent at the normal debounce cadence. Explicitly closed workspace
+paths remain persisted even when no workspace is open.
+
+Shutdown queues one final capture after previously admitted writes, with the same
+two-second deadline. It never falls back to a competing synchronous write after
+timeout. Terminal screen capture still runs under the existing short engine lock;
+this does not introduce a second persistent screen cache or promise constant-time
+capture for an arbitrary number of panes. Automation dispatch-intent persistence
+is a separate contract and is not made asynchronous by session saving.
+
 Three design decisions explain most of luvus's behavior.
 
 ## A headless server, a thin client


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 12 of 15** · Base: #294 · Next: #296 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

## Summary
Captures immutable layout and agent identity evidence on the app loop, then resolves native session stores, serializes, and replaces the pinned session file on the shared worker. One ordinary save can be outstanding. Later mutations retain their dirty flag across old acknowledgements. Failed writes retry at the debounce cadence and surface an error.

## Shutdown and compatibility
A reserved final write runs after older admitted jobs, with a two-second shutdown deadline. No synchronous fallback races a delayed write. Empty sessions retain explicit workspace closures. Windows uses the existing atomic replacement helper. Native session ambiguity and launch-argument matching remain unchanged.

## Verification
Three save lifecycle tests cover stale acknowledgements, final-write ordering, failure/retry, and empty-session closures. Twelve persistence tests and fourteen focused snapshot tests passed. Formatting and strict all-target Clippy passed on macOS. Screen capture remains on the existing engine lock and is not claimed constant time. No persistent second screen cache is added. Automation ledger durability is unchanged.

## Stack
Based on #294. No merge requested.