### PR TITLE
perf(config): persist settings through the shared worker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,18 @@ turn count, and per-turn p95/p99/maximum lock-held work, not end-to-end
 input/scroll latency. Run separate live
 latency checks before changing maintenance scheduling, especially on Windows.
 
+To check CLI/UHP responsiveness while configuration storage is locked (Unix):
+
+```bash
+cargo build --locked
+python3 examples/uhp/terminal/io_responsiveness.py --luvus target/debug/luvus
+```
+
+This starts its own isolated development server, reports baseline and contended
+request timings, deliberately exercises the lock timeout, and verifies that retry
+persists the setting. It never attaches to an existing session. Timings are host
+measurements, not hard CI thresholds or proof of Windows/TUI rendering latency.
+
 ## Adding agent support
 
 Use a detection manifest when an agent only needs identity and live-state

--- a/examples/uhp/terminal/io_responsiveness.py
+++ b/examples/uhp/terminal/io_responsiveness.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Opt-in Unix settings-lock responsiveness check in an isolated server."""
+
+import argparse
+import json
+import pathlib
+import statistics
+import subprocess
+import time
+
+from consumer import request
+from live_support import ROOT, isolated_server
+
+
+def summary(samples):
+    ordered = sorted(samples)
+    return {"samples": len(samples), "median_ms": statistics.median(samples),
+            "p95_ms": ordered[(len(ordered) - 1) * 95 // 100], "max_ms": max(samples)}
+
+
+def measure(server):
+    api_samples = []
+    for index in range(100):
+        start = time.perf_counter()
+        response = request(server.socket_path, {
+            "id": f"probe-{index}", "method": "uhp.capabilities", "params": {},
+        })
+        api_samples.append((time.perf_counter() - start) * 1000)
+        assert "result" in response, response
+    cli_samples = []
+    for _ in range(5):
+        start = time.perf_counter()
+        result = subprocess.run(
+            [str(server.binary), "uhp", "capabilities"], env=server.environment,
+            cwd=ROOT, capture_output=True, text=True, check=True, timeout=5,
+        )
+        cli_samples.append((time.perf_counter() - start) * 1000)
+        assert "result" in json.loads(result.stdout)
+    return {"uhp": summary(api_samples), "cli": summary(cli_samples)}
+
+
+def main():
+    import fcntl  # Unix-only fault injection, not a Windows validation claim.
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--luvus", default=str(ROOT / "target/debug/luvus"))
+    args = parser.parse_args()
+    binary = pathlib.Path(args.luvus).resolve(strict=True)
+    with isolated_server(binary, "io-responsiveness-") as server:
+        baseline = measure(server)
+        with (server.state / "config.lock").open("a+b") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            start = time.perf_counter()
+            response = request(server.socket_path, {
+                "id": "settings", "method": "config.patch",
+                "params": {"patch": {"agents_this_workspace": True}},
+            })
+            admission_ms = (time.perf_counter() - start) * 1000
+            assert "result" in response, response
+            time.sleep(0.1)
+            blocked = measure(server)
+            # Exercise the worker's lock timeout too. No throughput threshold:
+            # report host-dependent timings rather than turn noise into CI red.
+            time.sleep(1.1)
+            fcntl.flock(lock, fcntl.LOCK_UN)
+        response = request(server.socket_path, {
+            "id": "reload", "method": "server.reload_config", "params": {},
+        })
+        assert response.get("result", {}).get("config", {}).get("agents_this_workspace") is True, response
+        persisted = json.loads((server.state / "config.json").read_text())
+        assert persisted["agents_this_workspace"] is True
+        print(json.dumps({"binary": str(binary), "baseline": baseline,
+                          "locked_storage": blocked, "settings_admission_ms": admission_ms,
+                          "retry_persisted": True}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/config_persistence.rs
+++ b/src/app/config_persistence.rs
@@ -1,0 +1,339 @@
+//! Coalesced settings writes with acknowledged baselines and bounded retry.
+use super::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+struct Receipt {
+    desired: crate::config::Config,
+    explicit: Option<Value>,
+    saved: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    fn next_completion(events: &mpsc::Receiver<AppEvent>) -> super::super::io_jobs::Completion {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            match events
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .expect("I/O completion")
+            {
+                AppEvent::IoCompleted(done) => return done,
+                _ => continue,
+            }
+        }
+    }
+
+    #[test]
+    fn settings_coalesce_behind_slow_work_without_losing_newer_changes() {
+        let _env = persist::test_env("config-coalesced");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let (release, wait) = mpsc::channel();
+        app.io_jobs
+            .submit(app.app_tx.clone(), move || {
+                let _ = wait.recv();
+                Box::new(|_| false)
+            })
+            .unwrap();
+        app.config.agents_active_only = true;
+        app.persist_config();
+        app.config.agents_this_workspace = true;
+        app.persist_config();
+        assert!(app.config_persistence.inflight && app.config_persistence.dirty);
+        release.send(()).unwrap();
+        app.flush_config_for_test(&rx);
+        let saved = crate::config::load();
+        assert!(saved.agents_active_only && saved.agents_this_workspace);
+    }
+
+    #[test]
+    fn later_delta_preserves_other_sessions_changes_after_old_write() {
+        let _env = persist::test_env("config-ack-merge");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.config.agents_active_only = true;
+        app.persist_config();
+        let first = next_completion(&rx);
+        let mut external = crate::config::load();
+        external.theme = "gruvbox-dark".into();
+        crate::config::save(&external);
+        app.config.agents_this_workspace = true;
+        app.persist_config();
+        first.apply(&mut app);
+        app.flush_config_for_test(&rx);
+        let saved = crate::config::load();
+        assert_eq!(saved.theme, "gruvbox-dark");
+        assert!(saved.agents_active_only && saved.agents_this_workspace);
+    }
+
+    #[test]
+    fn failed_explicit_patch_is_retained_and_newer_patch_wins() {
+        let _env = persist::test_env("config-retry-patch");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let lock = persist::config_dir().join("config.lock");
+        std::fs::create_dir_all(&lock).unwrap();
+        app.persist_config_patch(&json!({"theme":"quattro-rally"}));
+        next_completion(&rx).apply(&mut app);
+        assert!(app.config_persistence.dirty);
+        assert!(app.config_persistence.retry_at.is_some());
+        app.config.theme = "gruvbox-dark".into();
+        app.persist_config_patch(&json!({"theme":"gruvbox-dark"}));
+        std::fs::remove_dir(lock).unwrap();
+        app.schedule_config_save(Instant::now() + Duration::from_secs(3));
+        app.flush_config_for_test(&rx);
+        assert_eq!(crate::config::load().theme, "gruvbox-dark");
+    }
+
+    #[test]
+    fn reload_waits_for_accepted_settings_write() {
+        let _env = persist::test_env("config-reload-order");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let stale = Box::new(app.config.clone());
+        app.config.agents_this_workspace = true;
+        app.persist_config();
+        let (reply, response) = mpsc::channel();
+        app.handle_event(AppEvent::ConfigReloaded {
+            id: "reload".into(),
+            config: stale,
+            reply,
+        });
+        assert!(response.try_recv().is_err());
+        app.flush_config_for_test(&rx);
+        next_completion(&rx).apply(&mut app);
+        let result: Value =
+            serde_json::from_str(&response.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        assert_eq!(result["result"]["config"]["agents_this_workspace"], true);
+        assert!(app.agents_this_workspace);
+    }
+}
+
+#[derive(Default)]
+pub(super) struct ConfigPersistence {
+    pub(super) inflight: bool,
+    pub(super) dirty: bool,
+    pub(super) retry_at: Option<Instant>,
+    explicit: Option<Value>,
+    epoch: u64,
+    receipt: Option<Receipt>,
+    revision: u64,
+    reloads: Vec<(String, Sender<String>)>,
+}
+
+// Compose explicit patches without losing null deletions. Arrays/scalars are
+// atomic values; newer leaves always win over earlier unacknowledged intent.
+fn merge_explicit(target: &mut Value, patch: &Value) {
+    match (target, patch) {
+        (Value::Object(target), Value::Object(patch)) => {
+            for (key, value) in patch {
+                match target.get_mut(key) {
+                    Some(current) => merge_explicit(current, value),
+                    None => {
+                        target.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+        (target, patch) => *target = patch.clone(),
+    }
+}
+
+impl App {
+    #[cfg(test)]
+    pub(crate) fn flush_config_for_test(&mut self, events: &std::sync::mpsc::Receiver<AppEvent>) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while self.config_save_pending() {
+            self.schedule_config_save(Instant::now());
+            let event = events
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .expect("config persistence completion");
+            if let AppEvent::IoCompleted(done) = event {
+                done.apply(self);
+            }
+        }
+    }
+    pub(crate) fn persist_config(&mut self) {
+        self.queue_config_patch(None);
+    }
+
+    pub(crate) fn persist_config_patch(&mut self, patch: &Value) {
+        self.queue_config_patch(Some(patch));
+    }
+
+    fn queue_config_patch(&mut self, patch: Option<&Value>) {
+        let state = &mut self.config_persistence;
+        state.revision = state.revision.wrapping_add(1);
+        state.dirty = true;
+        if let Some(patch) = patch {
+            if let Some(pending) = &mut state.explicit {
+                merge_explicit(pending, patch);
+            } else {
+                state.explicit = Some(patch.clone());
+            }
+        }
+        self.schedule_config_save(Instant::now());
+    }
+
+    pub(super) fn schedule_config_save(&mut self, now: Instant) {
+        let state = &self.config_persistence;
+        if state.inflight || !state.dirty || state.retry_at.is_some_and(|at| at > now) {
+            return;
+        }
+        let desired = self.config.clone();
+        let explicit = state.explicit.clone();
+        let epoch = state.epoch;
+        let saved_flag = Arc::new(AtomicBool::new(false));
+        let worker_saved = saved_flag.clone();
+        let receipt = Receipt {
+            desired: desired.clone(),
+            explicit: explicit.clone(),
+            saved: saved_flag,
+        };
+        let request = crate::config::SaveRequest::new(
+            self.config_baseline.clone(),
+            desired.clone(),
+            explicit.clone(),
+        );
+        let accepted = self.io_jobs.submit(self.app_tx.clone(), move || {
+            let saved = request.write();
+            worker_saved.store(saved, Ordering::Release);
+            Box::new(move |app| {
+                let state = &mut app.config_persistence;
+                state.inflight = false;
+                state.receipt = None;
+                if state.epoch == epoch {
+                    if saved {
+                        app.config_baseline = desired;
+                        state.retry_at = None;
+                    } else {
+                        state.dirty = true;
+                        state.retry_at = Some(Instant::now() + Duration::from_secs(2));
+                        if let Some(mut old) = explicit {
+                            if let Some(newer) = &state.explicit {
+                                merge_explicit(&mut old, newer);
+                            }
+                            state.explicit = Some(old);
+                        }
+                    }
+                }
+                if !saved {
+                    app.show_toast("settings save failed; changes will be retried");
+                }
+                app.schedule_config_save(Instant::now());
+                app.flush_config_reloads(saved);
+                !saved
+            })
+        });
+        let state = &mut self.config_persistence;
+        if accepted.is_ok() {
+            state.inflight = true;
+            state.receipt = Some(receipt);
+            state.dirty = false;
+            state.explicit = None;
+            state.retry_at = None;
+        } else {
+            state.retry_at = Some(now + Duration::from_secs(2));
+        }
+    }
+
+    pub(crate) fn reset_config_baseline(&mut self) {
+        self.config_baseline = self.config.clone();
+        let state = &mut self.config_persistence;
+        state.epoch = state.epoch.wrapping_add(1);
+        state.revision = state.revision.wrapping_add(1);
+        state.dirty = false;
+        state.explicit = None;
+        state.retry_at = None;
+    }
+
+    pub(super) fn config_save_pending(&self) -> bool {
+        self.config_persistence.inflight || self.config_persistence.dirty
+    }
+
+    pub(super) fn defer_config_reload(&mut self, id: String, reply: Sender<String>) {
+        if self.config_persistence.reloads.len() >= 8 {
+            let _ = reply.send(
+                json!({"id":id,"error":{"code":"busy","message":"settings reload queue is full"}})
+                    .to_string(),
+            );
+            return;
+        }
+        self.config_persistence.reloads.push((id, reply));
+    }
+
+    fn flush_config_reloads(&mut self, saved: bool) {
+        if self.config_persistence.reloads.is_empty() {
+            return;
+        }
+        if !saved {
+            for (id, reply) in self.config_persistence.reloads.drain(..) {
+                let _ = reply.send(json!({"id":id,"error":{"code":"persistence_failed","message":"settings save failed; reload was not applied"}}).to_string());
+            }
+            return;
+        }
+        if self.config_save_pending() {
+            return;
+        }
+        let reloads = self.config_persistence.reloads.clone();
+        let revision = self.config_persistence.revision;
+        let path = persist::config_dir().join("config.json");
+        if self.io_jobs.submit(self.app_tx.clone(), move || {
+            let config = std::fs::read_to_string(path).ok()
+                .and_then(|text| serde_json::from_str(&text).ok())
+                .map(crate::config::normalize_config).unwrap_or_default();
+            Box::new(move |app| {
+                let result = if app.config_persistence.revision != revision {
+                    Err(("state_changed".into(), "settings changed during reload; retry reload".into()))
+                } else { app.apply_socket_config(config, None) };
+                for (id, reply) in reloads {
+                    let response = match &result {
+                        Ok(()) => json!({"id":id,"result":{"type":"config_reloaded","config":app.config}}),
+                        Err((code, message)) => json!({"id":id,"error":{"code":code,"message":message}}),
+                    };
+                    let _ = reply.send(response.to_string());
+                }
+                result.is_ok()
+            })
+        }).is_ok() {
+            self.config_persistence.reloads.clear();
+        }
+    }
+
+    /// Final write follows the ordinary in-flight save on the same worker. Use
+    /// its captured desired config as baseline so already-accepted fields are
+    /// not needlessly written over another session's more recent changes.
+    pub(super) fn final_config_save(&self) -> impl FnOnce() -> bool + Send + 'static {
+        let state = &self.config_persistence;
+        let mut failed_explicit = state.receipt.as_ref().and_then(|r| r.explicit.clone());
+        if let Some(newer) = &state.explicit {
+            if let Some(old) = &mut failed_explicit {
+                merge_explicit(old, newer);
+            } else {
+                failed_explicit = Some(newer.clone());
+            }
+        }
+        let failure = crate::config::SaveRequest::new(
+            self.config_baseline.clone(),
+            self.config.clone(),
+            failed_explicit,
+        );
+        let success = state.receipt.as_ref().map(|receipt| {
+            (
+                receipt.saved.clone(),
+                crate::config::SaveRequest::new(
+                    receipt.desired.clone(),
+                    self.config.clone(),
+                    state.explicit.clone(),
+                ),
+            )
+        });
+        move || match success {
+            Some((saved, request)) if saved.load(Ordering::Acquire) => request.write(),
+            _ => failure.write(),
+        }
+    }
+}

--- a/src/app/config_persistence.rs
+++ b/src/app/config_persistence.rs
@@ -8,6 +8,43 @@ struct Receipt {
     saved: Arc<AtomicBool>,
 }
 
+struct ExplicitPatch {
+    value: Value,
+    desired: crate::config::Config,
+}
+
+impl ExplicitPatch {
+    fn refresh(&mut self, desired: &crate::config::Config) {
+        // Preserve explicit no-op intent (including null deletions), but let
+        // later UI edits supersede the leaves captured by an older patch.
+        refresh_explicit(
+            &mut self.value,
+            &serde_json::to_value(&self.desired).expect("config serializes"),
+            &serde_json::to_value(desired).expect("config serializes"),
+        );
+        self.desired = desired.clone();
+    }
+}
+
+fn refresh_explicit(patch: &mut Value, previous: &Value, desired: &Value) {
+    if previous == desired {
+        return;
+    }
+    if let (Value::Object(patch), Value::Object(previous), Value::Object(desired)) =
+        (&mut *patch, previous, desired)
+    {
+        for (key, value) in patch {
+            refresh_explicit(
+                value,
+                previous.get(key).unwrap_or(&Value::Null),
+                desired.get(key).unwrap_or(&Value::Null),
+            );
+        }
+    } else {
+        *patch = desired.clone();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -89,6 +126,87 @@ mod tests {
     }
 
     #[test]
+    fn failed_explicit_patch_yields_to_newer_ui_edits_before_and_after_ack() {
+        for edit_before_ack in [true, false] {
+            let _env = persist::test_env("config-retry-ui-precedence");
+            let (tx, rx) = mpsc::channel();
+            let mut app = App::new(80, 24, tx).unwrap();
+            let lock = persist::config_dir().join("config.lock");
+            std::fs::create_dir_all(&lock).unwrap();
+            app.config.agents_active_only = true;
+            app.persist_config_patch(&json!({"agents_active_only": true}));
+            let failed = next_completion(&rx);
+            if edit_before_ack {
+                assert!(app.set_agents_filter(false));
+            }
+            failed.apply(&mut app);
+            if !edit_before_ack {
+                assert!(app.set_agents_filter(false));
+            }
+            std::fs::remove_dir(lock).unwrap();
+            app.schedule_config_save(Instant::now() + Duration::from_secs(3));
+            app.flush_config_for_test(&rx);
+            assert!(!crate::config::load().agents_active_only);
+            assert!(!app.config_baseline.agents_active_only);
+            assert!(!app.config_save_pending());
+        }
+    }
+
+    #[test]
+    fn unadmitted_explicit_patch_yields_to_newer_ui_edits() {
+        let _env = persist::test_env("config-full-queue-ui-precedence");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        // Completed but unapplied jobs still consume the bounded queue budget.
+        while app
+            .io_jobs
+            .submit(app.app_tx.clone(), || Box::new(|_| false))
+            .is_ok()
+        {}
+        app.config.agents_active_only = true;
+        app.persist_config_patch(&json!({"agents_active_only": true}));
+        assert!(!app.config_persistence.inflight);
+        assert!(app.config_persistence.retry_at.is_some());
+        assert!(app.set_agents_filter(false));
+        next_completion(&rx).apply(&mut app);
+        app.schedule_config_save(Instant::now() + Duration::from_secs(3));
+        app.flush_config_for_test(&rx);
+        assert!(!crate::config::load().agents_active_only);
+        assert!(!app.config_baseline.agents_active_only);
+    }
+
+    #[test]
+    fn shutdown_failed_receipt_yields_to_newer_ui_edits() {
+        let _env = persist::test_env("config-shutdown-failed-ui-precedence");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let lock = persist::config_dir().join("config.lock");
+        std::fs::create_dir_all(&lock).unwrap();
+        app.config.agents_active_only = true;
+        app.persist_config_patch(&json!({"agents_active_only": true}));
+        let unapplied_ack = next_completion(&rx);
+        assert!(app.set_agents_filter(false));
+        std::fs::remove_dir(lock).unwrap();
+        assert!(app.final_config_save()());
+        assert!(!crate::config::load().agents_active_only);
+        drop(unapplied_ack);
+    }
+
+    #[test]
+    fn refreshing_explicit_intent_preserves_unchanged_nulls_and_nested_siblings() {
+        let mut patch = json!({"layout": {"first": true, "second": null}, "theme": "same"});
+        refresh_explicit(
+            &mut patch,
+            &json!({"layout": {"first": true, "second": "default"}, "theme": "same"}),
+            &json!({"layout": {"first": false, "second": "default"}, "theme": "same"}),
+        );
+        assert_eq!(
+            patch,
+            json!({"layout": {"first": false, "second": null}, "theme": "same"})
+        );
+    }
+
+    #[test]
     fn reload_waits_for_accepted_settings_write() {
         let _env = persist::test_env("config-reload-order");
         let (tx, rx) = mpsc::channel();
@@ -140,7 +258,7 @@ pub(super) struct ConfigPersistence {
     pub(super) inflight: bool,
     pub(super) dirty: bool,
     pub(super) retry_at: Option<Instant>,
-    explicit: Option<Value>,
+    explicit: Option<ExplicitPatch>,
     epoch: u64,
     receipt: Option<Receipt>,
     revision: u64,
@@ -191,11 +309,17 @@ impl App {
         let state = &mut self.config_persistence;
         state.revision = state.revision.wrapping_add(1);
         state.dirty = true;
+        if let Some(pending) = &mut state.explicit {
+            pending.refresh(&self.config);
+        }
         if let Some(patch) = patch {
             if let Some(pending) = &mut state.explicit {
-                merge_explicit(pending, patch);
+                merge_explicit(&mut pending.value, patch);
             } else {
-                state.explicit = Some(patch.clone());
+                state.explicit = Some(ExplicitPatch {
+                    value: patch.clone(),
+                    desired: self.config.clone(),
+                });
             }
         }
         self.schedule_config_save(Instant::now());
@@ -207,7 +331,7 @@ impl App {
             return;
         }
         let desired = self.config.clone();
-        let explicit = state.explicit.clone();
+        let explicit = state.explicit.as_ref().map(|patch| patch.value.clone());
         let epoch = state.epoch;
         let saved_flag = Arc::new(AtomicBool::new(false));
         let worker_saved = saved_flag.clone();
@@ -236,10 +360,18 @@ impl App {
                         state.dirty = true;
                         state.retry_at = Some(Instant::now() + Duration::from_secs(2));
                         if let Some(mut old) = explicit {
+                            refresh_explicit(
+                                &mut old,
+                                &serde_json::to_value(&desired).expect("config serializes"),
+                                &serde_json::to_value(&app.config).expect("config serializes"),
+                            );
                             if let Some(newer) = &state.explicit {
-                                merge_explicit(&mut old, newer);
+                                merge_explicit(&mut old, &newer.value);
                             }
-                            state.explicit = Some(old);
+                            state.explicit = Some(ExplicitPatch {
+                                value: old,
+                                desired: app.config.clone(),
+                            });
                         }
                     }
                 }
@@ -341,11 +473,18 @@ impl App {
     pub(super) fn final_config_save(&self) -> impl FnOnce() -> bool + Send + 'static {
         let state = &self.config_persistence;
         let mut failed_explicit = state.receipt.as_ref().and_then(|r| r.explicit.clone());
+        if let (Some(patch), Some(receipt)) = (&mut failed_explicit, &state.receipt) {
+            refresh_explicit(
+                patch,
+                &serde_json::to_value(&receipt.desired).expect("config serializes"),
+                &serde_json::to_value(&self.config).expect("config serializes"),
+            );
+        }
         if let Some(newer) = &state.explicit {
             if let Some(old) = &mut failed_explicit {
-                merge_explicit(old, newer);
+                merge_explicit(old, &newer.value);
             } else {
-                failed_explicit = Some(newer.clone());
+                failed_explicit = Some(newer.value.clone());
             }
         }
         let failure = crate::config::SaveRequest::new(
@@ -359,7 +498,7 @@ impl App {
                 crate::config::SaveRequest::new(
                     receipt.desired.clone(),
                     self.config.clone(),
-                    state.explicit.clone(),
+                    state.explicit.as_ref().map(|patch| patch.value.clone()),
                 ),
             )
         });

--- a/src/app/config_persistence.rs
+++ b/src/app/config_persistence.rs
@@ -110,6 +110,29 @@ mod tests {
         assert_eq!(result["result"]["config"]["agents_this_workspace"], true);
         assert!(app.agents_this_workspace);
     }
+
+    #[test]
+    fn shutdown_receipt_does_not_replay_a_saved_field_over_another_session() {
+        let _env = persist::test_env("config-shutdown-receipt");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.config.agents_active_only = true;
+        app.persist_config();
+        let unapplied_ack = next_completion(&rx);
+        let mut external = crate::config::load();
+        external.agents_active_only = false;
+        crate::config::save(&external);
+        app.config.agents_this_workspace = true;
+        app.persist_config();
+        app.finish_session_persistence();
+        let saved = crate::config::load();
+        assert!(
+            !saved.agents_active_only,
+            "already saved field belongs to latest external writer"
+        );
+        assert!(saved.agents_this_workspace);
+        drop(unapplied_ack);
+    }
 }
 
 #[derive(Default)]
@@ -282,13 +305,18 @@ impl App {
         let revision = self.config_persistence.revision;
         let path = persist::config_dir().join("config.json");
         if self.io_jobs.submit(self.app_tx.clone(), move || {
-            let config = std::fs::read_to_string(path).ok()
-                .and_then(|text| serde_json::from_str(&text).ok())
-                .map(crate::config::normalize_config).unwrap_or_default();
+            let config = std::fs::read_to_string(path).map_err(|error| error.to_string())
+                .and_then(|text| serde_json::from_str(&text).map_err(|error| error.to_string()))
+                .map(crate::config::normalize_config);
             Box::new(move |app| {
                 let result = if app.config_persistence.revision != revision {
                     Err(("state_changed".into(), "settings changed during reload; retry reload".into()))
-                } else { app.apply_socket_config(config, None) };
+                } else {
+                    match config {
+                        Ok(config) => app.apply_socket_config(config, None),
+                        Err(error) => Err(("io_error".into(), format!("could not reload saved settings: {error}"))),
+                    }
+                };
                 for (id, reply) in reloads {
                     let response = match &result {
                         Ok(()) => json!({"id":id,"result":{"type":"config_reloaded","config":app.config}}),
@@ -300,6 +328,10 @@ impl App {
             })
         }).is_ok() {
             self.config_persistence.reloads.clear();
+        } else {
+            for (id, reply) in self.config_persistence.reloads.drain(..) {
+                let _ = reply.send(json!({"id":id,"error":{"code":"busy","message":"settings reload could not be queued; retry reload"}}).to_string());
+            }
         }
     }
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1468,6 +1468,12 @@ impl App {
         clients_attached: bool,
     ) -> Option<Instant> {
         let mut deadline = None;
+        if self.config_persistence.dirty && !self.config_persistence.inflight {
+            Self::sooner_deadline(
+                &mut deadline,
+                self.config_persistence.retry_at.unwrap_or(now),
+            );
+        }
         let mut consider = |candidate: Instant, due: bool| {
             if candidate > now {
                 Self::sooner_deadline(&mut deadline, candidate);
@@ -1750,6 +1756,7 @@ impl App {
     }
 
     pub(crate) fn detect_tick_with(&mut self, now: Instant, clients_attached: bool) -> bool {
+        self.schedule_config_save(now);
         // No node open (docs/43 §3.3 — the session was closed). Closing the last
         // node also closed every pane, so there is nothing to classify, and
         // `layout()` below would index an empty `workspaces`. The server keeps

--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -1298,6 +1298,7 @@ mod tests {
         assert!(app.move_dock(&DockKind::Files, Side::Right));
         assert_eq!(app.sidebars.side_of(&DockKind::Files), Some(Side::Right));
         app.unmount_dock(&DockKind::Files);
+        app.flush_config_for_test(&_rx);
         assert_eq!(app.sidebars.side_of(&DockKind::Files), None);
         assert_eq!(
             app.config

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -467,6 +467,10 @@ impl App {
                 return true;
             }
             AppEvent::ConfigReloaded { id, config, reply } => {
+                if self.config_save_pending() {
+                    self.defer_config_reload(id, reply);
+                    return false;
+                }
                 let response = match self.apply_socket_config(*config, None) {
                     Ok(()) => {
                         json!({"id":id,"result":{"type":"config_reloaded","config":self.config}})

--- a/src/app/io_jobs.rs
+++ b/src/app/io_jobs.rs
@@ -142,6 +142,16 @@ impl App {
     }
 }
 
+impl Drop for IoJobs {
+    fn drop(&mut self) {
+        // Covers early startup/test exits as well as the explicit server drain.
+        // A completed explicit drain has already taken the sender.
+        if self.sender.is_some() {
+            let _ = self.finish(Duration::from_secs(2), || true);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1617,12 +1617,14 @@ mod tests {
         app.run_cmd(Cmd::ToggleAgentScope);
         assert!(app.agents_this_workspace);
         assert_eq!(app.agents_scroll, 0);
+        app.flush_config_for_test(&_rx);
         assert!(crate::config::load().agents_this_workspace);
 
         app.agents_scroll = 5;
         app.run_cmd(Cmd::ToggleAgentScope);
         assert!(!app.agents_this_workspace);
         assert_eq!(app.agents_scroll, 0);
+        app.flush_config_for_test(&_rx);
         assert!(!crate::config::load().agents_this_workspace);
     }
 
@@ -1641,12 +1643,14 @@ mod tests {
         app.handle_agents_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE));
         assert!(app.agents_active_only);
         assert_eq!(app.agents_scroll, 0);
+        app.flush_config_for_test(&_rx);
         assert!(crate::config::load().agents_active_only);
 
         app.agents_scroll = 5;
         app.handle_agents_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE));
         assert!(!app.agents_active_only);
         assert_eq!(app.agents_scroll, 0);
+        app.flush_config_for_test(&_rx);
         assert!(!crate::config::load().agents_active_only);
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,6 +25,7 @@ use crate::ui::theme::{State, Theme};
 mod automation;
 mod backend;
 mod board;
+mod config_persistence;
 mod cwd;
 pub use board::{
     agent_choices, automation_agent_choices, automation_agent_choices_for, task_agent_choices,
@@ -2145,6 +2146,7 @@ pub struct App {
     /// This server's last local config snapshot. Persistence diffs against this
     /// snapshot so another named server's newer, unrelated fields survive.
     config_baseline: crate::config::Config,
+    config_persistence: config_persistence::ConfigPersistence,
     io_jobs: io_jobs::IoJobs,
     file_metadata_inflight: bool,
     file_metadata_cursor: usize,
@@ -2836,6 +2838,7 @@ impl App {
             catalog,
             config,
             config_baseline,
+            config_persistence: config_persistence::ConfigPersistence::default(),
             io_jobs: io_jobs::IoJobs::default(),
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
@@ -3485,6 +3488,7 @@ impl App {
             catalog,
             config,
             config_baseline,
+            config_persistence: config_persistence::ConfigPersistence::default(),
             io_jobs: io_jobs::IoJobs::default(),
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
@@ -3821,29 +3825,6 @@ impl App {
         self.config.sidebars = Some(self.sidebars.to_config());
         self.config.sidebar_width = self.sidebars.left.width;
         self.persist_config();
-    }
-
-    /// Merge only this server's local changes into the shared home-level config.
-    /// A failed best-effort write keeps the old baseline so the next mutation
-    /// retries every unsaved field.
-    pub(crate) fn persist_config(&mut self) {
-        if crate::config::save_changes(&self.config_baseline, &self.config) {
-            self.config_baseline = self.config.clone();
-        }
-    }
-
-    /// Persist local changes while forcing an explicit user/API patch even when
-    /// this server already held the requested value in memory.
-    pub(crate) fn persist_config_patch(&mut self, patch: &serde_json::Value) {
-        if crate::config::save_changes_with_patch(&self.config_baseline, &self.config, Some(patch))
-        {
-            self.config_baseline = self.config.clone();
-        }
-    }
-
-    /// Adopt an externally reloaded config without writing it back to disk.
-    pub(crate) fn reset_config_baseline(&mut self) {
-        self.config_baseline = self.config.clone();
     }
 
     /// Apply the AGENTS All / Active projection without performing I/O. This is
@@ -7963,6 +7944,8 @@ mod tests {
 
         alpha.apply_theme("quattro-rally");
         assert!(beta.set_agents_filter(true));
+        alpha.flush_config_for_test(&_alpha_rx);
+        beta.flush_config_for_test(&_beta_rx);
 
         let merged = crate::config::load();
         assert_eq!(merged.theme, "quattro-rally");
@@ -8992,12 +8975,14 @@ mod tests {
 
         app.open_ws_menu(0, 0, 0);
         app.ws_menu_action(WsMenuItem::TogglePath);
+        app.flush_config_for_test(&_rx);
         let stored = crate::config::load();
         assert!(!stored.layout.workspace_paths);
         assert!(stored.layout.agent_paths);
 
         app.open_agent_menu(AgentTarget::Live(pane), 0, 0);
         app.agent_menu_action(AgentMenuItem::TogglePath);
+        app.flush_config_for_test(&_rx);
         let stored = crate::config::load();
         assert!(!stored.layout.workspace_paths);
         assert!(!stored.layout.agent_paths);
@@ -9993,6 +9978,7 @@ mod tests {
             "the left sidebar widened by the drag distance"
         );
         // Released width is persisted for the next launch.
+        app.flush_config_for_test(&_rx);
         assert_eq!(
             crate::config::load().sidebars.unwrap().left.width,
             before + 6,
@@ -12366,6 +12352,7 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         }));
         assert!(app.agents_this_workspace);
+        app.flush_config_for_test(&_rx);
         assert!(crate::config::load().agents_this_workspace);
         app.open_agent_menu(AgentTarget::Session(1), row.x + 1, row.y);
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
@@ -12663,6 +12650,7 @@ mod tests {
             crate::i18n::by_code(&app.config.language).workspaces,
             "catalog swapped live"
         );
+        app.flush_config_for_test(&_rx);
         assert_eq!(
             crate::config::load().language,
             app.config.language,

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -37,10 +37,11 @@ impl App {
             .io_jobs
             .submit(self.app_tx.clone(), || Box::new(|_| false));
         let capture = persist::capture_session(self);
-        if !self
-            .io_jobs
-            .finish(Duration::from_secs(2), move || capture.write())
-        {
+        let config = self.final_config_save();
+        if !self.io_jobs.finish(Duration::from_secs(2), move || {
+            let config_saved = config();
+            capture.write() && config_saved
+        }) {
             eprintln!("Luvus: final session save failed or exceeded the shutdown deadline");
         }
     }

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1596,6 +1596,7 @@ mod tests {
             app.config.layout.diff_marker_style,
             crate::diff::DiffMarkerStyle::Bars
         );
+        app.flush_config_for_test(&_rx);
         assert_eq!(
             crate::config::load().layout.diff_marker_style,
             crate::diff::DiffMarkerStyle::Bars,
@@ -1638,6 +1639,7 @@ mod tests {
             app.config.layout.diff_color_mode,
             crate::diff::DiffColorMode::Standard
         );
+        app.flush_config_for_test(&_rx);
         assert_eq!(
             crate::config::load().layout.diff_color_mode,
             crate::diff::DiffColorMode::Standard,
@@ -1676,6 +1678,7 @@ mod tests {
 
         app.adjust_general(row, 1);
         assert!(app.config.resume_launch_flags, "the toggle flipped");
+        app.flush_config_for_test(&_rx);
         assert!(
             crate::config::load().resume_launch_flags,
             "and it was saved"
@@ -1720,6 +1723,7 @@ mod tests {
             app.config.layout.new_pane_to_workspace_root,
             "the toggle flipped"
         );
+        app.flush_config_for_test(&_rx);
         assert!(
             crate::config::load().layout.new_pane_to_workspace_root,
             "and it was saved"
@@ -2059,6 +2063,7 @@ mod tests {
         app.settings_adjust(click, 1);
         assert_eq!(app.config.layout.file_click, config::FILE_CLICK_TAB);
         assert_eq!(app.file_click_label(), "Open in tab");
+        app.flush_config_for_test(&_rx);
         assert_eq!(
             crate::config::load().layout.file_click,
             config::FILE_CLICK_TAB,

--- a/src/config.rs
+++ b/src/config.rs
@@ -579,10 +579,6 @@ fn config_path() -> PathBuf {
     crate::persist::config_dir().join("config.json")
 }
 
-fn config_lock_path() -> PathBuf {
-    crate::persist::config_dir().join("config.lock")
-}
-
 /// Load the config, or defaults if missing / unparsable.
 pub fn load() -> Config {
     fs::read_to_string(config_path())
@@ -639,7 +635,8 @@ static CONFIG_WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 /// server may hold an older copy of fields changed by another server.
 #[cfg(test)]
 pub fn save(cfg: &Config) {
-    let _ = with_config_lock(|| write_config_atomic(cfg));
+    let path = config_path();
+    let _ = with_config_lock(&path, || write_config_atomic(cfg, &path));
 }
 
 /// Persist only fields changed between one server's last local config and its
@@ -650,6 +647,7 @@ pub fn save(cfg: &Config) {
 /// Returns `true` after either a successful write or a no-op. Callers retain
 /// their old baseline on `false`, allowing the next change to retry everything
 /// that has not reached disk yet.
+#[cfg(test)]
 pub fn save_changes(base: &Config, desired: &Config) -> bool {
     save_changes_with_patch(base, desired, None)
 }
@@ -659,6 +657,43 @@ pub fn save_changes(base: &Config, desired: &Config) -> bool {
 /// already has in memory: there may be no local delta, but the shared file must
 /// still record the user's choice.
 pub fn save_changes_with_patch(base: &Config, desired: &Config, explicit: Option<&Value>) -> bool {
+    SaveRequest::new(base.clone(), desired.clone(), explicit.cloned()).write()
+}
+
+/// Owned save inputs with a pinned path; workers never resolve session globals.
+pub(crate) struct SaveRequest {
+    base: Config,
+    desired: Config,
+    explicit: Option<Value>,
+    path: PathBuf,
+}
+
+impl SaveRequest {
+    pub(crate) fn new(base: Config, desired: Config, explicit: Option<Value>) -> Self {
+        Self {
+            base,
+            desired,
+            explicit,
+            path: config_path(),
+        }
+    }
+
+    pub(crate) fn write(self) -> bool {
+        save_changes_at(
+            &self.path,
+            &self.base,
+            &self.desired,
+            self.explicit.as_ref(),
+        )
+    }
+}
+
+fn save_changes_at(
+    path: &std::path::Path,
+    base: &Config,
+    desired: &Config,
+    explicit: Option<&Value>,
+) -> bool {
     let Ok(base) = serde_json::to_value(base) else {
         return false;
     };
@@ -670,8 +705,13 @@ pub fn save_changes_with_patch(base: &Config, desired: &Config, explicit: Option
         return true;
     }
 
-    with_config_lock(|| {
-        let mut latest = serde_json::to_value(load()).map_err(io::Error::other)?;
+    with_config_lock(path, || {
+        let latest: Config = fs::read_to_string(path)
+            .ok()
+            .and_then(|text| serde_json::from_str(&text).ok())
+            .map(normalize_config)
+            .unwrap_or_default();
+        let mut latest = serde_json::to_value(latest).map_err(io::Error::other)?;
         if let Some(delta) = &delta {
             apply_delta(&mut latest, delta);
         }
@@ -679,13 +719,26 @@ pub fn save_changes_with_patch(base: &Config, desired: &Config, explicit: Option
             apply_delta(&mut latest, explicit);
         }
         let merged: Config = serde_json::from_value(latest).map_err(io::Error::other)?;
-        write_config_atomic(&normalize_config(merged))
+        write_config_atomic(&normalize_config(merged), path)
     })
     .is_ok()
 }
 
-fn with_config_lock<T>(operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
-    let dir = crate::persist::ensure_config_dir();
+fn with_config_lock<T>(
+    path: &std::path::Path,
+    operation: impl FnOnce() -> io::Result<T>,
+) -> io::Result<T> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| io::Error::other("missing configuration directory"))?;
+    fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if Some(dir) != crate::platform::home_dir().as_deref() {
+            fs::set_permissions(dir, fs::Permissions::from_mode(0o700))?;
+        }
+    }
     if !dir.is_dir() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
@@ -697,14 +750,25 @@ fn with_config_lock<T>(operation: impl FnOnce() -> io::Result<T>) -> io::Result<
         .read(true)
         .write(true)
         .truncate(false)
-        .open(config_lock_path())?;
-    lock.lock_exclusive()?;
+        .open(dir.join("config.lock"))?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    loop {
+        match lock.try_lock_exclusive() {
+            Ok(()) => break,
+            Err(error)
+                if error.kind() == io::ErrorKind::WouldBlock
+                    && std::time::Instant::now() < deadline =>
+            {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(error) => return Err(error),
+        }
+    }
     operation()
 }
 
-fn write_config_atomic(cfg: &Config) -> io::Result<()> {
+fn write_config_atomic(cfg: &Config, path: &std::path::Path) -> io::Result<()> {
     let json = serde_json::to_vec_pretty(cfg).map_err(io::Error::other)?;
-    let path = config_path();
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -733,7 +797,7 @@ fn write_config_atomic(cfg: &Config) -> io::Result<()> {
         file.write_all(&json)?;
         file.flush()?;
         drop(file);
-        crate::platform::atomic_replace_file(&temporary, &path)
+        crate::platform::atomic_replace_file(&temporary, path)
     })();
     if result.is_err() {
         let _ = fs::remove_file(&temporary);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1433,6 +1433,7 @@ mod tests {
         }));
         assert!(app.agents_active_only);
         assert_eq!(app.agents_scroll, 0);
+        app.flush_config_for_test(&_rx);
         assert!(crate::config::load().agents_active_only);
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
         assert!(
@@ -1465,6 +1466,7 @@ mod tests {
         }));
         assert!(!app.agents_active_only);
         assert_eq!(app.agents_scroll, 0);
+        app.flush_config_for_test(&_rx);
         assert!(!crate::config::load().agents_active_only);
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
         assert!(buffer_contains(&term, "resume"));
@@ -1563,6 +1565,7 @@ mod tests {
         assert!(app.agents_this_workspace);
         assert!(!app.agents_active_only, "scope is independent of lifecycle");
         assert_eq!(app.agents_scroll, 0);
+        app.flush_config_for_test(&_rx);
         assert!(crate::config::load().agents_this_workspace);
 
         term.draw(|f| crate::ui::render(f, &mut app)).unwrap();

--- a/website/src/content/docs/docs/explanation/architecture.mdx
+++ b/website/src/content/docs/docs/explanation/architecture.mdx
@@ -31,6 +31,21 @@ this does not introduce a second persistent screen cache or promise constant-tim
 capture for an arbitrary number of panes. Automation dispatch-intent persistence
 is a separate contract and is not made asynchronous by session saving.
 
+Settings changes apply to the running UI immediately and are persisted through
+the same shared worker. Rapid changes coalesce behind one in-flight write.
+Acknowledged baselines preserve newer local edits and unrelated changes from
+other named sessions. Explicit API patches remain authoritative even when the
+requested value matches this server's old in-memory value. Cross-process lock
+acquisition is bounded to one second, and failures retain intent for a later
+retry and display an error. The worker pins the config path before admission.
+
+Socket config reloads that arrive during a save wait for its outcome and read
+the shared file again. A failed save or a concurrent edit during that fresh read
+returns a structured error instead of silently replacing newer settings.
+Shutdown uses the in-flight write receipt to avoid replaying already-saved fields
+over changes another session made afterward. This is not a multi-file transaction
+between configuration and the session snapshot.
+
 Three design decisions explain most of luvus's behavior.
 
 ## A headless server, a thin client

--- a/website/src/content/docs/docs/guides/settings.mdx
+++ b/website/src/content/docs/docs/guides/settings.mdx
@@ -6,6 +6,12 @@ description: Themes, layout, notifications, keybindings, language, and integrati
 Open with the **Menu** button (top right) or `Ctrl+Space =`. Every change
 applies live and persists to `~/.luvus/config.json`.
 
+Persistence runs off the UI loop. Rapid edits coalesce while an earlier write
+finishes, and unrelated settings saved by another named session are preserved.
+If storage is busy or a write fails, Luvus retains the changes for retry and
+reports the failure. Socket-based config reload waits for pending saves rather
+than replacing the live settings with an older disk copy.
+
 | Tab | What's there |
 |---|---|
 | **General** | **Open files with** (read-only or an editor you have installed) and **File click behavior** (**Preview**, the default, or **Open in tab**), see [Browsing & Opening Files](/docs/guides/files/), then a **Notify** section with Retro, Soft, and Pulse sound styles, separate done and blocked toggles, and a test row for each cue |


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 14 of 15** · Base: #296 · Next: #301 · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

## Summary
Moves settings serialization, cross-process locking, merge-with-latest, and atomic replacement off the app loop. Rapid changes coalesce behind one in-flight write. Baselines advance only after success, preserving newer local edits and unrelated changes from other named sessions. Explicit patches survive failures, with newer patch leaves winning. Lock acquisition is bounded to one second and failed writes retain retry intent.

## Ordering and safety
Socket reload waits for pending writes, re-reads the shared file, and rejects a concurrent edit rather than replacing newer settings. Read or parse errors fail closed instead of applying defaults. Shutdown uses the prior write receipt so its final delta does not replay already-saved fields over another session. The worker is shared with file/session jobs, with no additional thread for config.

## Verification
Final candidate c05bea1 passed formatting, strict all-target Clippy, 1535 unit tests (three opt-in tests ignored), 15 integration tests, and the locked release build. Focused tests cover coalescing, stale acknowledgements, cross-session merges, explicit-patch retry, ordered reload, and shutdown receipts. Isolated live UHP and failure conformance passed again. The final head passed the CI matrix, including Windows protocol/ConPTY checks; this is not full interactive Windows validation.

The repeatable Unix fault-injection script holds config.lock, measures CLI/UHP traffic, exercises lock timeout, and verifies retry persistence in an isolated server. Final release medians: UHP 0.575 ms baseline versus 0.558 ms during contention; CLI 4.030 ms versus 4.509 ms. Settings admission was 0.361 ms and retry persisted successfully. Samples: 100 UHP requests and five CLI subprocesses per condition. These are local fault-injection measurements, not a general throughput claim.

Public architecture, settings guide, and contributor instructions are updated. CodeRabbit skips automatic review for this non-default base; that is not a completed independent review.

## Stack
Based on #296. No merge requested. Automation ledger dispatch barriers remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings changes now save asynchronously, coalesce rapid edits, preserve concurrent changes, and retry after temporary lock or write failures.
  * Configuration reloads wait for pending saves, reducing the risk of overwriting newer settings.
  * Application shutdown now completes pending configuration and session saves more reliably.

* **Documentation**
  * Updated architecture and settings guides with details on persistence and reload behavior.
  * Added an optional Unix responsiveness check for configuration-lock scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->