### PR TITLE
perf(terminal): yield between bounded history packing turns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,9 @@ cargo test --release --locked history_maintenance_benchmark -- --ignored --nocap
 ```
 
 This uses 80x24 engines with 10,000 retained rows, both printable text and
-per-cell RGB styling, and three trials per corpus. It measures the synchronous
-maintenance boundary, not end-to-end input/scroll latency. Run separate live
+per-cell RGB styling, and three trials per corpus. It reports total maintenance,
+turn count, and per-turn p95/p99/maximum lock-held work, not end-to-end
+input/scroll latency. Run separate live
 latency checks before changing maintenance scheduling, especially on Windows.
 
 ## Adding agent support

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4446,6 +4446,12 @@ impl App {
         self.panes.values().any(|pane| pane.has_data_pending())
     }
 
+    pub(crate) fn has_history_maintenance(&self) -> bool {
+        self.panes
+            .values()
+            .any(|pane| pane.has_history_maintenance())
+    }
+
     /// Whether a pane is rendered in the active tab.
     pub fn pane_is_visible(&self, id: PaneId) -> bool {
         self.workspaces

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -426,10 +426,15 @@ pub fn run() -> Result<()> {
         // Otherwise sleep until the next real deadline, or block on the
         // channel when nothing is due (PTY/API/client/signal wake the loop).
         let now = Instant::now();
+        let rearm_interval = if app.has_history_maintenance() {
+            Duration::from_millis(1)
+        } else {
+            REARM_INTERVAL
+        };
         let persist_due = !app.session_save_inflight
             && ((app.persist_session_now && !immediate_save_attempted)
                 || (app.session_dirty && last_save.elapsed() >= SESSION_SAVE_DEBOUNCE));
-        let rearm_due = app.has_pending_pty_output() && last_rearm.elapsed() >= REARM_INTERVAL;
+        let rearm_due = app.has_pending_pty_output() && last_rearm.elapsed() >= rearm_interval;
         let received = if persist_due || rearm_due {
             // Already-due persist/re-arm must not `recv_timeout(0)`: that busy-loops
             // until the 100ms re-arm cadence elapses.
@@ -449,7 +454,7 @@ pub fn run() -> Result<()> {
                 App::sooner_deadline(&mut deadline, last_save + SESSION_SAVE_DEBOUNCE);
             }
             if app.has_pending_pty_output() {
-                App::sooner_deadline(&mut deadline, last_rearm + REARM_INTERVAL);
+                App::sooner_deadline(&mut deadline, last_rearm + rearm_interval);
             }
             match deadline.map(|at| at.saturating_duration_since(now)) {
                 Some(timeout) if !timeout.is_zero() => match rx.recv_timeout(timeout) {
@@ -607,7 +612,7 @@ pub fn run() -> Result<()> {
         }
         // Fallback re-arm (the render path below re-arms at the frame rate): a
         // flag still set here means un-rendered output → schedule a frame.
-        if last_rearm.elapsed() >= REARM_INTERVAL {
+        if last_rearm.elapsed() >= rearm_interval {
             last_rearm = Instant::now();
             let (visible, background, title_changed) = app.rearm_pty_notify_by_visibility();
             if title_changed {

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -107,6 +107,8 @@ pub struct Pane {
     /// exactly matches the screen snapshot it serialized.
     content_revision: Arc<AtomicU64>,
     observed_title_generation: AtomicU64,
+    #[cfg(windows)]
+    history_maintenance_pending: AtomicBool,
     /// `PtyData` coalescing: set by the reader when it announces new output,
     /// cleared by the app loop when it consumes the event. While set, further
     /// reads skip the send — a saturated PTY (thousands of 8 KB reads/s) wakes
@@ -471,6 +473,8 @@ impl Pane {
             terminal_runtime: Arc::new(Mutex::new(Some(terminal_runtime))),
             content_revision,
             observed_title_generation: AtomicU64::new(0),
+            #[cfg(windows)]
+            history_maintenance_pending: AtomicBool::new(true),
             master: Arc::new(Mutex::new(Some(pair.master))),
             input_tx,
             cwd,
@@ -679,6 +683,8 @@ impl Pane {
             terminal_runtime,
             content_revision,
             observed_title_generation: AtomicU64::new(0),
+            #[cfg(windows)]
+            history_maintenance_pending: AtomicBool::new(true),
             master,
             input_tx,
             cwd,
@@ -703,9 +709,11 @@ impl Pane {
         // Windows reader has no such event-loop deadline, so retain its
         // coalesced app-boundary maintenance.
         #[cfg(windows)]
-        if pending {
+        if pending || self.history_maintenance_pending.load(Ordering::Acquire) {
             if let Ok(mut engine) = self.engine.lock() {
-                engine.finish_output_batch();
+                let more = engine.finish_output_batch_step();
+                self.history_maintenance_pending
+                    .store(more, Ordering::Release);
             }
         }
         pending
@@ -715,7 +723,22 @@ impl Pane {
     /// consuming it. The server uses this to arm the 100 ms fallback only while
     /// a pane actually has pending bytes, instead of waking forever when idle.
     pub fn has_data_pending(&self) -> bool {
+        #[cfg(windows)]
+        if self.history_maintenance_pending.load(Ordering::Acquire) {
+            return true;
+        }
         self.data_pending.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub(crate) fn has_history_maintenance(&self) -> bool {
+        #[cfg(windows)]
+        {
+            self.history_maintenance_pending.load(Ordering::Acquire)
+        }
+        #[cfg(not(windows))]
+        {
+            false
+        }
     }
 
     /// Coalesce title-only presentation with the existing PTY output wake.
@@ -816,12 +839,19 @@ impl Pane {
         self.child_exited.load(Ordering::SeqCst)
     }
 
-    /// Apply a new per-pane history memory budget (Settings → Layout). Shrinks
-    /// retained history immediately when lowered.
+    fn wake_history_maintenance(&self) {
+        self.input_tx.wake();
+        #[cfg(windows)]
+        self.history_maintenance_pending
+            .store(true, Ordering::Release);
+    }
+
+    /// Apply a new per-pane history memory budget, shrinking retention immediately.
     pub fn set_history_budget(&self, bytes: usize) {
         if let Ok(mut e) = self.engine.lock() {
             e.set_history_budget(bytes);
         }
+        self.wake_history_maintenance();
     }
 
     /// Scroll this pane's scrollback viewport `delta` lines (positive = up into
@@ -1063,6 +1093,7 @@ impl Pane {
         if let Ok(mut e) = self.engine.lock() {
             e.resize(cols, rows);
         }
+        self.wake_history_maintenance();
         crate::logging::event(
             crate::logging::EventKind::PtyResize,
             &[
@@ -1347,6 +1378,40 @@ mod reap_tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
         drop(pane);
         assert!(wait_gone(pid), "exit is still reaped without a timer");
+    }
+
+    #[test]
+    fn quiet_pty_history_and_resize_finish_incremental_maintenance() {
+        let _env = crate::persist::test_env("pty-history-maintenance");
+        let (tx, rx) = mpsc::channel();
+        let mut pane = Pane::spawn_command(
+            PaneId::alloc(), 80, 24, std::env::current_dir().unwrap(), tx,
+            &["/bin/sh".into(), "-c".into(), "i=0; while [ $i -lt 2024 ]; do printf 'row %s cafe\n' \"$i\"; i=$((i + 1)); done; sleep 10".into()],
+            &[], 16 * 1024 * 1024, PaneAppearance::default(),
+        ).unwrap();
+        for resize in [false, true] {
+            if resize {
+                assert!(pane.resize(90, 24));
+            }
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                let complete = {
+                    let engine = pane.engine.lock().unwrap();
+                    let metrics = engine.history_metrics();
+                    metrics.retained_rows >= 1900
+                        && metrics.packed_rows.unwrap_or(0) > 1700
+                        && !engine.history_maintenance_pending()
+                };
+                if complete {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "quiet packing must finish without another output event"
+                );
+                let _ = rx.recv_timeout(std::time::Duration::from_millis(10));
+            }
+        }
     }
 
     /// A deferred pane (docs/82) is fully usable before its shell exists:

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -711,7 +711,8 @@ impl Pane {
         #[cfg(windows)]
         if pending || self.history_maintenance_pending.load(Ordering::Acquire) {
             if let Ok(mut engine) = self.engine.lock() {
-                let more = engine.finish_output_batch_step();
+                let more =
+                    engine.finish_output_batch_step() || engine.history_maintenance_pending();
                 self.history_maintenance_pending
                     .store(more, Ordering::Release);
             }

--- a/src/terminal/pty/io/unix_actor.rs
+++ b/src/terminal/pty/io/unix_actor.rs
@@ -179,6 +179,14 @@ fn actor_loop(
         }
 
         let now = Instant::now();
+        if history_compaction_deadline.is_none()
+            && engine
+                .lock()
+                .is_ok_and(|terminal| terminal.history_maintenance_pending())
+        {
+            history_compaction_started = Some(now);
+            history_compaction_deadline = Some(now + HISTORY_COMPACTION_QUIET);
+        }
         arm_or_finish_submit_delay(&mut pending, now);
         let wants_write = matches!(pending.front(), Some(PendingWrite::Bytes { .. }));
         let timeout = poll_timeout(&pending, history_compaction_deadline, now);
@@ -245,18 +253,25 @@ fn actor_loop(
             break;
         }
         if history_compaction_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
-            if let Ok(mut terminal) = engine.lock() {
-                terminal.finish_output_batch();
+            let more = engine
+                .lock()
+                .is_ok_and(|mut terminal| terminal.finish_output_batch_step());
+            // Yield the lock and service descriptor input/output before each
+            // continuation. No timer remains once the backlog is drained.
+            history_compaction_deadline = more.then(Instant::now);
+            if !more {
+                history_compaction_started = None;
             }
-            history_compaction_deadline = None;
-            history_compaction_started = None;
         }
     }
     // Preserve bounded memory when a pane exits or is cancelled before its
     // quiet-period deadline fires.
     if history_compaction_deadline.is_some() {
-        if let Ok(mut terminal) = engine.lock() {
-            terminal.finish_output_batch();
+        while engine
+            .lock()
+            .is_ok_and(|mut terminal| terminal.finish_output_batch_step())
+        {
+            thread::yield_now();
         }
     }
     let _ = app_tx.send(AppEvent::PtyExit(id));

--- a/src/terminal/vt/alacritty.rs
+++ b/src/terminal/vt/alacritty.rs
@@ -116,6 +116,9 @@ pub struct AlacrittyEngine {
     // One bounded summary, invalidated at every storage mutation boundary.
     // Output generation alone is insufficient: quiet packing changes storage.
     history_metrics_cache: Cell<Option<HistoryMetrics>>,
+    history_maintenance_cursors: [usize; 2],
+    history_maintenance_pending: bool,
+    history_maintenance_full_scan: bool,
     damage_line_indices: Vec<u16>,
     damage_rows: Vec<DamageRow>,
 }
@@ -168,7 +171,8 @@ impl AlacrittyEngine {
             kitty_keyboard: true,
             ..Config::default()
         };
-        let term = Term::new(config, &dims, proxy);
+        let mut term = Term::new(config, &dims, proxy);
+        term.set_deferred_history_maintenance(true);
         AlacrittyEngine {
             term,
             parser: Processor::new(),
@@ -178,12 +182,18 @@ impl AlacrittyEngine {
             history_budget_bytes,
             output_generation: 0,
             history_metrics_cache: Cell::new(None),
+            history_maintenance_cursors: [0; 2],
+            history_maintenance_pending: false,
+            history_maintenance_full_scan: false,
             damage_line_indices: Vec::new(),
             damage_rows: Vec::new(),
         }
     }
 
     fn apply_history_budget(&mut self) {
+        self.history_maintenance_full_scan = true;
+        self.history_maintenance_cursors = [0; 2];
+        self.history_maintenance_pending = true;
         self.history_metrics_cache.set(None);
         self.term.set_options(Config {
             scrolling_history: history_rows_for_budget(
@@ -364,6 +374,16 @@ fn history_rows_for_budget(bytes: usize, cols: u16) -> usize {
 
 impl VtEngine for AlacrittyEngine {
     fn advance(&mut self, bytes: &[u8]) {
+        // If output interrupts a partial pass, its packed frontier is no longer
+        // proof that all older rows are packed. Otherwise retain the O(1)
+        // already-packed frontier fast path for ordinary quiet output.
+        self.history_maintenance_full_scan |= self.history_maintenance_pending
+            && self
+                .history_maintenance_cursors
+                .iter()
+                .any(|cursor| *cursor > 0);
+        self.history_maintenance_cursors = [0; 2];
+        self.history_maintenance_pending = true;
         self.history_metrics_cache.set(None);
         self.parser.advance(&mut self.term, bytes);
         self.output_generation = self.output_generation.wrapping_add(1);
@@ -371,7 +391,26 @@ impl VtEngine for AlacrittyEngine {
 
     fn finish_output_batch(&mut self) {
         self.history_metrics_cache.set(None);
-        self.term.finish_output_batch();
+        while self.finish_output_batch_step() {}
+    }
+
+    fn finish_output_batch_step(&mut self) -> bool {
+        if !self.history_maintenance_pending {
+            return false;
+        }
+        self.history_metrics_cache.set(None);
+        self.history_maintenance_pending = self.term.finish_output_batch_step(
+            &mut self.history_maintenance_cursors,
+            self.history_maintenance_full_scan,
+        );
+        if !self.history_maintenance_pending {
+            self.history_maintenance_full_scan = false;
+        }
+        self.history_maintenance_pending
+    }
+
+    fn history_maintenance_pending(&self) -> bool {
+        self.history_maintenance_pending
     }
 
     fn output_generation(&self) -> u64 {
@@ -1345,12 +1384,76 @@ mod tests {
                 let mut engine = AlacrittyEngine::new(80, 24, tx, budget_for_rows(80, 10_000));
                 engine.advance(&corpus);
                 let start = Instant::now();
-                engine.finish_output_batch();
+                let mut steps = Vec::new();
+                loop {
+                    let step = Instant::now();
+                    let more = engine.finish_output_batch_step();
+                    steps.push(step.elapsed().as_secs_f64() * 1000.0);
+                    if !more {
+                        break;
+                    }
+                }
                 let elapsed = start.elapsed();
+                steps.sort_by(f64::total_cmp);
                 let metrics = black_box(engine.history_metrics());
-                eprintln!("history_maintenance styled={styled} trial={trial} rows={} packed_rows={} milliseconds={:.3}", metrics.retained_rows, metrics.packed_rows.unwrap_or(0), elapsed.as_secs_f64() * 1000.0);
+                eprintln!("history_maintenance styled={styled} trial={trial} rows={} packed_rows={} milliseconds={:.3} turns={} step_p95_ms={:.3} step_p99_ms={:.3} step_max_ms={:.3}", metrics.retained_rows, metrics.packed_rows.unwrap_or(0), elapsed.as_secs_f64() * 1000.0, steps.len(), steps[(steps.len()-1)*95/100], steps[(steps.len()-1)*99/100], steps.last().unwrap());
             }
         }
+    }
+
+    #[test]
+    fn incremental_history_maintenance_is_lossless_and_restarts_after_mutation() {
+        fn rows(engine: &AlacrittyEngine) -> Vec<String> {
+            let mut rows = Vec::new();
+            engine.for_each_retained_row(&mut |_, text| rows.push(text.to_owned()));
+            rows
+        }
+        let (tx, _rx) = channel();
+        let mut engine = AlacrittyEngine::new(80, 24, tx, budget_for_rows(80, 10_000));
+        for i in 0..1024 {
+            engine.advance(format!("row {i} cafe\u{301} 界\r\n").as_bytes());
+        }
+        let before = rows(&engine);
+        assert!(
+            engine.finish_output_batch_step(),
+            "large backlog takes multiple turns"
+        );
+        let packed = engine.history_metrics().packed_rows.unwrap();
+        assert!(packed > 0 && packed <= 512);
+        assert_eq!(before, rows(&engine));
+        engine.advance(b"new output\r\n");
+        engine.resize(90, 24);
+        let after_mutation = rows(&engine);
+        let mut turns = 0;
+        while engine.finish_output_batch_step() {
+            turns += 1;
+            assert!(turns < 200, "quiet backlog must finish without new output");
+        }
+        assert!(turns > 0);
+        assert!(!engine.history_maintenance_pending());
+        assert_eq!(after_mutation, rows(&engine));
+        let metrics = engine.history_metrics();
+        assert_eq!(
+            metrics.packed_rows.unwrap(),
+            metrics.retained_rows.saturating_sub(128)
+        );
+        assert!(
+            !engine.finish_output_batch_step(),
+            "no idle maintenance work"
+        );
+        engine.advance(b"\x1b]2;title only\x07");
+        assert!(
+            !engine.finish_output_batch_step(),
+            "packed frontier avoids a full quiet-history scan"
+        );
+        let blocks = engine.history_metrics().packed_blocks;
+        engine.advance(b"one more line\r\n");
+        assert!(!engine.finish_output_batch_step());
+        assert_eq!(
+            engine.history_metrics().packed_blocks,
+            blocks,
+            "trickle output retains the minimum batch size"
+        );
     }
 
     #[test]
@@ -1636,6 +1739,7 @@ mod tests {
         // the viewport intentionally consumes the oldest history rows in
         // Alacritty, which is a separate terminal semantic from reflow.
         e.resize(80, 5);
+        e.finish_output_batch(); // reflow packing is deferred to maintenance
         e.scroll_to_top();
         let after = e.history_metrics();
         assert!(after.compacted_rows.unwrap_or(0) > 0);

--- a/src/terminal/vt/mod.rs
+++ b/src/terminal/vt/mod.rs
@@ -323,6 +323,17 @@ pub trait VtEngine: Send {
     /// activity window; Windows uses the app's coalesced output boundary.
     fn finish_output_batch(&mut self);
 
+    /// Incremental maintenance. True requests another bounded turn; false
+    /// means no backlog. Engines without deferred work keep the full boundary.
+    fn finish_output_batch_step(&mut self) -> bool {
+        self.finish_output_batch();
+        false
+    }
+
+    fn history_maintenance_pending(&self) -> bool {
+        false
+    }
+
     /// Monotonic generation of successfully parsed terminal output.
     fn output_generation(&self) -> u64;
 

--- a/vendor/alacritty_terminal/src/grid/mod.rs
+++ b/vendor/alacritty_terminal/src/grid/mod.rs
@@ -530,6 +530,11 @@ where
         self.raw.pack_cold_history()
     }
 
+    /// Pack one bounded block; the caller resets the cursor after mutations.
+    pub fn pack_cold_history_step(&mut self, cursor: &mut usize, full_scan: bool) -> bool {
+        self.raw.pack_cold_history_step(cursor, full_scan)
+    }
+
     /// Repack every dense cold-history run after a structural mutation.
     #[inline]
     pub fn pack_all_cold_history(&mut self) -> usize {

--- a/vendor/alacritty_terminal/src/grid/storage.rs
+++ b/vendor/alacritty_terminal/src/grid/storage.rs
@@ -466,6 +466,49 @@ impl<T> Storage<T> {
         packed_rows
     }
 
+    /// Incremental consumer boundary. Visits at most 512 rows and encodes at
+    /// most one ordinary block. Reset `cursor` after any grid mutation.
+    pub(crate) fn pack_cold_history_step(&mut self, cursor: &mut usize, full_scan: bool) -> bool
+    where
+        T: Clone + Eq + Hash,
+    {
+        let first_turn = *cursor == 0;
+        let history_rows = self.len.saturating_sub(self.visible_lines);
+        if history_rows < HOT_HISTORY_ROWS + MIN_PACKED_BLOCK_ROWS {
+            *cursor = history_rows;
+            return false;
+        }
+        let mut age = (*cursor).max(HOT_HISTORY_ROWS);
+        let end = history_rows.min(age.saturating_add(PACKED_BLOCK_MAX_ROWS));
+        let mut rows = Vec::new();
+        let mut bytes = 0usize;
+        while age < end {
+            let index = self.compute_index(Line(-((age + 1) as i32)));
+            if self.inner[index].is_packed() {
+                if !full_scan {
+                    age = history_rows;
+                    break;
+                }
+                if !rows.is_empty() { break; }
+                age += 1;
+                continue;
+            }
+            let row_bytes = self.inner[index].physical_len().saturating_mul(mem::size_of::<T>());
+            if !rows.is_empty() && bytes.saturating_add(row_bytes) > PACKED_BLOCK_TARGET_BYTES {
+                break;
+            }
+            bytes = bytes.saturating_add(row_bytes);
+            rows.push(index);
+            age += 1;
+        }
+        // Keep ordinary trickle output from allocating one packed block per line.
+        let small_frontier = first_turn && !full_scan && age == history_rows
+            && rows.len() < MIN_PACKED_BLOCK_ROWS;
+        if !rows.is_empty() && !small_frontier { self.pack_rows(&rows); }
+        *cursor = age;
+        age < history_rows
+    }
+
     /// Repack every dense cold run after operations such as width reflow.
     pub(crate) fn pack_all_cold_history(&mut self) -> usize
     where

--- a/vendor/alacritty_terminal/src/term/mod.rs
+++ b/vendor/alacritty_terminal/src/term/mod.rs
@@ -330,6 +330,7 @@ pub struct Term<T> {
     /// Alternate-screen rebalancing updates logical history for every row but
     /// defers physical cache trimming until the frame leaves the parser path.
     history_cache_dirty: bool,
+    deferred_history_maintenance: bool,
 
     /// Config directly for the terminal.
     config: Config,
@@ -452,6 +453,7 @@ impl<T> Term<T> {
             event_proxy,
             damage,
             history_cache_dirty: false,
+            deferred_history_maintenance: false,
             config,
             grid,
             tabs,
@@ -522,6 +524,20 @@ impl<T> Term<T> {
         self.trim_history_cache_if_dirty();
         self.grid.pack_cold_history();
         self.inactive_grid.pack_cold_history();
+    }
+
+    /// Opt into consumer-scheduled maintenance after reflow instead of packing
+    /// all cold rows while the resize caller holds the terminal lock.
+    pub fn set_deferred_history_maintenance(&mut self, enabled: bool) {
+        self.deferred_history_maintenance = enabled;
+    }
+
+    /// One bounded block per grid. Cursors must reset after input or resize.
+    pub fn finish_output_batch_step(&mut self, cursors: &mut [usize; 2], full_scan: bool) -> bool {
+        self.trim_history_cache_if_dirty();
+        let active = self.grid.pack_cold_history_step(&mut cursors[0], full_scan);
+        let inactive = self.inactive_grid.pack_cold_history_step(&mut cursors[1], full_scan);
+        active || inactive
     }
 
     fn trim_history_cache_if_dirty(&mut self) {
@@ -771,8 +787,10 @@ impl<T> Term<T> {
         if is_alt {
             self.rebalance_alt_history();
         }
-        self.grid.pack_all_cold_history();
-        self.inactive_grid.pack_all_cold_history();
+        if !self.deferred_history_maintenance {
+            self.grid.pack_all_cold_history();
+            self.inactive_grid.pack_all_cold_history();
+        }
 
         // Invalidate selection and tabs only when necessary.
         if old_cols != num_cols {

--- a/website/src/content/docs/docs/guides/scrollback.mdx
+++ b/website/src/content/docs/docs/guides/scrollback.mdx
@@ -5,6 +5,18 @@ description: Scroll any pane's history with the wheel, trackpad, or keyboard scr
 
 ## Scrolling
 
+Cold-history packing runs in incremental maintenance turns, rather than encoding
+the entire backlog under one terminal lock. Each turn visits at most 512 rows and
+packs at most one block per grid, with a 128 KiB shallow-cell target (a single
+oversized row may exceed that target). This is a work bound, not a guaranteed
+wall-clock deadline. Visible and recently used history remain directly readable.
+
+On Unix, the existing PTY actor services input and output between continuations.
+Windows uses bounded app-loop maintenance with a short deadline only while work
+remains; maintenance alone does not request a redraw. Reflow queues repacking,
+and new output invalidates an interrupted scan safely. Once the backlog is
+complete, no maintenance timer remains. Retention and copy semantics are unchanged.
+
 **Mouse/trackpad:** just scroll over a pane. Apps that enable terminal mouse
 reporting receive their wheel input; full-screen apps that request alternate
 scrolling do too. Regular transcripts scroll Luvus's retained history.


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 13 of 15** · Base: #295 · Next: #298 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

## Summary
Adds incremental cold-history maintenance: at most 512 visited rows and one target-sized block per grid per turn. Unix services descriptor input/output between continuations. Windows uses the existing app-loop maintenance boundary with a short deadline only while backlog remains; maintenance does not itself force rendering. Reflow defers repacking and quiet resize wakes the Unix actor. Ordinary trickle output retains the minimum frontier batch and the already-packed fast path.

## Measurements
Optimized 80x24, 10,000-row macOS fixture: styled full-pass baseline median 23.437 ms. Incremental candidate total median 23.439 ms; per-turn p99 0.224–0.241 ms across three trials, maximum 0.397 ms. Plain total median 8.152 ms versus baseline 8.051 ms. All 10,000 rows retained, 9,872 packed. These isolate maintenance, not end-to-end p99 or a cross-platform speed guarantee. The work target allows a single oversized row and is not a hard wall-clock deadline.

## Verification
Terminal regressions, incremental Unicode fidelity, interrupted scan/reflow, trickle/frontier, and a real isolated PTY quiet-output/resize test passed on macOS. The complete stack locked suite passed 1,529 unit tests and 15 integration tests before the final extra PTY regression, which also passed independently. Formatting and strict Clippy passed. Contributor benchmark and public behavior documentation updated. Windows runtime behavior still requires CI and real-host validation.

## Stack
Based on #295. No merge requested.