### PR TITLE
fix(bar): accept numeric progress value alongside click payloads

### DIFF
--- a/src/bar/mod.rs
+++ b/src/bar/mod.rs
@@ -63,17 +63,25 @@ pub enum BarTone {
 pub enum BarSegmentKind {
     Text {
         text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
     },
     Symbol {
         symbol: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
     },
     State {
         state: String,
         #[serde(default)]
         label: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
     },
     Badge {
         text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
     },
     Progress {
         value: u64,
@@ -99,17 +107,17 @@ pub struct BarSegment {
     pub tone: BarTone,
     #[serde(default)]
     pub action: Option<String>,
-    #[serde(default)]
-    pub value: Option<String>,
 }
 
 impl BarSegment {
     pub fn text(text: impl Into<String>, tone: BarTone) -> Self {
         Self {
-            kind: BarSegmentKind::Text { text: text.into() },
+            kind: BarSegmentKind::Text {
+                text: text.into(),
+                value: None,
+            },
             tone,
             action: None,
-            value: None,
         }
     }
 
@@ -118,17 +126,30 @@ impl BarSegment {
             kind: BarSegmentKind::Separator,
             tone: BarTone::Muted,
             action: None,
-            value: None,
+        }
+    }
+
+    pub fn click_value(&self) -> Option<&str> {
+        match &self.kind {
+            BarSegmentKind::Text { value, .. }
+            | BarSegmentKind::Symbol { value, .. }
+            | BarSegmentKind::State { value, .. }
+            | BarSegmentKind::Badge { value, .. } => value.as_deref(),
+            BarSegmentKind::Progress { .. }
+            | BarSegmentKind::Spacer { .. }
+            | BarSegmentKind::Separator => None,
         }
     }
 
     pub fn display_width(&self) -> usize {
         match &self.kind {
-            BarSegmentKind::Text { text } | BarSegmentKind::Symbol { symbol: text } => text.width(),
+            BarSegmentKind::Text { text, .. } | BarSegmentKind::Symbol { symbol: text, .. } => {
+                text.width()
+            }
             BarSegmentKind::State { label, .. } => {
                 1 + label.as_deref().map_or(0, |label| 1 + label.width())
             }
-            BarSegmentKind::Badge { text } => text.width() + 2,
+            BarSegmentKind::Badge { text, .. } => text.width() + 2,
             BarSegmentKind::Progress { width, .. } => *width as usize,
             BarSegmentKind::Spacer { width } => *width as usize,
             BarSegmentKind::Separator => 5,
@@ -149,9 +170,9 @@ impl BarSegment {
             Ok(())
         };
         match &self.kind {
-            BarSegmentKind::Text { text } => check_text("text", text)?,
-            BarSegmentKind::Symbol { symbol } => check_text("symbol", symbol)?,
-            BarSegmentKind::State { state, label } => {
+            BarSegmentKind::Text { text, .. } => check_text("text", text)?,
+            BarSegmentKind::Symbol { symbol, .. } => check_text("symbol", symbol)?,
+            BarSegmentKind::State { state, label, .. } => {
                 if !["blocked", "working", "done", "idle", "unknown"].contains(&state.as_str()) {
                     return Err(format!("unknown state {state:?}"));
                 }
@@ -159,7 +180,7 @@ impl BarSegment {
                     check_text("state label", label)?;
                 }
             }
-            BarSegmentKind::Badge { text } => check_text("badge", text)?,
+            BarSegmentKind::Badge { text, .. } => check_text("badge", text)?,
             BarSegmentKind::Progress {
                 value,
                 total,
@@ -180,7 +201,7 @@ impl BarSegment {
         if self.action.as_deref().is_some_and(str::is_empty) {
             return Err("action must not be empty".into());
         }
-        if let Some(value) = &self.value {
+        if let Some(value) = self.click_value() {
             if value.len() > MAX_TEXT_BYTES || value.chars().any(char::is_control) {
                 return Err("action value is too long or contains controls".into());
             }
@@ -335,9 +356,14 @@ impl NotificationPush {
                 return Err("dedupe_key is empty, too long, or contains controls".into());
             }
         }
-        let mut segment = BarSegment::text(self.text.clone(), self.level.tone());
-        segment.action = self.action.clone();
-        segment.value = self.value.clone();
+        let segment = BarSegment {
+            kind: BarSegmentKind::Text {
+                text: self.text.clone(),
+                value: self.value.clone(),
+            },
+            tone: self.level.tone(),
+            action: self.action.clone(),
+        };
         BarWidget::new(
             BarWidgetKey::new(
                 self.owner.as_deref().unwrap_or(UNOWNED_NOTIFICATION_OWNER),
@@ -517,9 +543,11 @@ impl BarState {
             value,
             dedupe_key,
         } = request;
-        let mut segment = BarSegment::text(text, level.tone());
-        segment.action = action;
-        segment.value = value;
+        let segment = BarSegment {
+            kind: BarSegmentKind::Text { text, value },
+            tone: level.tone(),
+            action,
+        };
         let id = self.next_notification;
         self.next_notification = self.next_notification.wrapping_add(1);
         let widget = BarWidget::new(
@@ -671,7 +699,7 @@ impl crate::app::App {
     pub fn mobile_agent_summary(&self) -> Option<(String, crate::ui::theme::State)> {
         let widget = self.bar.widgets.get(CORE_AGENTS)?;
         widget.content.iter().find_map(|segment| {
-            let BarSegmentKind::State { state, label } = &segment.kind else {
+            let BarSegmentKind::State { state, label, .. } = &segment.kind else {
                 return None;
             };
             let parsed = match state.as_str() {
@@ -748,10 +776,10 @@ impl crate::app::App {
                 kind: BarSegmentKind::State {
                     state: state.to_string(),
                     label: Some(count.to_string()),
+                    value: None,
                 },
                 tone: BarTone::Normal,
                 action: None,
-                value: None,
             };
             if compact_segments.is_empty() {
                 compact_segments.push(state_segment.clone());
@@ -761,7 +789,6 @@ impl crate::app::App {
                 kind: BarSegmentKind::Spacer { width: 1 },
                 tone: BarTone::Normal,
                 action: None,
-                value: None,
             });
         }
         if segments.is_empty() {
@@ -838,10 +865,10 @@ fn mobile_segment_text(segments: &[BarSegment]) -> String {
     let mut output = String::new();
     for segment in segments {
         match &segment.kind {
-            BarSegmentKind::Text { text } | BarSegmentKind::Symbol { symbol: text } => {
+            BarSegmentKind::Text { text, .. } | BarSegmentKind::Symbol { symbol: text, .. } => {
                 output.push_str(text)
             }
-            BarSegmentKind::State { state, label } => {
+            BarSegmentKind::State { state, label, .. } => {
                 output.push_str(match state.as_str() {
                     "blocked" | "working" | "done" => "●",
                     _ => "○",
@@ -851,7 +878,7 @@ fn mobile_segment_text(segments: &[BarSegment]) -> String {
                     output.push_str(label);
                 }
             }
-            BarSegmentKind::Badge { text } => {
+            BarSegmentKind::Badge { text, .. } => {
                 output.push('[');
                 output.push_str(text);
                 output.push(']');
@@ -1047,26 +1074,28 @@ mod tests {
             BarSegment::text("界", BarTone::Normal),
             BarSegment {
                 kind: BarSegmentKind::Symbol {
-                    symbol: "✓".into()
+                    symbol: "✓".into(),
+                    value: None,
                 },
                 tone: BarTone::Success,
                 action: None,
-                value: None,
             },
             BarSegment {
                 kind: BarSegmentKind::State {
                     state: "done".into(),
                     label: Some("ok".into()),
+                    value: None,
                 },
                 tone: BarTone::Normal,
                 action: None,
-                value: None,
             },
             BarSegment {
-                kind: BarSegmentKind::Badge { text: "2".into() },
+                kind: BarSegmentKind::Badge {
+                    text: "2".into(),
+                    value: None,
+                },
                 tone: BarTone::Error,
                 action: None,
-                value: None,
             },
             BarSegment {
                 kind: BarSegmentKind::Progress {
@@ -1076,13 +1105,11 @@ mod tests {
                 },
                 tone: BarTone::Accent,
                 action: None,
-                value: None,
             },
             BarSegment {
                 kind: BarSegmentKind::Spacer { width: 2 },
                 tone: BarTone::Normal,
                 action: None,
-                value: None,
             },
             BarSegment::separator(),
         ];
@@ -1228,6 +1255,153 @@ mod tests {
         assert_eq!(state.notifications.len(), 1);
         assert!(state.tick(now + Duration::from_millis(501)));
         assert!(state.notifications.is_empty());
+    }
+
+    const DOCUMENTED_CONTENT: &str = r#"[
+        {"type":"text", "text":"CI", "tone":"muted"},
+        {"type":"symbol", "symbol":"✓", "tone":"success"},
+        {"type":"state", "state":"done", "label":"passing"},
+        {"type":"badge", "text":"2", "tone":"error",
+         "action":"details", "value":"run-1842"},
+        {"type":"progress", "value":3, "total":7, "width":8},
+        {"type":"spacer", "width":1},
+        {"type":"separator"}
+    ]"#;
+
+    #[test]
+    fn documented_progress_segment_keeps_its_numeric_value() {
+        let segment: BarSegment =
+            serde_json::from_str(r#"{"type":"progress","value":3,"total":7,"width":8}"#).unwrap();
+        assert_eq!(
+            segment.kind,
+            BarSegmentKind::Progress {
+                value: 3,
+                total: 7,
+                width: 8,
+            }
+        );
+        assert_eq!(segment.click_value(), None);
+        segment.validate().unwrap();
+    }
+
+    #[test]
+    fn progress_width_defaults_to_eight_and_stays_bounded() {
+        let segment: BarSegment =
+            serde_json::from_str(r#"{"type":"progress","value":0,"total":100}"#).unwrap();
+        let BarSegmentKind::Progress { width, .. } = segment.kind else {
+            panic!("expected a progress segment");
+        };
+        assert_eq!(width, default_progress_width());
+        assert_eq!(width, 8);
+
+        let over: BarSegment =
+            serde_json::from_str(r#"{"type":"progress","value":5,"total":4}"#).unwrap();
+        assert_eq!(
+            over.validate().unwrap_err(),
+            "progress requires 0 <= value <= total and total > 0"
+        );
+        let wide: BarSegment =
+            serde_json::from_str(r#"{"type":"progress","value":1,"total":4,"width":25}"#).unwrap();
+        assert_eq!(
+            wide.validate().unwrap_err(),
+            "progress width must be between 3 and 24"
+        );
+    }
+
+    #[test]
+    fn click_capable_segments_keep_their_string_value() {
+        let segment: BarSegment = serde_json::from_str(
+            r#"{"type":"badge","text":"2","tone":"error","action":"details","value":"run-1842"}"#,
+        )
+        .unwrap();
+        assert_eq!(segment.tone, BarTone::Error);
+        assert_eq!(segment.action.as_deref(), Some("details"));
+        assert_eq!(segment.click_value(), Some("run-1842"));
+        segment.validate().unwrap();
+
+        let mut oversized = segment.clone();
+        oversized.kind = BarSegmentKind::Badge {
+            text: "2".into(),
+            value: Some("x".repeat(MAX_TEXT_BYTES + 1)),
+        };
+        assert_eq!(
+            oversized.validate().unwrap_err(),
+            "action value is too long or contains controls"
+        );
+        let control = BarSegment {
+            kind: BarSegmentKind::Text {
+                text: "ok".into(),
+                value: Some("run\u{1b}[31m".into()),
+            },
+            tone: BarTone::Normal,
+            action: Some("details".into()),
+        };
+        assert_eq!(
+            control.validate().unwrap_err(),
+            "action value is too long or contains controls"
+        );
+    }
+
+    #[test]
+    fn segments_round_trip_through_json_without_a_duplicate_value_key() {
+        let progress = BarSegment {
+            kind: BarSegmentKind::Progress {
+                value: 23,
+                total: 100,
+                width: 6,
+            },
+            tone: BarTone::Accent,
+            action: None,
+        };
+        let encoded = serde_json::to_string(&progress).unwrap();
+        assert_eq!(
+            encoded.matches("\"value\"").count(),
+            1,
+            "progress emits exactly one value key: {encoded}"
+        );
+        assert!(encoded.contains("\"value\":23"), "{encoded}");
+        assert_eq!(
+            serde_json::from_str::<BarSegment>(&encoded).unwrap(),
+            progress
+        );
+
+        let badge = BarSegment {
+            kind: BarSegmentKind::Badge {
+                text: "2".into(),
+                value: Some("run-1842".into()),
+            },
+            tone: BarTone::Error,
+            action: Some("details".into()),
+        };
+        let encoded = serde_json::to_string(&badge).unwrap();
+        assert!(encoded.contains("\"value\":\"run-1842\""), "{encoded}");
+        assert_eq!(serde_json::from_str::<BarSegment>(&encoded).unwrap(), badge);
+    }
+
+    #[test]
+    fn the_documented_content_example_parses_and_validates() {
+        let segments: Vec<BarSegment> = serde_json::from_str(DOCUMENTED_CONTENT).unwrap();
+        assert_eq!(segments.len(), 7);
+        assert_eq!(segments[3].click_value(), Some("run-1842"));
+        assert_eq!(
+            segments[4].kind,
+            BarSegmentKind::Progress {
+                value: 3,
+                total: 7,
+                width: 8,
+            }
+        );
+        BarWidget::new(
+            BarWidgetKey::new("test", "documented"),
+            BarRegion::TopRight,
+            segments.clone(),
+            Vec::new(),
+            50,
+        )
+        .unwrap();
+        let round_tripped: Vec<BarSegment> =
+            serde_json::from_str(&serde_json::to_string(&segments).unwrap()).unwrap();
+        assert_eq!(round_tripped, segments);
     }
 
     #[test]

--- a/src/bar/mod.rs
+++ b/src/bar/mod.rs
@@ -91,8 +91,13 @@ pub enum BarSegmentKind {
     },
     Spacer {
         width: u16,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
     },
-    Separator,
+    Separator {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
+    },
 }
 
 fn default_progress_width() -> u16 {
@@ -123,21 +128,23 @@ impl BarSegment {
 
     pub fn separator() -> Self {
         Self {
-            kind: BarSegmentKind::Separator,
+            kind: BarSegmentKind::Separator { value: None },
             tone: BarTone::Muted,
             action: None,
         }
     }
 
+    /// Every segment type may carry a click payload except `progress`, whose
+    /// `value` is the numeric fill and cannot double as a string.
     pub fn click_value(&self) -> Option<&str> {
         match &self.kind {
             BarSegmentKind::Text { value, .. }
             | BarSegmentKind::Symbol { value, .. }
             | BarSegmentKind::State { value, .. }
-            | BarSegmentKind::Badge { value, .. } => value.as_deref(),
-            BarSegmentKind::Progress { .. }
-            | BarSegmentKind::Spacer { .. }
-            | BarSegmentKind::Separator => None,
+            | BarSegmentKind::Badge { value, .. }
+            | BarSegmentKind::Spacer { value, .. }
+            | BarSegmentKind::Separator { value } => value.as_deref(),
+            BarSegmentKind::Progress { .. } => None,
         }
     }
 
@@ -151,8 +158,8 @@ impl BarSegment {
             }
             BarSegmentKind::Badge { text, .. } => text.width() + 2,
             BarSegmentKind::Progress { width, .. } => *width as usize,
-            BarSegmentKind::Spacer { width } => *width as usize,
-            BarSegmentKind::Separator => 5,
+            BarSegmentKind::Spacer { width, .. } => *width as usize,
+            BarSegmentKind::Separator { .. } => 5,
         }
     }
 
@@ -193,10 +200,10 @@ impl BarSegment {
                     return Err("progress width must be between 3 and 24".into());
                 }
             }
-            BarSegmentKind::Spacer { width } if *width > 16 => {
+            BarSegmentKind::Spacer { width, .. } if *width > 16 => {
                 return Err("spacer width must be at most 16".into())
             }
-            BarSegmentKind::Spacer { .. } | BarSegmentKind::Separator => {}
+            BarSegmentKind::Spacer { .. } | BarSegmentKind::Separator { .. } => {}
         }
         if self.action.as_deref().is_some_and(str::is_empty) {
             return Err("action must not be empty".into());
@@ -786,7 +793,10 @@ impl crate::app::App {
             }
             segments.push(state_segment);
             segments.push(BarSegment {
-                kind: BarSegmentKind::Spacer { width: 1 },
+                kind: BarSegmentKind::Spacer {
+                    width: 1,
+                    value: None,
+                },
                 tone: BarTone::Normal,
                 action: None,
             });
@@ -886,8 +896,8 @@ fn mobile_segment_text(segments: &[BarSegment]) -> String {
             BarSegmentKind::Progress { value, total, .. } => {
                 output.push_str(&format!("{value}/{total}"));
             }
-            BarSegmentKind::Spacer { width } => output.push_str(&" ".repeat(*width as usize)),
-            BarSegmentKind::Separator => output.push_str("  ·  "),
+            BarSegmentKind::Spacer { width, .. } => output.push_str(&" ".repeat(*width as usize)),
+            BarSegmentKind::Separator { .. } => output.push_str("  ·  "),
         }
     }
     output
@@ -1107,7 +1117,10 @@ mod tests {
                 action: None,
             },
             BarSegment {
-                kind: BarSegmentKind::Spacer { width: 2 },
+                kind: BarSegmentKind::Spacer {
+                    width: 2,
+                    value: None,
+                },
                 tone: BarTone::Normal,
                 action: None,
             },

--- a/src/bar/render.rs
+++ b/src/bar/render.rs
@@ -129,8 +129,8 @@ fn draw_segment(
                 None,
             )
         }
-        BarSegmentKind::Spacer { width } => (Cow::Owned(" ".repeat(*width as usize)), None),
-        BarSegmentKind::Separator => (Cow::Borrowed("  ·  "), None),
+        BarSegmentKind::Spacer { width, .. } => (Cow::Owned(" ".repeat(*width as usize)), None),
+        BarSegmentKind::Separator { .. } => (Cow::Borrowed("  ·  "), None),
     };
     let color = if core_runtime_label {
         t.overlay1
@@ -273,6 +273,63 @@ mod tests {
             .map(|x| buffer.cell((x, 0)).map(|cell| cell.symbol()).unwrap_or(" "))
             .collect::<String>();
         assert!(rendered.starts_with("● agent"));
+    }
+
+    // A spacer or a separator may carry an action, and the Bar contract lets any
+    // segment with an action carry the click payload that action is invoked with.
+    // Dropping it for these two would make their clicks fire with no value, which
+    // is silent: the action still runs, just without the argument the module sent.
+    #[test]
+    fn spacer_and_separator_click_values_reach_the_hit_target() {
+        let segments: Vec<BarSegment> = serde_json::from_str(
+            r#"[
+                {"type":"text","text":"CI","action":"open","value":"run-1842"},
+                {"type":"spacer","width":2,"action":"open","value":"gap"},
+                {"type":"separator","action":"open","value":"rule"}
+            ]"#,
+        )
+        .unwrap();
+        assert_eq!(
+            segments
+                .iter()
+                .map(BarSegment::click_value)
+                .collect::<Vec<_>>(),
+            vec![Some("run-1842"), Some("gap"), Some("rule")],
+            "every click payload survives parsing"
+        );
+
+        let widget = super::super::BarWidget::new(
+            super::super::BarWidgetKey::new("test", "clickable"),
+            BarRegion::BottomRight,
+            segments,
+            Vec::new(),
+            50,
+        )
+        .unwrap();
+        let candidates = vec![WidgetCandidate {
+            key: "test:clickable",
+            widget: &widget,
+        }];
+        let layout = super::super::compose(&candidates, 40, 40);
+        let area = Rect::new(0, 0, 40, 1);
+        let mut buffer = Buffer::empty(area);
+        let mut target = RenderTarget::new(&mut buffer, area);
+        let (hits, _) = draw_region(
+            &mut target,
+            area,
+            BarRegion::BottomRight,
+            &candidates,
+            &layout,
+            &crate::ui::theme::by_name("quattro-rally"),
+        );
+
+        assert_eq!(
+            hits.iter()
+                .map(|hit| (hit.segment, hit.value.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![(0, Some("run-1842")), (1, Some("gap")), (2, Some("rule")),],
+            "each rendered hit carries its own segment's value"
+        );
     }
 
     #[test]

--- a/src/bar/render.rs
+++ b/src/bar/render.rs
@@ -55,7 +55,7 @@ pub fn draw_region(
                     segment: segment_index,
                     rect,
                     action: action.clone(),
-                    value: segment.value.clone(),
+                    value: segment.click_value().map(str::to_string),
                 });
             }
             x = x.saturating_add(width);
@@ -100,10 +100,10 @@ fn draw_segment(
     t: &Theme,
 ) {
     let (text, state_color): (Cow<'_, str>, Option<Color>) = match &segment.kind {
-        BarSegmentKind::Text { text } | BarSegmentKind::Symbol { symbol: text } => {
+        BarSegmentKind::Text { text, .. } | BarSegmentKind::Symbol { symbol: text, .. } => {
             (Cow::Borrowed(text), None)
         }
-        BarSegmentKind::State { state, label } => {
+        BarSegmentKind::State { state, label, .. } => {
             let state = parse_state(state);
             let glyph = state.dot();
             let text = label
@@ -112,7 +112,7 @@ fn draw_segment(
                 .unwrap_or_else(|| glyph.to_string());
             (Cow::Owned(text), Some(state.color(t)))
         }
-        BarSegmentKind::Badge { text } => (Cow::Owned(format!("[{text}]")), None),
+        BarSegmentKind::Badge { text, .. } => (Cow::Owned(format!("[{text}]")), None),
         BarSegmentKind::Progress {
             value,
             total,
@@ -256,10 +256,10 @@ mod tests {
             kind: BarSegmentKind::State {
                 state: "working".into(),
                 label: Some("agent".into()),
+                value: None,
             },
             tone: BarTone::Normal,
             action: None,
-            value: None,
         };
         draw_segment(
             &mut target,

--- a/website/src/content/docs/docs/extend/writing-modules.mdx
+++ b/website/src/content/docs/docs/extend/writing-modules.mdx
@@ -288,7 +288,9 @@ custom colors, and module-controlled rendering are rejected.
 
 An actionable segment names an action from the same manifest. Its command gets
 `LUVUS_MODULE_BAR_ID`, `LUVUS_MODULE_BAR_SEGMENT`, and
-`LUVUS_MODULE_BAR_VALUE`. Live content is in-memory, so restore it from a
+`LUVUS_MODULE_BAR_VALUE` — except on a `progress` segment, whose `value` is the
+numeric fill, so its click passes no payload; carry it on a neighboring `text`
+or `badge` segment instead. Live content is in-memory, so restore it from a
 one-shot startup hook. A repeated push is an atomic replacement, not an append.
 
 For transient status, use the bounded notification lane instead of repeatedly

--- a/website/src/content/docs/docs/guides/bar.mdx
+++ b/website/src/content/docs/docs/guides/bar.mdx
@@ -118,6 +118,11 @@ Supported segments are `text`, `symbol`, `state`, `badge`, `progress`,
 `success`, `warning`, and `error`—adapt to every active theme. Raw ANSI and
 custom rendering are rejected so a widget cannot corrupt the surrounding UI.
 
+Any segment may carry an `action` and the `value` that action is invoked with,
+**except `progress`**: its `value` is the numeric fill, so a `progress` segment
+can be clickable but cannot pass a payload. Put the payload on an adjacent
+`text` or `badge` segment when a bar needs one.
+
 For a full manifest, actions, click values, and validation limits, see
 [Writing a Module](/docs/extend/writing-modules/#bars-compact-chrome-widgets)
 and the [UHP reference](/docs/uhp/methods/#luvus-bar).

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -911,7 +911,10 @@ Tones are `normal`, `muted`, `accent`, `success`, `warning`, and `error`.
 States are `blocked`, `working`, `done`, `idle`, and `unknown`. An action must
 belong to the widget's enabled module. Clicks expose
 `LUVUS_MODULE_BAR_ID`, `LUVUS_MODULE_BAR_SEGMENT`, and optional
-`LUVUS_MODULE_BAR_VALUE` to that action.
+`LUVUS_MODULE_BAR_VALUE` to that action. Every segment shape accepts an
+`action` and a string `value` except `progress`, whose `value` is the numeric
+fill: a `progress` segment can be clickable, but its click carries no
+`LUVUS_MODULE_BAR_VALUE`.
 
 Limits are intentionally small: 16 segments and 256 display columns per
 widget, 16 live widgets per module, 64 live widgets globally, and 30 updates per


### PR DESCRIPTION
The documented Luvus Bar `progress` segment (`{"type":"progress","value":3,"total":7,"width":8}`) now publishes instead of failing with `invalid type: integer, expected a string`.

## What

- `BarSegmentKind::Progress` is now the sole owner of the `value` key, so numeric `value`/`total`/`width` deserialize, validate, and render as documented. Validation and error strings are unchanged (`0 <= value <= total`, `total > 0`, `width` 3..=24, default 8).
- The string click payload `value` (used with `action`) moved from the outer `BarSegment` onto the variants that can carry one: `text`, `symbol`, `state`, `badge`, `spacer`, `separator`. Their JSON shape is unchanged, e.g. `{"type":"badge","text":"2","action":"details","value":"run-1842"}` and `{"type":"separator"}`.
- `BarSegment::click_value()` replaces the removed public `value` field for readers (render hit-testing, notifications, core widgets).
- `progress` is the one shape with no string payload, because its `value` is the numeric fill: it may be clickable, but the click carries no `LUVUS_MODULE_BAR_VALUE`. Documented in the Bar guide, the module guide, and the UHP reference.
- Compatibility: segments with no click payload no longer serialize `"value": null` (the key is omitted). Input with an explicit `null` still deserializes. Serializing a progress segment no longer emits `value` twice.

## Why

Fixes #306.

`BarSegment` flattened the `type`-tagged `BarSegmentKind` enum and also declared its own `value: Option<String>`. Serde drains the outer struct's declared fields from the buffered content map before the internally tagged enum sees it, so progress's numeric `value` was always claimed as a string. There was no shape that published a progress bar.

## Verification

- [x] `cargo test --locked`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Manual testing

`cargo test bar::` → 39 passed, 0 failed. Full `cargo test --locked` → 1545 passed, 4 failed; those 4 (`platform::tests::unix_stoppable_pid_accepts_a_luvus_executable_with_arguments`, two `app::session_menu::tests::stopped_session_*`, `app::tests::keyboard_copy_mode_yanks_history_and_cancel_restores_its_viewport`) fail identically on `main` under the parallel run and pass in isolation — timing-sensitive, unrelated.

New tests: `documented_progress_segment_keeps_its_numeric_value`, `progress_width_defaults_to_eight_and_stays_bounded`, `click_capable_segments_keep_their_string_value`, `segments_round_trip_through_json_without_a_duplicate_value_key`, `the_documented_content_example_parses_and_validates` (the verbatim segment array from the UHP methods docs), and `bar::render::tests::spacer_and_separator_click_values_reach_the_hit_target` — which renders a region and asserts each emitted `BarHit` carries its own segment's payload, so a dropped `spacer`/`separator` value cannot come back silently.

End to end on an isolated server (`LUVUS_HOME` in a temp dir, `examples/modules/ci-bar` linked):

```text
$ luvus bar push --id status --content '[{"type":"progress","value":23,"total":100,"width":6}]'
{"changed": true, "key": "example.ci-bar:status", "type": "ok"}

$ luvus bar list
... {"type":"progress","value":3,"total":7,"width":8,"tone":"normal","action":null} ...
... {"type":"badge","text":"2","tone":"error","action":"details","value":"run-1842"} ...

$ luvus bar push --id status --content '[{"type":"progress","value":101,"total":100}]'
invalid_request: progress requires 0 <= value <= total and total > 0
```

A progress push without `width` lists with `"width": 8`, and a badge with a 300-byte `value` still returns `action value is too long or contains controls`. Rendering verified from a real module publishing four progress segments: https://github.com/RizRiyz/luvus/pull/307#issuecomment-5566303082

## Notes

- `luvus module link <relative path>` resolves against the server's working directory, not the client's. Unrelated to this fix, but worth a docs note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - All supported bar segment types can carry optional click payloads.
  - Click interactions preserve each segment’s associated payload when rendered and selected.

- **Behavior Updates**
  - Progress segments use their value for numeric fill and do not provide a click payload.
  - Payloads for progress interactions should be provided through adjacent text or badge segments.

- **Documentation**
  - Updated bar interaction guidance to clarify click payload behavior across segment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->