### PR TITLE
fix(diff): wrap content across responsive layouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ unicode-width = "0.2"
 # runs after the user chooses a Markdown/Mermaid preview action.
 pulldown-cmark = { version = "0.13", default-features = false }
 anyhow = "1"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 # SHA-256 tracks managed skill files and verifies release, theme, and diff
 # artifacts. The canonical Luvus skill itself is bundled with this release.

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -1811,19 +1811,22 @@ impl App {
                     KeyCode::Char('G') | KeyCode::End => view.selected = max,
                     KeyCode::Left => view.selected_side = crate::diff::DiffSide::Old,
                     KeyCode::Right => view.selected_side = crate::diff::DiffSide::New,
-                    KeyCode::Char('h') => view.horizontal = view.horizontal.saturating_sub(8),
-                    KeyCode::Char('l') => view.horizontal = view.horizontal.saturating_add(8),
+                    KeyCode::Char('h') if !is_split && !view.wrap => {
+                        view.horizontal = view.horizontal.saturating_sub(8)
+                    }
+                    KeyCode::Char('l') if !is_split && !view.wrap => {
+                        view.horizontal = view.horizontal.saturating_add(8)
+                    }
+                    KeyCode::Char('h' | 'l') => {}
                     KeyCode::Char('s') => {
-                        // When Auto resolves to Split (wide enough, no wrap),
+                        // When Auto resolves to Split at this viewport width,
                         // skip directly to Stack so the user doesn't need to
                         // press 's' twice to see a visual change.
-                        let was_effectively_split = !view.wrap
-                            && matches!(
-                                view.preference,
-                                crate::diff::DiffLayoutPreference::Split
-                                    | crate::diff::DiffLayoutPreference::Auto
-                            )
-                            && pane_width >= 96;
+                        let was_effectively_split = matches!(
+                            view.preference,
+                            crate::diff::DiffLayoutPreference::Split
+                                | crate::diff::DiffLayoutPreference::Auto
+                        ) && pane_width >= 96;
                         if was_effectively_split
                             && view.preference == crate::diff::DiffLayoutPreference::Auto
                         {

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -1069,12 +1069,7 @@ impl App {
             .find(|(pane, _)| *pane == id)
             .map(|(_, rect)| rect.width)
             .unwrap_or(120);
-        let split = !view.wrap
-            && match view.preference {
-                crate::diff::DiffLayoutPreference::Stack => false,
-                crate::diff::DiffLayoutPreference::Split => width >= 96,
-                crate::diff::DiffLayoutPreference::Auto => width >= 96,
-            };
+        let split = view.effective_split(width);
         if split {
             let anchor = view.stack_rows.get(view.selected).and_then(source_anchor)?;
             let row = view.split_rows.iter().find(|row| {
@@ -1659,11 +1654,14 @@ impl App {
             .map(|(_, rect)| rect.width)
             .unwrap_or(80);
         let marker_style = self.config.layout.diff_marker_style;
-        let is_split = {
+        let (is_split, wraps_lines) = {
             let Some(ViewKind::Diff(view)) = self.views.get(&id) else {
                 return false;
             };
-            view.effective_split(pane_width)
+            (
+                view.effective_split(pane_width),
+                view.effective_wrap(pane_width),
+            )
         };
 
         enum Deferred {
@@ -1811,10 +1809,10 @@ impl App {
                     KeyCode::Char('G') | KeyCode::End => view.selected = max,
                     KeyCode::Left => view.selected_side = crate::diff::DiffSide::Old,
                     KeyCode::Right => view.selected_side = crate::diff::DiffSide::New,
-                    KeyCode::Char('h') if !is_split && !view.wrap => {
+                    KeyCode::Char('h') if !is_split && !wraps_lines => {
                         view.horizontal = view.horizontal.saturating_sub(8)
                     }
-                    KeyCode::Char('l') if !is_split && !view.wrap => {
+                    KeyCode::Char('l') if !is_split && !wraps_lines => {
                         view.horizontal = view.horizontal.saturating_add(8)
                     }
                     KeyCode::Char('h' | 'l') => {}

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
@@ -595,7 +596,7 @@ impl App {
     pub(crate) fn load_diff_file_sync(
         &mut self,
         file: &crate::diff::DiffFile,
-    ) -> Result<crate::diff::model::FileDiff, String> {
+    ) -> Result<Arc<crate::diff::model::FileDiff>, String> {
         let root = self
             .diff
             .snapshot
@@ -607,9 +608,9 @@ impl App {
         if let Some(cached) = self.diff.cache_get(&file.key, context, &file.fingerprint) {
             return Ok(cached);
         }
-        let loaded = crate::diff::git::load_diff(&root, file, context)?;
+        let loaded = Arc::new(crate::diff::git::load_diff(&root, file, context)?);
         self.diff
-            .cache_insert(context, file.fingerprint.clone(), loaded.clone());
+            .cache_insert(context, file.fingerprint.clone(), Arc::clone(&loaded));
         Ok(loaded)
     }
 
@@ -739,14 +740,14 @@ impl App {
             let result = file
                 .ok_or_else(|| "change disappeared before the diff loaded".to_string())
                 .and_then(|file| {
-                    cached.map_or_else(|| crate::diff::git::load_diff(&root, &file, context), Ok)
+                    cached.map_or_else(
+                        || crate::diff::git::load_diff(&root, &file, context).map(Arc::new),
+                        Ok,
+                    )
                 })
                 .map(|diff| {
                     crate::diff::notes::reconcile(&mut notes, &diff);
-                    crate::diff::LoadedDiff {
-                        diff,
-                        reconciled_notes: notes,
-                    }
+                    crate::diff::LoadedDiff::prepare(diff, notes)
                 });
             let _ = tx.send(AppEvent::DiffLoaded { id, token, result });
         });
@@ -777,11 +778,12 @@ impl App {
             Ok(loaded) => {
                 let diff = loaded.diff;
                 reconciled = loaded.reconciled_notes;
-                view.stack_rows = crate::diff::rows::stack_rows(&diff);
-                view.split_rows = crate::diff::rows::split_rows(&diff);
-                view.rebuild_row_indices();
-                cache = Some(diff.clone());
-                DiffLoad::Ready(Box::new(diff))
+                view.stack_rows = loaded.stack_rows;
+                view.split_rows = loaded.split_rows;
+                view.stack_indices = loaded.stack_indices;
+                view.split_indices = loaded.split_indices;
+                cache = Some(Arc::clone(&diff));
+                DiffLoad::Ready(diff)
             }
             Err(error) if view.key.layer == crate::diff::DiffLayer::Conflict => {
                 DiffLoad::Conflict(error)
@@ -1079,11 +1081,11 @@ impl App {
             let preferred = match view.selected_side {
                 crate::diff::DiffSide::Old => row.old.as_ref().and_then(|line| {
                     line.old_line
-                        .map(|number| (crate::diff::DiffSide::Old, number, line.text.clone()))
+                        .map(|number| (crate::diff::DiffSide::Old, number, line.text.to_string()))
                 }),
                 crate::diff::DiffSide::New => row.new.as_ref().and_then(|line| {
                     line.new_line
-                        .map(|number| (crate::diff::DiffSide::New, number, line.text.clone()))
+                        .map(|number| (crate::diff::DiffSide::New, number, line.text.to_string()))
                 }),
             };
             if preferred.is_some() {
@@ -1093,12 +1095,13 @@ impl App {
                 .as_ref()
                 .and_then(|line| {
                     line.new_line
-                        .map(|number| (crate::diff::DiffSide::New, number, line.text.clone()))
+                        .map(|number| (crate::diff::DiffSide::New, number, line.text.to_string()))
                 })
                 .or_else(|| {
                     row.old.as_ref().and_then(|line| {
-                        line.old_line
-                            .map(|number| (crate::diff::DiffSide::Old, number, line.text.clone()))
+                        line.old_line.map(|number| {
+                            (crate::diff::DiffSide::Old, number, line.text.to_string())
+                        })
                     })
                 })
         } else {
@@ -1106,18 +1109,18 @@ impl App {
             match view.selected_side {
                 crate::diff::DiffSide::Old => line
                     .old_line
-                    .map(|number| (crate::diff::DiffSide::Old, number, line.text.clone())),
+                    .map(|number| (crate::diff::DiffSide::Old, number, line.text.to_string())),
                 crate::diff::DiffSide::New => line
                     .new_line
-                    .map(|number| (crate::diff::DiffSide::New, number, line.text.clone())),
+                    .map(|number| (crate::diff::DiffSide::New, number, line.text.to_string())),
             }
             .or_else(|| {
                 line.new_line
-                    .map(|number| (crate::diff::DiffSide::New, number, line.text.clone()))
+                    .map(|number| (crate::diff::DiffSide::New, number, line.text.to_string()))
             })
             .or_else(|| {
                 line.old_line
-                    .map(|number| (crate::diff::DiffSide::Old, number, line.text.clone()))
+                    .map(|number| (crate::diff::DiffSide::Old, number, line.text.to_string()))
             })
         }
     }
@@ -2606,7 +2609,7 @@ mod tests {
         view.split_rows = split_rows;
         view.rebuild_row_indices();
         view.horizontal = usize::MAX;
-        view.load = DiffLoad::Ready(Box::new(file_diff));
+        view.load = DiffLoad::Ready(Arc::new(file_diff));
 
         let mut terminal = Terminal::new(TestBackend::new(180, 40)).unwrap();
         terminal
@@ -2784,7 +2787,7 @@ mod tests {
         view.split_rows = crate::diff::rows::split_rows(&file_diff);
         view.selected_side = crate::diff::DiffSide::New;
         view.rebuild_row_indices();
-        view.load = DiffLoad::Ready(Box::new(file_diff));
+        view.load = DiffLoad::Ready(Arc::new(file_diff));
         app.pane_content_rects = vec![(id, Rect::new(0, 0, 120, 4))];
 
         assert!(app.handle_event(AppEvent::Mouse(MouseEvent {
@@ -2841,7 +2844,7 @@ mod tests {
         view.preference = crate::diff::DiffLayoutPreference::Stack;
         view.stack_rows = stack_rows;
         view.split_rows = split_rows;
-        view.load = DiffLoad::Ready(Box::new(file_diff));
+        view.load = DiffLoad::Ready(Arc::new(file_diff));
         app.diff.notes.push(crate::diff::ReviewNote {
             id: "clicked-note".into(),
             review_id: "review".into(),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2336,7 +2336,7 @@ impl App {
                     }
                     Some(crate::app::ViewKind::Diff(v)) => {
                         let is_split = v.effective_split(rect.width);
-                        if hscroll != 0 {
+                        if hscroll != 0 && !v.effective_wrap(rect.width) {
                             if hscroll < 0 {
                                 v.horizontal = v.horizontal.saturating_sub(8);
                             } else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3286,10 +3286,8 @@ impl App {
                         std::thread::spawn(move || {
                             let result =
                                 crate::diff::git::load_diff(&root, &file, context).map(|diff| {
-                                    crate::diff::LoadedDiff {
-                                        diff,
-                                        reconciled_notes: Vec::new(),
-                                    }
+                                    let diff = std::sync::Arc::new(diff);
+                                    crate::diff::LoadedDiff::prepare(diff, Vec::new())
                                 });
                             let _ = tx.send(crate::event::AppEvent::DiffLoaded {
                                 id,

--- a/src/diff/git.rs
+++ b/src/diff/git.rs
@@ -445,7 +445,7 @@ fn load_untracked(root: &Path, file: &DiffFile) -> Result<FileDiff, String> {
             kind: DiffLineKind::Addition,
             old_line: None,
             new_line: Some(index as u32 + 1),
-            text: bounded_line(line),
+            text: bounded_line(line).into(),
         });
     }
     let retained = lines.len();
@@ -542,7 +542,7 @@ fn parse_patch(
             kind,
             old_line: old,
             new_line: new,
-            text: bounded_line(content),
+            text: bounded_line(content).into(),
         });
         retained += 1;
     }
@@ -870,8 +870,8 @@ mod tests {
         };
         let patch = b"@@ -1 +1 @@\n-old\x1b[2J\n+new\x07\n";
         let diff = parse_patch(&file, patch, false).unwrap();
-        assert_eq!(diff.hunks[0].lines[0].text, "old[2J");
-        assert_eq!(diff.hunks[0].lines[1].text, "new");
+        assert_eq!(diff.hunks[0].lines[0].text.as_ref(), "old[2J");
+        assert_eq!(diff.hunks[0].lines[1].text.as_ref(), "new");
     }
 
     struct TestRepo(PathBuf);
@@ -955,12 +955,12 @@ mod tests {
             .hunks
             .iter()
             .flat_map(|h| &h.lines)
-            .any(|line| line.text == "staged"));
+            .any(|line| line.text.as_ref() == "staged"));
         assert!(worktree_diff
             .hunks
             .iter()
             .flat_map(|h| &h.lines)
-            .any(|line| line.text == "worktree"));
+            .any(|line| line.text.as_ref() == "worktree"));
         assert_eq!(before, repo.git(&["status", "--porcelain=v2", "-z"]));
     }
 

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -751,6 +751,10 @@ impl DiffView {
         marker_style: DiffMarkerStyle,
         split: bool,
     ) {
+        if split {
+            self.horizontal = 0;
+            return;
+        }
         let Some(line) = self.stack_rows.get(self.selected) else {
             return;
         };
@@ -759,12 +763,7 @@ impl DiffView {
         let symbol_w = if marker_style.shows_symbols() { 2 } else { 0 };
         let numbers_w = if self.show_line_numbers { 12 } else { 0 };
         let gutter_w = bar_w + symbol_w + numbers_w;
-        let side_width = if split {
-            (pane_width.saturating_sub(1)) / 2
-        } else {
-            pane_width
-        };
-        let text_w = side_width.saturating_sub(gutter_w as u16) as usize;
+        let text_w = pane_width.saturating_sub(gutter_w as u16) as usize;
         if text_w == 0 {
             return;
         }
@@ -778,12 +777,10 @@ impl DiffView {
     }
 
     pub fn effective_split(&self, pane_width: u16) -> bool {
-        !self.wrap
-            && matches!(
-                self.preference,
-                DiffLayoutPreference::Split | DiffLayoutPreference::Auto
-            )
-            && pane_width >= 96
+        matches!(
+            self.preference,
+            DiffLayoutPreference::Split | DiffLayoutPreference::Auto
+        ) && pane_width >= 96
     }
 
     pub fn rebuild_row_indices(&mut self) {
@@ -976,6 +973,26 @@ mod tests {
         assert_eq!(view.stack_row_for_split(1), Some(1));
         assert_eq!(view.stack_row_for_split(2), Some(2));
         assert_eq!(view.split_row_for_stack(3), 1);
+    }
+
+    #[test]
+    fn wrapping_does_not_force_a_wide_split_view_into_stack() {
+        let mut view = DiffView::new(
+            PathBuf::from("/repo"),
+            test_key(),
+            DiffLayoutPreference::Split,
+            3,
+            true,
+            true,
+        );
+
+        assert!(view.effective_split(96));
+        assert!(!view.effective_split(95));
+        view.horizontal = 12;
+        view.ensure_horizontal_visible(120, DiffMarkerStyle::Symbols, true);
+        assert_eq!(view.horizontal, 0);
+        view.preference = DiffLayoutPreference::Stack;
+        assert!(!view.effective_split(120));
     }
 
     #[test]

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -1,10 +1,14 @@
 use std::collections::{HashMap, VecDeque};
 use std::ffi::{OsStr, OsString};
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
 use crate::ids::PaneId;
+
+type StackRowIndices = HashMap<(DiffSide, u32), usize>;
+type SplitRowIndices = Vec<(Option<usize>, Option<usize>)>;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -553,32 +557,32 @@ impl DiffState {
         key: &DiffKey,
         context: u16,
         fingerprint: &str,
-    ) -> Option<FileDiff> {
+    ) -> Option<Arc<FileDiff>> {
         self.cache.get(key, context, fingerprint)
     }
 
-    pub fn cache_insert(&mut self, context: u16, fingerprint: String, diff: FileDiff) {
+    pub fn cache_insert(&mut self, context: u16, fingerprint: String, diff: Arc<FileDiff>) {
         self.cache.insert(context, fingerprint, diff);
     }
 }
 
 #[derive(Debug, Default)]
 struct DiffCache {
-    entries: HashMap<(DiffKey, u16, String), (FileDiff, usize)>,
+    entries: HashMap<(DiffKey, u16, String), (Arc<FileDiff>, usize)>,
     order: VecDeque<(DiffKey, u16, String)>,
     bytes: usize,
 }
 
 impl DiffCache {
-    fn get(&mut self, key: &DiffKey, context: u16, fingerprint: &str) -> Option<FileDiff> {
+    fn get(&mut self, key: &DiffKey, context: u16, fingerprint: &str) -> Option<Arc<FileDiff>> {
         let cache_key = (key.clone(), context, fingerprint.to_string());
-        let value = self.entries.get(&cache_key)?.0.clone();
+        let value = Arc::clone(&self.entries.get(&cache_key)?.0);
         self.order.retain(|existing| existing != &cache_key);
         self.order.push_back(cache_key);
         Some(value)
     }
 
-    fn insert(&mut self, context: u16, fingerprint: String, diff: FileDiff) {
+    fn insert(&mut self, context: u16, fingerprint: String, diff: Arc<FileDiff>) {
         let key = (diff.key.clone(), context, fingerprint);
         let size = estimate_diff_bytes(&diff);
         if size > crate::diff::DIFF_CACHE_BYTE_CAP {
@@ -635,7 +639,7 @@ pub struct DiffLine {
     pub kind: DiffLineKind,
     pub old_line: Option<u32>,
     pub new_line: Option<u32>,
-    pub text: String,
+    pub text: Arc<str>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -661,14 +665,34 @@ pub struct FileDiff {
 
 #[derive(Clone, Debug)]
 pub struct LoadedDiff {
-    pub diff: FileDiff,
+    pub diff: Arc<FileDiff>,
+    pub stack_rows: Vec<DiffLine>,
+    pub split_rows: Vec<crate::diff::rows::SplitRow>,
+    pub stack_indices: StackRowIndices,
+    pub split_indices: SplitRowIndices,
     pub reconciled_notes: Vec<crate::diff::ReviewNote>,
+}
+
+impl LoadedDiff {
+    pub fn prepare(diff: Arc<FileDiff>, reconciled_notes: Vec<crate::diff::ReviewNote>) -> Self {
+        let stack_rows = crate::diff::rows::stack_rows(&diff);
+        let split_rows = crate::diff::rows::split_rows(&diff);
+        let (stack_indices, split_indices) = build_row_indices(&stack_rows, &split_rows);
+        Self {
+            diff,
+            stack_rows,
+            split_rows,
+            stack_indices,
+            split_indices,
+            reconciled_notes,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DiffLoad {
     Loading,
-    Ready(Box<FileDiff>),
+    Ready(Arc<FileDiff>),
     Conflict(String),
     Error(String),
 }
@@ -688,8 +712,8 @@ pub struct DiffView {
     pub load: DiffLoad,
     pub stack_rows: Vec<DiffLine>,
     pub split_rows: Vec<crate::diff::rows::SplitRow>,
-    pub stack_indices: HashMap<(DiffSide, u32), usize>,
-    pub split_indices: Vec<(Option<usize>, Option<usize>)>,
+    pub stack_indices: StackRowIndices,
+    pub split_indices: SplitRowIndices,
     pub request_token: u64,
     pub preference: DiffLayoutPreference,
     pub scroll: usize,
@@ -795,51 +819,10 @@ impl DiffView {
             || !matches!(self.preference, DiffLayoutPreference::Stack)
     }
 
+    #[cfg(test)]
     pub fn rebuild_row_indices(&mut self) {
-        self.stack_indices.clear();
-        let mut headers = Vec::new();
-        for (index, line) in self.stack_rows.iter().enumerate() {
-            if line.kind == DiffLineKind::Header {
-                headers.push(index);
-            }
-            if let Some(number) = line.old_line {
-                self.stack_indices.insert((DiffSide::Old, number), index);
-            }
-            if let Some(number) = line.new_line {
-                self.stack_indices.insert((DiffSide::New, number), index);
-            }
-        }
-
-        let mut header = 0;
-        self.split_indices = self
-            .split_rows
-            .iter()
-            .map(|row| {
-                if row
-                    .old
-                    .as_ref()
-                    .or(row.new.as_ref())
-                    .is_some_and(|line| line.kind == DiffLineKind::Header)
-                {
-                    let index = headers.get(header).copied();
-                    header += 1;
-                    return (index, index);
-                }
-                let old = row
-                    .old
-                    .as_ref()
-                    .and_then(|line| line.old_line)
-                    .and_then(|number| self.stack_indices.get(&(DiffSide::Old, number)))
-                    .copied();
-                let new = row
-                    .new
-                    .as_ref()
-                    .and_then(|line| line.new_line)
-                    .and_then(|number| self.stack_indices.get(&(DiffSide::New, number)))
-                    .copied();
-                (old, new)
-            })
-            .collect();
+        (self.stack_indices, self.split_indices) =
+            build_row_indices(&self.stack_rows, &self.split_rows);
     }
 
     pub fn split_row_for_stack(&self, stack: usize) -> usize {
@@ -856,6 +839,56 @@ impl DiffView {
             DiffSide::New => new.or(old),
         }
     }
+}
+
+fn build_row_indices(
+    stack_rows: &[DiffLine],
+    split_rows: &[crate::diff::rows::SplitRow],
+) -> (StackRowIndices, SplitRowIndices) {
+    let mut stack_indices = HashMap::new();
+    let mut headers = Vec::new();
+    for (index, line) in stack_rows.iter().enumerate() {
+        if line.kind == DiffLineKind::Header {
+            headers.push(index);
+        }
+        if let Some(number) = line.old_line {
+            stack_indices.insert((DiffSide::Old, number), index);
+        }
+        if let Some(number) = line.new_line {
+            stack_indices.insert((DiffSide::New, number), index);
+        }
+    }
+
+    let mut header = 0;
+    let split_indices = split_rows
+        .iter()
+        .map(|row| {
+            if row
+                .old
+                .as_ref()
+                .or(row.new.as_ref())
+                .is_some_and(|line| line.kind == DiffLineKind::Header)
+            {
+                let index = headers.get(header).copied();
+                header += 1;
+                return (index, index);
+            }
+            let old = row
+                .old
+                .as_ref()
+                .and_then(|line| line.old_line)
+                .and_then(|number| stack_indices.get(&(DiffSide::Old, number)))
+                .copied();
+            let new = row
+                .new
+                .as_ref()
+                .and_then(|line| line.new_line)
+                .and_then(|number| stack_indices.get(&(DiffSide::New, number)))
+                .copied();
+            (old, new)
+        })
+        .collect();
+    (stack_indices, split_indices)
 }
 
 #[cfg(test)]
@@ -894,11 +927,57 @@ mod tests {
             omitted_lines: 0,
             hunks: Vec::new(),
         };
+        let diff = Arc::new(diff);
         let mut state = DiffState::default();
-        state.cache_insert(3, "before".into(), diff);
-        assert!(state.cache_get(&key, 3, "before").is_some());
+        state.cache_insert(3, "before".into(), Arc::clone(&diff));
+        let cached = state.cache_get(&key, 3, "before").unwrap();
+        assert!(Arc::ptr_eq(&cached, &diff));
         assert!(state.cache_get(&key, 3, "after").is_none());
         assert!(state.cache_get(&key, 4, "before").is_none());
+    }
+
+    #[test]
+    fn prepared_diff_shares_text_and_builds_navigation_indices() {
+        let line = DiffLine {
+            kind: DiffLineKind::Addition,
+            old_line: None,
+            new_line: Some(7),
+            text: "shared source text".into(),
+        };
+        let diff = Arc::new(FileDiff {
+            key: test_key(),
+            status: DiffFileStatus::Modified,
+            additions: 1,
+            deletions: 0,
+            binary: false,
+            truncated: false,
+            omitted_lines: 0,
+            hunks: vec![DiffHunk {
+                id: "h1".into(),
+                old_start: 7,
+                new_start: 7,
+                header: "@@ -7,0 +7 @@".into(),
+                lines: vec![line],
+            }],
+        });
+
+        let loaded = LoadedDiff::prepare(Arc::clone(&diff), Vec::new());
+
+        assert!(Arc::ptr_eq(&loaded.diff, &diff));
+        assert!(Arc::ptr_eq(
+            &loaded.diff.hunks[0].lines[0].text,
+            &loaded.stack_rows[1].text,
+        ));
+        assert!(Arc::ptr_eq(
+            &loaded.stack_rows[1].text,
+            &loaded.split_rows[1].new.as_ref().unwrap().text,
+        ));
+        assert_eq!(
+            serde_json::to_value(&loaded.diff.hunks[0].lines[0]).unwrap()["text"],
+            "shared source text"
+        );
+        assert_eq!(loaded.stack_indices[&(DiffSide::New, 7)], 1);
+        assert_eq!(loaded.split_indices[1], (None, Some(1)));
     }
 
     #[test]

--- a/src/diff/model.rs
+++ b/src/diff/model.rs
@@ -751,7 +751,7 @@ impl DiffView {
         marker_style: DiffMarkerStyle,
         split: bool,
     ) {
-        if split {
+        if split || self.effective_wrap(pane_width) {
             self.horizontal = 0;
             return;
         }
@@ -781,6 +781,18 @@ impl DiffView {
             self.preference,
             DiffLayoutPreference::Split | DiffLayoutPreference::Auto
         ) && pane_width >= 96
+    }
+
+    /// Whether source text wraps in the current viewport.
+    ///
+    /// Split and Auto are responsive layouts. Their two-column form wraps each
+    /// side independently, and their narrow Stack fallback must keep wrapping
+    /// too. Only an explicitly selected Stack layout may opt into horizontal
+    /// scrolling by disabling the Wrap preference.
+    pub fn effective_wrap(&self, pane_width: u16) -> bool {
+        self.wrap
+            || self.effective_split(pane_width)
+            || !matches!(self.preference, DiffLayoutPreference::Stack)
     }
 
     pub fn rebuild_row_indices(&mut self) {
@@ -993,6 +1005,31 @@ mod tests {
         assert_eq!(view.horizontal, 0);
         view.preference = DiffLayoutPreference::Stack;
         assert!(!view.effective_split(120));
+    }
+
+    #[test]
+    fn responsive_layouts_keep_wrapping_when_the_viewport_falls_back_to_stack() {
+        let mut view = DiffView::new(
+            PathBuf::from("/repo"),
+            test_key(),
+            DiffLayoutPreference::Split,
+            3,
+            true,
+            false,
+        );
+
+        assert!(view.effective_wrap(120));
+        assert!(view.effective_wrap(80));
+        view.horizontal = 12;
+        view.ensure_horizontal_visible(80, DiffMarkerStyle::Symbols, false);
+        assert_eq!(view.horizontal, 0);
+
+        view.preference = DiffLayoutPreference::Auto;
+        assert!(view.effective_wrap(80));
+        view.preference = DiffLayoutPreference::Stack;
+        assert!(!view.effective_wrap(80));
+        view.wrap = true;
+        assert!(view.effective_wrap(80));
     }
 
     #[test]

--- a/src/diff/notes.rs
+++ b/src/diff/notes.rs
@@ -488,7 +488,7 @@ pub fn anchor_context(
             DiffSide::New => line.new_line,
         };
         if let Some(number) = number {
-            source.entry(number).or_insert(line.text.as_str());
+            source.entry(number).or_insert(line.text.as_ref());
         }
     }
     if (start..=end).any(|line| !source.contains_key(&line)) {

--- a/src/diff/rows.rs
+++ b/src/diff/rows.rs
@@ -14,15 +14,15 @@ pub fn stack_rows(diff: &FileDiff) -> Vec<DiffLine> {
                 kind: DiffLineKind::Header,
                 old_line: None,
                 new_line: None,
-                text: hunk.header.clone(),
+                text: hunk.header.clone().into(),
             })
             .chain(hunk.lines.iter().cloned())
         })
         .collect()
 }
 
-/// Derive a side-by-side projection from the normalized hunk stream. Runs when
-/// a diff result lands or a view is rendered, never by reparsing Git output.
+/// Derive a side-by-side projection from the normalized hunk stream. UI loads
+/// run this on their existing loader worker, never while rendering a frame.
 pub fn split_rows(diff: &FileDiff) -> Vec<SplitRow> {
     let mut out = Vec::new();
     for hunk in &diff.hunks {
@@ -30,7 +30,7 @@ pub fn split_rows(diff: &FileDiff) -> Vec<SplitRow> {
             kind: DiffLineKind::Header,
             old_line: None,
             new_line: None,
-            text: hunk.header.clone(),
+            text: hunk.header.clone().into(),
         };
         out.push(SplitRow {
             old: Some(header.clone()),
@@ -130,11 +130,20 @@ mod tests {
             }],
         };
 
-        let rows = split_rows(&diff);
-        assert_eq!(rows.len(), 3);
-        assert_eq!(rows[1].old.as_ref().unwrap().text, "old one");
-        assert_eq!(rows[1].new.as_ref().unwrap().text, "new");
-        assert_eq!(rows[2].old.as_ref().unwrap().text, "old two");
-        assert!(rows[2].new.is_none());
+        let stack = stack_rows(&diff);
+        let split = split_rows(&diff);
+        assert_eq!(split.len(), 3);
+        assert_eq!(split[1].old.as_ref().unwrap().text.as_ref(), "old one");
+        assert_eq!(split[1].new.as_ref().unwrap().text.as_ref(), "new");
+        assert_eq!(split[2].old.as_ref().unwrap().text.as_ref(), "old two");
+        assert!(split[2].new.is_none());
+        assert!(std::sync::Arc::ptr_eq(
+            &diff.hunks[0].lines[0].text,
+            &stack[1].text,
+        ));
+        assert!(std::sync::Arc::ptr_eq(
+            &stack[1].text,
+            &split[1].old.as_ref().unwrap().text,
+        ));
     }
 }

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -77,21 +77,11 @@ pub(super) fn draw_diff_view(
         area.width,
         area.height.saturating_sub(1 + u16::from(show_footer)),
     );
-    let effective = if view.wrap {
-        DiffLayoutPreference::Stack
-    } else {
-        effective_layout(view.preference, area.width)
-    };
+    let effective = effective_layout(view.preference, area.width);
     let narrow_fallback = view.preference == DiffLayoutPreference::Split
         && effective == DiffLayoutPreference::Stack
-        && !view.wrap;
-    let layout = if view.wrap && view.preference != DiffLayoutPreference::Stack {
-        match view.preference {
-            DiffLayoutPreference::Auto => "AUTO → STACK (wrap)",
-            DiffLayoutPreference::Split => "SPLIT → STACK (wrap)",
-            DiffLayoutPreference::Stack => unreachable!(),
-        }
-    } else if narrow_fallback {
+        && area.width < SPLIT_MIN_WIDTH;
+    let layout = if narrow_fallback {
         "SPLIT → STACK (narrow)"
     } else {
         effective.as_str()
@@ -386,46 +376,60 @@ fn draw_split(
         } else {
             selected
         };
-        let old_rect = Rect::new(area.x, y, half, 1);
-        let new_rect = Rect::new(area.x + half + 1, y, area.width.saturating_sub(half + 1), 1);
-        draw_split_side(
-            f,
-            old_rect,
-            row.old.as_ref(),
-            true,
-            old_selected,
-            view,
-            options,
-            t,
-        );
-        if let Some(cell) = f.buffer_mut().cell_mut((area.x + half, y)) {
-            cell.set_symbol("│").set_fg(t.overlay0);
-        }
-        draw_split_side(
-            f,
-            new_rect,
-            row.new.as_ref(),
-            false,
-            new_selected,
-            view,
-            options,
-            t,
-        );
-        if hits.interactive {
-            if let Some(number) = row.old.as_ref().and_then(|line| line.old_line) {
-                if let Some(index) = view.stack_indices.get(&(DiffSide::Old, number)) {
-                    hits.source
-                        .push((hits.pane, *index, DiffSide::Old, old_rect));
+        let old_width = half;
+        let new_width = area.width.saturating_sub(half + 1);
+        let old_fragments = split_side_fragments(row.old.as_ref(), view, options, old_width);
+        let new_fragments = split_side_fragments(row.new.as_ref(), view, options, new_width);
+        let row_height = old_fragments.len().max(new_fragments.len()).max(1);
+        for fragment_index in 0..row_height {
+            if y >= area.bottom() {
+                break;
+            }
+            let old_rect = Rect::new(area.x, y, old_width, 1);
+            let new_rect = Rect::new(area.x + half + 1, y, new_width, 1);
+            draw_split_side(
+                f,
+                old_rect,
+                row.old.as_ref(),
+                old_fragments.get(fragment_index).map(String::as_str),
+                true,
+                fragment_index == 0,
+                old_selected,
+                view,
+                options,
+                t,
+            );
+            if let Some(cell) = f.buffer_mut().cell_mut((area.x + half, y)) {
+                cell.set_symbol("│").set_fg(t.overlay0);
+            }
+            draw_split_side(
+                f,
+                new_rect,
+                row.new.as_ref(),
+                new_fragments.get(fragment_index).map(String::as_str),
+                false,
+                fragment_index == 0,
+                new_selected,
+                view,
+                options,
+                t,
+            );
+            if hits.interactive {
+                if let Some(number) = row.old.as_ref().and_then(|line| line.old_line) {
+                    if let Some(index) = view.stack_indices.get(&(DiffSide::Old, number)) {
+                        hits.source
+                            .push((hits.pane, *index, DiffSide::Old, old_rect));
+                    }
+                }
+                if let Some(number) = row.new.as_ref().and_then(|line| line.new_line) {
+                    if let Some(index) = view.stack_indices.get(&(DiffSide::New, number)) {
+                        hits.source
+                            .push((hits.pane, *index, DiffSide::New, new_rect));
+                    }
                 }
             }
-            if let Some(number) = row.new.as_ref().and_then(|line| line.new_line) {
-                if let Some(index) = view.stack_indices.get(&(DiffSide::New, number)) {
-                    hits.source
-                        .push((hits.pane, *index, DiffSide::New, new_rect));
-                }
-            }
+            y = y.saturating_add(1);
         }
-        y = y.saturating_add(1);
         if let Some(line) = row.old.as_ref() {
             y = draw_notes_for_anchor(
                 f,
@@ -783,7 +787,9 @@ fn draw_split_side(
     f: &mut RenderTarget,
     area: Rect,
     line: Option<&DiffLine>,
+    fragment: Option<&str>,
     old_side: bool,
+    first_fragment: bool,
     selected: bool,
     view: &DiffView,
     options: DiffRenderOptions,
@@ -798,20 +804,23 @@ fn draw_split_side(
     } else {
         line.new_line
     };
-    let number = if view.show_line_numbers {
+    let number = if first_fragment && view.show_line_numbers {
         format!("{:>5} ", number.map_or(String::new(), |n| n.to_string()))
+    } else if view.show_line_numbers {
+        " ".repeat(6)
     } else {
         String::new()
     };
     let (bar, symbol) = gutter_markers(line.kind, options.marker_style);
+    let (bar, symbol) = if first_fragment {
+        (bar, symbol)
+    } else {
+        (
+            " ".repeat(bar.chars().count()),
+            " ".repeat(symbol.chars().count()),
+        )
+    };
     let style = line_style(line.kind, selected, options.color_mode, t);
-    let text = horizontal_text(
-        &line.text,
-        view.horizontal,
-        area.width.saturating_sub(
-            (bar.chars().count() + number.chars().count() + symbol.chars().count()) as u16,
-        ),
-    );
     fill_bg(f, area, style.bg);
     f.buffer_mut().set_line(
         area.x,
@@ -820,10 +829,29 @@ fn draw_split_side(
             Span::styled(bar, Style::new().fg(style.marker).bg(style.bg).bold()),
             Span::styled(number, Style::new().fg(t.overlay1).bg(style.bg)),
             Span::styled(symbol, Style::new().fg(style.marker).bg(style.bg).bold()),
-            Span::styled(text, Style::new().fg(style.text).bg(style.bg)),
+            Span::styled(
+                fragment.unwrap_or_default(),
+                Style::new().fg(style.text).bg(style.bg),
+            ),
         ]),
         area.width,
     );
+}
+
+fn split_side_fragments(
+    line: Option<&DiffLine>,
+    view: &DiffView,
+    options: DiffRenderOptions,
+    width: u16,
+) -> Vec<String> {
+    let Some(line) = line else {
+        return Vec::new();
+    };
+    let number_width = if view.show_line_numbers { 6 } else { 0 };
+    let (bar, symbol) = gutter_markers(line.kind, options.marker_style);
+    let gutter_width = number_width + bar.chars().count() + symbol.chars().count();
+    let text_width = width.saturating_sub(gutter_width as u16).max(1);
+    wrapped_text(&line.text, text_width)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -933,14 +961,24 @@ fn horizontal_text(text: &str, offset: usize, width: u16) -> String {
 
 fn wrapped_text(text: &str, width: u16) -> Vec<String> {
     let width = width.max(1) as usize;
-    let chars: Vec<char> = text.chars().collect();
-    if chars.is_empty() {
+    if text.is_empty() {
         return vec![String::new()];
     }
-    chars
-        .chunks(width)
-        .map(|chunk| chunk.iter().collect())
-        .collect()
+    let mut rows = Vec::new();
+    let mut row = String::new();
+    let mut used = 0;
+    for character in text.chars() {
+        let mut encoded = [0; 4];
+        let character_width = super::display_width(character.encode_utf8(&mut encoded));
+        if !row.is_empty() && used + character_width > width {
+            rows.push(std::mem::take(&mut row));
+            used = 0;
+        }
+        row.push(character);
+        used += character_width;
+    }
+    rows.push(row);
+    rows
 }
 
 fn center(f: &mut RenderTarget, area: Rect, text: &str, color: Color) {
@@ -1038,6 +1076,7 @@ mod tests {
     fn wrapping_is_unicode_safe_and_never_returns_zero_rows() {
         assert_eq!(wrapped_text("", 0), vec![""]);
         assert_eq!(wrapped_text("abçd", 2), vec!["ab", "çd"]);
+        assert_eq!(wrapped_text("a界b", 3), vec!["a界", "b"]);
     }
 
     #[test]
@@ -1333,6 +1372,8 @@ mod tests {
                 &mut target,
                 Rect::new(0, 0, 10, 1),
                 Some(&deletion),
+                Some("old"),
+                true,
                 true,
                 false,
                 &view,
@@ -1343,7 +1384,9 @@ mod tests {
                 &mut target,
                 Rect::new(11, 0, 10, 1),
                 Some(&addition),
+                Some("new"),
                 false,
+                true,
                 false,
                 &view,
                 options(DiffMarkerStyle::Symbols),
@@ -1360,6 +1403,63 @@ mod tests {
         assert_eq!(
             buffer[(20, 0)].bg,
             line_style(DiffLineKind::Addition, false, DiffColorMode::Theme, &theme).bg
+        );
+    }
+
+    #[test]
+    fn split_wraps_both_sides_inside_their_columns_and_aligns_row_groups() {
+        let theme = Theme::quattro_rally();
+        let old = DiffLine {
+            kind: DiffLineKind::Deletion,
+            old_line: Some(7),
+            new_line: None,
+            text: "abcdefghijklmnopqrst".into(),
+        };
+        let new = DiffLine {
+            kind: DiffLineKind::Addition,
+            old_line: None,
+            new_line: Some(8),
+            text: "new".into(),
+        };
+        let mut view = test_view(vec![old.clone(), new.clone()]);
+        view.preference = DiffLayoutPreference::Split;
+        view.split_rows.push(crate::diff::rows::SplitRow {
+            old: Some(old),
+            new: Some(new),
+        });
+        let area = Rect::new(0, 0, 21, 3);
+        let pane = crate::ids::PaneId(12);
+        let mut buffer = Buffer::empty(area);
+        let mut rects = Vec::new();
+        {
+            let mut target = RenderTarget::new(&mut buffer, area);
+            let mut note_rects = Vec::new();
+            let mut hits = DiffInteractionHits {
+                pane,
+                interactive: true,
+                source: &mut rects,
+                notes: &mut note_rects,
+            };
+            draw_split(
+                &mut target,
+                area,
+                &view,
+                &DiffState::default(),
+                options(DiffMarkerStyle::Symbols),
+                &mut hits,
+                &theme,
+            );
+        }
+        let row_text = |y| -> String { (0..area.width).map(|x| buffer[(x, y)].symbol()).collect() };
+
+        assert_eq!(row_text(0), "- abcdefgh│+ new     ");
+        assert_eq!(row_text(1), "  ijklmnop│          ");
+        assert_eq!(row_text(2), "  qrst    │          ");
+        assert_eq!(rects.len(), 6, "both sides own every aligned visual row");
+        assert!(rects.iter().all(|(_, _, _, rect)| rect.width == 10));
+        assert!(
+            (0..area.height).all(|y| buffer[(10, y)].symbol() == "│"),
+            "the center divider remains intact across wrapped rows"
         );
     }
 

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -257,8 +257,7 @@ fn draw_stack(
         let gutter_width = bar.chars().count() + numbers.chars().count() + symbol.chars().count();
         let text_w = area.width.saturating_sub(gutter_width as u16);
         if view.effective_wrap(area.width) {
-            let fragments = wrapped_text(&line.text, text_w.max(1));
-            for (fragment_index, text) in fragments.into_iter().enumerate() {
+            for (fragment_index, text) in wrapped_text(&line.text, text_w.max(1)).enumerate() {
                 if y >= area.bottom() {
                     break;
                 }
@@ -378,11 +377,16 @@ fn draw_split(
         };
         let old_width = half;
         let new_width = area.width.saturating_sub(half + 1);
-        let old_fragments = split_side_fragments(row.old.as_ref(), view, options, old_width);
-        let new_fragments = split_side_fragments(row.new.as_ref(), view, options, new_width);
-        let row_height = old_fragments.len().max(new_fragments.len()).max(1);
-        for fragment_index in 0..row_height {
+        let mut old_fragments = split_side_fragments(row.old.as_ref(), view, options, old_width);
+        let mut new_fragments = split_side_fragments(row.new.as_ref(), view, options, new_width);
+        let mut fragment_index = 0;
+        loop {
             if y >= area.bottom() {
+                break;
+            }
+            let old_fragment = old_fragments.as_mut().and_then(Iterator::next);
+            let new_fragment = new_fragments.as_mut().and_then(Iterator::next);
+            if fragment_index > 0 && old_fragment.is_none() && new_fragment.is_none() {
                 break;
             }
             let old_rect = Rect::new(area.x, y, old_width, 1);
@@ -391,7 +395,7 @@ fn draw_split(
                 f,
                 old_rect,
                 row.old.as_ref(),
-                old_fragments.get(fragment_index).map(String::as_str),
+                old_fragment,
                 true,
                 fragment_index == 0,
                 old_selected,
@@ -406,7 +410,7 @@ fn draw_split(
                 f,
                 new_rect,
                 row.new.as_ref(),
-                new_fragments.get(fragment_index).map(String::as_str),
+                new_fragment,
                 false,
                 fragment_index == 0,
                 new_selected,
@@ -429,6 +433,7 @@ fn draw_split(
                 }
             }
             y = y.saturating_add(1);
+            fragment_index += 1;
         }
         if let Some(line) = row.old.as_ref() {
             y = draw_notes_for_anchor(
@@ -726,7 +731,7 @@ fn note_range_label(side: DiffSide, start: u32, end: u32) -> String {
 
 fn note_editor_lines(text: &str, width: u16) -> Vec<String> {
     text.split('\n')
-        .flat_map(|line| wrapped_text(line, width))
+        .flat_map(|line| wrapped_text(line, width).map(str::to_owned))
         .collect()
 }
 
@@ -838,20 +843,19 @@ fn draw_split_side(
     );
 }
 
-fn split_side_fragments(
-    line: Option<&DiffLine>,
+fn split_side_fragments<'a>(
+    line: Option<&'a DiffLine>,
     view: &DiffView,
     options: DiffRenderOptions,
     width: u16,
-) -> Vec<String> {
-    let Some(line) = line else {
-        return Vec::new();
-    };
+) -> Option<WrappedText<'a>> {
+    let line = line?;
     let number_width = if view.show_line_numbers { 6 } else { 0 };
-    let (bar, symbol) = gutter_markers(line.kind, options.marker_style);
-    let gutter_width = number_width + bar.chars().count() + symbol.chars().count();
+    let bar_width = usize::from(options.marker_style.shows_bars());
+    let symbol_width = usize::from(options.marker_style.shows_symbols()) * 2;
+    let gutter_width = number_width + bar_width + symbol_width;
     let text_width = width.saturating_sub(gutter_width as u16).max(1);
-    wrapped_text(&line.text, text_width)
+    Some(wrapped_text(&line.text, text_width))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -959,26 +963,53 @@ fn horizontal_text(text: &str, offset: usize, width: u16) -> String {
     text.chars().skip(offset).take(width as usize).collect()
 }
 
-fn wrapped_text(text: &str, width: u16) -> Vec<String> {
-    let width = width.max(1) as usize;
-    if text.is_empty() {
-        return vec![String::new()];
-    }
-    let mut rows = Vec::new();
-    let mut row = String::new();
-    let mut used = 0;
-    for character in text.chars() {
-        let mut encoded = [0; 4];
-        let character_width = super::display_width(character.encode_utf8(&mut encoded));
-        if !row.is_empty() && used + character_width > width {
-            rows.push(std::mem::take(&mut row));
-            used = 0;
+struct WrappedText<'a> {
+    text: &'a str,
+    width: usize,
+    offset: usize,
+    emitted_empty: bool,
+}
+
+impl<'a> Iterator for WrappedText<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.text.is_empty() {
+            if self.emitted_empty {
+                return None;
+            }
+            self.emitted_empty = true;
+            return Some("");
         }
-        row.push(character);
-        used += character_width;
+        if self.offset >= self.text.len() {
+            return None;
+        }
+
+        let start = self.offset;
+        let mut end = start;
+        let mut used = 0;
+        for (relative, character) in self.text[start..].char_indices() {
+            let mut encoded = [0; 4];
+            let character_width = super::display_width(character.encode_utf8(&mut encoded));
+            if end > start && used + character_width > self.width {
+                break;
+            }
+            end = start + relative + character.len_utf8();
+            used += character_width;
+        }
+
+        self.offset = end;
+        Some(&self.text[start..end])
     }
-    rows.push(row);
-    rows
+}
+
+fn wrapped_text(text: &str, width: u16) -> WrappedText<'_> {
+    WrappedText {
+        text,
+        width: width.max(1) as usize,
+        offset: 0,
+        emitted_empty: false,
+    }
 }
 
 fn center(f: &mut RenderTarget, area: Rect, text: &str, color: Color) {
@@ -1075,9 +1106,20 @@ mod tests {
 
     #[test]
     fn wrapping_is_unicode_safe_and_never_returns_zero_rows() {
-        assert_eq!(wrapped_text("", 0), vec![""]);
-        assert_eq!(wrapped_text("abçd", 2), vec!["ab", "çd"]);
-        assert_eq!(wrapped_text("a界b", 3), vec!["a界", "b"]);
+        assert_eq!(wrapped_text("", 0).collect::<Vec<_>>(), vec![""]);
+        assert_eq!(
+            wrapped_text("abçd", 2).collect::<Vec<_>>(),
+            vec!["ab", "çd"]
+        );
+        assert_eq!(
+            wrapped_text("a界b", 3).collect::<Vec<_>>(),
+            vec!["a界", "b"]
+        );
+
+        let long = "x".repeat(crate::diff::PATCH_LINE_BYTE_CAP);
+        let mut fragments = wrapped_text(&long, 8);
+        assert_eq!(fragments.next(), Some("xxxxxxxx"));
+        assert_eq!(fragments.offset, 8, "the unseen tail remains unscanned");
     }
 
     #[test]
@@ -1476,7 +1518,7 @@ mod tests {
         let mut view = test_view(vec![line]);
         view.preference = DiffLayoutPreference::Split;
         view.wrap = false;
-        view.load = DiffLoad::Ready(Box::new(FileDiff {
+        view.load = DiffLoad::Ready(std::sync::Arc::new(FileDiff {
             key: view.key.clone(),
             status: crate::diff::DiffFileStatus::Modified,
             additions: 1,

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -256,7 +256,7 @@ fn draw_stack(
         let style = line_style(line.kind, selected, options.color_mode, t);
         let gutter_width = bar.chars().count() + numbers.chars().count() + symbol.chars().count();
         let text_w = area.width.saturating_sub(gutter_width as u16);
-        if view.wrap {
+        if view.effective_wrap(area.width) {
             let fragments = wrapped_text(&line.text, text_w.max(1));
             for (fragment_index, text) in fragments.into_iter().enumerate() {
                 if y >= area.bottom() {
@@ -1005,6 +1005,7 @@ mod tests {
     use ratatui::buffer::Buffer;
 
     use super::*;
+    use crate::diff::model::{DiffHunk, FileDiff};
     use crate::diff::{DiffKey, DiffLayer, RepoPath};
 
     fn test_view(rows: Vec<DiffLine>) -> DiffView {
@@ -1461,6 +1462,66 @@ mod tests {
             (0..area.height).all(|y| buffer[(10, y)].symbol() == "│"),
             "the center divider remains intact across wrapped rows"
         );
+    }
+
+    #[test]
+    fn narrow_split_fallback_wraps_stack_rows_without_the_wrap_setting() {
+        let theme = Theme::quattro_rally();
+        let line = DiffLine {
+            kind: DiffLineKind::Addition,
+            old_line: None,
+            new_line: Some(8),
+            text: "abcdefghijklmnopqrst".into(),
+        };
+        let mut view = test_view(vec![line]);
+        view.preference = DiffLayoutPreference::Split;
+        view.wrap = false;
+        view.load = DiffLoad::Ready(Box::new(FileDiff {
+            key: view.key.clone(),
+            status: crate::diff::DiffFileStatus::Modified,
+            additions: 1,
+            deletions: 0,
+            binary: false,
+            truncated: false,
+            omitted_lines: 0,
+            hunks: vec![DiffHunk {
+                id: "hunk".into(),
+                old_start: 1,
+                new_start: 1,
+                header: "@@ -1 +1 @@".into(),
+                lines: Vec::new(),
+            }],
+        }));
+        let area = Rect::new(0, 0, 10, 5);
+        let pane = crate::ids::PaneId(12);
+        let mut buffer = Buffer::empty(area);
+        let mut source_rects = Vec::new();
+        let mut note_rects = Vec::new();
+        {
+            let mut target = RenderTarget::new(&mut buffer, area);
+            draw_diff_view(
+                &mut target,
+                area,
+                pane,
+                &view,
+                DiffRenderContext {
+                    state: &DiffState::default(),
+                    picker: None,
+                    marker_style: DiffMarkerStyle::Symbols,
+                    color_mode: DiffColorMode::Theme,
+                    mobile: false,
+                    source_hits: &mut source_rects,
+                    note_hits: &mut note_rects,
+                },
+                &theme,
+            );
+        }
+        let row_text = |y| -> String { (0..area.width).map(|x| buffer[(x, y)].symbol()).collect() };
+
+        assert_eq!(row_text(1), "+ abcdefgh");
+        assert_eq!(row_text(2), "  ijklmnop");
+        assert_eq!(row_text(3), "  qrst    ");
+        assert_eq!(source_rects.len(), 3);
     }
 
     #[test]

--- a/website/src/content/docs/docs/guides/diff.mdx
+++ b/website/src/content/docs/docs/guides/diff.mdx
@@ -48,17 +48,19 @@ WORKTREE  1
 Luvus parses one selected file at a time and renders the same normalized data
 as **Auto**, **Split**, or **Stack**. Auto uses Split when both sides remain
 readable and falls back to Stack on a narrow local or remote viewport. Resizing
-one attachment does not change another attachment's effective layout.
+one attachment does not change another attachment's effective layout. Split
+wraps each side within its own column and keeps corresponding before and after
+rows vertically aligned, so long source lines never cross the center divider.
 
 | Key | Action |
 |---|---|
 | `j` / `k`, arrows | next or previous source row |
 | `d` / `u` | half page down or up |
 | `g` / `G` | first or last row |
-| `h` / `l` | scroll long lines horizontally |
+| `h` / `l` | scroll long lines horizontally in Stack when wrapping is off |
 | Left / Right | select the old or new side in Split |
 | `s` | cycle Auto, Split, Stack |
-| `w` | toggle wrapping preference |
+| `w` | toggle wrapping for Stack; Split always wraps within each side |
 | `/` | search the loaded file diff |
 | `{` / `}` | previous or next hunk |
 | `K` / `J` | previous or next file |

--- a/website/src/content/docs/docs/guides/diff.mdx
+++ b/website/src/content/docs/docs/guides/diff.mdx
@@ -50,7 +50,8 @@ as **Auto**, **Split**, or **Stack**. Auto uses Split when both sides remain
 readable and falls back to Stack on a narrow local or remote viewport. Resizing
 one attachment does not change another attachment's effective layout. Split
 wraps each side within its own column and keeps corresponding before and after
-rows vertically aligned, so long source lines never cross the center divider.
+rows vertically aligned. Its narrow Stack fallback keeps wrapping too, so long
+source lines remain inside the pane at every responsive width.
 
 | Key | Action |
 |---|---|
@@ -60,7 +61,7 @@ rows vertically aligned, so long source lines never cross the center divider.
 | `h` / `l` | scroll long lines horizontally in Stack when wrapping is off |
 | Left / Right | select the old or new side in Split |
 | `s` | cycle Auto, Split, Stack |
-| `w` | toggle wrapping for Stack; Split always wraps within each side |
+| `w` | toggle wrapping for an explicitly selected Stack layout; Split and Auto wrap at every responsive width |
 | `/` | search the loaded file diff |
 | `{` / `}` | previous or next hunk |
 | `K` / `J` | previous or next file |

--- a/website/src/content/docs/docs/reference/configuration.mdx
+++ b/website/src/content/docs/docs/reference/configuration.mdx
@@ -36,7 +36,7 @@ cleanly across versions because unknown fields get defaults.
 | `layout.workspace_paths` | show the cwd line beneath WORKSPACES rows; defaults to `true` and can be toggled from any workspace row menu |
 | `layout.agent_paths` | show the workspace/path detail line beneath AGENTS rows; defaults to `true` and can be toggled from any agent row menu |
 | `layout.diff_layout` | default native DIFF layout: `auto`, `split`, or `stack` |
-| `layout.diff_wrap` | wrap long diff rows instead of using horizontal navigation |
+| `layout.diff_wrap` | wrap long Stack rows instead of using horizontal navigation; Split always wraps within each side |
 | `layout.diff_context_lines` | unchanged Git context lines per hunk, from `0` to `20` |
 | `layout.diff_show_line_numbers` | show old and new source line gutters |
 | `layout.diff_marker_style` | changed-line indicator: `symbols` (default), `bars`, or `both` |

--- a/website/src/content/docs/docs/reference/configuration.mdx
+++ b/website/src/content/docs/docs/reference/configuration.mdx
@@ -36,7 +36,7 @@ cleanly across versions because unknown fields get defaults.
 | `layout.workspace_paths` | show the cwd line beneath WORKSPACES rows; defaults to `true` and can be toggled from any workspace row menu |
 | `layout.agent_paths` | show the workspace/path detail line beneath AGENTS rows; defaults to `true` and can be toggled from any agent row menu |
 | `layout.diff_layout` | default native DIFF layout: `auto`, `split`, or `stack` |
-| `layout.diff_wrap` | wrap long Stack rows instead of using horizontal navigation; Split always wraps within each side |
+| `layout.diff_wrap` | wrap long rows in an explicitly selected Stack layout; Split and Auto always wrap at every responsive width |
 | `layout.diff_context_lines` | unchanged Git context lines per hunk, from `0` to `20` |
 | `layout.diff_show_line_numbers` | show old and new source line gutters |
 | `layout.diff_marker_style` | changed-line indicator: `symbols` (default), `bars`, or `both` |


### PR DESCRIPTION
## Summary

- wrap long lines independently inside both columns of the native Split DIFF view
- keep old and new rows vertically aligned as one logical row group
- keep Split and Auto content wrapped when a narrow pane, preview, or tab falls back to Stack
- preserve line gutters, change markers, selection styling, click targets, and the center divider across continuation rows
- measure wrapped text using terminal display width so wide Unicode characters remain inside the available leaf width
- keep horizontal navigation only for an explicitly selected Stack layout with Wrap disabled
- use the same effective layout for rendering, source selection, keyboard input, and mouse scrolling

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test ui::diff::tests -- --nocapture`
- `cargo test diff::model::tests -- --nocapture`
- `cargo test app::diff::tests -- --nocapture`
- `cargo test --locked`
- `npm run build` in `website/`
- isolated debug server and client using `~/.luvus-dev`, session `diff-wrap-test`, and an 80 by 24 terminal

The isolated client rendered a requested Split DIFF as its narrow Stack fallback and continued long Rust lines across visual rows inside the native leaf. The locked suite passed with 1,563 tests and 3 intentionally ignored. Production Luvus was not contacted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split diff views wrap long lines independently in each column while keeping corresponding rows aligned.
  * Narrow layouts wrap content when falling back to Stack.
  * Multi-byte characters wrap correctly based on display width.

* **Bug Fixes**
  * Horizontal scrolling is limited to unwrapped Stack layouts, including mouse-wheel scrolling.

* **Documentation**
  * Clarified diff wrapping, responsive layout behavior, and horizontal scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->