### PR TITLE
fix(uhp): permit validated agent keys through control access

### DIFF
--- a/examples/uhp/access_keys_conformance.py
+++ b/examples/uhp/access_keys_conformance.py
@@ -14,6 +14,7 @@ import time
 
 
 def stop(process):
+    """Terminate and reap only a process launched by this fixture."""
     if process is not None and process.poll() is None:
         process.terminate()
         try:
@@ -24,6 +25,7 @@ def stop(process):
 
 
 def wait_for(predicate):
+    """Wait at most ten seconds for observable fixture readiness."""
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline:
         if predicate():
@@ -33,6 +35,7 @@ def wait_for(predicate):
 
 
 def main():
+    """Pair both Access modes and compare responses with raw child input."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--binary", required=True)
     parser.add_argument("--home", required=True)
@@ -50,6 +53,7 @@ def main():
     command = [binary, "--session", args.session]
 
     def owner(method, params):
+        """Issue one owner RPC to the explicitly isolated home and session."""
         response = subprocess.run(
             command + ["uhp", "proxy"], env=env,
             input=json.dumps({"id": "owner", "method": method, "params": params}) + "\n",
@@ -60,6 +64,7 @@ def main():
         return value["result"]
 
     def exchange(endpoint, request):
+        """Exchange one bounded NDJSON frame on the private loopback endpoint."""
         with socket.create_connection((endpoint["host"], endpoint["port"]), timeout=5) as stream:
             stream.sendall(json.dumps(request).encode() + b"\n")
             with stream.makefile("rb") as reader:
@@ -72,6 +77,7 @@ def main():
         # The explicit home/session is used by every owner request, including
         # the readiness probe; no inherited socket can select production.
         def server_ready():
+            """Retry startup connection failures without masking server exit."""
             if server.poll() is not None:
                 raise RuntimeError("isolated server exited during startup")
             try:

--- a/examples/uhp/access_keys_conformance.py
+++ b/examples/uhp/access_keys_conformance.py
@@ -114,7 +114,8 @@ def main():
             response = exchange(endpoint, request)
             allowed = control and args.expect == "allowed"
             if allowed:
-                assert response["result"] == {"type": "ok", "pane": pane}, response
+                assert response["result"]["type"] == "ok", response
+                assert response["result"]["pane"] == pane, response
                 expected = before + b"\x03\x1a\x1b[Zy" + "🙂".encode()
                 wait_for(lambda: log.read_bytes() == expected)
                 invalid = exchange(endpoint, {"id": "invalid", "method": "agent.keys", "params": {

--- a/examples/uhp/access_keys_conformance.py
+++ b/examples/uhp/access_keys_conformance.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Exercise agent.keys through Access against an isolated, named test server."""
+
+import argparse
+import json
+import os
+import pathlib
+import selectors
+import shlex
+import socket
+import subprocess
+import sys
+import time
+
+
+def stop(process):
+    if process is not None and process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def wait_for(predicate):
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.025)
+    raise AssertionError("isolated fixture did not become ready")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--home", required=True)
+    parser.add_argument("--session", default="luvus-pr-test")
+    parser.add_argument("--expect", choices=["forbidden", "allowed"], required=True)
+    args = parser.parse_args()
+    binary = str(pathlib.Path(args.binary).resolve(strict=True))
+    home = pathlib.Path(args.home).resolve(strict=True)
+    if any(home.iterdir()):
+        raise ValueError("--home must be a fresh empty test directory")
+    env = os.environ.copy()
+    for key in ("LUVUS_SOCKET_PATH", "LUVUS_SESSION", "LUVUS_ENV", "LUVUS_PANE_ID"):
+        env.pop(key, None)
+    env["LUVUS_HOME"] = str(home)
+    command = [binary, "--session", args.session]
+
+    def owner(method, params):
+        response = subprocess.run(
+            command + ["uhp", "proxy"], env=env,
+            input=json.dumps({"id": "owner", "method": method, "params": params}) + "\n",
+            text=True, capture_output=True, timeout=10, check=True,
+        )
+        value = json.loads(response.stdout)
+        assert "error" not in value, value
+        return value["result"]
+
+    def exchange(endpoint, request):
+        with socket.create_connection((endpoint["host"], endpoint["port"]), timeout=5) as stream:
+            stream.sendall(json.dumps(request).encode() + b"\n")
+            with stream.makefile("rb") as reader:
+                return json.loads(reader.readline(1024 * 1024 + 1))
+
+    server = gateway = None
+    try:
+        server = subprocess.Popen(command + ["server"], env=env, stdin=subprocess.DEVNULL,
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        # The explicit home/session is used by every owner request, including
+        # the readiness probe; no inherited socket can select production.
+        def server_ready():
+            if server.poll() is not None:
+                raise RuntimeError("isolated server exited during startup")
+            try:
+                return bool(owner("uhp.capabilities", {}))
+            except subprocess.CalledProcessError:
+                return False
+        wait_for(server_ready)
+        pane = owner("pane.split", {})["pane"]
+        log, ready = home / "input.bin", home / "ready"
+        child = [sys.executable, str(pathlib.Path(__file__).resolve()), "--child", str(log), str(ready)]
+        owner("pane.run", {"pane": pane, "command": "exec " + shlex.join(child)})
+        wait_for(ready.exists)
+        owner("pane.report_session", {"pane": pane, "agent": "codex", "session_id": "access-keys-fixture"})
+        print(json.dumps({"binary": binary, "home": str(home), "session": args.session, "pane": pane}))
+        for control in (False, True):
+            gateway = subprocess.Popen(command + ["uhp", "access"] + (["--control"] if control else []),
+                                       env=env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                                       stderr=subprocess.DEVNULL, text=True)
+            with selectors.DefaultSelector() as selector:
+                selector.register(gateway.stdout, selectors.EVENT_READ)
+                assert selector.select(10), "Access descriptor timeout"
+                descriptor = json.loads(gateway.stdout.readline())
+            endpoint = descriptor["endpoint"]
+            pair = {"type": "pair", "code": descriptor["pairing"]["code"]}
+            paired = exchange(endpoint, pair)
+            token = paired["token"]
+            replay = exchange(endpoint, pair)
+            assert replay["error"]["code"] == "forbidden"
+            before = log.read_bytes()
+            for method, params, auth in [
+                ("agent.keys", {"target": pane, "keys": ["enter"]}, "wrong"),
+                ("agent.send", {"target": pane, "text": "never"}, token),
+                ("pane.close", {"pane": pane}, token),
+                ("agent.keys.", {"target": pane, "keys": ["enter"]}, token),
+            ]:
+                denied = exchange(endpoint, {"id": "denied", "method": method, "params": params, "auth": auth})
+                assert denied["error"]["code"] == "forbidden", denied
+            request = {"id": "keys", "method": "agent.keys", "params": {
+                "target": pane, "keys": ["ctrl+c", "ctrl+z", "esc", "[", "Z", "y", "🙂"]}, "auth": token}
+            response = exchange(endpoint, request)
+            allowed = control and args.expect == "allowed"
+            if allowed:
+                assert response["result"] == {"type": "ok", "pane": pane}, response
+                expected = before + b"\x03\x1a\x1b[Zy" + "🙂".encode()
+                wait_for(lambda: log.read_bytes() == expected)
+                invalid = exchange(endpoint, {"id": "invalid", "method": "agent.keys", "params": {
+                    "target": pane, "keys": ["enter", "not-a-key"]}, "auth": token})
+                assert invalid["error"]["code"] == "invalid_request", invalid
+            else:
+                assert response["error"]["code"] == "forbidden", response
+                expected = before
+            # A quiet raw child makes partial admission observable as bytes.
+            time.sleep(0.1)
+            assert log.read_bytes() == expected
+            print(json.dumps({"mode": "control" if control else "read_only", "response": response,
+                              "input_hex": log.read_bytes().hex(), "rejections_admitted_bytes": 0}))
+            stop(gateway)
+            gateway = None
+    finally:
+        stop(gateway)
+        stop(server)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 4 and sys.argv[1] == "--child":
+        import tty
+        tty.setraw(sys.stdin.fileno())
+        with open(sys.argv[2], "wb", buffering=0) as output:
+            pathlib.Path(sys.argv[3]).touch()
+            while data := os.read(sys.stdin.fileno(), 4096):
+                output.write(data)
+    else:
+        main()

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -39,6 +39,13 @@ The client pairs once, then uses the returned token on ordinary UHP frames.
 Keep the loopback endpoint private and require an encrypted, authenticated
 transport.
 
+Control Access permits `agent.keys` for recognized agent panes; read-only
+Access denies it. The RPC retains local key grammar, including `ctrl+z`,
+printable Unicode, and `["esc","[","Z"]` for Shift+Tab, which is wider than
+control-stream `send_key`. Invalid batches queue no prefix. Success identifies
+the resolved `pane` and means queued, not consumed. Inspect before answering;
+do not infer permission for `agent.send`, raw pane input, launch, fork, or close.
+
 ## Bootstrap and maintain state
 
 Use this order for a stateful harness:

--- a/protocol/uhp/v1/access/README.md
+++ b/protocol/uhp/v1/access/README.md
@@ -51,3 +51,15 @@ the Luvus server and panes remain alive.
 
 UHP Access is not a new UHP version. Clients must discover live capabilities
 after pairing and validate frames against the installed UHP schema bundle.
+
+Control Access permits the exact `agent.keys` RPC for a recognized agent pane;
+read-only Access refuses it. It retains the owner key grammar: named keys,
+`ctrl+`/`c-` plus any ASCII letter (including `ctrl+z`), and single printable
+Unicode codepoints. A batch can compose escape sequences such as
+`["esc","[","Z"]`. This is intentionally wider than control-stream `send_key`.
+The ordinary 1 MiB frame limit still applies. Validation rejects an entire bad
+batch before queueing any prefix; success returns `{"type":"ok","pane":"7"}`
+and means queue admission, not child consumption. `agent.send`, pane raw input,
+agent launch/fork, close, token management, and standalone terminal input
+actions remain forbidden through Access. No request, response, or event shape
+changes are introduced by this permission.

--- a/protocol/uhp/v1/fixtures/manifest.json
+++ b/protocol/uhp/v1/fixtures/manifest.json
@@ -1,8 +1,8 @@
 {
   "protocol": { "name": "luvus-uhp", "major": 1, "minor": 0 },
   "files": [
-    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 44 },
-    { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 7 },
+    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 45 },
+    { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 8 },
     { "path": "valid/events.jsonl", "kind": "event", "expect": "valid", "count": 3 },
     { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 34 },
     { "path": "invalid/responses.jsonl", "kind": "response", "expect": "invalid", "count": 4 }

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -42,3 +42,4 @@
 {"id":"41","method":"task.start","params":{"id":"t4","branch":"luvus/t4","mode":"worktree","workspace_id":"workspace_example","agent":"codex"}}
 {"id":"42","method":"task.heartbeat","params":{"id":"t1","context":0.6}}
 {"id":"43","method":"agent.keys","params":{"target":"reviewer","keys":["up","enter","CTRL+C","x","\u00e9"]}}
+{"id":"access-keys","method":"agent.keys","params":{"target":"7","keys":["ctrl+z","esc","[","Z","🙂"]},"auth":"example-client-token"}

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -42,4 +42,4 @@
 {"id":"41","method":"task.start","params":{"id":"t4","branch":"luvus/t4","mode":"worktree","workspace_id":"workspace_example","agent":"codex"}}
 {"id":"42","method":"task.heartbeat","params":{"id":"t1","context":0.6}}
 {"id":"43","method":"agent.keys","params":{"target":"reviewer","keys":["up","enter","CTRL+C","x","\u00e9"]}}
-{"id":"access-keys","method":"agent.keys","params":{"target":"7","keys":["ctrl+z","esc","[","Z","🙂"]},"auth":"example-client-token"}
+{"id":"access-keys","method":"agent.keys","params":{"target":"7","keys":["ctrl+z","esc","[","Z","\ud83d\ude42"]},"auth":"example-client-token"}

--- a/protocol/uhp/v1/fixtures/valid/responses.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/responses.jsonl
@@ -5,3 +5,4 @@
 {"id":"5","result":{"type":"mission_snapshot","scope":"all","workspace":"0","refreshing":false,"summary":{"agents":0,"tokens":0,"cost_usd":0.0,"burn_usd_per_hour":null},"rows":[]}}
 {"id":"6","result":{"type":"agent_wait","matched":true,"pane":"7","status":"done"}}
 {"id":"7","result":{"type":"agent_wait","matched":false,"pane":null,"status":null}}
+{"id":"access-keys","result":{"type":"ok","pane":"7"}}

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -39,6 +39,13 @@ The client pairs once, then uses the returned token on ordinary UHP frames.
 Keep the loopback endpoint private and require an encrypted, authenticated
 transport.
 
+Control Access permits `agent.keys` for recognized agent panes; read-only
+Access denies it. The RPC retains local key grammar, including `ctrl+z`,
+printable Unicode, and `["esc","[","Z"]` for Shift+Tab, which is wider than
+control-stream `send_key`. Invalid batches queue no prefix. Success identifies
+the resolved `pane` and means queued, not consumed. Inspect before answering;
+do not infer permission for `agent.send`, raw pane input, launch, fork, or close.
+
 ## Bootstrap and maintain state
 
 Use this order for a stateful harness:

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -411,6 +411,7 @@ fn allowed_method(mode: AccessMode, method: &str) -> bool {
                     | "tab.focus"
                     | "pane.focus"
                     | "agent.prompt"
+                    | "agent.keys"
                     | "automation.create"
                     | "automation.update"
                     | "automation.enable"

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -925,6 +925,8 @@ mod tests {
         assert!(allowed_method(AccessMode::Control, "tab.focus"));
         assert!(allowed_method(AccessMode::Control, "pane.focus"));
         assert!(allowed_method(AccessMode::Control, "agent.prompt"));
+        assert!(allowed_method(AccessMode::Control, "agent.keys"));
+        assert!(!allowed_method(AccessMode::ReadOnly, "agent.keys"));
         assert!(!allowed_method(AccessMode::ReadOnly, "automation.create"));
         assert!(!allowed_method(AccessMode::ReadOnly, "automation.rebind"));
         assert!(allowed_method(AccessMode::ReadOnly, "automation.health"));
@@ -1220,6 +1222,172 @@ mod tests {
         drop(stream);
         local_server.join().unwrap();
         gateway.stop();
+    }
+
+    #[test]
+    fn control_access_forwards_validated_agent_keys() {
+        // Fail before starting an upstream accept if the RPC is still denied.
+        assert!(allowed_method(AccessMode::Control, "agent.keys"));
+        let _env = crate::persist::test_env("access-agent-keys");
+        let path = crate::persist::ensure_config_dir().join("keys.sock");
+        let listener = crate::ipc::transport::bind(&path).unwrap();
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).unwrap().agent = "claude".into();
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
+        let token = "luv_tok_keys_test";
+        let mut gateway = Gateway::start(
+            path,
+            token.into(),
+            None,
+            "upstream-keys-test".into(),
+            Pairing::new(Duration::from_secs(60)).unwrap(),
+            AccessMode::Control,
+        )
+        .unwrap();
+        let relay = |app: &mut crate::app::App, params: Value| {
+            let request = json!({"id":"keys","method":"agent.keys","params":params,"auth":token});
+            thread::scope(|scope| {
+                let address = gateway.address();
+                let client = scope.spawn(move || exchange(address, &request));
+                let mut local = BufReader::new(listener.accept().unwrap());
+                let forwarded: Value = serde_json::from_str(
+                    &crate::ipc::api::read_response_frame(&mut local).unwrap(),
+                )
+                .unwrap();
+                assert_eq!(forwarded["auth"], "upstream-keys-test");
+                let response = match app.dispatch("agent.keys", &forwarded["params"]) {
+                    Ok(result) => json!({"id":"keys","result":result}),
+                    Err((code, message)) => {
+                        json!({"id":"keys","error":{"code":code,"message":message}})
+                    }
+                };
+                writeln!(local.get_mut(), "{response}").unwrap();
+                local.get_mut().flush().unwrap();
+                client.join().unwrap()
+            })
+        };
+        for (keys, bytes) in [
+            (json!(["ctrl+c"]), b"\x03".as_slice()),
+            (json!(["esc"]), b"\x1b".as_slice()),
+            (json!(["y", "🙂"]), "y🙂".as_bytes()),
+            (
+                json!(["up", "down", "left", "right"]),
+                b"\x1b[A\x1b[B\x1b[D\x1b[C".as_slice(),
+            ),
+            (json!(["esc", "[", "Z"]), b"\x1b[Z".as_slice()),
+            // Unlike the control stream's send_key, this RPC retains the
+            // owner key grammar, including all ctrl+letter chords.
+            (
+                json!(["ctrl+z", "CTRL+X", "c-a"]),
+                b"\x1a\x18\x01".as_slice(),
+            ),
+        ] {
+            let response = relay(&mut app, json!({"target":pane.0.to_string(),"keys":keys}));
+            assert_eq!(
+                response["result"],
+                json!({"type":"ok","pane":pane.0.to_string()})
+            );
+            let crate::terminal::pty::InputAction::Bytes(actual) = input_rx.recv().unwrap() else {
+                panic!("keys must be one byte batch");
+            };
+            assert_eq!(actual, bytes);
+            assert!(input_rx.try_recv().is_err());
+        }
+        for params in [
+            json!({"target":pane.0.to_string(),"keys":[]}),
+            json!({"target":pane.0.to_string(),"keys":"enter"}),
+            json!({"target":pane.0.to_string(),"keys":["enter",7]}),
+            json!({"target":pane.0.to_string(),"keys":["enter","invalid"]}),
+            json!({"target":pane.0.to_string(),"keys":["enter"],"extra":true}),
+            json!({"target":"missing-agent","keys":["enter"]}),
+        ] {
+            assert!(relay(&mut app, params).get("error").is_some());
+            assert!(
+                input_rx.try_recv().is_err(),
+                "rejection must not queue a prefix"
+            );
+        }
+        app.status.get_mut(&pane).unwrap().agent.clear();
+        let params = json!({"target":pane.0.to_string(),"keys":["enter"]});
+        assert_eq!(
+            relay(&mut app, params.clone())["error"]["code"],
+            "agent_not_ready"
+        );
+        assert!(input_rx.try_recv().is_err());
+        app.status.get_mut(&pane).unwrap().agent = "claude".into();
+        drop(input_rx);
+        assert_eq!(relay(&mut app, params)["error"]["code"], "send_failed");
+        gateway.stop();
+    }
+
+    #[test]
+    fn access_keys_rejections_never_admit_input() {
+        let _env = crate::persist::test_env("access-keys-denied");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
+        for (mode, expiry, auth, methods) in [
+            (AccessMode::ReadOnly, None, "client", vec!["agent.keys"]),
+            (AccessMode::Control, None, "wrong", vec!["agent.keys"]),
+            (AccessMode::Control, Some(1), "client", vec!["agent.keys"]),
+            (
+                AccessMode::Control,
+                None,
+                "client",
+                vec![
+                    "agent.key",
+                    "Agent.keys",
+                    "agent.keys.",
+                    "agent.keys ",
+                    "agent.send",
+                    "agent.start",
+                    "agent.fork",
+                    "pane.send_input",
+                    "pane.run",
+                    "pane.close",
+                    "terminal.backend.type_literal",
+                    "terminal.backend.submit_text",
+                    "terminal.backend.send_key",
+                    "uhp.token.list",
+                    "uhp.token.create",
+                    "uhp.token.revoke",
+                ],
+            ),
+        ] {
+            // No listener exists: forbidden, rather than unavailable, proves
+            // the gateway rejects before connecting to an upstream writer.
+            let mut gateway = Gateway::start(
+                crate::persist::ensure_config_dir().join("no-upstream.sock"),
+                "client".into(),
+                expiry,
+                "upstream".into(),
+                Pairing::new(Duration::from_secs(60)).unwrap(),
+                mode,
+            )
+            .unwrap();
+            for method in methods {
+                let response = exchange(
+                    gateway.address(),
+                    &json!({
+                        "id":"denied","method":method,"params":{"target":pane.0.to_string(),"keys":["enter"]},"auth":auth
+                    }),
+                );
+                assert_eq!(response["error"]["code"], "forbidden", "{method}");
+                assert!(input_rx.try_recv().is_err());
+            }
+            gateway.stop();
+        }
     }
 
     fn exchange(address: SocketAddr, request: &Value) -> Value {

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -387,6 +387,12 @@ read-only and control access both default to 24 hours. `--no-expiry` binds the
 client token to the foreground access process and keeps it valid until that
 process closes.
 
+Control Access permits `agent.keys` for recognized agent panes with the local
+key grammar, including `ctrl+z`, printable Unicode and `["esc","[","Z"]`.
+Read-only Access denies it. A rejected batch queues no prefix; success returns
+the resolved `pane` and means queued, not consumed. This does not authorize
+`agent.send`, raw pane input, launch, fork, or close through the gateway.
+
 ## Remote use
 
 ```sh

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -44,6 +44,12 @@ accepted the submission, not that the agent completed it. A closed queue fails
 without recording a successful handoff. Submission uses the existing PTY writer
 and does not create a delayed-send thread.
 
+Paired control Access also permits this exact RPC; read-only Access refuses
+it. The key grammar stays identical to local `agent keys`, including `ctrl+z`
+and printable Unicode. `["esc","[","Z"]` sends Shift+Tab as one ordered batch.
+Inspect the prompt before answering; Enter remains a separate intentional
+action. Access does not permit the compatibility `agent.send` method.
+
 For line-specific feedback, the native [DIFF review](/docs/guides/diff/) uses
 the same target validation. It groups selected local notes into one bounded
 message, quotes source context as untrusted review data, and records delivery

--- a/website/src/content/docs/docs/uhp/conformance.mdx
+++ b/website/src/content/docs/docs/uhp/conformance.mdx
@@ -111,6 +111,19 @@ cargo build --locked
 Never point live mutation or failure tests at `~/.luvus/`, an installed server,
 or a production named session.
 
+On Unix, validate control Access key admission with a raw fixture child:
+
+```sh
+test_home=$(mktemp -d "$PWD/target/access-keys.XXXXXX")
+python3 examples/uhp/access_keys_conformance.py --binary target/debug/luvus \
+  --home "$test_home" --session luvus-pr-test --expect allowed
+```
+
+The runner requires an empty home, removes inherited socket/session selectors,
+pairs read-only and control gateways, checks admitted bytes and rejected
+batches, and stops its own processes. Use `--expect forbidden` against a build
+before control Access permitted `agent.keys`.
+
 ## Benchmark the protocol path
 
 Use an optimized build and equivalent workloads:

--- a/website/src/content/docs/docs/uhp/remote-access.mdx
+++ b/website/src/content/docs/docs/uhp/remote-access.mdx
@@ -65,12 +65,19 @@ its upstream server tokens bounded and rotates them internally, so
 `--no-expiry` does not create a permanent token in the server.
 
 Control mode does not expose every local mutation. The gateway allows the
-advertised read surface plus selected focus, prompt, terminal-control, and
+advertised read surface plus selected focus, prompt, agent-key, terminal-control, and
 automation methods. An automation created remotely is durable and can run
 after the pairing token or access command expires; disable or delete it
 explicitly when that is not intended. Discover the exact live method set after
 pairing rather than treating a scope name as permission to call every method in
 that namespace.
+
+`agent.keys` is allowed only in control mode and only for a recognized agent
+pane. It uses the same key vocabulary as local `luvus agent keys`, including
+`ctrl+z`, printable Unicode, and composed sequences such as `["esc","[","Z"]`.
+This vocabulary is wider than a terminal control stream's `send_key` action.
+A bad batch queues no prefix; success means queued, not consumed. `agent.send`,
+raw pane input, agent launch/fork, and pane close remain forbidden.
 
 ## Connection sequence
 


### PR DESCRIPTION
Control-paired UHP clients can now send validated `agent.keys` to a recognized agent pane. Previously the gateway advertised the server catalog but returned `forbidden` for this RPC.

Base: `4494d819e60e9d4c4537fe3673de337c2eaa5cd8`
Head: `a8356bf3147694878409267aee4bf10523702251`

## What

Add exactly `agent.keys` to the control Access allowlist. Retain owner key grammar (oracle option A): named keys, ASCII ctrl+letter/c-letter chords including ctrl+z, single printable Unicode, and composed escape sequences such as `["esc","[","Z"]`. This RPC is intentionally wider than control-stream `send_key`. Success identifies the resolved pane and means admission, not child consumption. Read-only Access and unrelated writes remain denied.

Regression list: all existing focus/prompt/automation/control methods, enter/return/cr, esc/escape, tab, space, backspace/bs, delete/del, arrows, home/end, pageup/pgup/pagedown/pgdn, case-insensitive named keys, ctrl+c/CTRL+Z/C-d, ASCII and Unicode printables. No existing accepted input is narrowed. Frame cap remains 1 MiB.

## Tests

First commit `3045cf2680de6fdb2a6a14649e878df0644987bc` adds tests and a live harness. Red: `cargo test --locked access_ -- --nocapture` → **5 passed, 2 failed**. Both `access_allowlist_separates_observation_from_control` and `control_access_forwards_validated_agent_keys` failed with:
```text
assertion failed: allowed_method(AccessMode::Control, "agent.keys")
```
Green: `cargo test --locked uhp::gateway::tests -- --nocapture` → **10 passed, 0 failed**. Empty queues are asserted for invalid/mixed/extra-field batches, unknown target, non-agent pane and gateway rejection; closed writers return send_failed. The gateway matrix covers read-only, wrong/expired token, exact-name near misses, raw input, launch/fork/close and token methods. Pair replay and raw child rejection are checked live.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --locked`: passed.
`env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION LUVUS_HOME="$PWD/target/mobile-pr-e782/test-home-k1" cargo test --locked`: **1508 passed, 0 failed, 1 ignored**.
`python3 examples/uhp/consumer.py`: **94 fixtures**; terminal consumer: **55 fixtures**. Both bundled references identical.

Isolated before/after (Unix; production was never contacted):
```sh
# Base binary built using cargo build --locked before the implementation;
# saved locally as target/mobile-pr-e782/base-4494d819.
analysis_home=$(mktemp -d "$PWD/target/k1-base.XXXXXX")
python3 examples/uhp/access_keys_conformance.py --binary target/mobile-pr-e782/base-4494d819 --home "$analysis_home" --session luvus-pr-test --expect forbidden
analysis_home=$(mktemp -d "$PWD/target/k1-after.XXXXXX")
python3 examples/uhp/access_keys_conformance.py --binary target/debug/luvus --home "$analysis_home" --session luvus-pr-test --expect allowed
```
The harness launches the exact binary with `--session luvus-pr-test server` and `uhp access [--control]`, sets the fresh LUVUS_HOME, removes inherited socket/session selectors, and terminates its own gateway and server in finally. Owner setup binds a fixture identity only in that namespace. Literal sanitized results:
```json
{"before":"read_only and control","response":{"error":{"code":"forbidden","message":"private gateway authorization failed"},"id":"keys"},"input_hex":"","rejections_admitted_bytes":0}
{"after":"read_only","response":{"error":{"code":"forbidden","message":"private gateway authorization failed"},"id":"keys"},"input_hex":"","rejections_admitted_bytes":0}
{"after":"control","response":{"id":"keys","result":{"pane":"2","revision":7,"type":"ok"}},"input_hex":"031a1b5b5a79f09f9982","rejections_admitted_bytes":0}
```
The live harness initially assumed an exact result object; a test-only follow-up accepts the existing additive `revision` field and the rerun passed. No Rust behavior changed after the full suite. Windows/macOS live behavior is untested here.

CI follow-up: Windows fixture validation exposed default-codepage decoding of the new literal emoji. Commit `a8356bf` uses the equivalent JSON surrogate escape; the 94-fixture consumer and explicit cp1252 decode check pass. This fixture-only fix and harness docstrings do not change Rust behavior. Linux/macOS tests passed in CI; final-head CI is pending.

## First-pass checklist

- R1: One exact allowlist entry; existing grammar and denied near matches explicitly tested; compatibility list above.
- R2: No new production error branches; gateway denials occur before IPC, dispatch rejects before one queue admission, live child and unit queues prove no prefix.
- R3: CodeRabbit docstring warning fixed in a8356bf; late wait_for/owner timeout thread answered with a code-tied harness-only limitation (separate 10s scheduling/RPC bounds and finally cleanup) and resolved. No production defect or additional code push; no Greptile findings.
- R4: Fresh-home named-session before/after commands and actual JSON/bytes above; all test processes stopped.
- R5: No wire shape or event change, so schema/event catalog/CLI syntax are no-ops; request/response fixtures, manifest, Access docs, website and both skill references updated together.
- R6: Existing resolved pane plus standard revision returned; no broadened target selector.
- R7: Only Access key authorization; capability projection is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control Access now supports sending validated key sequences to recognized agent panes through `agent.keys`.
  * Supports control keys, printable Unicode, and escape sequences.
  * Invalid requests and unauthorized access are rejected without queuing input.

* **Documentation**
  * Added guidance covering permissions, supported key formats, batching, and queued-success behavior.
  * Clarified terminal frame replacement and reconnection behavior after EOF or resynchronization.
  * Added conformance testing instructions and examples for validating Control Access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->