### PR TITLE
feat(theme): add seven built-in palettes

### DIFF
--- a/src/theme/baitong/baitong.toml
+++ b/src/theme/baitong/baitong.toml
@@ -1,0 +1,32 @@
+# Luvus semantic adaptation of the Baitong color palette by cyphbt.
+# Source: https://github.com/cyphbt/baitong-theme
+# The original palette values are credited here without assigning a license.
+
+schema = 1
+id = "baitong"
+display_name = "Baitong"
+description = "Deep teal surfaces with neon green and magenta accents."
+author = "cyphbt"
+version = "1.0.0"
+requires_luvus = ">=0.13.4"
+appearance = "dark"
+
+[colors]
+crust = "#081b1b"
+mantle = "#112a2a"
+base = "#173838"
+surface0 = "#1d4646"
+surface1 = "#255454"
+overlay0 = "#326b6b"
+overlay1 = "#4b8585"
+subtext0 = "#6fa5a5"
+subtext1 = "#87cefa"
+text = "#33ff33"
+accent = "#ff00ff"
+sel_bg = "#254d32"
+border = "#326b6b"
+border_focus = "#ff66ff"
+green = "#33ff33"
+mint = "#68fdfe"
+amber = "#1ae642"
+coral = "#f77272"

--- a/src/theme/builtin.rs
+++ b/src/theme/builtin.rs
@@ -1,0 +1,67 @@
+use std::sync::LazyLock;
+
+use super::format::ThemeFile;
+use crate::ui::theme::Theme;
+
+const SOURCES: &[&str] = &[
+    include_str!("baitong/baitong.toml"),
+    include_str!("paper/paper.toml"),
+    include_str!("papercolor/papercolor.toml"),
+    include_str!("rose-pine/rose-pine.toml"),
+    include_str!("rose-pine/rose-pine-moon.toml"),
+    include_str!("rose-pine/rose-pine-dawn.toml"),
+    include_str!("tokyo-night/tokyo-night.toml"),
+];
+
+struct BuiltinTheme {
+    file: ThemeFile,
+    theme: Theme,
+}
+
+static THEMES: LazyLock<Vec<BuiltinTheme>> = LazyLock::new(|| {
+    SOURCES
+        .iter()
+        .map(|source| {
+            let file = ThemeFile::parse(source.as_bytes())
+                .expect("bundled theme files must pass schema validation");
+            let theme = file
+                .colors
+                .resolve(None)
+                .expect("bundled themes must define every semantic color");
+            BuiltinTheme { file, theme }
+        })
+        .collect()
+});
+
+pub fn file(id: &str) -> Option<&'static ThemeFile> {
+    THEMES
+        .iter()
+        .find(|theme| theme.file.id == id)
+        .map(|theme| &theme.file)
+}
+
+pub fn theme(id: &str) -> Option<Theme> {
+    THEMES
+        .iter()
+        .find(|theme| theme.file.id == id)
+        .map(|theme| theme.theme.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_theme_files_are_valid_and_unique() {
+        let mut ids = std::collections::HashSet::new();
+        for bundled in THEMES.iter() {
+            let file = &bundled.file;
+            assert!(
+                ids.insert(file.id.clone()),
+                "duplicate theme ID {}",
+                file.id
+            );
+        }
+        assert_eq!(ids.len(), SOURCES.len());
+    }
+}

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,6 +1,9 @@
+mod builtin;
 pub mod format;
 pub mod install;
 pub mod registry;
+
+pub use builtin::{file as builtin_file, theme as builtin_theme};
 
 use std::fs;
 use std::path::PathBuf;

--- a/src/theme/paper/NOTICE
+++ b/src/theme/paper/NOTICE
@@ -1,0 +1,9 @@
+Paper is a Luvus semantic adaptation of the Paper Theme Alacritty palette:
+
+https://github.com/s6muel/paper-theme
+
+The upstream palette is maintained by s6muel and builds on the original Paper
+theme by Yorick Peterse. The upstream repository is licensed under the Mozilla
+Public License 2.0:
+
+https://www.mozilla.org/MPL/2.0/

--- a/src/theme/paper/paper.toml
+++ b/src/theme/paper/paper.toml
@@ -1,0 +1,34 @@
+# Luvus semantic adaptation of Paper Theme's Alacritty palette by s6muel.
+# Source: https://github.com/s6muel/paper-theme
+# The palette builds on the original Paper theme by Yorick Peterse.
+# Upstream is licensed under the Mozilla Public License 2.0.
+
+schema = 1
+id = "paper"
+display_name = "Paper"
+description = "Warm notebook paper with black ink and restrained color."
+author = "s6muel and Yorick Peterse"
+license = "MPL-2.0"
+version = "1.0.0"
+requires_luvus = ">=0.13.4"
+appearance = "light"
+
+[colors]
+crust = "#fffdf5"
+mantle = "#f2eede"
+base = "#e9e5d7"
+surface0 = "#e0dccf"
+surface1 = "#d8d5c7"
+overlay0 = "#c8c4b7"
+overlay1 = "#aaaaaa"
+subtext0 = "#77746c"
+subtext1 = "#555555"
+text = "#000000"
+accent = "#1e6fcc"
+sel_bg = "#d8d5c7"
+border = "#c8c4b7"
+border_focus = "#1e6fcc"
+green = "#216609"
+mint = "#158c86"
+amber = "#b58900"
+coral = "#cc3e28"

--- a/src/theme/papercolor/LICENSE
+++ b/src/theme/papercolor/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2020 Nikyle Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/theme/papercolor/papercolor.toml
+++ b/src/theme/papercolor/papercolor.toml
@@ -1,0 +1,33 @@
+# Luvus semantic adaptation of the PaperColor light palette by Nikyle Nguyen.
+# Source: https://github.com/NLKNguyen/papercolor-theme
+# Copyright (c) 2015-2020 Nikyle Nguyen. Licensed under the MIT License.
+
+schema = 1
+id = "papercolor"
+display_name = "PaperColor"
+description = "Neutral white paper with dark ink and a deep blue accent."
+author = "Nikyle Nguyen"
+license = "MIT"
+version = "1.0.0"
+requires_luvus = ">=0.13.4"
+appearance = "light"
+
+[colors]
+crust = "#ffffff"
+mantle = "#eeeeee"
+base = "#e4e4e4"
+surface0 = "#dadada"
+surface1 = "#d0d0d0"
+overlay0 = "#c6c6c6"
+overlay1 = "#bcbcbc"
+subtext0 = "#6c6c6c"
+subtext1 = "#555555"
+text = "#444444"
+accent = "#005f87"
+sel_bg = "#afd7ff"
+border = "#bcbcbc"
+border_focus = "#005f87"
+green = "#008700"
+mint = "#0087af"
+amber = "#af5f00"
+coral = "#af0000"

--- a/src/theme/registry.rs
+++ b/src/theme/registry.rs
@@ -251,27 +251,40 @@ impl ThemeRegistry {
         let mut entries = Vec::new();
         for id in theme::THEMES {
             let virtual_theme = *id == "terminal";
+            let bundled = super::builtin_file(id);
             entries.push(ThemeEntry {
                 id: (*id).to_string(),
-                display_name: display_name(id),
-                description: theme::describe(id).to_string(),
-                author: "Luvus".to_string(),
-                license: String::new(),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                appearance: if virtual_theme {
-                    Appearance::Terminal
-                } else if matches!(*id, "sky" | "catppuccin-latte" | "gruvbox-light") {
-                    Appearance::Light
-                } else {
-                    Appearance::Dark
-                },
+                display_name: bundled
+                    .map(|file| file.display_name.clone())
+                    .unwrap_or_else(|| display_name(id)),
+                description: bundled
+                    .map(|file| file.description.clone())
+                    .unwrap_or_else(|| theme::describe(id).to_string()),
+                author: bundled
+                    .map(|file| file.author.clone())
+                    .unwrap_or_else(|| "Luvus".to_string()),
+                license: bundled.map(|file| file.license.clone()).unwrap_or_default(),
+                version: bundled
+                    .map(|file| file.version.clone())
+                    .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string()),
+                appearance: bundled.map(|file| file.appearance).unwrap_or_else(|| {
+                    if virtual_theme {
+                        Appearance::Terminal
+                    } else if matches!(*id, "sky" | "catppuccin-latte" | "gruvbox-light") {
+                        Appearance::Light
+                    } else {
+                        Appearance::Dark
+                    }
+                }),
                 source: if virtual_theme {
                     ThemeSource::Virtual
                 } else {
                     ThemeSource::BuiltIn
                 },
                 extends: None,
-                theme: theme::by_name(id),
+                theme: bundled
+                    .and_then(|_| super::builtin_theme(id))
+                    .unwrap_or_else(|| theme::by_name(id)),
                 warnings: Vec::new(),
             });
         }
@@ -560,6 +573,68 @@ accent = "#222222"
             registry.index_of("mocha"),
             registry.index_of("catppuccin-mocha")
         );
+    }
+
+    #[test]
+    fn rose_pine_builtins_retain_upstream_attribution() {
+        let registry = ThemeRegistry::load_from(Path::new("/path/that/does/not/exist"));
+        for id in ["rose-pine", "rose-pine-moon", "rose-pine-dawn"] {
+            let entry = registry.get(id).expect("Rosé Pine theme is registered");
+            assert_eq!(entry.author, "Rosé Pine");
+            assert_eq!(entry.license, "MIT");
+        }
+        assert_eq!(registry.get("rose-pine").unwrap().display_name, "Rosé Pine");
+        assert_eq!(
+            registry.get("rose-pine-moon").unwrap().display_name,
+            "Rosé Pine Moon"
+        );
+        assert_eq!(
+            registry.get("rose-pine-dawn").unwrap().appearance,
+            Appearance::Light
+        );
+    }
+
+    #[test]
+    fn tokyo_night_builtin_retains_upstream_attribution() {
+        let registry = ThemeRegistry::load_from(Path::new("/path/that/does/not/exist"));
+        let entry = registry
+            .get("tokyo-night")
+            .expect("Tokyo Night theme is registered");
+        assert_eq!(entry.display_name, "Tokyo Night");
+        assert_eq!(entry.author, "Zak Hammerman and Enkia");
+        assert_eq!(entry.license, "MIT");
+        assert_eq!(entry.appearance, Appearance::Dark);
+    }
+
+    #[test]
+    fn baitong_builtin_retains_upstream_credit() {
+        let registry = ThemeRegistry::load_from(Path::new("/path/that/does/not/exist"));
+        let entry = registry
+            .get("baitong")
+            .expect("Baitong theme is registered");
+        assert_eq!(entry.display_name, "Baitong");
+        assert_eq!(entry.author, "cyphbt");
+        assert!(entry.license.is_empty());
+        assert_eq!(entry.appearance, Appearance::Dark);
+    }
+
+    #[test]
+    fn paper_builtins_retain_credit_and_light_contrast() {
+        let registry = ThemeRegistry::load_from(Path::new("/path/that/does/not/exist"));
+        for (id, author, license) in [
+            ("papercolor", "Nikyle Nguyen", "MIT"),
+            ("paper", "s6muel and Yorick Peterse", "MPL-2.0"),
+        ] {
+            let entry = registry.get(id).expect("paper theme is registered");
+            assert_eq!(entry.author, author);
+            assert_eq!(entry.license, license);
+            assert_eq!(entry.appearance, Appearance::Light);
+            let file = super::super::builtin_file(id).expect("paper theme file is embedded");
+            assert!(
+                file.warnings(&entry.theme).is_empty(),
+                "{id} must preserve readable text and distinct semantic colors"
+            );
+        }
     }
 
     #[test]

--- a/src/theme/rose-pine/LICENSE
+++ b/src/theme/rose-pine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Rosé Pine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/theme/rose-pine/rose-pine-dawn.toml
+++ b/src/theme/rose-pine/rose-pine-dawn.toml
@@ -1,0 +1,33 @@
+# Adapted from the official Rosé Pine Dawn palette.
+# https://github.com/rose-pine/rose-pine-theme
+# Copyright (c) 2023 Rosé Pine. Licensed under the MIT License.
+
+schema = 1
+id = "rose-pine-dawn"
+display_name = "Rosé Pine Dawn"
+description = "Light Rosé Pine with a rose accent."
+author = "Rosé Pine"
+license = "MIT"
+version = "1.0.0"
+requires_luvus = ">=0.13.4"
+appearance = "light"
+
+[colors]
+crust = "#fffaf3"
+mantle = "#faf4ed"
+base = "#f8f0e7"
+surface0 = "#f4ede8"
+surface1 = "#f2e9e1"
+overlay0 = "#dfdad9"
+overlay1 = "#cecacd"
+subtext0 = "#9893a5"
+subtext1 = "#797593"
+text = "#464261"
+accent = "#d7827e"
+sel_bg = "#dfdad9"
+border = "#cecacd"
+border_focus = "#797593"
+green = "#6d8f89"
+mint = "#56949f"
+amber = "#ea9d34"
+coral = "#b4637a"

--- a/src/theme/rose-pine/rose-pine-moon.toml
+++ b/src/theme/rose-pine/rose-pine-moon.toml
@@ -1,0 +1,33 @@
+# Adapted from the official Rosé Pine Moon palette.
+# https://github.com/rose-pine/rose-pine-theme
+# Copyright (c) 2023 Rosé Pine. Licensed under the MIT License.
+
+schema = 1
+id = "rose-pine-moon"
+display_name = "Rosé Pine Moon"
+description = "Soft moonlit Rosé Pine with a rose accent."
+author = "Rosé Pine"
+license = "MIT"
+version = "1.0.0"
+requires_luvus = ">=0.13.4"
+appearance = "dark"
+
+[colors]
+crust = "#1f1d30"
+mantle = "#232136"
+base = "#2a273f"
+surface0 = "#2a283e"
+surface1 = "#393552"
+overlay0 = "#44415a"
+overlay1 = "#56526e"
+subtext0 = "#6e6a86"
+subtext1 = "#908caa"
+text = "#e0def4"
+accent = "#ea9a97"
+sel_bg = "#44415a"
+border = "#44415a"
+border_focus = "#908caa"
+green = "#95b1ac"
+mint = "#9ccfd8"
+amber = "#f6c177"
+coral = "#eb6f92"

--- a/src/theme/rose-pine/rose-pine.toml
+++ b/src/theme/rose-pine/rose-pine.toml
@@ -1,0 +1,33 @@
+# Adapted from the official Rosé Pine main palette.
+# https://github.com/rose-pine/rose-pine-theme
+# Copyright (c) 2023 Rosé Pine. Licensed under the MIT License.
+
+schema = 1
+id = "rose-pine"
+display_name = "Rosé Pine"
+description = "Soft dark Rosé Pine with a rose accent."
+author = "Rosé Pine"
+license = "MIT"
+version = "1.0.0"
+requires_luvus = ">=0.13.4"
+appearance = "dark"
+
+[colors]
+crust = "#16141f"
+mantle = "#191724"
+base = "#1f1d2e"
+surface0 = "#21202e"
+surface1 = "#26233a"
+overlay0 = "#403d52"
+overlay1 = "#524f67"
+subtext0 = "#6e6a86"
+subtext1 = "#908caa"
+text = "#e0def4"
+accent = "#ebbcba"
+sel_bg = "#403d52"
+border = "#403d52"
+border_focus = "#908caa"
+green = "#95b1ac"
+mint = "#9ccfd8"
+amber = "#f6c177"
+coral = "#eb6f92"

--- a/src/theme/tokyo-night/LICENSE
+++ b/src/theme/tokyo-night/LICENSE
@@ -1,0 +1,45 @@
+MIT License
+
+Copyright (c) 2020 Zak Hammerman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The semantic surface colors also derive from the original Tokyo Night theme:
+
+The MIT License (MIT)
+
+Copyright (c) 2018-present Enkia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/theme/tokyo-night/tokyo-night.toml
+++ b/src/theme/tokyo-night/tokyo-night.toml
@@ -1,0 +1,36 @@
+# Adapted from the standard Tokyo Night Alacritty palette, not Storm.
+# https://github.com/zatchheems/tokyo-night-alacritty-theme
+# Based on the original Tokyo Night palette by Enkia.
+# https://github.com/tokyo-night/tokyo-night-vscode-theme
+# Copyright (c) 2020 Zak Hammerman and (c) 2018-present Enkia.
+# Both upstream projects are licensed under the MIT License.
+
+schema = 1
+id = "tokyo-night"
+display_name = "Tokyo Night"
+description = "Deep Tokyo night surfaces with a clear blue accent."
+author = "Zak Hammerman and Enkia"
+license = "MIT"
+version = "1.0.0"
+requires_luvus = ">=0.13.4"
+appearance = "dark"
+
+[colors]
+crust = "#16161e"
+mantle = "#1a1b26"
+base = "#1f2335"
+surface0 = "#24283b"
+surface1 = "#292e42"
+overlay0 = "#32344a"
+overlay1 = "#444b6a"
+subtext0 = "#787c99"
+subtext1 = "#acb0d0"
+text = "#a9b1d6"
+accent = "#7aa2f7"
+sel_bg = "#292e42"
+border = "#32344a"
+border_focus = "#7da6ff"
+green = "#9ece6a"
+mint = "#0db9d7"
+amber = "#e0af68"
+coral = "#f7768e"

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -663,16 +663,23 @@ pub const THEMES: &[&str] = &[
     "ocean",
     "dracula",
     "nord",
+    "tokyo-night",
     "sky",
     "catppuccin-mocha",
     "catppuccin-macchiato",
     "catppuccin-frappe",
+    "rose-pine",
+    "rose-pine-moon",
     "gruvbox",
     "sunset",
     "homebrew",
     "grass",
+    "baitong",
     "redsands",
     "catppuccin-latte",
+    "rose-pine-dawn",
+    "papercolor",
+    "paper",
     "gruvbox-light",
     "mono",
     // Terminal is capability-derived rather than a bundled palette, and is
@@ -695,6 +702,9 @@ pub fn canonical(name: &str) -> &str {
 }
 
 pub fn by_name(name: &str) -> Theme {
+    if let Some(theme) = crate::theme::builtin_theme(canonical(name)) {
+        return theme;
+    }
     match name {
         // The client-supplied RGB palette is applied after startup. Until then,
         // use terminal-native Reset/ANSI colors rather than a bundled palette.
@@ -722,6 +732,9 @@ pub fn by_name(name: &str) -> Theme {
 }
 
 pub fn describe(name: &str) -> &'static str {
+    if let Some(file) = crate::theme::builtin_file(canonical(name)) {
+        return file.description.as_str();
+    }
     match name {
         "terminal" => "inferred from your terminal",
         "ocean" => "deep cmd-blue, cyan accent",

--- a/website/src/lib/themes.ts
+++ b/website/src/lib/themes.ts
@@ -14,16 +14,23 @@ export const THEMES: { id: string; label: string; note: string }[] = [
   { id: 'ocean', label: 'ocean', note: 'deep cmd-blue, cyan accent' },
   { id: 'dracula', label: 'dracula', note: 'indigo dark, violet accent' },
   { id: 'nord', label: 'nord', note: 'cool arctic blue-grey' },
+  { id: 'tokyo-night', label: 'tokyo night', note: 'deep night blue, clear blue accent' },
   { id: 'sky', label: 'sky', note: 'light paper, sky-blue accent' },
   { id: 'catppuccin-mocha', label: 'catppuccin mocha', note: 'darkest Catppuccin, mauve' },
   { id: 'catppuccin-macchiato', label: 'catppuccin macchiato', note: 'softer dark Catppuccin' },
   { id: 'catppuccin-frappe', label: 'catppuccin frappe', note: 'lightest dark Catppuccin' },
+  { id: 'rose-pine', label: 'rosé pine', note: 'soft dark Rosé Pine, rose accent' },
+  { id: 'rose-pine-moon', label: 'rosé pine moon', note: 'soft moonlit Rosé Pine, rose accent' },
   { id: 'gruvbox', label: 'gruvbox', note: 'retro warm dark, yellow accent' },
   { id: 'sunset', label: 'sunset', note: 'neon synthwave, hot-pink' },
   { id: 'homebrew', label: 'homebrew', note: 'classic green-on-black' },
   { id: 'grass', label: 'grass', note: 'green field, pale-yellow text' },
+  { id: 'baitong', label: 'baitong', note: 'deep teal, neon green and magenta' },
   { id: 'redsands', label: 'redsands', note: 'warm dark red, orange accent' },
   { id: 'catppuccin-latte', label: 'catppuccin latte', note: 'light Catppuccin, warm' },
+  { id: 'rose-pine-dawn', label: 'rosé pine dawn', note: 'light Rosé Pine, rose accent' },
+  { id: 'papercolor', label: 'papercolor', note: 'neutral white paper, deep blue accent' },
+  { id: 'paper', label: 'paper', note: 'warm notebook paper, black ink' },
   { id: 'gruvbox-light', label: 'gruvbox light', note: 'Gruvbox on cream, burnt orange' },
   { id: 'mono', label: 'mono', note: 'grayscale, no accent color' },
 ];
@@ -37,7 +44,14 @@ export const DEFAULT_THEME = 'quattro-rally';
  * own rules (and Expressive Code's syntax theme) off `data-theme`, so the docs
  * have to say which side of the line each palette falls on.
  */
-export const LIGHT_THEMES = ['catppuccin-latte', 'gruvbox-light', 'sky'];
+export const LIGHT_THEMES = [
+  'catppuccin-latte',
+  'gruvbox-light',
+  'paper',
+  'papercolor',
+  'rose-pine-dawn',
+  'sky',
+];
 
 /** `data-theme` for a palette: what Starlight's own light/dark rules key off. */
 export const modeOf = (id: string) => (LIGHT_THEMES.includes(id) ? 'light' : 'dark');

--- a/website/src/styles/themes.css
+++ b/website/src/styles/themes.css
@@ -107,6 +107,27 @@ html[data-bh-theme='nord'] {
   --coral: #bf616a;
 }
 .td-sw[data-theme='nord'] { background: #88c0d0; }
+html[data-bh-theme='tokyo-night'] {
+  --bg: #16161e;
+  --bg2: #1a1b26;
+  --base: #1f2335;
+  --surface: #24283b;
+  --line: #292e42;
+  --border: #32344a;
+  --border-focus: #7da6ff;
+  --overlay0: #32344a;
+  --overlay1: #444b6a;
+  --sub: #787c99;
+  --sub2: #acb0d0;
+  --text: #a9b1d6;
+  --accent: #7aa2f7;
+  --sel: #292e42;
+  --green: #9ece6a;
+  --mint: #0db9d7;
+  --amber: #e0af68;
+  --coral: #f7768e;
+}
+.td-sw[data-theme='tokyo-night'] { background: #7aa2f7; }
 html[data-bh-theme='sky'] {
   --bg: #f5f8fc;
   --bg2: #ebf1f9;
@@ -191,6 +212,48 @@ html[data-bh-theme='catppuccin-frappe'] {
   --coral: #e78284;
 }
 .td-sw[data-theme='catppuccin-frappe'] { background: #ca9ee6; }
+html[data-bh-theme='rose-pine'] {
+  --bg: #16141f;
+  --bg2: #191724;
+  --base: #1f1d2e;
+  --surface: #21202e;
+  --line: #26233a;
+  --border: #403d52;
+  --border-focus: #908caa;
+  --overlay0: #403d52;
+  --overlay1: #524f67;
+  --sub: #6e6a86;
+  --sub2: #908caa;
+  --text: #e0def4;
+  --accent: #ebbcba;
+  --sel: #403d52;
+  --green: #95b1ac;
+  --mint: #9ccfd8;
+  --amber: #f6c177;
+  --coral: #eb6f92;
+}
+.td-sw[data-theme='rose-pine'] { background: #ebbcba; }
+html[data-bh-theme='rose-pine-moon'] {
+  --bg: #1f1d30;
+  --bg2: #232136;
+  --base: #2a273f;
+  --surface: #2a283e;
+  --line: #393552;
+  --border: #44415a;
+  --border-focus: #908caa;
+  --overlay0: #44415a;
+  --overlay1: #56526e;
+  --sub: #6e6a86;
+  --sub2: #908caa;
+  --text: #e0def4;
+  --accent: #ea9a97;
+  --sel: #44415a;
+  --green: #95b1ac;
+  --mint: #9ccfd8;
+  --amber: #f6c177;
+  --coral: #eb6f92;
+}
+.td-sw[data-theme='rose-pine-moon'] { background: #ea9a97; }
 html[data-bh-theme='gruvbox'] {
   --bg: #1d2021;
   --bg2: #282828;
@@ -275,6 +338,27 @@ html[data-bh-theme='grass'] {
   --coral: #f06a5a;
 }
 .td-sw[data-theme='grass'] { background: #bee632; }
+html[data-bh-theme='baitong'] {
+  --bg: #081b1b;
+  --bg2: #112a2a;
+  --base: #173838;
+  --surface: #1d4646;
+  --line: #255454;
+  --border: #326b6b;
+  --border-focus: #ff66ff;
+  --overlay0: #326b6b;
+  --overlay1: #4b8585;
+  --sub: #6fa5a5;
+  --sub2: #87cefa;
+  --text: #33ff33;
+  --accent: #ff00ff;
+  --sel: #254d32;
+  --green: #33ff33;
+  --mint: #68fdfe;
+  --amber: #1ae642;
+  --coral: #f77272;
+}
+.td-sw[data-theme='baitong'] { background: #ff00ff; }
 html[data-bh-theme='redsands'] {
   --bg: #1f0a06;
   --bg2: #38120c;
@@ -317,6 +401,69 @@ html[data-bh-theme='catppuccin-latte'] {
   --coral: #d20f39;
 }
 .td-sw[data-theme='catppuccin-latte'] { background: #40a02b; }
+html[data-bh-theme='rose-pine-dawn'] {
+  --bg: #fffaf3;
+  --bg2: #faf4ed;
+  --base: #f8f0e7;
+  --surface: #f4ede8;
+  --line: #f2e9e1;
+  --border: #cecacd;
+  --border-focus: #797593;
+  --overlay0: #dfdad9;
+  --overlay1: #cecacd;
+  --sub: #9893a5;
+  --sub2: #797593;
+  --text: #464261;
+  --accent: #d7827e;
+  --sel: #dfdad9;
+  --green: #6d8f89;
+  --mint: #56949f;
+  --amber: #ea9d34;
+  --coral: #b4637a;
+}
+.td-sw[data-theme='rose-pine-dawn'] { background: #d7827e; }
+html[data-bh-theme='papercolor'] {
+  --bg: #ffffff;
+  --bg2: #eeeeee;
+  --base: #e4e4e4;
+  --surface: #dadada;
+  --line: #d0d0d0;
+  --border: #bcbcbc;
+  --border-focus: #005f87;
+  --overlay0: #c6c6c6;
+  --overlay1: #bcbcbc;
+  --sub: #6c6c6c;
+  --sub2: #555555;
+  --text: #444444;
+  --accent: #005f87;
+  --sel: #afd7ff;
+  --green: #008700;
+  --mint: #0087af;
+  --amber: #af5f00;
+  --coral: #af0000;
+}
+.td-sw[data-theme='papercolor'] { background: #005f87; }
+html[data-bh-theme='paper'] {
+  --bg: #fffdf5;
+  --bg2: #f2eede;
+  --base: #e9e5d7;
+  --surface: #e0dccf;
+  --line: #d8d5c7;
+  --border: #c8c4b7;
+  --border-focus: #1e6fcc;
+  --overlay0: #c8c4b7;
+  --overlay1: #aaaaaa;
+  --sub: #77746c;
+  --sub2: #555555;
+  --text: #000000;
+  --accent: #1e6fcc;
+  --sel: #d8d5c7;
+  --green: #216609;
+  --mint: #158c86;
+  --amber: #b58900;
+  --coral: #cc3e28;
+}
+.td-sw[data-theme='paper'] { background: #1e6fcc; }
 html[data-bh-theme='gruvbox-light'] {
   --bg: #fbf1c7;
   --bg2: #f2e5bc;


### PR DESCRIPTION
## Summary

Add seven built-in palettes backed by embedded, schema-validated TOML instead of adding more hardcoded Rust color constructors.

- add Rosé Pine, Rosé Pine Moon, and Rosé Pine Dawn
- add standard Tokyo Night, excluding Storm
- add Baitong with its upstream source credited
- add PaperColor and Paper as readable light themes
- expose every palette through Settings, CLI theme metadata, and the website picker
- keep upstream authorship and available license notices beside the bundled palette files

## Implementation

- parse and resolve bundled TOML palettes once with `LazyLock`
- source built-in display metadata, appearance, authorship, and license information from each theme file
- preserve Baitong source credit without inventing license metadata
- keep website colors and light-mode behavior aligned with the native palettes
- add focused tests for unique IDs, attribution, appearance, readability, and semantic color validation

## Verification

- `cargo fmt --all --check`
- `CARGO_INCREMENTAL=0 cargo test builtin -- --nocapture` with 10 passing tests
- `npm run build` in `website/`
- `git diff --check origin/main..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added seven built-in themes: Tokyo Night, Rosé Pine, Rosé Pine Moon, Rosé Pine Dawn, Baitong, PaperColor, and Paper.
  - Added light and dark theme variants with coordinated palettes across the application and website.
  - Added theme metadata, attribution, and licensing information.
  - Added built-in theme lookup and registration support.
- **Tests**
  - Added validation ensuring bundled themes are uniquely identified and maintain expected metadata and contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->