### PR TITLE
fix(terminal): advance observe cursor from the emitted frame

### DIFF
--- a/examples/uhp/terminal/observe_revision_conformance.py
+++ b/examples/uhp/terminal/observe_revision_conformance.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Check final replacement frames through isolated named-session Access streams."""
+
+import argparse
+import json
+import os
+import pathlib
+import selectors
+import shlex
+import socket
+import subprocess
+import sys
+import time
+
+
+def stop(process):
+    """Terminate and reap a fixture-owned process with a bounded fallback."""
+    if process is not None and process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def main():
+    """Test observe/control transport; the deterministic race proof is in Rust."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--home", required=True)
+    parser.add_argument("--session", default="luvus-pr-test")
+    args = parser.parse_args()
+    binary = str(pathlib.Path(args.binary).resolve(strict=True))
+    home = pathlib.Path(args.home).resolve(strict=True)
+    if any(home.iterdir()):
+        raise ValueError("--home must be fresh and empty")
+    env = os.environ.copy()
+    for key in ("LUVUS_SOCKET_PATH", "LUVUS_SESSION", "LUVUS_ENV", "LUVUS_PANE_ID"):
+        env.pop(key, None)
+    env["LUVUS_HOME"] = str(home)
+    command = [binary, "--session", args.session]
+
+    def owner(method, params):
+        """Route one owner request through the explicitly selected namespace."""
+        process = subprocess.run(command + ["uhp", "proxy"], env=env, capture_output=True,
+                                 text=True, timeout=10, check=True,
+                                 input=json.dumps({"id": "owner", "method": method, "params": params}) + "\n")
+        response = json.loads(process.stdout)
+        assert "error" not in response, response
+        return response["result"]
+
+    server = gateway = None
+    try:
+        server = subprocess.Popen(command + ["server"], env=env, stdin=subprocess.DEVNULL,
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        deadline = time.monotonic() + 10
+        while True:
+            assert server.poll() is None, "isolated server exited"
+            try:
+                owner("uhp.capabilities", {})
+                break
+            except subprocess.CalledProcessError:
+                assert time.monotonic() < deadline, "server startup timeout"
+                time.sleep(0.025)
+        print(json.dumps({"binary": binary, "home": str(home), "session": args.session}))
+        for control in (False, True):
+            pane = owner("pane.split", {})["pane"]
+            trigger = home / f"trigger-{control}"
+            child = [sys.executable, str(pathlib.Path(__file__).resolve()), "--child", str(trigger)]
+            owner("pane.run", {"pane": pane, "command": "exec " + shlex.join(child)})
+            inventory = owner("terminal.backend.inventory", {})
+            terminal = next(t for t in inventory["terminals"] if t["pane_id"] == pane)
+            params = {key: terminal[key] for key in ("terminal_id", "pane_id")}
+            params["server_generation"] = inventory["server_generation"]
+            params.update(mode="recent_unwrapped", lines=200, ansi=True)
+            gateway = subprocess.Popen(command + ["uhp", "access"] + (["--control"] if control else []),
+                                       env=env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                                       stderr=subprocess.DEVNULL, text=True)
+            with selectors.DefaultSelector() as selector:
+                selector.register(gateway.stdout, selectors.EVENT_READ)
+                assert selector.select(10), "Access descriptor timeout"
+                descriptor = json.loads(gateway.stdout.readline())
+            address = (descriptor["endpoint"]["host"], descriptor["endpoint"]["port"])
+            with socket.create_connection(address, timeout=5) as pair:
+                pair.sendall(json.dumps({"type": "pair", "code": descriptor["pairing"]["code"]}).encode() + b"\n")
+                with pair.makefile("rb") as reader:
+                    token = json.loads(reader.readline())["token"]
+            with socket.create_connection(address, timeout=5) as stream:
+                method = "terminal.backend.control" if control else "terminal.backend.observe"
+                stream.sendall(json.dumps({"id": "observe", "method": method, "params": params, "auth": token}).encode() + b"\n")
+                with stream.makefile("rb") as reader:
+                    ack = json.loads(reader.readline(1024 * 1024 + 1))
+                    assert ack["result"]["type"] == "terminal_backend_stream", ack
+                    # Trigger a final update before consuming the initial frame.
+                    # Timing does not guarantee the baseline race: Rust's writer
+                    # barrier test is the authoritative red/green evidence.
+                    trigger.touch()
+                    time.sleep(0.05)
+                    revisions = []
+                    deadline = time.monotonic() + 10
+                    while time.monotonic() < deadline:
+                        frame = json.loads(reader.readline(1024 * 1024 + 1))
+                        assert frame["event"] == "terminal.frame", frame
+                        revisions.append(frame["data"]["content_revision"])
+                        if "FINAL_QUIET_MARKER" in frame["data"]["text"]:
+                            print(json.dumps({"method": method, "revisions": revisions,
+                                              "final_frame": frame, "timing_race_proof": False}))
+                            break
+                    else:
+                        raise AssertionError("final quiet marker was not delivered")
+            stop(gateway)
+            gateway = None
+    finally:
+        stop(gateway)
+        stop(server)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3 and sys.argv[1] == "--child":
+        print("OBSERVE_READY", flush=True)
+        while not pathlib.Path(sys.argv[2]).exists():
+            time.sleep(0.01)
+        print("FINAL_QUIET_MARKER", flush=True)
+        while True:
+            time.sleep(60)
+    else:
+        main()

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -127,6 +127,9 @@ required and authorized.
 - Handle `terminal.frame`, `terminal.output_ready`, exit, close, and resync
   events by their exact terminal ID and sequence.
 - Treat the control stream as an exclusive lease and release it promptly.
+- Apply `terminal.frame` as a complete replacement at its captured revision;
+  the acknowledgment revision is not an emitted-frame cursor. Reconnect for a
+  fresh frame after EOF or resync, including when the child is quiet.
 - Use typed literal, submit, and key actions instead of inventing escape
   sequences.
 - Never replace semantic agent or pane commands with terminal control merely

--- a/protocol/uhp/v1/terminal/README.md
+++ b/protocol/uhp/v1/terminal/README.md
@@ -71,6 +71,13 @@ stream may lease a terminal at a time. There are at most eight combined
 observe/control streams per server. Overflow requires a fresh capture and
 reconnect.
 
+Each `terminal.frame` replaces the previous capture. Its `content_revision`
+belongs to the text captured under the terminal-engine lock. Both initial and
+subsequent sends advance the stream cursor only to that emitted revision,
+after a successful write; output arriving during a write remains eligible for
+the next frame. The acknowledgment's revision is an earlier observation, not
+proof that a frame has been emitted. The wire shape and event catalog are unchanged.
+
 An installed binary exposes the same contract with `luvus uhp schema`,
 live negotiation with `luvus uhp capabilities`, the fenced inventory
 with `luvus uhp snapshot`, and terminal events with

--- a/protocol/uhp/v1/terminal/conformance/README.md
+++ b/protocol/uhp/v1/terminal/conformance/README.md
@@ -58,6 +58,21 @@ conformance. The event queue overflow path itself remains a deterministic Rust
 unit test because operating-system socket buffer sizes make a deliberately slow
 live reader nondeterministic.
 
+The initial-write regression is also deterministic: Rust tests pause the writer
+after capturing revision 3, publish one final revision 4, and require both
+frames for observe and control. The Unix transport check below adds live
+evidence but is not the race's red proof:
+
+```sh
+test_home=$(mktemp -d "$PWD/target/observe-revision.XXXXXX")
+python3 examples/uhp/terminal/observe_revision_conformance.py \
+  --binary target/debug/luvus --home "$test_home" --session luvus-pr-test
+```
+
+The runner starts and stops only its fresh named test namespace and paired
+gateways, clearing inherited socket/session selectors. It prints actual frames
+for observe/control without exposing pairing codes or tokens.
+
 On Windows, build the debug binary and run the independent PowerShell consumer:
 
 ```powershell

--- a/protocol/uhp/v1/terminal/fixtures/manifest.json
+++ b/protocol/uhp/v1/terminal/fixtures/manifest.json
@@ -3,7 +3,7 @@
   "files":[
     {"path":"valid/requests.jsonl","kind":"request","expect":"valid","count":19},
     {"path":"valid/responses.jsonl","kind":"response","expect":"valid","count":12},
-    {"path":"valid/events.jsonl","kind":"event","expect":"valid","count":4},
+    {"path":"valid/events.jsonl","kind":"event","expect":"valid","count":5},
     {"path":"valid/control-frames.jsonl","kind":"control","expect":"valid","count":3},
     {"path":"invalid/requests.jsonl","kind":"request","expect":"invalid","count":10},
     {"path":"invalid/responses.jsonl","kind":"response","expect":"invalid","count":1},

--- a/protocol/uhp/v1/terminal/fixtures/valid/events.jsonl
+++ b/protocol/uhp/v1/terminal/fixtures/valid/events.jsonl
@@ -2,3 +2,4 @@
 {"event":"terminal.output_ready","sequence":13,"data":{"server_generation":"11111111111111111111111111111111","terminal_id":"22222222222222222222222222222222","pane_id":"7","content_revision":5,"workspace":1,"tab":2,"detail":{}}}
 {"event":"terminal.resync_required","sequence":14,"data":{"reason":"subscriber_overflow"}}
 {"event":"terminal.frame","sequence":15,"data":{"server_generation":"11111111111111111111111111111111","terminal_id":"22222222222222222222222222222222","pane_id":"7","content_revision":5,"mode":"visible","ansi":true,"text":"ready","lines":1,"bytes":5,"truncated":false}}
+{"event":"terminal.frame","sequence":16,"data":{"server_generation":"11111111111111111111111111111111","terminal_id":"22222222222222222222222222222222","pane_id":"7","content_revision":6,"mode":"visible","ansi":true,"text":"ready\nfinal","lines":2,"bytes":11,"truncated":false}}

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -127,6 +127,9 @@ required and authorized.
 - Handle `terminal.frame`, `terminal.output_ready`, exit, close, and resync
   events by their exact terminal ID and sequence.
 - Treat the control stream as an exclusive lease and release it promptly.
+- Apply `terminal.frame` as a complete replacement at its captured revision;
+  the acknowledgment revision is not an emitted-frame cursor. Reconnect for a
+  fresh frame after EOF or resync, including when the child is quiet.
 - Use typed literal, submit, and key actions instead of inventing escape
   sequences.
 - Never replace semantic agent or pane commands with terminal control merely

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -1277,6 +1277,8 @@ fn stream_event_for_target(line: &str, terminal_id: &str) -> Option<(String, u64
 }
 
 fn write_shared_frame(writer: &Mutex<Conn>, frame: &str) -> io::Result<()> {
+    #[cfg(test)]
+    tests::pause_initial_frame_write(frame);
     let mut writer = writer
         .lock()
         .map_err(|_| io::Error::other("terminal stream writer unavailable"))?;
@@ -2700,6 +2702,133 @@ mod tests {
         assert!(reject_duplicate_keys(br#"{"id":"1","id":"2"}"#).is_err());
         assert!(reject_duplicate_keys(br#"{"params":{"x":1,"x":2}}"#).is_err());
         assert!(reject_duplicate_keys(br#"{"id":"1","params":{"x":2}}"#).is_ok());
+    }
+
+    struct FrameWriteBarrier {
+        captured: Sender<()>,
+        resume: mpsc::Receiver<()>,
+    }
+
+    static FRAME_WRITE_BARRIERS: std::sync::LazyLock<
+        Mutex<std::collections::HashMap<String, FrameWriteBarrier>>,
+    > = std::sync::LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
+
+    pub(super) fn pause_initial_frame_write(frame: &str) {
+        let value: Value = serde_json::from_str(frame).unwrap();
+        if value["event"] != "terminal.frame" {
+            return;
+        }
+        let barrier = FRAME_WRITE_BARRIERS
+            .lock()
+            .unwrap()
+            .remove(value["data"]["terminal_id"].as_str().unwrap());
+        if let Some(barrier) = barrier {
+            barrier.captured.send(()).unwrap();
+            barrier
+                .resume
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .unwrap();
+        }
+    }
+
+    fn assert_final_update_during_initial_write(control: bool) {
+        let _env = crate::persist::test_env("observe-write-race");
+        let root = crate::persist::ensure_config_dir();
+        let path = root.join("race.sock");
+        let lock = transport::acquire_server_startup_lock(&root).unwrap();
+        let listener = bind_server(&path, &lock).unwrap();
+        let (events, event_rx) = mpsc::channel();
+        let bus = new_bus();
+        start_server(listener, events, bus.clone());
+        drop(lock);
+        let mut target = observe_target();
+        target.terminal_id = format!("initial-write-race-{control}");
+        let terminal_id = target.terminal_id.clone();
+        let engine = Arc::clone(&target.engine);
+        let revision = Arc::clone(&target.content_revision);
+        let (captured_tx, captured_rx) = mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
+        FRAME_WRITE_BARRIERS.lock().unwrap().insert(
+            terminal_id.clone(),
+            FrameWriteBarrier {
+                captured: captured_tx,
+                resume: resume_rx,
+            },
+        );
+        let client_terminal = terminal_id.clone();
+        let client =
+            thread::spawn(move || {
+                let mut stream = transport::connect(&path).unwrap();
+                stream
+                    .set_timeouts(std::time::Duration::from_secs(5))
+                    .unwrap();
+                writeln!(stream, "{}", json!({"id":"race","method":if control {
+                "terminal.backend.control"
+            } else { "terminal.backend.observe" },"params":{
+                "server_generation":"generation","terminal_id":client_terminal,"pane_id":"7",
+                "mode":"visible","lines":4,"ansi":true
+            }})).unwrap();
+                let mut reader = BufReader::new(stream);
+                let mut frames = Vec::new();
+                loop {
+                    let frame: Value =
+                        serde_json::from_str(&read_response_frame(&mut reader).unwrap()).unwrap();
+                    if frame["event"] == "terminal.closed" {
+                        break;
+                    }
+                    if frame["event"] == "terminal.frame" {
+                        frames.push(frame);
+                    }
+                }
+                frames
+            });
+        let AppEvent::BackendObserve { reply, .. } = event_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap()
+        else {
+            panic!("stream must resolve its target");
+        };
+        reply.send(Ok(target)).unwrap();
+        captured_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+        {
+            let mut engine = engine.lock().unwrap();
+            engine.advance(b"\r\nfinal-quiet-marker");
+            revision.fetch_add(1, Ordering::AcqRel);
+        }
+        publish_event(
+            &bus,
+            "terminal.output_ready",
+            json!({"terminal_id":terminal_id,"content_revision":4}),
+        );
+        // Both events fit the bounded queue. Close gives a deterministic end
+        // marker even on the buggy baseline; no timeout is the red proof.
+        publish_event(&bus, "terminal.closed", json!({"terminal_id":terminal_id}));
+        resume_tx.send(()).unwrap();
+        let frames = client.join().unwrap();
+        assert_eq!(
+            frames
+                .iter()
+                .map(|f| f["data"]["content_revision"].as_u64().unwrap())
+                .collect::<Vec<_>>(),
+            vec![3, 4],
+            "the final quiet revision must follow the emitted initial frame"
+        );
+        assert!(frames[1]["data"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("final-quiet-marker"));
+    }
+
+    #[test]
+    fn observe_does_not_skip_output_during_initial_frame_write() {
+        assert_final_update_during_initial_write(false);
+    }
+
+    #[test]
+    fn control_does_not_skip_output_during_initial_frame_write() {
+        assert_final_update_during_initial_write(true);
     }
 
     fn observe_target() -> crate::terminal::backend::ObserveTarget {

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -1226,11 +1226,13 @@ fn matching_event(line: &str, event: &str, predicate: &Value) -> Option<Value> {
         .then_some(value)
 }
 
+/// A capture and the revision observed while its engine lock was held.
 struct TerminalStreamFrame {
     serialized: String,
     content_revision: u64,
 }
 
+/// Capture one bounded replacement frame together with its exact revision.
 fn terminal_stream_frame(
     target: &crate::terminal::backend::ObserveTarget,
     sequence: u64,
@@ -1284,6 +1286,7 @@ fn stream_event_for_target(line: &str, terminal_id: &str) -> Option<(String, u64
     })
 }
 
+/// Serialize writes from the output forwarder and correlated control replies.
 fn write_shared_frame(writer: &Mutex<Conn>, frame: &str) -> io::Result<()> {
     #[cfg(test)]
     tests::pause_initial_frame_write(frame);
@@ -1371,6 +1374,7 @@ fn control_action_response(
         })
 }
 
+/// Own a bounded observe/control subscription until disconnect or cancellation.
 fn handle_terminal_stream(
     reader: &mut BufReader<Conn>,
     writer: Conn,
@@ -2721,6 +2725,7 @@ mod tests {
         Mutex<std::collections::HashMap<String, FrameWriteBarrier>>,
     > = std::sync::LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 
+    /// Apply a terminal-specific, one-shot barrier after capture in tests only.
     pub(super) fn pause_initial_frame_write(frame: &str) {
         let value: Value = serde_json::from_str(frame).unwrap();
         if value["event"] != "terminal.frame" {
@@ -2739,6 +2744,7 @@ mod tests {
         }
     }
 
+    /// Force the quiet-final-update schedule through the real IPC forwarder.
     fn assert_final_update_during_initial_write(control: bool) {
         let _env = crate::persist::test_env("observe-write-race");
         let root = crate::persist::ensure_config_dir();
@@ -2830,11 +2836,13 @@ mod tests {
     }
 
     #[test]
+    /// Pin observe delivery when output advances before the first write finishes.
     fn observe_does_not_skip_output_during_initial_frame_write() {
         assert_final_update_during_initial_write(false);
     }
 
     #[test]
+    /// Pin the same initial-write invariant on the shared control forwarder.
     fn control_does_not_skip_output_during_initial_frame_write() {
         assert_final_update_during_initial_write(true);
     }
@@ -2858,6 +2866,7 @@ mod tests {
     }
 
     #[test]
+    /// Keep serialized identity, captured revision and payload bounds coupled.
     fn terminal_stream_frame_is_bounded_and_identified() {
         let target = observe_target();
         let frame = terminal_stream_frame(&target, 12).unwrap();
@@ -2939,6 +2948,7 @@ mod tests {
     }
 
     #[test]
+    /// Preserve initial/change frames, exact filtering, deduplication and exit.
     fn observe_stream_sends_initial_and_change_driven_frames() {
         let _env = crate::persist::test_env("terminal-observe-stream");
         let root = crate::persist::ensure_config_dir();

--- a/src/ipc/api.rs
+++ b/src/ipc/api.rs
@@ -1226,10 +1226,15 @@ fn matching_event(line: &str, event: &str, predicate: &Value) -> Option<Value> {
         .then_some(value)
 }
 
+struct TerminalStreamFrame {
+    serialized: String,
+    content_revision: u64,
+}
+
 fn terminal_stream_frame(
     target: &crate::terminal::backend::ObserveTarget,
     sequence: u64,
-) -> Result<String, &'static str> {
+) -> Result<TerminalStreamFrame, &'static str> {
     let engine = target
         .engine
         .lock()
@@ -1260,7 +1265,10 @@ fn terminal_stream_frame(
     })
     .to_string();
     (frame.len().saturating_add(1) <= crate::terminal::backend::MAX_FRAME_BYTES)
-        .then_some(frame)
+        .then_some(TerminalStreamFrame {
+            serialized: frame,
+            content_revision,
+        })
         .ok_or("serialized terminal frame exceeded protocol limit")
 }
 
@@ -1484,11 +1492,11 @@ fn handle_terminal_stream(
         .spawn(move || {
             let mut last_revision = u64::MAX;
             if let Ok(frame) = terminal_stream_frame(&forward_target, sequence) {
-                if write_shared_frame(&forward_writer, &frame).is_err() {
+                if write_shared_frame(&forward_writer, &frame.serialized).is_err() {
                     forward_active.store(false, Ordering::Release);
                     return;
                 }
-                last_revision = forward_target.content_revision.load(Ordering::Acquire);
+                last_revision = frame.content_revision;
             }
             for line in receiver {
                 if !forward_active.load(Ordering::Acquire) {
@@ -1515,11 +1523,11 @@ fn handle_terminal_stream(
                         forward_active.store(false, Ordering::Release);
                         break;
                     };
-                    if write_shared_frame(&forward_writer, &frame).is_err() {
+                    if write_shared_frame(&forward_writer, &frame.serialized).is_err() {
                         forward_active.store(false, Ordering::Release);
                         break;
                     }
-                    last_revision = revision;
+                    last_revision = frame.content_revision;
                 } else if matches!(event.as_str(), "terminal.exited" | "terminal.closed") {
                     let _ = write_shared_frame(&forward_writer, &line);
                     forward_active.store(false, Ordering::Release);
@@ -2853,7 +2861,8 @@ mod tests {
     fn terminal_stream_frame_is_bounded_and_identified() {
         let target = observe_target();
         let frame = terminal_stream_frame(&target, 12).unwrap();
-        let frame: Value = serde_json::from_str(&frame).unwrap();
+        assert_eq!(frame.content_revision, 3);
+        let frame: Value = serde_json::from_str(&frame.serialized).unwrap();
         assert_eq!(frame["event"], "terminal.frame");
         assert_eq!(frame["sequence"], 12);
         assert_eq!(frame["data"]["terminal_id"], "terminal");
@@ -2943,6 +2952,7 @@ mod tests {
 
         let client_path = path.clone();
         let (initial_tx, initial_rx) = mpsc::channel();
+        let (updated_tx, updated_rx) = mpsc::channel();
         let client = thread::spawn(move || {
             let mut stream = transport::connect(&client_path).unwrap();
             stream
@@ -2959,12 +2969,15 @@ mod tests {
             .unwrap();
             let mut reader = BufReader::new(stream);
             let mut lines = Vec::new();
-            for index in 0..3 {
+            for index in 0..4 {
                 let mut line = String::new();
                 reader.read_line(&mut line).unwrap();
                 lines.push(serde_json::from_str::<Value>(&line).unwrap());
                 if index == 1 {
                     initial_tx.send(()).unwrap();
+                }
+                if index == 2 {
+                    updated_tx.send(()).unwrap();
                 }
             }
             lines
@@ -2978,6 +2991,11 @@ mod tests {
         let revision = Arc::clone(&target.content_revision);
         reply.send(Ok(target)).unwrap();
         initial_rx.recv().unwrap();
+        publish_event(
+            &bus,
+            "terminal.output_ready",
+            json!({"terminal_id":"other-terminal","content_revision":99}),
+        );
         engine.lock().unwrap().advance(b"\r\nupdated");
         revision.fetch_add(1, Ordering::AcqRel);
         publish_event(
@@ -2986,6 +3004,16 @@ mod tests {
             json!({"terminal_id":"terminal","pane":"7","content_revision":4}),
         );
 
+        updated_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        publish_event(
+            &bus,
+            "terminal.output_ready",
+            json!({"terminal_id":"terminal","content_revision":4}),
+        );
+        publish_event(&bus, "terminal.exited", json!({"terminal_id":"terminal"}));
+
         let lines = client.join().unwrap();
         assert_eq!(lines[0]["result"]["type"], "terminal_backend_stream");
         assert_eq!(lines[0]["result"]["queue_capacity"], 2);
@@ -2993,6 +3021,10 @@ mod tests {
         assert_eq!(lines[1]["data"]["content_revision"], 3);
         assert_eq!(lines[2]["event"], "terminal.frame");
         assert_eq!(lines[2]["data"]["content_revision"], 4);
+        assert_eq!(
+            lines[3]["event"], "terminal.exited",
+            "duplicate revisions must not emit another frame"
+        );
         assert!(lines[2]["data"]["text"]
             .as_str()
             .unwrap()

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -389,6 +389,11 @@ process closes.
 
 ## Remote use
 
+Observe/control `terminal.frame` messages replace the previous capture at the
+frame's own `content_revision`. The acknowledgment revision is not an emitted
+frame cursor. A quiet final update must remain deliverable after an in-flight
+write; reconnect for a fresh frame after EOF or `terminal.resync_required`.
+
 ```sh
 ssh <host>             # run Luvus on that machine
 luvus --remote <host>  # local thin client, remote Luvus server

--- a/website/src/content/docs/docs/uhp/conformance.mdx
+++ b/website/src/content/docs/docs/uhp/conformance.mdx
@@ -111,6 +111,12 @@ cargo build --locked
 Never point live mutation or failure tests at `~/.luvus/`, an installed server,
 or a production named session.
 
+For final quiet output on Unix, run
+`examples/uhp/terminal/observe_revision_conformance.py --binary target/debug/luvus --home <fresh-empty-home> --session luvus-pr-test`.
+It checks both paired observe/control streams and stops its own processes.
+The Rust initial-write barrier tests provide the deterministic race proof;
+successful live delivery alone does not force that interleaving.
+
 ## Benchmark the protocol path
 
 Use an optimized build and equivalent workloads:

--- a/website/src/content/docs/docs/uhp/terminal.mdx
+++ b/website/src/content/docs/docs/uhp/terminal.mdx
@@ -94,6 +94,12 @@ combined observe/control streams. Slow clients receive best-effort
 `terminal.resync_required` and disconnect. Treat EOF the same way and reconnect
 for a fresh initial frame.
 
+Frames are complete replacements. Their `content_revision` identifies the
+captured text, and the sender advances its cursor to that revision only after
+writing the frame successfully. Output arriving during the initial or a later
+write remains eligible for delivery, even when the child then becomes quiet.
+The acknowledgment revision does not mean that output has already been emitted.
+
 `terminal.backend.control` has the same output stream and accepts correlated
 action frames after its acknowledgment:
 


### PR DESCRIPTION
Observe and control streams retain a quiet final update that arrives while the initial frame is being written. The cursor now records the revision of the captured frame actually emitted, on both initial and subsequent sends.

Base: `4494d819e60e9d4c4537fe3673de337c2eaa5cd8`
Head: `6c19b300374cd7bf34b7fcca578708f3ac8fd468`

## What

`terminal_stream_frame` returns an internal serialized-frame/captured-revision record. Only a successful write advances the cursor, directly to that record's revision; no live reload or max. The acknowledgment revision, wire shape, capacity, filters, cancellation and error paths remain unchanged.

A test-only one-shot writer barrier forces: capture revision 3 → pause → advance engine/revision to 4 and queue exactly one output event → finish writing revision 3. Closing the test stream provides deterministic termination even on the buggy base; the red proof is the revision assertion, not a timeout. Both observe and control use the real IPC handler/forwarder. A separate regression pins other-terminal filtering, subsequent output, duplicate-revision suppression and exit.

## Tests

First commit `3ab209e` adds only tests and a Unix live harness.
Red: `cargo test --locked does_not_skip_output_during_initial_frame_write -- --nocapture` → **0 passed, 2 failed** (`observe_does_not_skip_output_during_initial_frame_write`, `control_does_not_skip_output_during_initial_frame_write`):
```text
assertion `left == right` failed: the final quiet revision must follow the emitted initial frame
  left: [3]
 right: [3, 4]
```
Green: `cargo test --locked ipc::api::tests -- --nocapture` → **33 passed, 0 failed**. This also runs bounded framing/EOF, immediate flush, exact-terminal filtering, exclusive control lease/release, overflow/resync, cancellation and malformed-action tests.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --locked`: passed.
`env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION LUVUS_HOME="$PWD/target/mobile-pr-e782/test-home-o1" cargo test --locked`: **1508 passed, 0 failed, 1 ignored**.
General consumer: **92 fixtures**; terminal consumer: **56 fixtures**.

Literal isolated live commands, using the exact base binary saved before implementation and the patched debug binary:
```sh
analysis_home=$(mktemp -d "$PWD/target/o1-base.XXXXXX")
python3 examples/uhp/terminal/observe_revision_conformance.py --binary target/mobile-pr-e782/base-4494d819 --home "$analysis_home" --session luvus-pr-test
analysis_home=$(mktemp -d "$PWD/target/o1-after.XXXXXX")
python3 examples/uhp/terminal/observe_revision_conformance.py --binary target/debug/luvus --home "$analysis_home" --session luvus-pr-test
```
The harness launches `--session luvus-pr-test server` and paired `uhp access [--control]` with the fresh LUVUS_HOME and inherited socket/session selectors removed, then stops only its own processes in finally. Both base and patched live runs delivered the final marker; these are transport checks, **not** deterministic reproductions of the race. The unit barrier supplies red/green ordering evidence.

<details><summary>Literal baseline JSON</summary>

```json
{"binary": "/home/ubuntu/projects/Rust/luvus/target/mobile-pr-e782/base-4494d819", "home": "/home/ubuntu/projects/Rust/luvus/target/o1-base.ZUFt0q", "session": "luvus-pr-test"}
{"method": "terminal.backend.observe", "revisions": [1, 4], "final_frame": {"data": {"ansi": true, "bytes": 507, "content_revision": 4, "lines": 20, "mode": "recent_unwrapped", "pane_id": "2", "server_generation": "a42c29af866919317891e55a5121b623", "terminal_id": "918467275a0603e62345160b68a8fc91", "text": "exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-base.ZUFt0q/trigger-False\n\u001b[0;1;38;5;2mubuntu@instance-20260324-1922\u001b[0m:\u001b[0;1;38;5;4m~/projects/Rust/luvus\u001b[0m$ exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-base.ZUFt0q/trigger-False\nOBSERVE_READY\nFINAL_QUIET_MARKER\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", "truncated": false}, "event": "terminal.frame", "sequence": 7}, "timing_race_proof": false}
{"method": "terminal.backend.control", "revisions": [1, 4], "final_frame": {"data": {"ansi": true, "bytes": 505, "content_revision": 4, "lines": 20, "mode": "recent_unwrapped", "pane_id": "3", "server_generation": "a42c29af866919317891e55a5121b623", "terminal_id": "0e4efedfd94cf5db0419bf55f4ee7d3c", "text": "exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-base.ZUFt0q/trigger-True\n\u001b[0;1;38;5;2mubuntu@instance-20260324-1922\u001b[0m:\u001b[0;1;38;5;4m~/projects/Rust/luvus\u001b[0m$ exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-base.ZUFt0q/trigger-True\nOBSERVE_READY\nFINAL_QUIET_MARKER\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", "truncated": false}, "event": "terminal.frame", "sequence": 12}, "timing_race_proof": false}
```
</details>

<details><summary>Literal patched JSON</summary>

```json
{"binary": "/home/ubuntu/projects/Rust/luvus/target/debug/luvus", "home": "/home/ubuntu/projects/Rust/luvus/target/o1-after.WUr3d1", "session": "luvus-pr-test"}
{"method": "terminal.backend.observe", "revisions": [1, 4], "final_frame": {"data": {"ansi": true, "bytes": 509, "content_revision": 4, "lines": 20, "mode": "recent_unwrapped", "pane_id": "2", "server_generation": "d637144aebaead6f72b0c91f5ea16b00", "terminal_id": "08870b123f35aa3cb1ac0a3274d94b51", "text": "exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-after.WUr3d1/trigger-False\n\u001b[0;1;38;5;2mubuntu@instance-20260324-1922\u001b[0m:\u001b[0;1;38;5;4m~/projects/Rust/luvus\u001b[0m$ exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-after.WUr3d1/trigger-False\nOBSERVE_READY\nFINAL_QUIET_MARKER\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", "truncated": false}, "event": "terminal.frame", "sequence": 7}, "timing_race_proof": false}
{"method": "terminal.backend.control", "revisions": [1, 4], "final_frame": {"data": {"ansi": true, "bytes": 507, "content_revision": 4, "lines": 20, "mode": "recent_unwrapped", "pane_id": "3", "server_generation": "d637144aebaead6f72b0c91f5ea16b00", "terminal_id": "b8467d3d5e41b7fc77988bf6ce599601", "text": "exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-after.WUr3d1/trigger-True\n\u001b[0;1;38;5;2mubuntu@instance-20260324-1922\u001b[0m:\u001b[0;1;38;5;4m~/projects/Rust/luvus\u001b[0m$ exec /usr/bin/python3 /home/ubuntu/projects/Rust/luvus/examples/uhp/terminal/observe_revision_conformance.py --child /home/ubuntu/projects/Rust/luvus/target/o1-after.WUr3d1/trigger-True\nOBSERVE_READY\nFINAL_QUIET_MARKER\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", "truncated": false}, "event": "terminal.frame", "sequence": 12}, "timing_race_proof": false}
```
</details>

Additional `python3 examples/uhp/terminal/failure_conformance.py --luvus target/debug/luvus` could not reach its assertions: the pre-existing endpoint validator rejects group-writable checkout ancestors (`/home/ubuntu/projects`, mode 775). Its isolated server stopped in finally. No permission changes or validator weakening were made. This extra suite is unverified; the named-session R4 harness above and Rust API/full suites passed. Windows/macOS live behavior is untested here.

## First-pass checklist

- R1: Exact terminal-id filtering unchanged and exercised; observe/control, visible/recent/ANSI capture parameters and event names remain accepted. Duplicate revisions stay suppressed.
- R2: No new production rejection branches. Captured revision is assigned only after successful write; existing capture/write/cancel/overflow cleanup branches remain intact and API boundary tests pass.
- R3: CodeRabbit completed with no code findings; its docstring warning is addressed by comment-only 6c19b30. Inline comments/reviews rechecked (empty); no Greptile findings received.
- R4: Named fresh-home baseline/patched commands and literal frames above; deterministic race red proof is separate; all harness-owned processes stopped.
- R5: No wire shape change, so schema/event catalog/CLI syntax are no-ops. Terminal replay fixture/manifest, protocol docs, website and both bundled references updated together.
- R6: Frame terminal/pane identity and captured revision stay coupled; acknowledgment semantics remain unchanged.
- R7: Only emitted-frame cursor correctness; no persisted-screen fidelity, binary client projection, queue refactor or polling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal observe and control streams so output produced during frame delivery is not skipped, including final updates from quiet processes.
  - Ensured terminal frames are applied as complete replacements using their captured content revision.
  - Improved recovery after stream end or resynchronization by allowing clients to retrieve a fresh frame.
  - Clarified and documented terminal input queue limits and capacity errors.

- **Documentation**
  - Clarified frame, acknowledgment, revision, and reconnection behavior.
  - Added terminal stream conformance check instructions.

- **Tests**
  - Expanded coverage for initial-write races, duplicate revisions, cross-terminal filtering, and subsequent frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->