### PR TITLE
perf(automation): checkpoint ledger writes off the app loop

### DIFF
--- a/examples/automation/README.md
+++ b/examples/automation/README.md
@@ -1,5 +1,17 @@
 # Agent Automation example
 
+For an isolated Unix checkpoint regression test (no agent is launched):
+
+```sh
+cargo build --locked
+python3 examples/uhp/terminal/automation_checkpoints.py
+```
+
+This holds the shared storage worker, verifies that automation success waits
+for persistence while other requests remain responsive, checks the CLI, and
+restarts only its scratch server to verify idempotency. Pass `--luvus` to select
+an exact debug or release binary. It does not operate an existing user session.
+
 `weekday-readonly-review.sh` creates a weekday read-only review for an existing
 Luvus workspace. It previews the next occurrences before storing anything and
 uses an idempotency key so retrying the same command cannot create a duplicate.

--- a/examples/uhp/terminal/automation_checkpoints.py
+++ b/examples/uhp/terminal/automation_checkpoints.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Opt-in Unix automation checkpoint/CLI/restart test; never launches an agent."""
+
+import argparse
+import concurrent.futures
+import json
+import pathlib
+import statistics
+import subprocess
+import time
+
+from consumer import request
+from live_support import ROOT, isolated_server
+
+
+def call(server, method, params=None):
+    return request(server.socket_path, {
+        "id": method, "method": method, "params": params or {},
+    })
+
+
+def main():
+    import fcntl
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--luvus", default=str(ROOT / "target/debug/luvus"))
+    args = parser.parse_args()
+    with isolated_server(pathlib.Path(args.luvus).resolve(strict=True), "automation-checkpoints-") as server:
+        workspaces = call(server, "workspace.list")["result"]["workspaces"]
+        params = {
+            "name": "checkpoint regression", "enabled": False,
+            "trigger": {"kind": "once", "at_utc": int(time.time()) + 3600},
+            "task": {
+                "title": "checkpoint regression", "prompt": "Do not execute this disabled fixture.",
+                "agent_id": "codex", "workspace_id": workspaces[0]["workspace_id"],
+                "mode": "workspace", "access": "read_only",
+            },
+            "idempotency_key": "checkpoint-regression",
+        }
+        # Hold the existing shared worker in a bounded config-lock acquisition.
+        # Automation acknowledgement must wait, while unrelated API stays live.
+        samples = []
+        with (server.state / "config.lock").open("a+b") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            assert "result" in call(server, "config.patch", {"patch": {"agents_this_workspace": True}})
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(call, server, "automation.create", params)
+                time.sleep(0.05)
+                assert not future.done(), "automation acknowledged before its checkpoint"
+                for _ in range(50):
+                    start = time.perf_counter()
+                    assert "result" in call(server, "ping")
+                    samples.append((time.perf_counter() - start) * 1000)
+                fcntl.flock(lock, fcntl.LOCK_UN)
+                created = future.result(timeout=10)
+        assert "result" in created, created
+        identity = created["result"]["automation"]["id"]
+        ledger = json.loads((server.state / "automations.json").read_text())
+        assert any(item["id"] == identity for item in ledger["automations"])
+        assert not ledger["runs"], "disabled fixture must not launch anything"
+        retry = call(server, "automation.create", params)
+        assert retry["result"]["automation"]["id"] == identity
+        cli = subprocess.run([str(server.binary), "automation", "list"],
+                             env=server.environment, cwd=ROOT, capture_output=True,
+                             text=True, check=True, timeout=10)
+        assert identity in cli.stdout
+        server.stop()
+        server.start()
+        retry = call(server, "automation.create", params)
+        assert retry["result"]["automation"]["id"] == identity, retry
+        assert len(call(server, "automation.list")["result"]["automations"]) == 1
+        assert not call(server, "automation.history")["result"]["runs"]
+        print(json.dumps({"checkpoint_ack_order": "passed", "cli": "passed",
+                          "restart_idempotency": "passed", "agents_launched": 0,
+                          "ping_samples": len(samples),
+                          "blocked_worker_ping_median_ms": statistics.median(samples),
+                          "blocked_worker_ping_max_ms": max(samples)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/uhp/terminal/automation_checkpoints.py
+++ b/examples/uhp/terminal/automation_checkpoints.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Opt-in Unix automation checkpoint/CLI/restart test; never launches an agent."""
+"""Opt-in Unix checkpoint/CLI/restart test using a fake worker, never a provider."""
 
 import argparse
 import concurrent.futures
@@ -7,6 +7,7 @@ import json
 import pathlib
 import statistics
 import subprocess
+import sys
 import time
 
 from consumer import request
@@ -19,6 +20,48 @@ def call(server, method, params=None):
     })
 
 
+def install_fixture_worker(server):
+    """Restrict worker resolution before admitting any runnable definition."""
+    server.stop()
+    fixtures = server.state / "fixture-bin"
+    fixtures.mkdir()
+    marker = server.state / "fixture-launches.jsonl"
+    executable = fixtures / "codex"
+    executable.write_text(
+        f"#!{pathlib.Path(sys.executable).resolve()}\n"
+        "import json, os, pathlib, sys\n"
+        f"marker = pathlib.Path({str(marker)!r})\n"
+        "record = {'argv': sys.argv[1:], 'task_id': os.environ.get('LUVUS_TASK_ID')}\n"
+        "with marker.open('a') as stream:\n"
+        "    stream.write(json.dumps(record) + '\\n')\n"
+        "assert sys.argv[1:-1] == ['exec', '--sandbox', 'read-only', '-c', 'approval_policy=never']\n"
+        "assert len(sys.argv) == 7 and record['task_id']\n"
+        "assert 'Checkpoint fixture only.' in sys.argv[-1]\n"
+        "print('checkpoint fixture completed')\n"
+    )
+    executable.chmod(0o700)
+    # No user shell startup/PATH or real provider executable participates.
+    server.environment["PATH"] = f"{fixtures}:/usr/bin:/bin"
+    server.environment["SHELL"] = "/bin/sh"
+    for key in ("ENV", "BASH_ENV", "ZDOTDIR"):
+        server.environment.pop(key, None)
+    (server.state / "config.json").write_text(json.dumps({"shell": "/bin/sh"}))
+    server.start()
+    return marker
+
+
+def wait_for_completed_run(server, identity, run_id):
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        runs = call(server, "automation.history", {"id": identity})["result"]["runs"]
+        run = next(item for item in runs if item["id"] == run_id)
+        assert run["status"] not in ("failed", "cancelled", "skipped", "review"), run
+        if run["status"] == "succeeded":
+            return run
+        time.sleep(0.05)
+    raise AssertionError(f"fixture worker failed to complete: {run}")
+
+
 def main():
     import fcntl
 
@@ -26,6 +69,7 @@ def main():
     parser.add_argument("--luvus", default=str(ROOT / "target/debug/luvus"))
     args = parser.parse_args()
     with isolated_server(pathlib.Path(args.luvus).resolve(strict=True), "automation-checkpoints-") as server:
+        marker = install_fixture_worker(server)
         workspaces = call(server, "workspace.list")["result"]["workspaces"]
         params = {
             "name": "checkpoint regression", "enabled": False,
@@ -64,14 +108,38 @@ def main():
                              env=server.environment, cwd=ROOT, capture_output=True,
                              text=True, check=True, timeout=10)
         assert identity in cli.stdout
+        assert "result" in call(server, "automation.update", {
+            **{key: value for key, value in params.items() if key != "idempotency_key"},
+            "id": identity,
+            "task": {**params["task"], "prompt": "Checkpoint fixture only."},
+        })
+        assert "result" in call(server, "automation.enable", {"id": identity})
+        run_params = {"id": identity, "idempotency_key": "fixture-run-once"}
+        admitted = call(server, "automation.run", run_params)
+        assert "result" in admitted, admitted
+        run_id = admitted["result"]["run"]["id"]
+        assert call(server, "automation.run", run_params)["result"]["run"]["id"] == run_id
+        completed = wait_for_completed_run(server, identity, run_id)
+        task_id = completed["task_id"]
+        assert call(server, "task.get", {"id": task_id})["result"]["task"]["status"] == "done"
+        assert len(call(server, "task.list")["result"]["tasks"]) == 1
+        launches = [json.loads(line) for line in marker.read_text().splitlines()]
+        assert len(launches) == 1 and launches[0]["task_id"] == task_id, launches
+
         server.stop()
         server.start()
         retry = call(server, "automation.create", params)
         assert retry["result"]["automation"]["id"] == identity, retry
         assert len(call(server, "automation.list")["result"]["automations"]) == 1
-        assert not call(server, "automation.history")["result"]["runs"]
+        assert call(server, "automation.run", run_params)["result"]["run"]["id"] == run_id
+        restored = wait_for_completed_run(server, identity, run_id)
+        assert restored["task_id"] == task_id
+        assert len(call(server, "automation.history")["result"]["runs"]) == 1
+        assert len(call(server, "task.list")["result"]["tasks"]) == 1
+        assert len(marker.read_text().splitlines()) == 1, "retry/restart launched the fixture twice"
         print(json.dumps({"checkpoint_ack_order": "passed", "cli": "passed",
-                          "restart_idempotency": "passed", "agents_launched": 0,
+                          "restart_idempotency": "passed", "external_agents_launched": 0,
+                          "fixture_workers_launched": 1, "worker_completion": "passed",
                           "ping_samples": len(samples),
                           "blocked_worker_ping_median_ms": statistics.median(samples),
                           "blocked_worker_ping_max_ms": max(samples)}, indent=2))

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -393,6 +393,10 @@ surface:
   idempotency key for retryable create/run requests, and never turn an
   automation into an arbitrary scheduled shell command. Disabling prevents
   future occurrences; it does not stop a live ORCH task or pane.
+  Mutation success waits for the ledger checkpoint. After `persistence_failed`
+  or a lost response, inspect state and retry the same idempotency key; do not
+  assume the definition is absent or create a duplicate schedule. A failed
+  prelaunch occurrence is not automatically relaunched on storage recovery.
   `target=new_worker` is the durable default. Use `active_agent` only with
   the exact discovered pane, terminal lifetime, agent, and workspace identities;
   treat `delivered` as input-queue evidence rather than completed work, and do

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -393,6 +393,10 @@ surface:
   idempotency key for retryable create/run requests, and never turn an
   automation into an arbitrary scheduled shell command. Disabling prevents
   future occurrences; it does not stop a live ORCH task or pane.
+  Mutation success waits for the ledger checkpoint. After `persistence_failed`
+  or a lost response, inspect state and retry the same idempotency key; do not
+  assume the definition is absent or create a duplicate schedule. A failed
+  prelaunch occurrence is not automatically relaunched on storage recovery.
   `target=new_worker` is the durable default. Use `active_agent` only with
   the exact discovered pane, terminal lifetime, agent, and workspace identities;
   treat `delivered` as input-queue evidence rather than completed work, and do

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -111,7 +111,7 @@ impl App {
             }
         }
         if changed {
-            let _ = self.automation.save();
+            self.persist_automation();
         }
         changed |= self.reconcile_durable_active_targets(None);
         let restoring_panes = self
@@ -194,6 +194,9 @@ impl App {
     /// O(1) on ordinary server ticks. Definition scans happen only when the
     /// cached nearest UTC deadline is due.
     pub fn tick_automations(&mut self, now: u64) -> bool {
+        if self.automation_save_pending() {
+            return false;
+        }
         let due = self
             .automation
             .next_deadline()
@@ -201,26 +204,19 @@ impl App {
         if !due {
             return false;
         }
-        let created = self.automation.collect_due(now);
+        self.automation.collect_due(now);
         // Persist the advanced deadline and every occurrence outcome before an
         // ORCH task or PTY can be created. A skipped overlap has no pending run
         // to launch, but its occurrence key and next deadline are still durable.
-        if let Err(error) = self.automation.save() {
-            for run_id in created {
-                let _ = self.automation.set_run_status(
-                    &run_id,
-                    RunStatus::Failed,
-                    Some(format!("automation persistence failed: {error}")),
-                    now,
-                );
-            }
-            return true;
-        }
+        self.persist_automation();
         self.start_pending_automation_runs(now);
         true
     }
 
     pub fn start_pending_automation_runs(&mut self, now: u64) -> bool {
+        if self.automation_save_pending() {
+            return false;
+        }
         let pending = self.automation.pending_runs();
         let mut changed = false;
         for run_id in pending {
@@ -230,6 +226,9 @@ impl App {
     }
 
     pub fn start_automation_run(&mut self, run_id: &str, now: u64) -> bool {
+        if self.automation_save_pending() {
+            return false;
+        }
         let Some(run) = self.automation.run(run_id).cloned() else {
             return false;
         };
@@ -252,7 +251,7 @@ impl App {
                 Some(message.clone()),
                 now,
             );
-            let _ = self.automation.save();
+            self.persist_automation();
             self.emit_event(
                 "automation.run_failed",
                 json!({"run_id": run_id, "automation_id": run.automation_id, "code": "no_session"}),
@@ -271,7 +270,7 @@ impl App {
                     Some(message.clone()),
                     now,
                 );
-                let _ = self.automation.save();
+                self.persist_automation();
                 self.emit_event(
                     "automation.run_failed",
                     json!({"run_id": run_id, "automation_id": run.automation_id, "code": code}),
@@ -281,6 +280,13 @@ impl App {
                 return true;
             }
         };
+
+        // A new ORCH provenance/link checkpoint must become durable before the
+        // worker is started. Acknowledgement re-enters this path with the same
+        // run/task IDs, so no second task is materialized.
+        if self.automation_save_pending() {
+            return true;
+        }
 
         // A scheduled launch must not steal the attached client's workspace or
         // active tab. Snapshot presentation selection and restore it afterwards.
@@ -324,7 +330,7 @@ impl App {
                 let _ = self
                     .automation
                     .set_run_status(run_id, RunStatus::Running, None, now);
-                let _ = self.automation.save();
+                self.persist_automation();
                 self.emit_event(
                     "automation.run_started",
                     json!({
@@ -342,7 +348,7 @@ impl App {
                 let _ =
                     self.automation
                         .set_run_status(run_id, RunStatus::Failed, Some(message), now);
-                let _ = self.automation.save();
+                self.persist_automation();
                 self.emit_event(
                     "automation.run_failed",
                     json!({"automation_id": run.automation_id, "run_id": run_id, "task_id": task_id, "code": code}),
@@ -821,7 +827,7 @@ impl App {
             }
         }
         if changed {
-            let _ = self.automation.save();
+            self.persist_automation();
         }
         for (id, state) in events {
             if let Some(automation) = self.automation.automation(&id).cloned() {
@@ -913,7 +919,6 @@ impl App {
                 "selected pane belongs to a different native agent conversation".into(),
             ));
         }
-        let before = self.automation.clone();
         let item = self
             .automation
             .replace_active_target(automation_id, target, crate::automation::unix_now())
@@ -934,10 +939,7 @@ impl App {
                 crate::automation::ActiveTargetState::Restoring
             },
         );
-        if let Err(error) = self.automation.save() {
-            self.automation = before;
-            return Err(persistence_err(error));
-        }
+        self.persist_automation();
         if ready {
             self.wake_active_agent_automations(pane);
         } else {
@@ -1011,7 +1013,7 @@ impl App {
                 let _ =
                     self.automation
                         .set_run_status(&run.id, RunStatus::Pending, Some(waiting), now);
-                let _ = self.automation.save();
+                self.persist_automation();
                 self.emit_event(
                     "automation.run_updated",
                     serde_json::json!({
@@ -1032,17 +1034,73 @@ impl App {
         let _ = self
             .automation
             .set_run_status(&run.id, RunStatus::Starting, None, now);
-        if let Err(error) = self.automation.save() {
+        self.persist_automation();
+        let run = run.clone();
+        let was_enabled = self
+            .automation
+            .automation(&run.automation_id)
+            .is_some_and(|a| a.enabled);
+        self.after_automation_save(move |app, result| {
+            app.deliver_checkpointed_active_run(&run, was_enabled, result);
+        });
+        true
+    }
+
+    fn deliver_checkpointed_active_run(
+        &mut self,
+        run: &AutomationRun,
+        was_enabled: bool,
+        saved: Result<(), String>,
+    ) {
+        // The app kept processing input and lifecycle events during storage I/O.
+        // Never revive a cancelled run or deliver to a replaced/rebound target.
+        if !self.automation.run(&run.id).is_some_and(|current| {
+            current.status == RunStatus::Starting && current.target == run.target
+        }) {
+            return;
+        }
+        let now = crate::automation::unix_now();
+        if was_enabled
+            && !self
+                .automation
+                .automation(&run.automation_id)
+                .is_some_and(|a| a.enabled)
+        {
             self.finish_active_agent_run(
                 run,
-                RunStatus::Failed,
-                Some(format!(
-                    "could not persist active-agent dispatch intent: {error}"
-                )),
+                RunStatus::Cancelled,
+                Some("automation was disabled while saving dispatch intent".into()),
                 now,
                 false,
             );
-            return true;
+            return;
+        }
+        if let Err(message) = saved {
+            self.finish_active_agent_run(run, RunStatus::Failed, Some(message), now, false);
+            return;
+        }
+        let (pane_id, state) = match self.validate_active_agent_target(&run.target, &run.task) {
+            Ok(valid) => valid,
+            Err((_, message)) => {
+                self.finish_active_agent_run(run, RunStatus::Failed, Some(message), now, true);
+                return;
+            }
+        };
+        if !matches!(state, State::Idle | State::Done)
+            || (run.target.is_durable_active_agent()
+                && !self
+                    .automation
+                    .ready_active_targets
+                    .contains(&run.automation_id))
+        {
+            let _ = self.automation.set_run_status(
+                &run.id,
+                RunStatus::Pending,
+                Some("target readiness changed while saving dispatch intent".into()),
+                now,
+            );
+            self.persist_automation();
+            return;
         }
         self.emit_event(
             "automation.run_updated",
@@ -1065,7 +1123,6 @@ impl App {
                 self.finish_active_agent_run(run, RunStatus::Failed, Some(message), now, true)
             }
         }
-        true
     }
 
     fn wait_for_durable_active_target(
@@ -1086,7 +1143,7 @@ impl App {
         let _ = self
             .automation
             .set_run_status(&run.id, RunStatus::Pending, Some(waiting), now);
-        let _ = self.automation.save();
+        self.persist_automation();
         self.emit_event(
             "automation.run_updated",
             serde_json::json!({
@@ -1111,7 +1168,7 @@ impl App {
         if disable {
             let _ = self.automation.set_enabled(&run.automation_id, false, now);
         }
-        let _ = self.automation.save();
+        self.persist_automation();
         self.emit_event(
             if status == RunStatus::Failed {
                 "automation.run_failed"
@@ -1226,7 +1283,7 @@ impl App {
                 }
             }
         }
-        let _ = self.automation.save();
+        self.persist_automation();
         true
     }
 
@@ -1241,7 +1298,7 @@ impl App {
                 self.automation
                     .bind_task(&run.id, task_id.clone(), now)
                     .map_err(automation_err)?;
-                self.automation.save().map_err(persistence_err)?;
+                self.persist_automation();
             }
             return Ok(task_id);
         }
@@ -1277,7 +1334,7 @@ impl App {
         self.automation
             .bind_task(&run.id, task.id.clone(), now)
             .map_err(automation_err)?;
-        self.automation.save().map_err(persistence_err)?;
+        self.persist_automation();
         self.emit_event(
             "automation.run_materialized",
             json!({"automation_id": run.automation_id, "run_id": run.id, "task_id": task.id}),
@@ -1317,7 +1374,7 @@ impl App {
         let automation_id = run.automation_id.clone();
         let terminal = !status.is_live();
         let _ = self.automation.set_run_status(&run_id, status, error, now);
-        let _ = self.automation.save();
+        self.persist_automation();
         self.emit_event(
             if terminal {
                 "automation.run_finished"
@@ -1784,7 +1841,7 @@ mod tests {
     #[test]
     fn skipped_overlap_and_advanced_deadline_are_persisted() {
         let _env = crate::persist::test_env("automation-persist-skipped-overlap");
-        let (tx, _rx) = std::sync::mpsc::channel();
+        let (tx, rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         let path = crate::persist::session_dir().join("automations.json");
         app.automation.persist_path = Some(path.clone());
@@ -1810,6 +1867,7 @@ mod tests {
         app.automation.save().unwrap();
 
         assert!(app.tick_automations(160));
+        app.flush_automation_for_test(&rx);
 
         let persisted: crate::automation::AutomationState =
             serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
@@ -1877,6 +1935,89 @@ mod tests {
         assert!(run.task_id.is_none());
         assert!(run.error.is_none());
         assert!(app.orch.tasks.is_empty());
+    }
+
+    #[test]
+    fn active_checkpoint_revalidates_cancel_busy_identity_and_storage_failure() {
+        for scenario in [
+            "deliver", "disable", "toggle", "busy", "identity", "failure",
+        ] {
+            let _env = crate::persist::test_env(&format!("automation-checkpoint-{scenario}"));
+            let (tx, rx) = std::sync::mpsc::channel();
+            let mut app = App::new(80, 24, tx).unwrap();
+            let (pane, input) = active_agent_input(
+                &mut app,
+                State::Idle,
+                crate::automation::ActiveAgentBusyPolicy::Wait,
+            );
+            let definition = app.automation.create(input, None, 10).unwrap();
+            let run = app
+                .automation
+                .request_run(&definition.id, None, 20)
+                .unwrap();
+            let path = crate::persist::session_dir().join("automations.json");
+            if scenario == "failure" {
+                std::fs::create_dir_all(&path).unwrap();
+            }
+            app.automation.persist_path = Some(path.clone());
+            let (release, wait) = std::sync::mpsc::channel();
+            app.io_jobs
+                .submit(app.app_tx.clone(), move || {
+                    wait.recv_timeout(Duration::from_secs(5)).unwrap();
+                    Box::new(|_| false)
+                })
+                .unwrap();
+            assert!(app.start_automation_run(&run.id, 20));
+            assert_eq!(
+                app.automation.run(&run.id).unwrap().status,
+                RunStatus::Starting
+            );
+            assert!(!app.start_automation_run(&run.id, 21));
+            match scenario {
+                "disable" | "toggle" => {
+                    app.automation
+                        .set_enabled(&definition.id, false, 21)
+                        .unwrap();
+                    if scenario == "toggle" {
+                        app.automation
+                            .set_enabled(&definition.id, true, 22)
+                            .unwrap();
+                    }
+                    app.persist_automation();
+                }
+                "busy" => app.status.get_mut(&pane).unwrap().state = State::Working,
+                "identity" => app.status.get_mut(&pane).unwrap().agent = "claude".into(),
+                _ => {}
+            }
+            release.send(()).unwrap();
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while app.automation.run(&run.id).unwrap().status == RunStatus::Starting {
+                if let AppEvent::IoCompleted(done) = rx
+                    .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                    .unwrap()
+                {
+                    done.apply(&mut app);
+                }
+            }
+            let expected = match scenario {
+                "deliver" => RunStatus::Delivered,
+                "disable" | "toggle" => RunStatus::Cancelled,
+                "busy" => RunStatus::Pending,
+                _ => RunStatus::Failed,
+            };
+            assert_eq!(
+                app.automation.run(&run.id).unwrap().status,
+                expected,
+                "{scenario}"
+            );
+            assert!(app.orch.tasks.is_empty());
+            if scenario != "failure" {
+                app.flush_automation_for_test(&rx);
+                let saved: crate::automation::AutomationState =
+                    serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+                assert_eq!(saved.run(&run.id).unwrap().status, expected);
+            }
+        }
     }
 
     #[test]

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -1298,6 +1298,9 @@ impl App {
                 self.automation
                     .bind_task(&run.id, task_id.clone(), now)
                     .map_err(automation_err)?;
+                self.automation
+                    .set_run_status(&run.id, RunStatus::Pending, None, now)
+                    .map_err(automation_err)?;
                 self.persist_automation();
             }
             return Ok(task_id);
@@ -1333,6 +1336,12 @@ impl App {
         // startup reconciliation recover the link without duplicating the task.
         self.automation
             .bind_task(&run.id, task.id.clone(), now)
+            .map_err(automation_err)?;
+        // Linking is not launching. Keep this occurrence eligible for the
+        // checkpoint acknowledgement's pending-run pump (and cancellation or
+        // failed-checkpoint terminalization) until the worker actually starts.
+        self.automation
+            .set_run_status(&run.id, RunStatus::Pending, None, now)
             .map_err(automation_err)?;
         self.persist_automation();
         self.emit_event(
@@ -1836,6 +1845,84 @@ mod tests {
             app.automation.run(&run.id).unwrap().status,
             RunStatus::Running
         );
+    }
+
+    #[test]
+    fn worker_link_checkpoint_resumes_once_or_fails_closed() {
+        for scenario in ["resume", "failure", "disable"] {
+            let _env = crate::persist::test_env(&format!("worker-link-{scenario}"));
+            let (tx, rx) = std::sync::mpsc::channel();
+            let mut app = App::new(80, 24, tx).unwrap();
+            let mut input = automation_input(
+                app.workspaces[0].id.clone(),
+                crate::automation::Trigger::Once {
+                    at_utc: 4_000_000_000,
+                },
+            );
+            // Reach the launch validation path without spawning a real agent.
+            input.task.agent_id = "checkpoint-test-unknown-agent".into();
+            let definition = app.automation.create(input, None, 10).unwrap();
+            let run = app
+                .automation
+                .request_run(&definition.id, None, 20)
+                .unwrap();
+            let path = crate::persist::session_dir().join("automations.json");
+            if scenario == "failure" {
+                std::fs::create_dir_all(&path).unwrap();
+            }
+            app.automation.persist_path = Some(path.clone());
+
+            assert!(app.start_automation_run(&run.id, 20));
+            let linked = app.automation.run(&run.id).unwrap();
+            assert_eq!(linked.status, RunStatus::Pending);
+            let task_id = linked.task_id.clone().unwrap();
+            assert_eq!(app.orch.task(&task_id).unwrap().status, TaskStatus::Queued);
+            assert!(!app.start_automation_run(&run.id, 21));
+            assert_eq!(app.orch.tasks.len(), 1);
+            if scenario == "disable" {
+                app.automation
+                    .set_enabled(&definition.id, false, 21)
+                    .unwrap();
+                app.persist_automation();
+            }
+            loop {
+                if let AppEvent::IoCompleted(done) =
+                    rx.recv_timeout(Duration::from_secs(5)).unwrap()
+                {
+                    done.apply(&mut app);
+                    break;
+                }
+            }
+            if scenario == "failure" {
+                assert_eq!(
+                    app.automation.run(&run.id).unwrap().status,
+                    RunStatus::Failed
+                );
+                std::fs::remove_dir(&path).unwrap();
+                app.schedule_automation_save(Instant::now() + Duration::from_secs(3));
+            }
+            app.flush_automation_for_test(&rx);
+            assert_eq!(app.orch.tasks.len(), 1, "{scenario}: no duplicate task");
+            let task = app.orch.task(&task_id).unwrap();
+            assert_eq!(task.automation.as_ref().unwrap().run_id, run.id);
+            if scenario == "resume" {
+                // Failed launch validation proves acknowledgement resumed the
+                // linked run, rather than leaving it stranded before launch.
+                assert_eq!(task.status, TaskStatus::Failed);
+            } else {
+                assert_eq!(task.status, TaskStatus::Queued, "must not attempt launch");
+            }
+            let expected = if scenario == "disable" {
+                RunStatus::Cancelled
+            } else {
+                RunStatus::Failed
+            };
+            assert_eq!(app.automation.run(&run.id).unwrap().status, expected);
+            let saved: crate::automation::AutomationState =
+                serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+            assert_eq!(saved.run(&run.id).unwrap().status, expected);
+            assert!(!app.start_pending_automation_runs(30));
+        }
     }
 
     #[test]

--- a/src/app/automation_persistence.rs
+++ b/src/app/automation_persistence.rs
@@ -75,7 +75,16 @@ impl App {
                         // An API error must not turn into a later automatic launch
                         // when storage recovers. Terminalize unlaunched occurrences;
                         // retry only their bookkeeping, never the failed effect.
-                        let pending = app.automation.pending_runs();
+                        // pending_runs() is the launch-ready projection: it
+                        // excludes queue-one occurrences behind a live run.
+                        // Those occurrences also belong to the failed ledger.
+                        let pending: Vec<_> = app
+                            .automation
+                            .runs
+                            .iter()
+                            .filter(|run| run.status == crate::automation::RunStatus::Pending)
+                            .map(|run| run.id.clone())
+                            .collect();
                         let now = crate::automation::unix_now();
                         for id in &pending {
                             let _ = app.automation.set_run_status(
@@ -260,6 +269,22 @@ mod tests {
             },
             policy: crate::automation::AutomationPolicy::default(),
         };
+        let mut queued_input = input.clone();
+        queued_input.trigger = crate::automation::Trigger::Interval {
+            every_seconds: 60,
+            anchor_utc: 100,
+        };
+        queued_input.policy.overlap = crate::automation::OverlapPolicy::QueueOne;
+        let queued_definition = app.automation.create(queued_input, None, 10).unwrap();
+        let running = app
+            .automation
+            .request_run(&queued_definition.id, None, 20)
+            .unwrap();
+        app.automation
+            .set_run_status(&running.id, crate::automation::RunStatus::Running, None, 20)
+            .unwrap();
+        let queued = app.automation.collect_due(100).pop().unwrap();
+        assert!(!app.automation.pending_runs().contains(&queued));
         let definition = app.automation.create(input, None, 10).unwrap();
         let run = app
             .automation
@@ -296,6 +321,15 @@ mod tests {
             app.automation.run(&run.id).unwrap().status,
             crate::automation::RunStatus::Failed
         );
+        assert_eq!(
+            app.automation.run(&queued).unwrap().status,
+            crate::automation::RunStatus::Failed,
+            "failed checkpoint must also terminalize occurrences blocked by a live run"
+        );
+        app.automation
+            .set_run_status(&running.id, crate::automation::RunStatus::Failed, None, 200)
+            .unwrap();
+        assert!(!app.start_pending_automation_runs(200));
         assert!(
             app.orch.tasks.is_empty(),
             "storage recovery must not launch the failed occurrence"

--- a/src/app/automation_persistence.rs
+++ b/src/app/automation_persistence.rs
@@ -1,0 +1,304 @@
+//! Ordered automation checkpoints on the shared filesystem worker.
+//!
+//! One immutable ledger may be in flight. Later mutations coalesce, but an
+//! external effect waits for acknowledgement of its own revision. A failed
+//! checkpoint never grants permission to launch a worker or submit a prompt.
+use super::*;
+
+type AfterSave = Box<dyn FnOnce(&mut App, Result<(), String>) + Send>;
+
+#[derive(Default)]
+pub(super) struct AutomationPersistence {
+    revision: u64,
+    saved: u64,
+    inflight: bool,
+    retry_at: Option<Instant>,
+    waiters: Vec<(u64, AfterSave)>,
+}
+
+impl App {
+    pub(super) fn automation_save_pending(&self) -> bool {
+        self.automation_persistence.revision != self.automation_persistence.saved
+    }
+
+    pub(super) fn persist_automation(&mut self) {
+        // In-memory ledgers have no durability boundary (unit fixtures).
+        if self.automation.persist_path.is_none() {
+            return;
+        }
+        self.automation_persistence.revision += 1;
+        self.schedule_automation_save(Instant::now());
+    }
+
+    pub(super) fn after_automation_save(
+        &mut self,
+        after: impl FnOnce(&mut App, Result<(), String>) + Send + 'static,
+    ) {
+        if !self.automation_save_pending() {
+            after(self, Ok(()));
+        } else if self.automation_persistence.waiters.len() >= 64 {
+            after(self, Err("automation checkpoint wait queue is full".into()));
+        } else {
+            self.automation_persistence
+                .waiters
+                .push((self.automation_persistence.revision, Box::new(after)));
+        }
+    }
+
+    pub(super) fn schedule_automation_save(&mut self, now: Instant) {
+        let state = &self.automation_persistence;
+        if state.inflight
+            || !self.automation_save_pending()
+            || state.retry_at.is_some_and(|deadline| now < deadline)
+        {
+            return;
+        }
+        let revision = state.revision;
+        let snapshot = self.automation.clone();
+        if self
+            .io_jobs
+            .submit(self.app_tx.clone(), move || {
+                let result = snapshot.save().map_err(|error| error.to_string());
+                Box::new(move |app| {
+                    app.automation_persistence.inflight = false;
+                    let (ready, pending): (Vec<_>, Vec<_>) =
+                        std::mem::take(&mut app.automation_persistence.waiters)
+                            .into_iter()
+                            .partition(|(required, _)| result.is_err() || *required <= revision);
+                    app.automation_persistence.waiters = pending;
+                    if result.is_ok() {
+                        app.automation_persistence.saved = revision;
+                        app.automation_persistence.retry_at = None;
+                    } else {
+                        app.automation_persistence.retry_at =
+                            Some(Instant::now() + Duration::from_secs(2));
+                        // An API error must not turn into a later automatic launch
+                        // when storage recovers. Terminalize unlaunched occurrences;
+                        // retry only their bookkeeping, never the failed effect.
+                        let pending = app.automation.pending_runs();
+                        let now = crate::automation::unix_now();
+                        for id in &pending {
+                            let _ = app.automation.set_run_status(
+                                id,
+                                crate::automation::RunStatus::Failed,
+                                Some("automation checkpoint failed before launch".into()),
+                                now,
+                            );
+                            if let Some(run) = app.automation.run(id) {
+                                app.emit_event(
+                                    "automation.run_failed",
+                                    json!({
+                                        "automation_id":run.automation_id,
+                                        "run_id":run.id,
+                                        "code":"persistence_failed",
+                                    }),
+                                );
+                            }
+                        }
+                        if !pending.is_empty() {
+                            app.automation_persistence.revision += 1;
+                        }
+                        app.show_toast(
+                            "automation save failed; dispatch paused until persistence recovers",
+                        );
+                    }
+                    for (_, after) in ready {
+                        after(app, result.clone());
+                    }
+                    app.schedule_automation_save(Instant::now());
+                    if !app.automation_save_pending() {
+                        app.start_pending_automation_runs(crate::automation::unix_now());
+                    }
+                    true
+                })
+            })
+            .is_ok()
+        {
+            self.automation_persistence.inflight = true;
+            self.automation_persistence.retry_at = None;
+        } else {
+            self.automation_persistence.retry_at = Some(now + Duration::from_secs(2));
+        }
+    }
+
+    pub(super) fn automation_save_deadline(&self) -> Option<Instant> {
+        self.automation_persistence.retry_at
+    }
+
+    pub(super) fn reply_after_automation_save(
+        &mut self,
+        req: crate::ipc::api::ApiRequest,
+        response: String,
+    ) {
+        if !Self::is_automation_mutation(&req.method) || !self.automation_save_pending() {
+            let _ = req.reply.send(response);
+            return;
+        }
+        // Even an idempotent retry must not acknowledge an uncommitted record.
+        let failed = serde_json::from_str::<Value>(&response)
+            .is_ok_and(|value| value.get("error").is_some());
+        if !failed {
+            self.after_automation_save(move |_, result| {
+                let response = match result {
+                    Ok(()) => response,
+                    Err(message) => json!({"id":req.id,"error":{
+                        "code":"persistence_failed", "message":message
+                    }})
+                    .to_string(),
+                };
+                let _ = req.reply.send(response);
+            });
+        } else {
+            let _ = req.reply.send(response);
+        }
+    }
+
+    pub(super) fn is_automation_mutation(method: &str) -> bool {
+        matches!(
+            method,
+            "automation.create"
+                | "automation.update"
+                | "automation.enable"
+                | "automation.disable"
+                | "automation.delete"
+                | "automation.rebind"
+                | "automation.run"
+        )
+    }
+
+    pub(super) fn automation_admission_full(&self) -> bool {
+        self.automation_persistence.waiters.len() >= 63
+    }
+
+    #[cfg(test)]
+    pub(super) fn flush_automation_for_test(&mut self, rx: &std::sync::mpsc::Receiver<AppEvent>) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while self.automation_save_pending() {
+            if let AppEvent::IoCompleted(done) = rx
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .expect("automation checkpoint completion")
+            {
+                done.apply(self);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    };
+
+    #[test]
+    fn checkpoint_is_nonblocking_coalesces_and_fences_acknowledgements() {
+        let _env = persist::test_env("automation-async-checkpoint");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let path = persist::session_dir().join("automations.json");
+        app.automation.persist_path = Some(path.clone());
+        let (release, wait) = mpsc::channel();
+        app.io_jobs
+            .submit(app.app_tx.clone(), move || {
+                wait.recv_timeout(Duration::from_secs(5)).unwrap();
+                Box::new(|_| false)
+            })
+            .unwrap();
+        app.persist_automation();
+        let first = Arc::new(AtomicBool::new(false));
+        let flag = first.clone();
+        app.after_automation_save(move |_, result| {
+            result.unwrap();
+            flag.store(true, Ordering::SeqCst);
+        });
+        app.persist_automation();
+        let latest = Arc::new(AtomicBool::new(false));
+        let flag = latest.clone();
+        app.after_automation_save(move |app, result| {
+            result.unwrap();
+            assert_eq!(app.automation_persistence.saved, 2);
+            flag.store(true, Ordering::SeqCst);
+        });
+        assert!(!first.load(Ordering::SeqCst));
+        assert!(!latest.load(Ordering::SeqCst));
+        assert!(!path.exists());
+        assert_eq!(app.dispatch("ping", &json!({})).unwrap()["type"], "pong");
+        release.send(()).unwrap();
+        app.flush_automation_for_test(&rx);
+        assert!(first.load(Ordering::SeqCst));
+        assert!(latest.load(Ordering::SeqCst));
+        let _: crate::automation::AutomationState =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn failed_checkpoint_rejects_effect_and_api_success_then_retries() {
+        let _env = persist::test_env("automation-async-failure");
+        let (tx, rx) = mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let path = persist::session_dir().join("automations.json");
+        std::fs::create_dir_all(&path).unwrap();
+        app.automation.persist_path = Some(path.clone());
+        let input = crate::automation::CreateAutomation {
+            name: "failed admission".into(),
+            enabled: true,
+            trigger: crate::automation::Trigger::Once {
+                at_utc: 4_000_000_000,
+            },
+            target: crate::automation::AutomationTarget::NewWorker,
+            task: crate::automation::TaskTemplate {
+                title: "failed admission".into(),
+                prompt: "must not launch".into(),
+                agent_id: "codex".into(),
+                workspace_id: app.workspaces[0].id.clone(),
+                mode: crate::orch::TaskWorkerMode::Workspace,
+                access: crate::automation::AutomationAccess::ReadOnly,
+                paths: Vec::new(),
+                gate: None,
+            },
+            policy: crate::automation::AutomationPolicy::default(),
+        };
+        let definition = app.automation.create(input, None, 10).unwrap();
+        let run = app
+            .automation
+            .request_run(&definition.id, None, 20)
+            .unwrap();
+        app.persist_automation();
+        let (reply, response) = mpsc::channel();
+        app.reply_after_automation_save(
+            crate::ipc::api::ApiRequest {
+                id: "mutation".into(),
+                method: "automation.create".into(),
+                params: json!({}),
+                reply,
+            },
+            json!({"id":"mutation","result":{}}).to_string(),
+        );
+        assert!(response.try_recv().is_err());
+        loop {
+            if let AppEvent::IoCompleted(done) = rx.recv_timeout(Duration::from_secs(5)).unwrap() {
+                done.apply(&mut app);
+                break;
+            }
+        }
+        let result: Value = serde_json::from_str(&response.try_recv().unwrap()).unwrap();
+        assert_eq!(result["error"]["code"], "persistence_failed");
+        assert!(app.automation_save_pending());
+        assert!(!app.start_pending_automation_runs(crate::automation::unix_now()));
+        assert!(app.automation_save_deadline().is_some());
+        std::fs::remove_dir(path).unwrap();
+        app.schedule_automation_save(Instant::now() + Duration::from_secs(3));
+        app.flush_automation_for_test(&rx);
+        assert!(!app.automation_save_pending());
+        assert_eq!(
+            app.automation.run(&run.id).unwrap().status,
+            crate::automation::RunStatus::Failed
+        );
+        assert!(
+            app.orch.tasks.is_empty(),
+            "storage recovery must not launch the failed occurrence"
+        );
+    }
+}

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -1360,15 +1360,11 @@ impl App {
                 )
                 .map_err(|error| error.message)?;
         }
-        let before = self.automation.clone();
         let item = self
             .automation
             .create(input, None, now)
             .map_err(|error| error.message)?;
-        if let Err(error) = self.automation.save() {
-            self.automation = before;
-            return Err(format!("could not save automation: {error}"));
-        }
+        self.persist_automation();
         if item.target.is_durable_active_agent() {
             self.initialize_durable_active_target_state(&item);
         }
@@ -1500,7 +1496,6 @@ impl App {
             .automation
             .automation(&id)
             .is_some_and(|item| item.enabled);
-        let before = self.automation.clone();
         let now = crate::automation::unix_now();
         if enabled {
             let Some(automation) = self.automation.automation(&id).cloned() else {
@@ -1519,26 +1514,21 @@ impl App {
             }
         }
         match self.automation.set_enabled(&id, enabled, now) {
-            Ok(item) => match self.automation.save() {
-                Ok(()) => {
-                    self.emit_event(
-                        if enabled {
-                            "automation.enabled"
-                        } else {
-                            "automation.disabled"
-                        },
-                        crate::automation::definition_event(&item),
-                    );
-                    self.show_toast(format!(
-                        "{id}: {}",
-                        if enabled { "scheduled" } else { "paused" }
-                    ));
-                }
-                Err(error) => {
-                    self.automation = before;
-                    self.show_toast(format!("could not save automation: {error}"));
-                }
-            },
+            Ok(item) => {
+                self.persist_automation();
+                self.emit_event(
+                    if enabled {
+                        "automation.enabled"
+                    } else {
+                        "automation.disabled"
+                    },
+                    crate::automation::definition_event(&item),
+                );
+                self.show_toast(format!(
+                    "{id}: {}",
+                    if enabled { "scheduled" } else { "paused" }
+                ));
+            }
             Err(error) => self.show_toast(error.message),
         }
     }
@@ -1554,23 +1544,17 @@ impl App {
         let Some(id) = self.selected_automation_id() else {
             return;
         };
-        let before = self.automation.clone();
         let now = crate::automation::unix_now();
         match self.automation.request_run(&id, None, now) {
-            Ok(run) => match self.automation.save() {
-                Ok(()) => {
-                    let run_id = run.id.clone();
-                    self.emit_event(
-                        "automation.run_queued",
-                        serde_json::json!({"automation_id": id, "run_id": run_id, "scheduled_at": now}),
-                    );
-                    self.start_pending_automation_runs(now);
-                }
-                Err(error) => {
-                    self.automation = before;
-                    self.show_toast(format!("could not save automation: {error}"));
-                }
-            },
+            Ok(run) => {
+                self.persist_automation();
+                let run_id = run.id.clone();
+                self.emit_event(
+                    "automation.run_queued",
+                    serde_json::json!({"automation_id": id, "run_id": run_id, "scheduled_at": now}),
+                );
+                self.start_pending_automation_runs(now);
+            }
             Err(error) => self.show_toast(error.message),
         }
     }
@@ -1606,21 +1590,15 @@ impl App {
         let Some(id) = self.selected_automation_id() else {
             return;
         };
-        let before = self.automation.clone();
         match self.automation.delete(&id) {
-            Ok(item) => match self.automation.save() {
-                Ok(()) => {
-                    self.orch_automation_cursor = self
-                        .orch_automation_cursor
-                        .min(self.automation.automations.len().saturating_sub(1));
-                    self.emit_event("automation.deleted", serde_json::json!({"id": item.id}));
-                    self.show_toast(format!("{id} deleted"));
-                }
-                Err(error) => {
-                    self.automation = before;
-                    self.show_toast(format!("could not save automation: {error}"));
-                }
-            },
+            Ok(item) => {
+                self.persist_automation();
+                self.orch_automation_cursor = self
+                    .orch_automation_cursor
+                    .min(self.automation.automations.len().saturating_sub(1));
+                self.emit_event("automation.deleted", serde_json::json!({"id": item.id}));
+                self.show_toast(format!("{id} deleted"));
+            }
             Err(error) => self.show_toast(error.message),
         }
     }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1571,7 +1571,14 @@ impl App {
             );
         }
 
-        if let Some(at_utc) = self.automation.next_deadline() {
+        if let Some(retry) = self.automation_save_deadline() {
+            consider(retry, true);
+        }
+        if let Some(at_utc) = self
+            .automation
+            .next_deadline()
+            .filter(|_| !self.automation_save_pending())
+        {
             let now_unix = crate::automation::unix_now();
             let instant = if at_utc <= now_unix {
                 now
@@ -1757,6 +1764,7 @@ impl App {
 
     pub(crate) fn detect_tick_with(&mut self, now: Instant, clients_attached: bool) -> bool {
         self.schedule_config_save(now);
+        self.schedule_automation_save(now);
         // No node open (docs/43 §3.3 — the session was closed). Closing the last
         // node also closed every pane, so there is nothing to classify, and
         // `layout()` below would index an empty `workspaces`. The server keeps
@@ -2328,6 +2336,12 @@ impl App {
 
     /// Validate and execute one bounded local API method against server-owned state.
     pub(crate) fn dispatch(&mut self, method: &str, p: &Value) -> Result<Value, (String, String)> {
+        if Self::is_automation_mutation(method) && self.automation_admission_full() {
+            return Err((
+                "busy".into(),
+                "automation checkpoint queue is full; retry later".into(),
+            ));
+        }
         match method {
             "ping" => Ok(json!({
                 "type":"pong",
@@ -5151,7 +5165,6 @@ impl App {
                     }
                 }
                 validate_automation_target(self, &mut input)?;
-                let before = self.automation.clone();
                 let automation = if method == "automation.create" {
                     self.automation
                         .create(input, opt_borrowed_str(p, "idempotency_key"), now)
@@ -5162,13 +5175,7 @@ impl App {
                         .update(id, input, now)
                         .map_err(automation_err)?
                 };
-                if let Err(error) = self.automation.save() {
-                    self.automation = before;
-                    return Err((
-                        "persistence_failed".into(),
-                        format!("could not persist automation: {error}"),
-                    ));
-                }
+                self.persist_automation();
                 if automation.target.is_durable_active_agent() {
                     self.initialize_durable_active_target_state(&automation);
                 } else {
@@ -5233,15 +5240,11 @@ impl App {
                         self.validate_active_agent_target(&automation.target, &automation.task)?;
                     }
                 }
-                let before = self.automation.clone();
                 let automation = self
                     .automation
                     .set_enabled(id, enable, crate::automation::unix_now())
                     .map_err(automation_err)?;
-                if let Err(error) = self.automation.save() {
-                    self.automation = before;
-                    return Err(("persistence_failed".into(), error.to_string()));
-                }
+                self.persist_automation();
                 self.emit_event(
                     if automation.enabled {
                         "automation.enabled"
@@ -5290,12 +5293,8 @@ impl App {
             "automation.delete" => {
                 reject_api_fields(p, &["id"])?;
                 let id = req_str(p, "id")?;
-                let before = self.automation.clone();
                 let automation = self.automation.delete(id).map_err(automation_err)?;
-                if let Err(error) = self.automation.save() {
-                    self.automation = before;
-                    return Err(("persistence_failed".into(), error.to_string()));
-                }
+                self.persist_automation();
                 self.emit_event("automation.deleted", json!({"id":id}));
                 Ok(
                     json!({"type":"automation", "automation":crate::automation::public_automation(&automation, None)}),
@@ -5317,15 +5316,11 @@ impl App {
                         json!({"type":"automation_run", "run":crate::automation::public_run(&run)}),
                     );
                 }
-                let before = self.automation.clone();
                 let run = self
                     .automation
                     .request_run(&id, opt_borrowed_str(p, "idempotency_key"), now)
                     .map_err(automation_err)?;
-                if let Err(error) = self.automation.save() {
-                    self.automation = before;
-                    return Err(("persistence_failed".into(), error.to_string()));
-                }
+                self.persist_automation();
                 self.emit_event(
                     "automation.run_queued",
                     json!({"automation_id":run.automation_id, "run_id":run.id, "scheduled_at":run.scheduled_at}),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -337,7 +337,7 @@ impl App {
             return true;
         };
         let response = self.handle_api(&req);
-        let _ = req.reply.send(response);
+        self.reply_after_automation_save(req, response);
         true
     }
 
@@ -591,7 +591,7 @@ impl App {
                         return true;
                     }
                     let resp = self.handle_api(&req);
-                    let _ = req.reply.send(resp);
+                    self.reply_after_automation_save(req, resp);
                     return true;
                 }
                 AppEvent::WaitOutput { id, reply, .. } => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,6 +23,7 @@ use crate::terminal::pty::Pane;
 use crate::ui::theme::{State, Theme};
 
 mod automation;
+mod automation_persistence;
 mod backend;
 mod board;
 mod config_persistence;
@@ -2148,6 +2149,7 @@ pub struct App {
     config_baseline: crate::config::Config,
     config_persistence: config_persistence::ConfigPersistence,
     io_jobs: io_jobs::IoJobs,
+    automation_persistence: automation_persistence::AutomationPersistence,
     file_metadata_inflight: bool,
     file_metadata_cursor: usize,
     file_mutation_inflight: bool,
@@ -2840,6 +2842,7 @@ impl App {
             config_baseline,
             config_persistence: config_persistence::ConfigPersistence::default(),
             io_jobs: io_jobs::IoJobs::default(),
+            automation_persistence: automation_persistence::AutomationPersistence::default(),
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
             file_mutation_inflight: false,
@@ -3490,6 +3493,7 @@ impl App {
             config_baseline,
             config_persistence: config_persistence::ConfigPersistence::default(),
             io_jobs: io_jobs::IoJobs::default(),
+            automation_persistence: automation_persistence::AutomationPersistence::default(),
             file_metadata_inflight: false,
             file_metadata_cursor: 0,
             file_mutation_inflight: false,

--- a/src/app/persistence.rs
+++ b/src/app/persistence.rs
@@ -38,9 +38,13 @@ impl App {
             .submit(self.app_tx.clone(), || Box::new(|_| false));
         let capture = persist::capture_session(self);
         let config = self.final_config_save();
+        let automation = self
+            .automation_save_pending()
+            .then(|| self.automation.clone());
         if !self.io_jobs.finish(Duration::from_secs(2), move || {
             let config_saved = config();
-            capture.write() && config_saved
+            let automation_saved = automation.is_none_or(|snapshot| snapshot.save().is_ok());
+            capture.write() && config_saved && automation_saved
         }) {
             eprintln!("Luvus: final session save failed or exceeded the shutdown deadline");
         }

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -205,11 +205,12 @@ impl AutomationState {
         automation.next_run_at = next_run_at;
         let automation = automation.clone();
         if !enabled {
-            for run in self
-                .runs
-                .iter_mut()
-                .filter(|run| run.automation_id == id && run.status == RunStatus::Pending)
-            {
+            for run in self.runs.iter_mut().filter(|run| {
+                run.automation_id == id
+                    && (run.status == RunStatus::Pending
+                        || (run.status == RunStatus::Starting
+                            && matches!(run.target, AutomationTarget::ActiveAgent { .. })))
+            }) {
                 run.status = RunStatus::Cancelled;
                 run.error = Some("automation disabled before launch".into());
                 run.finished_at = Some(now);

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -329,6 +329,10 @@ the worktree/workspace Git mode, and unsupported agent/access pairs are rejected
 before a worker is created. Read definitions with `automation.list`,
 runs with `automation.history`, and fleet health with `automation.health`.
 Create and manual-run requests accept idempotency keys for safe retries.
+Mutation success waits for its ledger checkpoint. After `persistence_failed`
+or a lost response, inspect state and retry the same idempotency key instead of
+creating a duplicate schedule. Failed prelaunch runs do not automatically
+relaunch when storage recovers.
 Use `automation.rebind` only to reconnect a durable active-agent definition to
 a pane that proves the same native conversation; it requires orchestration
 authority and is safe to repeat with the same pane.

--- a/website/src/content/docs/docs/guides/automation.mdx
+++ b/website/src/content/docs/docs/guides/automation.mdx
@@ -7,6 +7,28 @@ Agent Automation turns a prompt into a durable one-time or recurring schedule.
 A definition can start a fresh ORCH worker, or deliver its prompt to one exact
 agent that is already running in Luvus.
 
+## Saving and responsiveness
+
+The server serializes and flushes the automation ledger on its shared, bounded
+filesystem worker. It keeps one ledger snapshot in flight and coalesces later
+changes. This adds no separate scheduler persistence thread. Input, rendering,
+and unrelated CLI/UHP requests continue while that worker waits for storage.
+
+An occurrence cannot launch until its checkpoint is acknowledged. Active-agent
+delivery additionally saves dispatch intent and then rechecks the terminal,
+agent identity, readiness, and cancellation before submitting the prompt. A
+restart with uncertain dispatch intent fails that occurrence instead of replaying
+it. Existing ORCH provenance writes remain ordered before worker launch.
+
+CLI/UHP mutation success waits for the required ledger checkpoint. On a storage
+failure, Luvus reports `persistence_failed`, fails unlaunched occurrences, and
+retries pending bookkeeping with backoff. A failed run is not automatically
+relaunched when storage recovers. A failed or lost response does not prove that
+the definition is absent: inspect it or retry with the same idempotency key.
+Reads may show the current in-memory state while a checkpoint is pending.
+Shutdown drains accepted writes and makes a final ledger checkpoint within the
+shared bounded shutdown deadline; it never races a synchronous fallback write.
+
 :::tip[Quick path]
 Open ORCH with `Ctrl+Space o`, press `Tab` for **Automations BETA**, then press
 `a`. Choose **Run with → New agent** or **Active agent**, then set its

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -146,6 +146,13 @@ repository, while workspace mode creates a dedicated branchless task tab there.
 
 ## Agent automation
 
+Mutating automation responses wait for a durable ledger checkpoint, including
+idempotent retries of records whose save is still pending. Unrelated requests do
+not wait for automation storage. Admission is bounded and can return `busy`;
+storage failure returns `persistence_failed`. After an error or lost response,
+inspect state or retry the same idempotency key rather than creating a second
+schedule. Read-only projections can include changes awaiting persistence.
+
 Automations are durable agent-task templates owned by one named Luvus server.
 Each due occurrence is persisted before Luvus creates a fresh ORCH task, takes
 leases, creates a workspace tab or worktree, and starts the exact built-in


### PR DESCRIPTION
<!-- luvus-audit-stack:start -->
## Luvus reliability and performance PR stack

**Part 15 of 15** · Base: #298 · Next: stack tip · Index: #284

Each PR targets the preceding branch, so its Files changed tab shows its incremental change. The complete stack runs from #284 to #301.

<details>
<summary>Full stack, base to tip</summary>

| Order | Pull request | Change |
|---|---|---|
| 1 | #284 | test(ipc): isolate and bound lifecycle fixtures |
| 2 | #285 | fix(terminal): preserve live-screen snapshot fidelity |
| 3 | #286 | fix(pty): submit agent prompts atomically |
| 4 | #287 | perf(render): invalidate retained frames only when titles change |
| 5 | #288 | perf(render): retain independent passive client baselines |
| 6 | #289 | perf(terminal): cache storage-aware history accounting |
| 7 | #290 | fix(pty): bound input admission across writer stages |
| 8 | #291 | perf(runtime): scope cwd discovery to active tab evidence |
| 9 | #292 | test(perf): measure cold-history maintenance latency |
| 10 | #293 | perf(files): offload metadata to a bounded shared worker |
| 11 | #294 | perf(files): execute confirmed mutations off the app loop |
| 12 | #295 | perf(persist): serialize session saves off the app loop |
| 13 | #296 | perf(terminal): yield between bounded history packing turns |
| 14 | #298 | perf(config): persist settings through the shared worker |
| 15 | #301 | perf(automation): checkpoint ledger writes off the app loop |

</details>
<!-- luvus-audit-stack:end -->

## Summary
Moves automation ledger serialization, fsync, atomic replacement, and parent-directory flush off the app loop, using the existing shared filesystem worker. One ledger snapshot is in flight, later mutations coalesce by revision, and acknowledgement callbacks are bounded. No extra worker thread or dependency is added.

## Durability and launch ordering
- Due occurrences cannot materialize/start until their checkpoint is acknowledged.
- New workers preserve the existing ORCH provenance-first ordering and wait for the automation task-link checkpoint before launch.
- Active-agent dispatch checkpoints Starting before prompt submission, then revalidates terminal lifetime, identity, readiness, and cancellation.
- Disabling and immediately re-enabling an active automation cannot revive a prompt cancelled during the checkpoint gap.
- CLI/UHP mutation success, including idempotent retries, waits for the required ledger revision. Read-only and unrelated methods remain responsive.
- Failed writes fail unlaunched occurrences and retry bookkeeping with backoff, never automatically relaunching those failed occurrences.
- Shutdown puts a final dirty-ledger snapshot after accepted writes within the existing bounded drain. No racing synchronous fallback is introduced.

## Compatibility and scope
Commands and JSON response shapes are unchanged. Read projections may show pending in-memory changes. After persistence_failed or a lost response, inspect state or reuse the idempotency key: an error is not proof that a definition is absent. Public docs and both bundled skill copies explain this distinction.

Existing synchronous ORCH task-provenance writes are deliberately unchanged. This PR addresses automation ledger blocking, not every orchestration disk operation. Snapshot capture still clones bounded state on the app loop; there is no claim of reduced total CPU or RSS. Obsolete synchronous rollback copies were removed from converted callers.

## Verification
- Formatting and strict all-target Clippy passed.
- 1538 unit tests and 15 integration tests passed; three opt-in tests ignored.
- Locked debug and release builds passed.
- Website build passed with the existing missing-404-entry warning.
- Focused fixtures cover coalesced acknowledgements, failed-write recovery without launch, active target drift/busy/cancellation, disable/re-enable, and skipped-overlap durability.
- Both exact debug and release binaries passed the new isolated checkpoint/CLI/restart-idempotency script. It launches no provider and does not touch an existing user server.
- Existing isolated terminal live and failure conformance passed.

During a deliberately blocked shared worker, 50 ping samples measured debug median 0.150 ms (max 0.388 ms) and release median 0.142 ms (max 0.279 ms). These are local responsiveness measurements, not an old/new throughput comparison or a full TUI/Windows runtime validation.

Repeat with:
```sh
cargo build --locked
python3 examples/uhp/terminal/automation_checkpoints.py
python3 examples/uhp/terminal/automation_checkpoints.py --luvus target/release/luvus
```

## Stack
Based on #298. Review the incremental diff against that branch. No merge requested.