### PR TITLE
feat(orch): add multiline task briefings

### DIFF
--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -382,6 +382,9 @@ surface:
   retrying. Leases coordinate declared paths but do not sandbox a shared
   checkout. `task release` requeues an
   active task and releases its path leases; it does not stop the worker pane.
+  `task add --prompt <text>` or `--prompt-file <path>` stores a detailed worker
+  briefing; `task update` may replace it only while a manual task is still
+  queued and unassigned. Inspect the stored prompt before starting the worker.
   Report work progress only with `task update --note`. `task heartbeat
   --context-used <0..1>` means the fraction of the model context window already
   consumed, never task-completion progress; `0.6` means 60% consumed. Omit the

--- a/protocol/uhp/v1/schema/event-catalog.schema.json
+++ b/protocol/uhp/v1/schema/event-catalog.schema.json
@@ -394,6 +394,7 @@
       "properties": {
         "id": { "type": "string" },
         "title": { "type": "string" },
+        "prompt": { "type": ["string", "null"] },
         "status": { "enum": ["queued", "claimed", "running", "blocked", "review", "done", "merging", "merged", "failed"] },
         "assignee": { "type": ["integer", "null"], "minimum": 1 },
         "deps": { "type": "array", "items": { "type": "string" } },

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -147,6 +147,26 @@
         }
       }
     },
+    "taskAddParams": {
+      "type": "object", "additionalProperties": false, "required": ["title"],
+      "properties": {
+        "title": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "prompt": { "type": "string", "maxLength": 32768 },
+        "paths": { "type": "array", "items": { "type": "string" } },
+        "deps": { "type": "array", "items": { "type": "string" } },
+        "gate": { "type": "string" }
+      }
+    },
+    "taskUpdateParams": {
+      "type": "object", "additionalProperties": false, "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "prompt": { "type": ["string", "null"], "maxLength": 32768 },
+        "status": { "enum": ["queued", "claimed", "running", "blocked", "review", "done", "failed"] },
+        "output": { "type": "string" },
+        "note": { "type": "string" }
+      }
+    },
     "taskStartParams": {
       "type": "object", "additionalProperties": false, "required": ["id"],
       "properties": {
@@ -308,6 +328,10 @@
       "then": { "properties": { "params": { "$ref": "#/$defs/integrationChangeParams" } } } },
     { "if": { "properties": { "method": { "const": "pane.report_session" } } },
       "then": { "properties": { "params": { "$ref": "#/$defs/paneReportSessionParams" } } } },
+    { "if": { "properties": { "method": { "const": "task.add" } } },
+      "then": { "properties": { "params": { "$ref": "#/$defs/taskAddParams" } } } },
+    { "if": { "properties": { "method": { "const": "task.update" } } },
+      "then": { "properties": { "params": { "$ref": "#/$defs/taskUpdateParams" } } } },
     { "if": { "properties": { "method": { "const": "task.start" } } },
       "then": { "properties": { "params": { "$ref": "#/$defs/taskStartParams" } } } },
     { "if": { "properties": { "method": { "const": "task.next" } } },

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -150,8 +150,8 @@
     "taskAddParams": {
       "type": "object", "additionalProperties": false, "required": ["title"],
       "properties": {
-        "title": { "type": "string", "minLength": 1, "maxLength": 256 },
-        "prompt": { "type": "string", "maxLength": 32768 },
+        "title": { "type": "string", "minLength": 1, "$comment": "Consumers must enforce a 256-byte UTF-8 limit." },
+        "prompt": { "type": "string", "$comment": "Consumers must enforce a 32768-byte UTF-8 limit." },
         "paths": { "type": "array", "items": { "type": "string" } },
         "deps": { "type": "array", "items": { "type": "string" } },
         "gate": { "type": "string" }
@@ -161,7 +161,7 @@
       "type": "object", "additionalProperties": false, "required": ["id"],
       "properties": {
         "id": { "type": "string", "minLength": 1, "maxLength": 128 },
-        "prompt": { "type": ["string", "null"], "maxLength": 32768 },
+        "prompt": { "type": ["string", "null"], "$comment": "Consumers must enforce a 32768-byte UTF-8 limit." },
         "status": { "enum": ["queued", "claimed", "running", "blocked", "review", "done", "failed"] },
         "output": { "type": "string" },
         "note": { "type": "string" }

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -382,6 +382,9 @@ surface:
   retrying. Leases coordinate declared paths but do not sandbox a shared
   checkout. `task release` requeues an
   active task and releases its path leases; it does not stop the worker pane.
+  `task add --prompt <text>` or `--prompt-file <path>` stores a detailed worker
+  briefing; `task update` may replace it only while a manual task is still
+  queued and unassigned. Inspect the stored prompt before starting the worker.
   Report work progress only with `task update --note`. `task heartbeat
   --context-used <0..1>` means the fraction of the model context window already
   consumed, never task-completion progress; `0.6` means 60% consumed. Omit the

--- a/src/api/capabilities.rs
+++ b/src/api/capabilities.rs
@@ -399,6 +399,8 @@ pub fn capabilities(event_sequence: u64) -> Value {
             "event_wait_timeout_s":super::topology::MAX_EVENT_WAIT_S,
             "layout_depth":super::topology::MAX_LAYOUT_DEPTH,
             "workspace_move_block":super::topology::MAX_WORKSPACE_MOVE_BLOCK,
+            "task_title_bytes":crate::orch::MAX_TASK_TITLE_BYTES,
+            "task_prompt_bytes":crate::orch::MAX_TASK_PROMPT_BYTES,
             "automations":crate::automation::MAX_AUTOMATIONS,
             "automation_runs":crate::automation::MAX_RUNS,
             "automation_prompt_bytes":crate::automation::MAX_PROMPT_BYTES,
@@ -459,6 +461,14 @@ mod tests {
         let capabilities = capabilities(0);
         assert_eq!(capabilities["limits"]["terminal_stream_capacity"], 8);
         assert_eq!(capabilities["limits"]["terminal_stream_queue"], 2);
+        assert_eq!(
+            capabilities["limits"]["task_title_bytes"],
+            crate::orch::MAX_TASK_TITLE_BYTES
+        );
+        assert_eq!(
+            capabilities["limits"]["task_prompt_bytes"],
+            crate::orch::MAX_TASK_PROMPT_BYTES
+        );
         assert!(is_idempotent("pane.list"));
         assert!(!is_read_only("mission.open"));
         assert_eq!(required_scope("mission.open"), "workspace");

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -104,6 +104,25 @@ mod tests {
     }
 
     #[test]
+    fn task_prompt_request_contract_is_bounded_and_editable() {
+        let bundle = schema_bundle();
+        let definitions = &bundle["request"]["$defs"];
+        assert_eq!(definitions["taskAddParams"]["required"], json!(["title"]));
+        assert_eq!(
+            definitions["taskAddParams"]["properties"]["title"]["maxLength"],
+            crate::orch::MAX_TASK_TITLE_BYTES
+        );
+        assert_eq!(
+            definitions["taskAddParams"]["properties"]["prompt"]["maxLength"],
+            crate::orch::MAX_TASK_PROMPT_BYTES
+        );
+        assert_eq!(
+            definitions["taskUpdateParams"]["properties"]["prompt"]["type"],
+            json!(["string", "null"])
+        );
+    }
+
+    #[test]
     fn schema_bundle_publishes_the_general_event_catalog() {
         let bundle = schema_bundle();
         let catalog = bundle["event_catalog"]["properties"].as_object().unwrap();
@@ -293,6 +312,7 @@ mod tests {
             .iter()
             .map(|value| value.as_str().unwrap())
             .collect();
+        assert!(!task_required.contains("prompt"));
         assert!(!task_required.contains("mode"));
         assert!(!task_required.contains("workspace_worker"));
         assert_eq!(
@@ -302,6 +322,10 @@ mod tests {
         assert_eq!(
             task["properties"]["workspace_worker"]["$ref"],
             "#/$defs/workspace_worker"
+        );
+        assert_eq!(
+            task["properties"]["prompt"]["type"],
+            json!(["string", "null"])
         );
 
         let workspace_worker = &definitions["workspace_worker"];

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -109,17 +109,39 @@ mod tests {
         let definitions = &bundle["request"]["$defs"];
         assert_eq!(definitions["taskAddParams"]["required"], json!(["title"]));
         assert_eq!(
-            definitions["taskAddParams"]["properties"]["title"]["maxLength"],
-            crate::orch::MAX_TASK_TITLE_BYTES
+            definitions["taskAddParams"]["properties"]["title"]["$comment"],
+            format!(
+                "Consumers must enforce a {}-byte UTF-8 limit.",
+                crate::orch::MAX_TASK_TITLE_BYTES
+            )
         );
         assert_eq!(
-            definitions["taskAddParams"]["properties"]["prompt"]["maxLength"],
-            crate::orch::MAX_TASK_PROMPT_BYTES
+            definitions["taskAddParams"]["properties"]["prompt"]["$comment"],
+            format!(
+                "Consumers must enforce a {}-byte UTF-8 limit.",
+                crate::orch::MAX_TASK_PROMPT_BYTES
+            )
         );
+        assert!(definitions["taskAddParams"]["properties"]["title"]
+            .get("maxLength")
+            .is_none());
+        assert!(definitions["taskAddParams"]["properties"]["prompt"]
+            .get("maxLength")
+            .is_none());
         assert_eq!(
             definitions["taskUpdateParams"]["properties"]["prompt"]["type"],
             json!(["string", "null"])
         );
+        assert_eq!(
+            definitions["taskUpdateParams"]["properties"]["prompt"]["$comment"],
+            format!(
+                "Consumers must enforce a {}-byte UTF-8 limit.",
+                crate::orch::MAX_TASK_PROMPT_BYTES
+            )
+        );
+        assert!(definitions["taskUpdateParams"]["properties"]["prompt"]
+            .get("maxLength")
+            .is_none());
     }
 
     #[test]

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -1066,10 +1066,10 @@ impl App {
             && key
                 .modifiers
                 .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT)
-            && self.orch_form.as_ref().is_some_and(|form| {
-                form.kind == crate::app::OrchFormKind::Automation
-                    && form.field == crate::app::OrchFormField::Prompt
-            })
+            && self
+                .orch_form
+                .as_ref()
+                .is_some_and(|form| form.field == crate::app::OrchFormField::Prompt)
         {
             if let Some(form) = self.orch_form.as_mut() {
                 form.push_char('\n');
@@ -1234,11 +1234,13 @@ impl App {
         let before = self.orch.clone();
         let task = self
             .orch
-            .add_task(title, paths, deps, gate)
-            .map_err(|error| error.message)?;
-        let task = self
-            .orch
-            .set_prompt(&task.id, (!prompt.is_empty()).then_some(prompt))
+            .add_task_with_prompt(
+                title,
+                (!prompt.is_empty()).then_some(prompt),
+                paths,
+                deps,
+                gate,
+            )
             .map_err(|error| error.message)?;
         if let Err(error) = self.orch.try_save() {
             self.orch = before;
@@ -2091,7 +2093,16 @@ fn task_briefing(task: &crate::orch::Task, mode: TaskWorkerMode) -> String {
         .filter(|prompt| !prompt.trim().is_empty())
     {
         b.push(' ');
-        b.push_str(prompt.trim());
+        // Manual workers are launched by typing one command into a PTY. Keep
+        // the stored prompt multiline for editing and APIs, but fold its line
+        // boundaries at this final terminal boundary so a newline can never
+        // submit a partial shell command.
+        for (index, line) in prompt.lines().map(str::trim).enumerate() {
+            if index > 0 {
+                b.push(' ');
+            }
+            b.push_str(line);
+        }
     }
     if !task.paths.is_empty() {
         b.push_str(&format!(
@@ -3230,7 +3241,7 @@ mod tests {
     #[test]
     fn agent_launch_line_is_one_quoted_line_with_the_contract() {
         let mut s = crate::orch::OrchState::default();
-        let t = s
+        let mut t = s
             .add_task(
                 "fix the auth's bug".into(),
                 vec!["src/auth/**".into()],
@@ -3238,8 +3249,10 @@ mod tests {
                 Some("cargo test auth".into()),
             )
             .unwrap();
+        t.prompt = Some("Review the contract.\nInclude rollback risks.".into());
         let line = agent_launch_line("claude", &t, TaskWorkerMode::Worktree).unwrap();
         assert!(!line.contains('\n'), "typed into a shell — one line");
+        assert!(line.contains("Review the contract. Include rollback risks."));
         assert!(line.contains("claude"));
         assert!(line.contains("luvus task done t1"));
         assert!(line.contains("LUVUS_BIN_PATH"));
@@ -3262,9 +3275,9 @@ mod tests {
         app.orch
             .add_task("safe title".into(), vec![], vec![], None)
             .unwrap();
-        app.orch
-            .set_prompt("t1", Some("review this\rwhoami".into()))
-            .unwrap();
+        // Simulate a ledger written by an older version before task text was
+        // validated on mutation. Launch still fails closed at the PTY boundary.
+        app.orch.tasks[0].prompt = Some("review this\rwhoami".into());
         let panes_before = app.panes.len();
 
         let error = app
@@ -3489,6 +3502,20 @@ mod tests {
         for c in "src/auth/**".chars() {
             app.handle_orch_form_key(k(c));
         }
+        for _ in 0..4 {
+            app.handle_orch_form_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
+        assert_eq!(
+            app.orch_form.as_ref().unwrap().field,
+            crate::app::OrchFormField::Prompt
+        );
+        for c in "Implement token validation".chars() {
+            app.handle_orch_form_key(k(c));
+        }
+        app.handle_orch_form_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+        for c in "Cover rollback behavior".chars() {
+            app.handle_orch_form_key(k(c));
+        }
         app.handle_orch_form_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
         assert!(
@@ -3498,6 +3525,10 @@ mod tests {
         let t = app.orch.task("t1").expect("task was created from the UI");
         assert_eq!(t.title, "auth");
         assert_eq!(t.paths, vec!["src/auth/**".to_string()]);
+        assert_eq!(
+            t.prompt.as_deref(),
+            Some("Implement token validation\nCover rollback behavior")
+        );
     }
 
     #[test]
@@ -3729,12 +3760,12 @@ mod tests {
     }
 
     #[test]
-    fn automation_prompt_shift_enter_inserts_a_newline_without_submitting() {
+    fn task_and_automation_prompt_shift_enter_insert_a_newline_without_submitting() {
         let _env = crate::persist::test_env("orch-form-multiline-prompt");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
         app.orch_form = Some(crate::app::OrchForm {
-            kind: crate::app::OrchFormKind::Automation,
+            kind: crate::app::OrchFormKind::Task,
             field: crate::app::OrchFormField::Prompt,
             prompt: "Review the changes".into(),
             ..crate::app::OrchForm::default()
@@ -3748,7 +3779,7 @@ mod tests {
         let form = app
             .orch_form
             .as_ref()
-            .expect("Shift+Enter keeps the automation form open");
+            .expect("Shift+Enter keeps the task form open");
         assert_eq!(form.prompt, "Review the changes\nand report risks");
         assert!(app.automation.automations.is_empty());
         assert!(app.orch.tasks.is_empty());
@@ -3759,6 +3790,10 @@ mod tests {
             "Review the changes\nand report risks\n",
             "Alt+Enter is the ESC-CR fallback used when a terminal cannot report Shift+Enter"
         );
+
+        app.orch_form.as_mut().unwrap().kind = crate::app::OrchFormKind::Automation;
+        app.handle_orch_form_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
+        assert!(app.orch_form.as_ref().unwrap().prompt.ends_with("\n\n"));
     }
 
     #[test]

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -5369,11 +5369,14 @@ impl App {
             }
             // ── ORCH-1/2: task ledger + path leases (docs/22, M0) ──────────
             "task.add" => {
+                reject_api_fields(p, &["title", "prompt", "paths", "deps", "gate"])?;
                 let title = req_str(p, "title")?.to_string();
+                let prompt = optional_task_prompt(p)?;
                 let task = self
                     .orch
-                    .add_task(
+                    .add_task_with_prompt(
                         title,
+                        prompt,
                         str_array(p, "paths"),
                         str_array(p, "deps"),
                         opt_str(p, "gate"),
@@ -5427,6 +5430,7 @@ impl App {
                 }))
             }
             "task.update" => {
+                reject_api_fields(p, &["id", "status", "output", "note", "prompt"])?;
                 let id = req_str(p, "id")?.to_string();
                 let status = if let Some(s) = p.get("status").and_then(|v| v.as_str()) {
                     let st = crate::orch::TaskStatus::parse(s).ok_or_else(|| {
@@ -5455,6 +5459,11 @@ impl App {
                             format!("{id} is already {}", current.as_str()),
                         ));
                     }
+                }
+                if p.get("prompt").is_some() {
+                    self.orch
+                        .set_prompt(&id, optional_task_prompt(p)?)
+                        .map_err(orch_err)?;
                 }
                 if let Some(st) = status {
                     self.orch.set_status(&id, st).map_err(orch_err)?;
@@ -7582,6 +7591,12 @@ pub(crate) fn task_json(t: &crate::orch::Task) -> Value {
         "created": t.created,
         "updated": t.updated,
     });
+    // Manual task briefings are part of the ORCH task contract. Automation
+    // prompts remain private to their definition/run projection and must not
+    // leak through the general task list or event stream.
+    if t.automation.is_none() {
+        value["prompt"] = json!(t.prompt);
+    }
     if let Some(mode) = t.worker_mode {
         value["mode"] = json!(mode);
     }
@@ -7589,6 +7604,17 @@ pub(crate) fn task_json(t: &crate::orch::Task) -> Value {
         value["workspace_worker"] = json!(workspace);
     }
     value
+}
+
+fn optional_task_prompt(p: &Value) -> Result<Option<String>, (String, String)> {
+    match p.get("prompt") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(prompt)) => Ok(Some(prompt.clone())),
+        Some(_) => Err((
+            "invalid_request".to_string(),
+            "prompt must be a string or null".to_string(),
+        )),
+    }
 }
 
 /// A trimmed JSON view of an installed module for `module.list`.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1117,8 +1117,8 @@ impl App {
     /// Route pasted text into an open text-input modal by replaying it as
     /// keypresses, so a paste fills the field instead of leaking to the pane
     /// underneath. Mirrors `handle_key`'s text-input precedence; returns whether
-    /// a modal consumed it. Control chars (newlines/tabs) are dropped — these are
-    /// all single-line fields.
+    /// a modal consumed it. Control characters are dropped from single-line
+    /// fields; the ORCH prompt preserves normalized line feeds.
     fn paste_into_modal(&mut self, s: &str) -> bool {
         use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         if self.named_session_menu.is_some() {
@@ -1144,6 +1144,25 @@ impl App {
             self.picker_paste(s);
             return true;
         }
+        if self.orch_form.is_some() {
+            let multiline = self
+                .orch_form
+                .as_ref()
+                .is_some_and(|form| form.field == crate::app::OrchFormField::Prompt);
+            for character in s.replace("\r\n", "\n").replace('\r', "\n").chars() {
+                if character == '\n' && multiline {
+                    if let Some(form) = self.orch_form.as_mut() {
+                        form.push_char('\n');
+                    }
+                } else if !character.is_control() {
+                    self.handle_orch_form_key(KeyEvent::new(
+                        KeyCode::Char(character),
+                        KeyModifiers::NONE,
+                    ));
+                }
+            }
+            return true;
+        }
         let handler: fn(&mut Self, KeyEvent) = if self.worktree_prompt.is_some() {
             Self::handle_worktree_prompt_key
         } else if self.tab_rename.is_some() {
@@ -1154,8 +1173,6 @@ impl App {
             Self::handle_ws_rename_key
         } else if self.pane_rename.is_some() {
             Self::handle_pane_rename_key
-        } else if self.orch_form.is_some() {
-            Self::handle_orch_form_key
         } else {
             return false;
         };
@@ -4316,6 +4333,24 @@ fn csi_tilde_key(code: u8, modifiers: KeyModifiers) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn task_prompt_paste_preserves_normalized_newlines() {
+        let _env = crate::persist::test_env("orch-prompt-paste");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        app.orch_form = Some(crate::app::OrchForm {
+            kind: crate::app::OrchFormKind::Task,
+            field: crate::app::OrchFormField::Prompt,
+            ..crate::app::OrchForm::default()
+        });
+
+        assert!(app.paste_into_modal("first\r\nsecond\rthird\tline"));
+        assert_eq!(
+            app.orch_form.as_ref().unwrap().prompt,
+            "first\nsecond\nthirdline"
+        );
+    }
 
     #[test]
     fn prefix_digits_jump_to_tabs_and_shifted_digits_jump_to_workspaces() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1148,6 +1148,7 @@ const TASK_MANUAL_FIELDS: &[OrchFormField] = &[
     OrchFormField::Deps,
     OrchFormField::Gate,
     OrchFormField::Start,
+    OrchFormField::Prompt,
 ];
 const TASK_NOW_FIELDS: &[OrchFormField] = &[
     OrchFormField::Title,
@@ -1474,8 +1475,15 @@ impl OrchForm {
             self.schedule.clear();
             self.schedule_prefilled = false;
         }
+        let limit = match self.field {
+            OrchFormField::Title => Some(crate::orch::MAX_TASK_TITLE_BYTES),
+            OrchFormField::Prompt => Some(crate::orch::MAX_TASK_PROMPT_BYTES),
+            _ => None,
+        };
         if let Some(field) = self.active_mut() {
-            field.push(value);
+            if limit.is_none_or(|limit| field.len() + value.len_utf8() <= limit) {
+                field.push(value);
+            }
         }
     }
 
@@ -11821,10 +11829,24 @@ mod tests {
         let r = call(
             &mut app,
             "task.add",
-            json!({"title":"auth","paths":["src/auth/**"]}),
+            json!({
+                "title":"auth",
+                "prompt":"Review the API.\nInclude rollback coverage.",
+                "paths":["src/auth/**"]
+            }),
         );
         assert_eq!(r["result"]["task"]["id"], "t1");
+        assert_eq!(
+            r["result"]["task"]["prompt"],
+            "Review the API.\nInclude rollback coverage."
+        );
         call(&mut app, "task.add", json!({"title":"api","deps":["t1"]}));
+        let r = call(
+            &mut app,
+            "task.update",
+            json!({"id":"t2", "prompt":"Implement the API client."}),
+        );
+        assert_eq!(r["result"]["task"]["prompt"], "Implement the API client.");
 
         // t2 can't be claimed while its dependency is unfinished.
         let r = call(
@@ -11841,6 +11863,16 @@ mod tests {
             json!({"id":"t1","pane": a.0.to_string()}),
         );
         assert_eq!(r["result"]["task"]["status"], "claimed");
+        let r = call(
+            &mut app,
+            "task.update",
+            json!({"id":"t1", "prompt":"too late"}),
+        );
+        assert_eq!(r["error"]["code"], "task_active");
+        assert_eq!(
+            app.orch.task("t1").unwrap().prompt.as_deref(),
+            Some("Review the API.\nInclude rollback coverage.")
+        );
         let r = call(
             &mut app,
             "lease.acquire",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! CLI client (M4): `luvus pane …` / `luvus ping` / `luvus events` connect to
 //! the session socket, send one JSON request, and print the reply. See docs/08.
 
-use std::io::{BufReader, Write};
+use std::io::{BufReader, Read, Write};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
@@ -270,7 +270,7 @@ worktrees:
   worktree remove <path>     remove a worktree (its branch is kept)
 
 orchestration (multiple agents on one project, docs/22):
-  task add \"<title>\" [--paths <glob>...] [--dep <id>...] [--gate <cmd>]
+  task add \"<title>\" [--prompt <text>|--prompt-file <path>] [--paths <glob>...] [--dep <id>...] [--gate <cmd>]
   task list                  list all tasks + their status/assignee
   task get <id>              show one task
   task claim <id>            claim a task for this pane (deps must be done)
@@ -281,7 +281,7 @@ orchestration (multiple agents on one project, docs/22):
   task heartbeat <id> --context-used <0..1>
                              report model context-window use, not task progress
                              (>85% blocks done; --context remains accepted)
-  task update <id> [--status <s>] [--output <o>] [--note <n>]
+  task update <id> [--prompt <text>|--prompt-file <path>] [--status <s>] [--output <o>] [--note <n>]
   task done <id>             mark done + release its leases
   task merge <id>            integrate the task's branch into luvus/integration
                              (isolated worktree, conflicts block the task)
@@ -3735,6 +3735,9 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             obj.insert("title".into(), json!(title.unwrap_or_default()));
             obj.insert("paths".into(), json!(multi_flag(args, "--paths")));
             obj.insert("deps".into(), json!(multi_flag(args, "--dep")));
+            if let Some(prompt) = task_prompt_arg(args)? {
+                obj.insert("prompt".into(), json!(prompt));
+            }
             if let Some(g) = flag(args, "--gate") {
                 obj.insert("gate".into(), json!(g));
             }
@@ -3826,6 +3829,9 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             if let Some(n) = flag(args, "--note") {
                 obj.insert("note".into(), json!(n));
             }
+            if let Some(prompt) = task_prompt_arg(args)? {
+                obj.insert("prompt".into(), json!(prompt));
+            }
             ("task.update".into(), Value::Object(obj))
         }
         ("task", _) => ("task.list".into(), json!({})),
@@ -3873,6 +3879,41 @@ fn multi_flag(args: &[String], name: &str) -> Vec<String> {
         }
     }
     out
+}
+
+/// Read an optional task prompt from argv without allowing a prompt file to
+/// allocate past the same limit enforced by the server and UHP schema.
+fn task_prompt_arg(args: &[String]) -> Result<Option<String>> {
+    let inline = flag(args, "--prompt").filter(|value| !value.starts_with("--"));
+    let file = flag(args, "--prompt-file").filter(|value| !value.starts_with("--"));
+    if inline.is_some() && file.is_some() {
+        return Err(anyhow!("use only one of --prompt and --prompt-file"));
+    }
+    if args.iter().any(|arg| arg == "--prompt") && inline.is_none() {
+        return Err(anyhow!("--prompt requires text"));
+    }
+    if args.iter().any(|arg| arg == "--prompt-file") && file.is_none() {
+        return Err(anyhow!("--prompt-file requires a path"));
+    }
+    if let Some(prompt) = inline {
+        return Ok(Some(prompt));
+    }
+    let Some(path) = file else {
+        return Ok(None);
+    };
+    let file =
+        std::fs::File::open(&path).map_err(|error| anyhow!("cannot read {path}: {error}"))?;
+    let mut prompt = String::new();
+    file.take((crate::orch::MAX_TASK_PROMPT_BYTES + 1) as u64)
+        .read_to_string(&mut prompt)
+        .map_err(|error| anyhow!("cannot read {path} as UTF-8 text: {error}"))?;
+    if prompt.len() > crate::orch::MAX_TASK_PROMPT_BYTES {
+        return Err(anyhow!(
+            "task prompt exceeds the {}-byte limit",
+            crate::orch::MAX_TASK_PROMPT_BYTES
+        ));
+    }
+    Ok(Some(prompt))
 }
 
 fn automation_definition_params(
@@ -4986,6 +5027,43 @@ mod tests {
         );
         assert_eq!(p.get("gate").and_then(|v| v.as_str()), Some("cargo"));
 
+        let prompt_args = [
+            "luvus",
+            "task",
+            "add",
+            "Detailed review task that remains one title argument",
+            "--prompt",
+            "Inspect the API.\nCover rollback behavior.",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let (method, params) = parse(&prompt_args).unwrap();
+        assert_eq!(method, "task.add");
+        assert_eq!(
+            params["prompt"],
+            "Inspect the API.\nCover rollback behavior."
+        );
+
+        let update_args = [
+            "luvus",
+            "task",
+            "update",
+            "t1",
+            "--prompt",
+            "Updated briefing",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let (method, params) = parse(&update_args).unwrap();
+        assert_eq!(method, "task.update");
+        assert_eq!(params["prompt"], "Updated briefing");
+        assert!(parse(&argv(
+            "luvus task add title --prompt inline --prompt-file task.md"
+        ))
+        .is_err());
+
         let (m, _) = parse(&argv("luvus task list")).unwrap();
         assert_eq!(m, "task.list");
         let (m, p) = parse(&argv("luvus task claim t3")).unwrap();
@@ -5058,6 +5136,36 @@ mod tests {
         let (m, p) = parse(&argv("luvus task merge t1")).unwrap();
         assert_eq!(m, "task.merge");
         assert_eq!(p.get("id").and_then(|v| v.as_str()), Some("t1"));
+    }
+
+    #[test]
+    fn task_prompt_file_is_bounded_and_maps_to_the_prompt_field() {
+        let _env = crate::persist::test_env("task-prompt-file");
+        let root = crate::persist::config_dir();
+        fs::create_dir_all(&root).unwrap();
+        let prompt_path = root.join("task.md");
+        fs::write(&prompt_path, "Review the API.\nCover rollback behavior.\n").unwrap();
+        let args = vec![
+            "luvus".into(),
+            "task".into(),
+            "add".into(),
+            "Review API".into(),
+            "--prompt-file".into(),
+            prompt_path.display().to_string(),
+        ];
+        let (method, params) = parse(&args).unwrap();
+        assert_eq!(method, "task.add");
+        assert_eq!(
+            params["prompt"],
+            "Review the API.\nCover rollback behavior.\n"
+        );
+
+        fs::write(
+            &prompt_path,
+            "x".repeat(crate::orch::MAX_TASK_PROMPT_BYTES + 1),
+        )
+        .unwrap();
+        assert!(parse(&args).unwrap_err().to_string().contains("byte limit"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3910,9 +3910,21 @@ fn task_prompt_arg(args: &[String]) -> Result<Option<String>> {
     };
     let file =
         std::fs::File::open(&path).map_err(|error| anyhow!("cannot read {path}: {error}"))?;
-    let mut prompt = String::new();
-    file.take((crate::orch::MAX_TASK_PROMPT_BYTES + 1) as u64)
-        .read_to_string(&mut prompt)
+    // Every normalized LF can occupy at most two source bytes as CRLF. Read
+    // one byte beyond that largest valid representation so an oversized file
+    // is rejected instead of silently accepted after a truncated read.
+    let max_source_bytes = crate::orch::MAX_TASK_PROMPT_BYTES * 2;
+    let mut bytes = Vec::with_capacity(max_source_bytes + 1);
+    file.take((max_source_bytes + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| anyhow!("cannot read {path}: {error}"))?;
+    if bytes.len() > max_source_bytes {
+        return Err(anyhow!(
+            "task prompt exceeds the {}-byte limit",
+            crate::orch::MAX_TASK_PROMPT_BYTES
+        ));
+    }
+    let mut prompt = String::from_utf8(bytes)
         .map_err(|error| anyhow!("cannot read {path} as UTF-8 text: {error}"))?;
     prompt = prompt.replace("\r\n", "\n").replace('\r', "\n");
     if prompt.len() > crate::orch::MAX_TASK_PROMPT_BYTES {
@@ -5193,6 +5205,23 @@ mod tests {
             params["prompt"],
             "Review the API.\nCover rollback behavior.\nCheck recovery.\n"
         );
+
+        fs::write(
+            &prompt_path,
+            "\r\n".repeat(crate::orch::MAX_TASK_PROMPT_BYTES),
+        )
+        .unwrap();
+        let (_, params) = parse(&args).unwrap();
+        let prompt = params["prompt"].as_str().unwrap();
+        assert_eq!(prompt.len(), crate::orch::MAX_TASK_PROMPT_BYTES);
+        assert!(prompt.bytes().all(|byte| byte == b'\n'));
+
+        fs::write(
+            &prompt_path,
+            "\r\n".repeat(crate::orch::MAX_TASK_PROMPT_BYTES + 1),
+        )
+        .unwrap();
+        assert!(parse(&args).unwrap_err().to_string().contains("byte limit"));
 
         fs::write(
             &prompt_path,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3907,6 +3907,7 @@ fn task_prompt_arg(args: &[String]) -> Result<Option<String>> {
     file.take((crate::orch::MAX_TASK_PROMPT_BYTES + 1) as u64)
         .read_to_string(&mut prompt)
         .map_err(|error| anyhow!("cannot read {path} as UTF-8 text: {error}"))?;
+    prompt = prompt.replace("\r\n", "\n").replace('\r', "\n");
     if prompt.len() > crate::orch::MAX_TASK_PROMPT_BYTES {
         return Err(anyhow!(
             "task prompt exceeds the {}-byte limit",
@@ -5059,6 +5060,16 @@ mod tests {
         let (method, params) = parse(&update_args).unwrap();
         assert_eq!(method, "task.update");
         assert_eq!(params["prompt"], "Updated briefing");
+        let (_, params) = parse(&[
+            "luvus".into(),
+            "task".into(),
+            "update".into(),
+            "t1".into(),
+            "--prompt".into(),
+            "inline\r\nprompt\rtext".into(),
+        ])
+        .unwrap();
+        assert_eq!(params["prompt"], "inline\r\nprompt\rtext");
         assert!(parse(&argv(
             "luvus task add title --prompt inline --prompt-file task.md"
         ))
@@ -5144,7 +5155,11 @@ mod tests {
         let root = crate::persist::config_dir();
         fs::create_dir_all(&root).unwrap();
         let prompt_path = root.join("task.md");
-        fs::write(&prompt_path, "Review the API.\nCover rollback behavior.\n").unwrap();
+        fs::write(
+            &prompt_path,
+            "Review the API.\r\nCover rollback behavior.\rCheck recovery.\r\n",
+        )
+        .unwrap();
         let args = vec![
             "luvus".into(),
             "task".into(),
@@ -5157,7 +5172,7 @@ mod tests {
         assert_eq!(method, "task.add");
         assert_eq!(
             params["prompt"],
-            "Review the API.\nCover rollback behavior.\n"
+            "Review the API.\nCover rollback behavior.\nCheck recovery.\n"
         );
 
         fs::write(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3730,9 +3730,13 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
 
         // ── orchestration (docs/22, M0): task ledger + path leases ──────────
         ("task", "add") => {
-            let title = rest.iter().find(|a| !a.starts_with("--")).cloned();
+            let title = rest
+                .first()
+                .filter(|value| !value.starts_with("--"))
+                .cloned()
+                .ok_or_else(|| anyhow!("task add requires a title"))?;
             let mut obj = serde_json::Map::new();
-            obj.insert("title".into(), json!(title.unwrap_or_default()));
+            obj.insert("title".into(), json!(title));
             obj.insert("paths".into(), json!(multi_flag(args, "--paths")));
             obj.insert("deps".into(), json!(multi_flag(args, "--dep")));
             if let Some(prompt) = task_prompt_arg(args)? {
@@ -3816,10 +3820,13 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
         ("task", "merge") => ("task.merge".into(), one("id", arg0())),
         ("task", "release") => ("task.release".into(), one("id", arg0())),
         ("task", "update") => {
+            let id = rest
+                .first()
+                .filter(|value| !value.starts_with("--"))
+                .cloned()
+                .ok_or_else(|| anyhow!("task update requires an id"))?;
             let mut obj = serde_json::Map::new();
-            if let Some(id) = arg0() {
-                obj.insert("id".into(), json!(id));
-            }
+            obj.insert("id".into(), json!(id));
             if let Some(s) = flag(args, "--status") {
                 obj.insert("status".into(), json!(s));
             }
@@ -5074,6 +5081,18 @@ mod tests {
             "luvus task add title --prompt inline --prompt-file task.md"
         ))
         .is_err());
+        assert_eq!(
+            parse(&argv("luvus task add --prompt briefing"))
+                .unwrap_err()
+                .to_string(),
+            "task add requires a title"
+        );
+        assert_eq!(
+            parse(&argv("luvus task update --prompt briefing"))
+                .unwrap_err()
+                .to_string(),
+            "task update requires an id"
+        );
 
         let (m, _) = parse(&argv("luvus task list")).unwrap();
         assert_eq!(m, "task.list");

--- a/src/orch/mod.rs
+++ b/src/orch/mod.rs
@@ -162,6 +162,10 @@ pub const COMPACTION_THRESHOLD: f64 = 0.85;
 /// `orch.json` on disk, and the UHP can drive it programmatically — so
 /// nothing may grow without bound. Limits far above real use, well below harm.
 pub const MAX_TASKS: usize = 1000;
+/// Task titles remain compact board labels while still allowing descriptive names.
+pub const MAX_TASK_TITLE_BYTES: usize = 256;
+/// Detailed worker briefings share the reviewed automation prompt budget.
+pub const MAX_TASK_PROMPT_BYTES: usize = 32 * 1024;
 /// Per-task `outputs` / `notes` keep only the most recent entries…
 pub const MAX_TASK_LOG: usize = 100;
 /// …and each entry is truncated to this many bytes (a runaway agent piping a
@@ -174,11 +178,35 @@ pub const MAX_LEASE_PATHS: usize = 64;
 /// Maximum UTF-8 byte length of one path pattern.
 pub const MAX_LEASE_PATH_BYTES: usize = 1024;
 
-/// Task briefings are sent to a live shell as terminal input. Reject control
-/// characters before launch so restored or remotely supplied task text cannot
-/// synthesize Enter, Escape, or another terminal action.
+/// Task briefings are sent to a live shell as terminal input. Reject every
+/// control character before launch so restored task text cannot synthesize an
+/// Enter, Escape, or another terminal action.
 pub(crate) fn contains_terminal_control(value: &str) -> bool {
     value.chars().any(char::is_control)
+}
+
+fn validate_task_text(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+    multiline: bool,
+) -> OrchResult<()> {
+    if value.len() > max_bytes {
+        return Err(Reject::new(
+            "bad_request",
+            format!("{field} exceeds the {max_bytes}-byte limit"),
+        ));
+    }
+    if value
+        .chars()
+        .any(|character| character.is_control() && !(multiline && character == '\n'))
+    {
+        return Err(Reject::new(
+            "bad_request",
+            format!("{field} contains an unsupported control character"),
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -238,8 +266,24 @@ impl OrchState {
         deps: Vec<TaskId>,
         gate: Option<String>,
     ) -> OrchResult<Task> {
+        self.add_task_with_prompt(title, None, paths, deps, gate)
+    }
+
+    /// Add a task and its optional detailed worker briefing atomically.
+    pub fn add_task_with_prompt(
+        &mut self,
+        title: String,
+        prompt: Option<String>,
+        paths: Vec<String>,
+        deps: Vec<TaskId>,
+        gate: Option<String>,
+    ) -> OrchResult<Task> {
         if title.trim().is_empty() {
             return Err(Reject::new("bad_request", "task title is required"));
+        }
+        validate_task_text("task title", &title, MAX_TASK_TITLE_BYTES, false)?;
+        if let Some(prompt) = &prompt {
+            validate_task_text("task prompt", prompt, MAX_TASK_PROMPT_BYTES, true)?;
         }
         if self.tasks.len() >= MAX_TASKS {
             return Err(Reject::new(
@@ -258,7 +302,7 @@ impl OrchState {
         let task = Task {
             id: format!("t{}", self.next_task),
             title,
-            prompt: None,
+            prompt: prompt.filter(|value| !value.trim().is_empty()),
             status: TaskStatus::Queued,
             assignee: None,
             deps,
@@ -288,6 +332,7 @@ impl OrchState {
         prompt: String,
         provenance: AutomationProvenance,
     ) -> OrchResult<Task> {
+        validate_task_text("task prompt", &prompt, MAX_TASK_PROMPT_BYTES, true)?;
         if self.tasks.iter().any(|task| {
             task.id != id
                 && task
@@ -329,6 +374,16 @@ impl OrchState {
             .iter_mut()
             .find(|task| task.id == id)
             .ok_or_else(|| Reject::new("not_found", format!("no such task: {id}")))?;
+        if task.status != TaskStatus::Queued || task.assignee.is_some() || task.automation.is_some()
+        {
+            return Err(Reject::new(
+                "task_active",
+                "task prompt can only be edited before a manual task starts",
+            ));
+        }
+        if let Some(prompt) = &prompt {
+            validate_task_text("task prompt", prompt, MAX_TASK_PROMPT_BYTES, true)?;
+        }
         task.prompt = prompt.filter(|value| !value.trim().is_empty());
         task.updated = unix_now();
         Ok(task.clone())
@@ -1059,6 +1114,72 @@ mod tests {
         let stored = s.task("t2").unwrap().outputs.last().unwrap().clone();
         assert!(stored.len() <= MAX_LOG_ENTRY + '…'.len_utf8());
         assert!(stored.ends_with('…'));
+    }
+
+    #[test]
+    fn task_title_and_prompt_are_bounded_and_created_atomically() {
+        let mut state = OrchState::default();
+        let task = state
+            .add_task_with_prompt(
+                "Review the authentication migration".into(),
+                Some("Check the API contract.\nCover rollback behavior.".into()),
+                vec!["src/auth/**".into()],
+                vec![],
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            task.prompt.as_deref(),
+            Some("Check the API contract.\nCover rollback behavior.")
+        );
+
+        let too_long_title = "x".repeat(MAX_TASK_TITLE_BYTES + 1);
+        let error = state
+            .add_task(too_long_title, vec![], vec![], None)
+            .unwrap_err();
+        assert_eq!(error.code, "bad_request");
+
+        let too_long_prompt = "x".repeat(MAX_TASK_PROMPT_BYTES + 1);
+        let error = state
+            .add_task_with_prompt(
+                "not inserted".into(),
+                Some(too_long_prompt),
+                vec![],
+                vec![],
+                None,
+            )
+            .unwrap_err();
+        assert_eq!(error.code, "bad_request");
+        assert_eq!(state.tasks.len(), 1, "a rejected prompt creates no task");
+    }
+
+    #[test]
+    fn manual_prompt_is_editable_only_before_start() {
+        let mut state = OrchState::default();
+        state
+            .add_task_with_prompt(
+                "Review".into(),
+                Some("First briefing".into()),
+                vec![],
+                vec![],
+                None,
+            )
+            .unwrap();
+        state
+            .set_prompt("t1", Some("Updated\nbriefing".into()))
+            .unwrap();
+        assert_eq!(
+            state.task("t1").unwrap().prompt.as_deref(),
+            Some("Updated\nbriefing")
+        );
+
+        state.claim("t1", 7).unwrap();
+        let error = state.set_prompt("t1", Some("too late".into())).unwrap_err();
+        assert_eq!(error.code, "task_active");
+        assert_eq!(
+            state.task("t1").unwrap().prompt.as_deref(),
+            Some("Updated\nbriefing")
+        );
     }
 
     #[test]

--- a/src/ui/board.rs
+++ b/src/ui/board.rs
@@ -1608,6 +1608,23 @@ fn draw_summary(f: &mut RenderTarget, area: Rect, task: &Task, cat: &Catalog, t:
     add(cat.board_f_paths, task.paths.join(" "));
     add(cat.board_f_deps, task.deps.join(" "));
     add(cat.board_f_gate, task.gate.clone().unwrap_or_default());
+    if let Some(prompt) = task
+        .prompt
+        .as_deref()
+        .filter(|prompt| !prompt.trim().is_empty())
+    {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!(" {}", cat.board_f_prompt),
+            Style::new().fg(t.subtext1).bold(),
+        )));
+        lines.extend(prompt.lines().take(3).map(|line| {
+            Line::from(Span::styled(
+                format!("  {line}"),
+                Style::new().fg(t.subtext0),
+            ))
+        }));
+    }
     if let Some(output) = task.outputs.last() {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -1644,6 +1661,83 @@ fn fill_bg(f: &mut RenderTarget, rect: Rect, color: Color) {
             buf[(x, y)].set_bg(color);
         }
     }
+}
+
+/// Keep the insertion cursor visible for a long single-line form value. This
+/// crops from the left by terminal display cells and never splits a wide glyph.
+fn input_tail(value: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if super::display_width(value) <= width {
+        return value.to_string();
+    }
+    let budget = width.saturating_sub(1);
+    let mut tail = Vec::new();
+    let mut used = 0;
+    for character in value.chars().rev() {
+        let mut encoded = [0; 4];
+        let character_width = super::display_width(character.encode_utf8(&mut encoded));
+        if used + character_width > budget {
+            break;
+        }
+        tail.push(character);
+        used += character_width;
+    }
+    tail.reverse();
+    format!("…{}", tail.into_iter().collect::<String>())
+}
+
+/// Split text into explicit display-width rows so scrolling and the visible
+/// insertion cursor agree without relying on unstable widget measurements.
+fn wrap_display_lines(value: &str, width: usize) -> Vec<String> {
+    let mut rows = Vec::new();
+    for logical in value.split('\n') {
+        if logical.is_empty() {
+            rows.push(String::new());
+            continue;
+        }
+        let mut remaining = logical;
+        while !remaining.is_empty() {
+            let mut used = 0;
+            let mut end = 0;
+            for (index, character) in remaining.char_indices() {
+                let mut encoded = [0; 4];
+                let character_width = super::display_width(character.encode_utf8(&mut encoded));
+                if end > 0 && used + character_width > width.max(1) {
+                    break;
+                }
+                used += character_width;
+                end = index + character.len_utf8();
+            }
+            if end >= remaining.len() {
+                rows.push(remaining.to_string());
+                break;
+            }
+            let candidate = &remaining[..end];
+            let split = candidate
+                .char_indices()
+                .rev()
+                .find_map(|(index, character)| {
+                    (index > 0 && character.is_whitespace()).then_some(index)
+                })
+                .unwrap_or(end);
+            rows.push(candidate[..split].to_string());
+            let mut consumed = split;
+            if split < end {
+                consumed += remaining[split..]
+                    .chars()
+                    .take_while(|character| character.is_whitespace())
+                    .map(char::len_utf8)
+                    .sum::<usize>();
+            }
+            remaining = &remaining[consumed..];
+        }
+    }
+    if rows.is_empty() {
+        rows.push(String::new());
+    }
+    rows
 }
 
 /// The in-TUI creation form. Task and automation tabs share the common fields,
@@ -1841,37 +1935,62 @@ pub(super) fn draw_form(
                 field_rect.width.saturating_sub(LABEL_WIDTH),
                 field_rect.height,
             );
-            let mut lines = if value.is_empty() && !active {
-                vec![Line::from(Span::styled(hint, Style::new().fg(t.overlay0)))]
+            let (mut display_value, value_style) = if value.is_empty() && !active {
+                (hint.to_string(), Style::new().fg(t.overlay0))
             } else {
-                value
-                    .split('\n')
-                    .map(|line| Line::from(Span::styled(line.to_string(), Style::new().fg(t.text))))
-                    .collect::<Vec<_>>()
+                (value, Style::new().fg(t.text))
             };
             if active {
-                lines
-                    .last_mut()
-                    .expect("a prompt always renders at least one line")
-                    .spans
-                    .push(Span::styled("▏", Style::new().fg(t.accent)));
+                display_value.push('▏');
             }
-            let scroll = lines.len().saturating_sub(body_rect.height as usize) as u16;
-            let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
-            f.render_widget(paragraph.scroll((scroll, 0)), body_rect);
+            let lines = wrap_display_lines(&display_value, body_rect.width as usize);
+            let scroll = lines.len().saturating_sub(body_rect.height as usize);
+            let visible = lines.into_iter().skip(scroll).map(|line| {
+                if let Some(text) = active.then(|| line.strip_suffix('▏')).flatten() {
+                    Line::from(vec![
+                        Span::styled(text.to_string(), value_style),
+                        Span::styled("▏", Style::new().fg(t.accent)),
+                    ])
+                } else {
+                    Line::from(Span::styled(line, value_style))
+                }
+            });
+            f.render_widget(Paragraph::new(visible.collect::<Vec<_>>()), body_rect);
         } else {
+            const LABEL_WIDTH: u16 = 11;
+            f.render_widget(
+                Paragraph::new(Span::styled(format!(" {label:<8}: "), label_style)),
+                Rect::new(
+                    field_rect.x,
+                    field_rect.y,
+                    LABEL_WIDTH.min(field_rect.width),
+                    1,
+                ),
+            );
+            let body_rect = Rect::new(
+                field_rect.x.saturating_add(LABEL_WIDTH),
+                field_rect.y,
+                field_rect.width.saturating_sub(LABEL_WIDTH),
+                1,
+            );
+            let cursor_width = usize::from(active && body_rect.width > 0);
+            let available = body_rect.width as usize - cursor_width;
             let body = if value.is_empty() && !active {
-                Span::styled(hint, Style::new().fg(t.overlay0))
+                Span::styled(
+                    super::truncate(hint, available),
+                    Style::new().fg(t.overlay0),
+                )
+            } else if active {
+                Span::styled(input_tail(&value, available), Style::new().fg(t.text))
             } else {
-                Span::styled(value, Style::new().fg(t.text))
+                Span::styled(super::truncate(&value, available), Style::new().fg(t.text))
             };
             f.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled(format!(" {label:<8}: "), label_style),
                     body,
                     Span::styled(if active { "▏" } else { "" }, Style::new().fg(t.accent)),
                 ])),
-                field_rect,
+                body_rect,
             );
         }
         hits.push((crate::app::OrchHit::FormField(field), field_rect));
@@ -1886,9 +2005,7 @@ pub(super) fn draw_form(
         );
     } else {
         let mut shortcuts = vec![("⏎", cat.act_create)];
-        if form.kind == crate::app::OrchFormKind::Automation
-            && form.field == crate::app::OrchFormField::Prompt
-        {
+        if form.field == crate::app::OrchFormField::Prompt {
             shortcuts.push(("⇧⏎", cat.settings.shift_newline));
         }
         shortcuts.extend([
@@ -2291,20 +2408,21 @@ pub(super) fn draw_detail(
     );
 
     let sc = status_color(task.status, t);
-    let mut lines: Vec<Line> = vec![
-        Line::from(vec![
-            Span::styled(format!(" {} ", task.id), Style::new().fg(t.subtext1).bold()),
-            Span::styled(status_label(task.status, cat), Style::new().fg(sc)),
-            Span::styled(
-                format!(
-                    "  {}",
-                    pad(&task.title, (inner.width as usize).saturating_sub(14))
-                ),
-                Style::new().fg(t.text).bold(),
-            ),
-        ]),
-        Line::from(""),
-    ];
+    let mut lines: Vec<Line> = vec![Line::from(vec![
+        Span::styled(format!(" {} ", task.id), Style::new().fg(t.subtext1).bold()),
+        Span::styled(status_label(task.status, cat), Style::new().fg(sc)),
+    ])];
+    lines.extend(
+        wrap_display_lines(&task.title, inner.width.saturating_sub(1) as usize)
+            .into_iter()
+            .map(|title| {
+                Line::from(Span::styled(
+                    format!(" {title}"),
+                    Style::new().fg(t.text).bold(),
+                ))
+            }),
+    );
+    lines.push(Line::from(""));
     let kv = |k: &'static str, v: String, lines: &mut Vec<Line>| {
         if !v.is_empty() {
             lines.push(Line::from(vec![
@@ -2353,6 +2471,26 @@ pub(super) fn draw_detail(
         task.gate.clone().unwrap_or_default(),
         &mut lines,
     );
+    if let Some(prompt) = task
+        .prompt
+        .as_deref()
+        .filter(|prompt| !prompt.trim().is_empty())
+    {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!(" {}", cat.board_f_prompt),
+            Style::new().fg(t.subtext1).bold(),
+        )));
+        for logical in prompt.split('\n') {
+            lines.extend(
+                wrap_display_lines(logical, inner.width.saturating_sub(2) as usize)
+                    .into_iter()
+                    .map(|line| {
+                        Line::from(Span::styled(format!("  {line}"), Style::new().fg(t.text)))
+                    }),
+            );
+        }
+    }
     if !task.outputs.is_empty() {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -3033,11 +3171,11 @@ mod tests {
     }
 
     #[test]
-    fn automation_form_keeps_the_multiline_prompt_tail_visible() {
+    fn task_form_keeps_the_multiline_prompt_tail_visible() {
         let area = Rect::new(0, 0, 90, 30);
         let mut buffer = Buffer::empty(area);
         let mut target = RenderTarget::new(&mut buffer, area);
-        let mut form = OrchForm::for_kind(crate::app::OrchFormKind::Automation);
+        let mut form = OrchForm::for_kind(crate::app::OrchFormKind::Task);
         form.field = crate::app::OrchFormField::Prompt;
         form.prompt = "first line\nsecond line\nthird line\nfourth line".into();
 
@@ -3062,6 +3200,71 @@ mod tests {
         assert!(rendered.contains("third line"));
         assert!(rendered.contains("fourth line▏"));
         assert!(rendered.contains("newline"));
+    }
+
+    #[test]
+    fn long_task_title_keeps_its_tail_and_cursor_visible() {
+        let area = Rect::new(0, 0, 52, 22);
+        let mut buffer = Buffer::empty(area);
+        let mut target = RenderTarget::new(&mut buffer, area);
+        let mut form = OrchForm::for_kind(crate::app::OrchFormKind::Task);
+        form.field = crate::app::OrchFormField::Title;
+        form.title = "A long descriptive task title whose ending stays visible".into();
+
+        draw_form(
+            &mut target,
+            area,
+            &form,
+            &crate::i18n::EN,
+            &Theme::quattro_rally(),
+        );
+
+        let rendered = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("…"));
+        assert!(rendered.contains("ending stays visible▏"));
+        assert!(!rendered.contains("A long descriptive task title"));
+    }
+
+    #[test]
+    fn task_detail_shows_the_full_wrapped_title_and_prompt() {
+        let area = Rect::new(0, 0, 52, 24);
+        let mut buffer = Buffer::empty(area);
+        let mut target = RenderTarget::new(&mut buffer, area);
+        let mut state = OrchState::default();
+        let task = state
+            .add_task_with_prompt(
+                "Review the complete authentication migration and rollback path".into(),
+                Some("Inspect the API contract.\nCover data rollback and recovery.".into()),
+                vec![],
+                vec![],
+                None,
+            )
+            .unwrap();
+
+        draw_detail(
+            &mut target,
+            area,
+            &task,
+            0,
+            &crate::i18n::EN,
+            &Theme::quattro_rally(),
+        );
+        let rendered = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("Review the complete authentication"));
+        assert!(rendered.contains("migration and rollback path"));
+        assert!(rendered.contains("Inspect the API contract."));
+        assert!(rendered.contains("Cover data rollback and recovery."));
     }
 
     #[test]

--- a/src/ui/board.rs
+++ b/src/ui/board.rs
@@ -1942,9 +1942,11 @@ pub(super) fn draw_form(
                 display_value.push('▏');
             }
             let lines = wrap_display_lines(&display_value, body_rect.width as usize);
-            let scroll = active
-                .then(|| lines.len().saturating_sub(body_rect.height as usize))
-                .unwrap_or(0);
+            let scroll = if active {
+                lines.len().saturating_sub(body_rect.height as usize)
+            } else {
+                0
+            };
             let visible = lines.into_iter().skip(scroll).map(|line| {
                 if let Some(text) = active.then(|| line.strip_suffix('▏')).flatten() {
                     Line::from(vec![

--- a/src/ui/board.rs
+++ b/src/ui/board.rs
@@ -1724,13 +1724,11 @@ fn wrap_display_lines(value: &str, width: usize) -> Vec<String> {
                 .unwrap_or(end);
             rows.push(candidate[..split].to_string());
             let mut consumed = split;
-            if split < end {
-                consumed += remaining[split..]
-                    .chars()
-                    .take_while(|character| character.is_whitespace())
-                    .map(char::len_utf8)
-                    .sum::<usize>();
-            }
+            consumed += remaining[split..]
+                .chars()
+                .take_while(|character| character.is_whitespace())
+                .map(char::len_utf8)
+                .sum::<usize>();
             remaining = &remaining[consumed..];
         }
     }
@@ -1944,7 +1942,9 @@ pub(super) fn draw_form(
                 display_value.push('▏');
             }
             let lines = wrap_display_lines(&display_value, body_rect.width as usize);
-            let scroll = lines.len().saturating_sub(body_rect.height as usize);
+            let scroll = active
+                .then(|| lines.len().saturating_sub(body_rect.height as usize))
+                .unwrap_or(0);
             let visible = lines.into_iter().skip(scroll).map(|line| {
                 if let Some(text) = active.then(|| line.strip_suffix('▏')).flatten() {
                     Line::from(vec![
@@ -3168,6 +3168,42 @@ mod tests {
         assert!(rendered.contains("Binding"));
         assert!(rendered.contains("Survives server restart"));
         assert!(!rendered.contains("private-session"));
+    }
+
+    #[test]
+    fn display_wrapping_consumes_whitespace_at_an_exact_word_boundary() {
+        assert_eq!(wrap_display_lines("hello world", 5), ["hello", "world"]);
+    }
+
+    #[test]
+    fn inactive_task_prompt_starts_at_the_first_wrapped_line() {
+        let area = Rect::new(0, 0, 90, 30);
+        let mut buffer = Buffer::empty(area);
+        let mut target = RenderTarget::new(&mut buffer, area);
+        let mut form = OrchForm::for_kind(crate::app::OrchFormKind::Task);
+        form.field = crate::app::OrchFormField::Title;
+        form.prompt = "first line\nsecond line\nthird line\nfourth line".into();
+
+        draw_form(
+            &mut target,
+            area,
+            &form,
+            &crate::i18n::EN,
+            &Theme::quattro_rally(),
+        );
+
+        let rendered = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("first line"));
+        assert!(rendered.contains("second line"));
+        assert!(rendered.contains("third line"));
+        assert!(!rendered.contains("fourth line"));
     }
 
     #[test]

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -134,6 +134,9 @@ Branch-backed dependencies unblock only after they are merged into the shared
 integration history.
 `task release` requeues active work and releases its path leases, but it does
 not stop the worker pane or discard its worktree.
+Use `task add --prompt <text>` or `--prompt-file <path>` for the detailed worker
+briefing. A manual task's prompt can be replaced with `task update` only while
+the task is queued and unassigned; inspect it before starting the worker.
 Use `task update --note` for work progress. `task heartbeat --context-used
 <0..1>` reports only the fraction of the model context window already consumed,
 where `0.6` means 60% consumed, not 60% task progress. Omit the heartbeat when

--- a/website/src/content/docs/docs/guides/orchestration.mdx
+++ b/website/src/content/docs/docs/guides/orchestration.mdx
@@ -113,16 +113,18 @@ before an action is chosen.
 | `q` | close the board without stopping tasks or workers |
 
 The form starts on a compact **Task · Automation** choice. The active board view
-selects its matching type by default. Task shows Title, Paths, Deps, Gate, and a
-`Manual`/`Now` Start choice; Prompt and Agent appear only for `Now`. Automation
+selects its matching type by default. Task shows Title, Paths, Deps, Gate, a
+`Manual`/`Now` Start choice, and a three-row Prompt editor; Agent appears only
+for `Now`. Automation
 hides concrete dependencies and owns a registry-backed Agent, an explicit
 `Run in` choice for an isolated Worktree or the existing Workspace, an `Access`
 choice (`Read only`, `Workspace`, or `Full access`), `Once later`,
 `Hourly`, `Daily`, or `Weekly`, and Schedule, followed by a three-row Prompt editor. Use
 `Tab` to switch between Task and Automation, Down or Up to move between fields,
 Left/Right to change the selected Agent, Run in, Access, or Start value, and
-`Shift+Enter` to add a new line to the Automation prompt. Plain `Enter` creates
-the automation. Agent
+`Shift+Enter` to add a new line to either prompt. Plain `Enter` creates the task
+or automation. Pasted task prompts preserve line breaks, and long titles scroll
+horizontally with the active cursor instead of hiding the end. Agent
 choices come from the built-in adapters that declare at least one reviewed
 unattended launch profile. A selected agent/access combination that is not supported
 is rejected before Luvus creates a task, worktree, lease, or pane. Task and Automation
@@ -154,7 +156,8 @@ Automation definition.
 Say you want an auth module and an API layer that depends on it:
 
 1. `a` → Title `OAuth token module`, Paths `src/auth/**`, Gate
-   `cargo test auth`, `⏎`.
+   `cargo test auth`, Prompt `Implement the token parser and cover rollback
+   behavior`, `⏎`.
 2. `a` → Title `API layer`, Paths `src/api/**`, Deps `t1`, `⏎`.
 3. Select `t1` and press `s`. luvus creates a worktree on branch `luvus/t1`,
    opens a pane in it, and takes you there. Run your agent in that pane (or
@@ -178,8 +181,12 @@ can run the whole loop itself:
 
 ```sh
 # create + inspect
-luvus task add "OAuth module" --paths "src/auth/**" --gate "cargo test auth"
-luvus task list · get t1 · update t1 --status running --note "learning: …"
+luvus task add "OAuth module" \
+  --prompt "Implement the token parser and cover rollback behavior." \
+  --paths "src/auth/**" --gate "cargo test auth"
+luvus task list · get t1
+luvus task update t1 --prompt-file ./task-brief.md # editable until the task starts
+luvus task update t1 --status running --note "learning: …"
 
 # start workers (worktree remains the default)
 luvus task start t1 --agent "claude"

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -210,7 +210,7 @@ worktrees:
   worktree remove <path>     remove a worktree (its branch is kept)
 
 orchestration (multiple agents on one project, docs/22):
-  task add "<title>" [--paths <glob>...] [--dep <id>...] [--gate <cmd>]
+  task add "<title>" [--prompt <text>|--prompt-file <path>] [--paths <glob>...] [--dep <id>...] [--gate <cmd>]
   task list                  list all tasks + their status/assignee
   task get <id>              show one task
   task claim <id>            claim a task for this pane (deps must be done)
@@ -221,7 +221,7 @@ orchestration (multiple agents on one project, docs/22):
   task heartbeat <id> --context-used <0..1>
                              report model context-window use, not task progress
                              (>85% blocks done; --context remains accepted)
-  task update <id> [--status <s>] [--output <o>] [--note <n>]
+  task update <id> [--prompt <text>|--prompt-file <path>] [--status <s>] [--output <o>] [--note <n>]
   task done <id>             mark done + release its leases
   task merge <id>            integrate the task's branch into luvus/integration
                              (isolated worktree, conflicts block the task)

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -104,6 +104,14 @@ pane fails with `not_found`; malformed or out-of-range IDs fail with
 `invalid_request` before any mutation. Pane IDs accept an unsigned 32-bit JSON
 integer or its decimal string form.
 
+`task.add` accepts a short `title` and an optional multiline `prompt` containing
+the detailed worker briefing. `task.get`, `task.list`, and task events return
+that prompt for manual tasks; automation-generated task projections continue to
+hide their private stored briefing. A queued, unassigned manual task can replace
+or clear its prompt through `task.update` with a string or `null`; prompt edits
+fail closed after the task starts. Capability limits publish the exact UTF-8
+byte budgets as `task_title_bytes` and `task_prompt_bytes`.
+
 For `task.heartbeat`, the canonical UHP `context` field is the fraction of the
 model context window already consumed. `0.6` means 60% of that window has been
 used, not 60% task progress. Send work progress through the `note` field of


### PR DESCRIPTION
## Summary

- add a persistent multiline briefing field to manual ORCH task creation
- support Shift+Enter and Alt+Enter for new lines in both task and automation prompts
- keep long task titles usable by preserving the active cursor and showing complete content in task details
- expose bounded prompt creation and queued-task editing through the CLI, local API, and UHP schemas
- update the bundled agent guidance and public orchestration, CLI, and UHP documentation

## Behavior and safety

- task titles are limited to 256 UTF-8 bytes and prompts to 32 KiB
- prompts can only be edited while a manual task is queued and unassigned
- pasted line endings are normalized while unsafe control characters are rejected
- multiline briefings are folded only at the final PTY launch boundary so they cannot submit a partial shell command
- automation-generated briefings remain private and are not exposed through ordinary task projections
- prompt-bearing tasks are created atomically so persistence never observes a partially initialized task

## Public surfaces

- `luvus task add` accepts `--prompt` or `--prompt-file`
- `luvus task update` accepts `--prompt` or `--prompt-file`
- `task.add` and `task.update` accept prompt data through the local API and UHP
- UHP capabilities advertise the title and prompt byte limits

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked --quiet` (1553 passed, 3 ignored; all integration suites passed)
- `cargo build --release --locked`
- `npm run build --prefix website` (49 pages)
- isolated debug server/client smoke test covering prompt creation, retrieval, update, TUI attach, and detach

Closes #283


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional multiline worker prompts for task creation and updates through the web interface, CLI, and API.
  * Prompts can be supplied inline or from files, displayed for manual tasks, and edited or cleared while queued and unassigned.
  * Added prompt size limits and exposed title and prompt limits through capabilities.
  * Automation prompts remain private from general task listings and events.

* **Bug Fixes**
  * Improved multiline input handling, wrapping, cursor visibility, and prompt normalization.
  * Task commands now require a title or task ID.

* **Documentation**
  * Updated CLI, API, orchestration, and agent guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->