### PR TITLE
fix(input): negotiate native Windows input records

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2687,8 +2687,18 @@ impl App {
             "pane.send_input" => {
                 let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let text = p.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                let paste = match p.get("paste") {
+                    None => false,
+                    Some(Value::Bool(paste)) => *paste,
+                    Some(_) => {
+                        return Err((
+                            "invalid_request".to_string(),
+                            "paste must be a boolean".to_string(),
+                        ))
+                    }
+                };
                 let pane = self.panes.get(&id).ok_or_else(not_found)?;
-                let result = if p.get("paste").and_then(|value| value.as_bool()) == Some(true) {
+                let result = if paste {
                     pane.try_send_paste(text)
                 } else {
                     pane.try_send(text.as_bytes())
@@ -9221,6 +9231,19 @@ command = ["true"]
             panic!("expected bracketed paste")
         };
         assert_eq!(bytes, b"\x1b[200~first\nsecond\x1b[201~");
+        let error = app
+            .dispatch(
+                "pane.send_input",
+                &json!({
+                    "pane": pane.0.to_string(),
+                    "text": "must not be sent",
+                    "paste": "true",
+                }),
+            )
+            .expect_err("a non-boolean paste value must be rejected");
+        assert_eq!(error.0, "invalid_request");
+        assert_eq!(error.1, "paste must be a boolean");
+        assert!(rx.try_recv().is_err());
         drop(rx);
         for (method, params) in [
             (

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2688,8 +2688,12 @@ impl App {
                 let id = self.resolve_pane(p)?.ok_or_else(not_found)?;
                 let text = p.get("text").and_then(|v| v.as_str()).unwrap_or("");
                 let pane = self.panes.get(&id).ok_or_else(not_found)?;
-                pane.try_send(text.as_bytes())
-                    .map_err(|message| ("send_failed".to_string(), message))?;
+                let result = if p.get("paste").and_then(|value| value.as_bool()) == Some(true) {
+                    pane.try_send_paste(text)
+                } else {
+                    pane.try_send(text.as_bytes())
+                };
+                result.map_err(|message| ("send_failed".to_string(), message))?;
                 Ok(json!({"type":"ok"}))
             }
             "pane.read" => {
@@ -9199,6 +9203,24 @@ command = ["true"]
         };
         assert_eq!(bytes, b"echo hi\r");
         assert!(rx.try_recv().is_err());
+        app.panes[&pane]
+            .engine
+            .lock()
+            .unwrap()
+            .advance(b"\x1b[?2004h");
+        app.dispatch(
+            "pane.send_input",
+            &json!({
+                "pane": pane.0.to_string(),
+                "text": "first\nsecond",
+                "paste": true,
+            }),
+        )
+        .unwrap();
+        let crate::terminal::pty::InputAction::Bytes(bytes) = rx.try_recv().unwrap() else {
+            panic!("expected bracketed paste")
+        };
+        assert_eq!(bytes, b"\x1b[200~first\nsecond\x1b[201~");
         drop(rx);
         for (method, params) in [
             (

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,7 +146,7 @@ panes / agents:
   pane focus <id>            focus a pane (jumps to its workspace/tab)
   pane move [<id>] (--tab <n> | --new-tab)  move a pane within its workspace
   pane run [<id>] <cmd...>   run a command in a pane
-  pane send [<id>] <text>    send raw text to a pane
+  pane send [<id>] <text>    paste text into a pane
   pane read [<id>]           print a pane's recent output
   pane status [<id>]         print a pane's agent status and history metrics (any workspace)
   pane processes [<id>]      list cached executable identities without exposing arguments
@@ -3236,6 +3236,7 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             let text = tail().join(" ");
             let mut obj = serde_json::Map::new();
             obj.insert("text".to_string(), json!(text));
+            obj.insert("paste".to_string(), json!(true));
             ("pane.send_input".into(), with_pane(obj))
         }
         ("pane", "read") => ("pane.read".into(), with_pane(serde_json::Map::new())),
@@ -4463,6 +4464,28 @@ mod tests {
             let args = argv(raw);
             assert_eq!(command_help_request(&args), None, "{raw}");
         }
+    }
+
+    #[test]
+    fn pane_send_requests_atomic_paste_semantics() {
+        let (method, params) = parse(&argv("luvus pane send 9 first second")).unwrap();
+        assert_eq!(method, "pane.send_input");
+        assert_eq!(params.get("pane").and_then(Value::as_str), Some("9"));
+        assert_eq!(
+            params.get("text").and_then(Value::as_str),
+            Some("first second")
+        );
+        assert_eq!(params.get("paste").and_then(Value::as_bool), Some(true));
+
+        let args = ["luvus", "pane", "send", "9", "first\nsecond"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>();
+        let (_, params) = parse(&args).unwrap();
+        assert_eq!(
+            params.get("text").and_then(Value::as_str),
+            Some("first\nsecond")
+        );
     }
 
     #[test]

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -1278,15 +1278,15 @@ static HELP: &[Translation] = &[
         "패널에서 명령어 실행"
     ),
     tr!(
-        "send raw text to a pane",
-        "enviar texto sin procesar a un panel",
-        "enviar texto bruto para um painel",
-        "envoyer du texte brut à un volet",
-        "Rohtext an einen Bereich senden",
-        "kirim teks mentah ke panel",
-        "向窗格发送原始文本",
-        "ペインへ生テキストを送信",
-        "패널에 원본 텍스트 전송"
+        "paste text into a pane",
+        "pegar texto en un panel",
+        "colar texto em um painel",
+        "coller du texte dans un volet",
+        "Text in einen Bereich einfügen",
+        "tempelkan teks ke panel",
+        "将文本粘贴到窗格",
+        "ペインにテキストを貼り付け",
+        "패널에 텍스트 붙여넣기"
     ),
     tr!(
         "print a pane's recent output",

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -8,11 +8,11 @@ use std::thread;
 use anyhow::{anyhow, Result};
 use ratatui::backend::Backend;
 use ratatui::buffer::Cell;
-#[cfg(windows)]
-use ratatui::crossterm::event::poll as poll_event;
+#[cfg(not(windows))]
+use ratatui::crossterm::event::read as read_event;
 use ratatui::crossterm::event::{
-    read as read_event, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture,
-    EnableBracketedPaste, EnableFocusChange, EnableMouseCapture, Event,
+    DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+    EnableFocusChange, EnableMouseCapture, Event,
 };
 use ratatui::crossterm::execute;
 use ratatui::layout::Position;
@@ -349,32 +349,9 @@ fn switched_args(raw: &[String], name: &str) -> Vec<String> {
 fn input_loop<W: Write>(mut writer: W, pending: Vec<Event>) {
     #[cfg(windows)]
     {
-        let mut decoder = crate::terminal::host_input::HostInputDecoder::default();
-        for event in pending {
-            if !write_decoded_input(&mut writer, decoder.push(event)) {
-                return;
-            }
-        }
-        loop {
-            if let Some(timeout) = decoder.wait_timeout() {
-                match poll_event(timeout) {
-                    Ok(false) => {
-                        if !write_decoded_input(&mut writer, decoder.flush_expired()) {
-                            break;
-                        }
-                        continue;
-                    }
-                    Ok(true) => {}
-                    Err(_) => break,
-                }
-            }
-            let Ok(event) = read_event() else {
-                break;
-            };
-            if !write_decoded_input(&mut writer, decoder.push(event)) {
-                break;
-            }
-        }
+        crate::terminal::host_input::run_input_loop(pending, |event| {
+            write_input_event(&mut writer, event)
+        });
     }
 
     #[cfg(not(windows))]
@@ -394,20 +371,6 @@ fn input_loop<W: Write>(mut writer: W, pending: Vec<Event>) {
 
 fn write_input_event(writer: &mut impl Write, event: Event) -> bool {
     event_message(event).is_none_or(|message| protocol::write_message(writer, &message).is_ok())
-}
-
-#[cfg(windows)]
-fn write_decoded_input(
-    writer: &mut impl Write,
-    decoded: crate::terminal::host_input::DecodedEvents,
-) -> bool {
-    let mut connected = true;
-    decoded.for_each(|event| {
-        if connected {
-            connected = write_input_event(writer, event);
-        }
-    });
-    connected
 }
 
 fn event_message(event: Event) -> Option<ClientMessage> {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -214,6 +214,8 @@ where
         EnableFocusChange,
         crossterm::terminal::SetTitle(crate::window_title())
     );
+    #[cfg(windows)]
+    let _windows_input_mode = crate::terminal::host_input::enable_input_mode();
     // Let the terminal report Shift+Enter et al. as distinct keys, so agents get
     // a real "new line" key instead of a bare CR (see `push_key_protocol`).
     crate::push_key_protocol();

--- a/src/logging/redact.rs
+++ b/src/logging/redact.rs
@@ -306,6 +306,14 @@ pub(crate) enum FieldKey {
     DurationMs,
     Dropped,
     Reason,
+    InputKind,
+    KeyDown,
+    RepeatCount,
+    VirtualKey,
+    ScanCode,
+    Utf16,
+    ControlState,
+    Bytes,
 }
 
 impl FieldKey {
@@ -340,6 +348,14 @@ impl FieldKey {
             Self::DurationMs => "duration_ms",
             Self::Dropped => "dropped",
             Self::Reason => "reason",
+            Self::InputKind => "input_kind",
+            Self::KeyDown => "key_down",
+            Self::RepeatCount => "repeat_count",
+            Self::VirtualKey => "virtual_key",
+            Self::ScanCode => "scan_code",
+            Self::Utf16 => "utf16",
+            Self::ControlState => "control_state",
+            Self::Bytes => "bytes",
         }
     }
 }
@@ -376,6 +392,14 @@ pub enum Field {
     DurationMs(u64),
     Dropped(u64),
     Reason(Reason),
+    InputKind(SafeId),
+    KeyDown(bool),
+    RepeatCount(u64),
+    VirtualKey(u64),
+    ScanCode(u64),
+    Utf16(u64),
+    ControlState(u64),
+    Bytes(u64),
 }
 
 impl Field {
@@ -410,6 +434,14 @@ impl Field {
             Self::DurationMs(_) => FieldKey::DurationMs,
             Self::Dropped(_) => FieldKey::Dropped,
             Self::Reason(_) => FieldKey::Reason,
+            Self::InputKind(_) => FieldKey::InputKind,
+            Self::KeyDown(_) => FieldKey::KeyDown,
+            Self::RepeatCount(_) => FieldKey::RepeatCount,
+            Self::VirtualKey(_) => FieldKey::VirtualKey,
+            Self::ScanCode(_) => FieldKey::ScanCode,
+            Self::Utf16(_) => FieldKey::Utf16,
+            Self::ControlState(_) => FieldKey::ControlState,
+            Self::Bytes(_) => FieldKey::Bytes,
         }
     }
 
@@ -422,8 +454,9 @@ impl Field {
             | Self::Method(value)
             | Self::RequestId(value)
             | Self::Agent(value)
-            | Self::ModuleId(value) => value.as_str().into(),
-            Self::IdOmitted(value) => value.into(),
+            | Self::ModuleId(value)
+            | Self::InputKind(value) => value.as_str().into(),
+            Self::IdOmitted(value) | Self::KeyDown(value) => value.into(),
             Self::PaneId(value)
             | Self::WorkspaceIndex(value)
             | Self::TabIndex(value)
@@ -436,7 +469,13 @@ impl Field {
             | Self::RestorePanes(value)
             | Self::RestoreSkipped(value)
             | Self::DurationMs(value)
-            | Self::Dropped(value) => value.into(),
+            | Self::Dropped(value)
+            | Self::RepeatCount(value)
+            | Self::VirtualKey(value)
+            | Self::ScanCode(value)
+            | Self::Utf16(value)
+            | Self::ControlState(value)
+            | Self::Bytes(value) => value.into(),
             Self::SpawnKind(value) => value.as_str().into(),
             Self::ExitClass(value) => value.as_str().into(),
             Self::AgentState(value) | Self::FromState(value) => value.as_str().into(),
@@ -489,6 +528,8 @@ pub enum EventKind {
     ClientResize,
     ClientFrameError,
     ClientRenderFailed,
+    ClientInputRecord,
+    ClientInputDecoded,
     LogWriteRecovered,
     UhpConnectionOpen,
     UhpConnectionClose,
@@ -542,6 +583,8 @@ impl EventKind {
             Self::ClientResize => "client.resize",
             Self::ClientFrameError => "client.frame_error",
             Self::ClientRenderFailed => "client.render_failed",
+            Self::ClientInputRecord => "client.input_record",
+            Self::ClientInputDecoded => "client.input_decoded",
             Self::LogWriteRecovered => "log.write_recovered",
             Self::UhpConnectionOpen => "uhp.connection.open",
             Self::UhpConnectionClose => "uhp.connection.close",
@@ -575,6 +618,8 @@ impl EventKind {
             | Self::TabClose
             | Self::PtyResize
             | Self::ClientResize
+            | Self::ClientInputRecord
+            | Self::ClientInputDecoded
             | Self::UhpConnectionOpen
             | Self::UhpConnectionClose
             | Self::UhpRequestStart
@@ -594,7 +639,9 @@ impl EventKind {
             | Self::ClientDisconnect
             | Self::ClientResize
             | Self::ClientFrameError
-            | Self::ClientRenderFailed => Some(LoggerKind::Client),
+            | Self::ClientRenderFailed
+            | Self::ClientInputRecord
+            | Self::ClientInputDecoded => Some(LoggerKind::Client),
             Self::LogWriteRecovered => None,
             _ => Some(LoggerKind::Server),
         }
@@ -655,6 +702,16 @@ impl EventKind {
             E::ClientDisconnect => matches!(key, F::Reason),
             E::ClientResize => matches!(key, F::Cols | F::Rows),
             E::ClientFrameError => matches!(key, F::ErrorCode),
+            E::ClientInputRecord => matches!(
+                key,
+                F::KeyDown
+                    | F::RepeatCount
+                    | F::VirtualKey
+                    | F::ScanCode
+                    | F::Utf16
+                    | F::ControlState
+            ),
+            E::ClientInputDecoded => matches!(key, F::InputKind | F::Bytes),
             E::LogWriteRecovered => matches!(key, F::ErrorCode | F::Dropped),
             E::UhpRequestStart => matches!(key, F::RequestId | F::Method | F::IdOmitted),
             E::UhpRequestComplete | E::UhpRequestFailed => matches!(
@@ -702,5 +759,9 @@ mod tests {
         assert_eq!(EventKind::UhpRequestComplete.level(), Level::Debug);
         assert_eq!(EventKind::UhpRequestFailed.level(), Level::Warn);
         assert!(EventKind::UhpRequestFailed.allows(FieldKey::ErrorCode));
+        assert!(EventKind::ClientInputRecord.allows(FieldKey::Utf16));
+        assert!(!EventKind::ClientInputRecord.allows(FieldKey::Method));
+        assert!(EventKind::ClientInputDecoded.allows(FieldKey::InputKind));
+        assert!(!EventKind::ClientInputDecoded.allows(FieldKey::Utf16));
     }
 }

--- a/src/logging/redact.rs
+++ b/src/logging/redact.rs
@@ -311,7 +311,7 @@ pub(crate) enum FieldKey {
     RepeatCount,
     VirtualKey,
     ScanCode,
-    Utf16,
+    Utf16Class,
     ControlState,
     Bytes,
 }
@@ -353,7 +353,7 @@ impl FieldKey {
             Self::RepeatCount => "repeat_count",
             Self::VirtualKey => "virtual_key",
             Self::ScanCode => "scan_code",
-            Self::Utf16 => "utf16",
+            Self::Utf16Class => "utf16_class",
             Self::ControlState => "control_state",
             Self::Bytes => "bytes",
         }
@@ -397,7 +397,7 @@ pub enum Field {
     RepeatCount(u64),
     VirtualKey(u64),
     ScanCode(u64),
-    Utf16(u64),
+    Utf16Class(u64),
     ControlState(u64),
     Bytes(u64),
 }
@@ -439,7 +439,7 @@ impl Field {
             Self::RepeatCount(_) => FieldKey::RepeatCount,
             Self::VirtualKey(_) => FieldKey::VirtualKey,
             Self::ScanCode(_) => FieldKey::ScanCode,
-            Self::Utf16(_) => FieldKey::Utf16,
+            Self::Utf16Class(_) => FieldKey::Utf16Class,
             Self::ControlState(_) => FieldKey::ControlState,
             Self::Bytes(_) => FieldKey::Bytes,
         }
@@ -473,7 +473,7 @@ impl Field {
             | Self::RepeatCount(value)
             | Self::VirtualKey(value)
             | Self::ScanCode(value)
-            | Self::Utf16(value)
+            | Self::Utf16Class(value)
             | Self::ControlState(value)
             | Self::Bytes(value) => value.into(),
             Self::SpawnKind(value) => value.as_str().into(),
@@ -708,7 +708,7 @@ impl EventKind {
                     | F::RepeatCount
                     | F::VirtualKey
                     | F::ScanCode
-                    | F::Utf16
+                    | F::Utf16Class
                     | F::ControlState
             ),
             E::ClientInputDecoded => matches!(key, F::InputKind | F::Bytes),
@@ -759,9 +759,9 @@ mod tests {
         assert_eq!(EventKind::UhpRequestComplete.level(), Level::Debug);
         assert_eq!(EventKind::UhpRequestFailed.level(), Level::Warn);
         assert!(EventKind::UhpRequestFailed.allows(FieldKey::ErrorCode));
-        assert!(EventKind::ClientInputRecord.allows(FieldKey::Utf16));
+        assert!(EventKind::ClientInputRecord.allows(FieldKey::Utf16Class));
         assert!(!EventKind::ClientInputRecord.allows(FieldKey::Method));
         assert!(EventKind::ClientInputDecoded.allows(FieldKey::InputKind));
-        assert!(!EventKind::ClientInputDecoded.allows(FieldKey::Utf16));
+        assert!(!EventKind::ClientInputDecoded.allows(FieldKey::Utf16Class));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1297,6 +1297,8 @@ fn run(terminal: &mut DefaultTerminal) -> Result<bool> {
         EnableFocusChange,
         crossterm::terminal::SetTitle(window_title())
     );
+    #[cfg(windows)]
+    let _windows_input_mode = terminal::host_input::enable_input_mode();
     push_key_protocol();
     {
         let tx = tx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,11 +45,11 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
-#[cfg(windows)]
-use ratatui::crossterm::event::poll as poll_event;
+#[cfg(not(windows))]
+use ratatui::crossterm::event::read as read_event;
 use ratatui::crossterm::event::{
-    read as read_event, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture,
-    EnableBracketedPaste, EnableFocusChange, EnableMouseCapture, Event, KeyboardEnhancementFlags,
+    DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+    EnableFocusChange, EnableMouseCapture, Event, KeyboardEnhancementFlags,
     PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use ratatui::crossterm::execute;
@@ -1411,32 +1411,7 @@ fn remove_unbound_socket(path: &Path) -> std::io::Result<()> {
 fn input_loop(tx: Sender<AppEvent>, pending: Vec<Event>) {
     #[cfg(windows)]
     {
-        let mut decoder = crate::terminal::host_input::HostInputDecoder::default();
-        for event in pending {
-            if !send_decoded_input(&tx, decoder.push(event)) {
-                return;
-            }
-        }
-        loop {
-            if let Some(timeout) = decoder.wait_timeout() {
-                match poll_event(timeout) {
-                    Ok(false) => {
-                        if !send_decoded_input(&tx, decoder.flush_expired()) {
-                            break;
-                        }
-                        continue;
-                    }
-                    Ok(true) => {}
-                    Err(_) => break,
-                }
-            }
-            let Ok(event) = read_event() else {
-                break;
-            };
-            if !send_decoded_input(&tx, decoder.push(event)) {
-                break;
-            }
-        }
+        crate::terminal::host_input::run_input_loop(pending, |event| send_input_event(&tx, event));
     }
 
     #[cfg(not(windows))]
@@ -1456,20 +1431,6 @@ fn input_loop(tx: Sender<AppEvent>, pending: Vec<Event>) {
 
 fn send_input_event(tx: &Sender<AppEvent>, event: Event) -> bool {
     app_event(event).is_none_or(|event| tx.send(event).is_ok())
-}
-
-#[cfg(windows)]
-fn send_decoded_input(
-    tx: &Sender<AppEvent>,
-    decoded: crate::terminal::host_input::DecodedEvents,
-) -> bool {
-    let mut connected = true;
-    decoded.for_each(|event| {
-        if connected {
-            connected = send_input_event(tx, event);
-        }
-    });
-    connected
 }
 
 fn app_event(event: Event) -> Option<AppEvent> {

--- a/src/terminal/host_input.rs
+++ b/src/terminal/host_input.rs
@@ -11,17 +11,19 @@ use std::time::{Duration, Instant};
 use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind};
 
 #[cfg(any(windows, test))]
+#[cfg_attr(not(windows), allow(dead_code))]
 mod console;
 #[cfg(windows)]
 mod windows;
 
 #[cfg(windows)]
-pub use windows::run_input_loop;
+pub use windows::{enable_input_mode, run_input_loop};
 
 const START_MARKER: &[char] = &['\u{1b}', '[', '2', '0', '0', '~'];
 const END_MARKER: &[char] = &['\u{1b}', '[', '2', '0', '1', '~'];
 const PREFIX_TIMEOUT: Duration = Duration::from_millis(40);
-const NATIVE_PREFIX_TIMEOUT: Duration = Duration::from_secs(1);
+const NATIVE_PREFIX_TIMEOUT: Duration = Duration::from_millis(100);
+const PASTE_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_PASTE_CHUNK_BYTES: usize = 8 * 1024 * 1024;
 
 /// Zero, one, or a rare batch of decoded terminal events.
@@ -75,6 +77,7 @@ enum DecodeState {
     Paste {
         text: String,
         ending: String,
+        deadline: Instant,
     },
 }
 
@@ -101,12 +104,6 @@ impl HostInputDecoder {
         self.push_at_with_policy(event, now, true, PREFIX_TIMEOUT)
     }
 
-    /// Decode one event produced from a native Windows console record.
-    ///
-    /// A physical Escape key has a scan code and can bypass marker detection,
-    /// so it is delivered immediately. Synthetic scan-code-zero Escape records
-    /// may begin a terminal control sequence and receive a wider continuation
-    /// window than Crossterm's fallback path.
     pub(super) fn push_native(
         &mut self,
         event: Event,
@@ -161,6 +158,7 @@ impl HostInputDecoder {
                         self.state = DecodeState::Paste {
                             text: String::new(),
                             ending: String::new(),
+                            deadline: now + PASTE_IDLE_TIMEOUT,
                         };
                     } else {
                         self.state = DecodeState::Prefix {
@@ -178,7 +176,8 @@ impl HostInputDecoder {
             DecodeState::Paste {
                 mut text,
                 mut ending,
-            } => self.push_paste(event, &mut text, &mut ending),
+                deadline: _,
+            } => self.push_paste(event, now, &mut text, &mut ending),
         }
     }
 
@@ -204,6 +203,7 @@ impl HostInputDecoder {
     fn push_paste(
         &mut self,
         event: Event,
+        now: Instant,
         text: &mut String,
         ending: &mut String,
     ) -> DecodedEvents {
@@ -211,13 +211,14 @@ impl HostInputDecoder {
             text.push_str(ending);
             ending.clear();
             text.push_str(&pasted);
-            return self.keep_or_chunk(text, ending);
+            return self.keep_or_chunk(text, ending, now);
         }
 
         let Event::Key(key) = &event else {
             self.state = DecodeState::Paste {
                 text: std::mem::take(text),
                 ending: std::mem::take(ending),
+                deadline: now + PASTE_IDLE_TIMEOUT,
             };
             return DecodedEvents::One(event);
         };
@@ -225,6 +226,7 @@ impl HostInputDecoder {
             self.state = DecodeState::Paste {
                 text: std::mem::take(text),
                 ending: std::mem::take(ending),
+                deadline: now + PASTE_IDLE_TIMEOUT,
             };
             return DecodedEvents::None;
         }
@@ -243,6 +245,7 @@ impl HostInputDecoder {
                 self.state = DecodeState::Paste {
                     text: std::mem::take(text),
                     ending: std::mem::take(ending),
+                    deadline: now + PASTE_IDLE_TIMEOUT,
                 };
                 return DecodedEvents::None;
             }
@@ -255,10 +258,15 @@ impl HostInputDecoder {
         } else {
             text.push(character);
         }
-        self.keep_or_chunk(text, ending)
+        self.keep_or_chunk(text, ending, now)
     }
 
-    fn keep_or_chunk(&mut self, text: &mut String, ending: &mut String) -> DecodedEvents {
+    fn keep_or_chunk(
+        &mut self,
+        text: &mut String,
+        ending: &mut String,
+        now: Instant,
+    ) -> DecodedEvents {
         let output = if text.len() >= MAX_PASTE_CHUNK_BYTES {
             DecodedEvents::One(Event::Paste(std::mem::take(text)))
         } else {
@@ -267,16 +275,18 @@ impl HostInputDecoder {
         self.state = DecodeState::Paste {
             text: std::mem::take(text),
             ending: std::mem::take(ending),
+            deadline: now + PASTE_IDLE_TIMEOUT,
         };
         output
     }
 
-    /// Time until a possible start-marker prefix must be released. Once a full
-    /// start marker arrives, only its matching end marker closes the paste.
+    /// Time until held input must be released. Detection always uses explicit
+    /// markers; this deadline only prevents a lone Escape or damaged paste from
+    /// leaving the decoder stuck indefinitely.
     pub fn wait_timeout(&self) -> Option<Duration> {
         let deadline = match &self.state {
-            DecodeState::Idle | DecodeState::Paste { .. } => return None,
-            DecodeState::Prefix { deadline, .. } => *deadline,
+            DecodeState::Idle => return None,
+            DecodeState::Prefix { deadline, .. } | DecodeState::Paste { deadline, .. } => *deadline,
         };
         Some(deadline.saturating_duration_since(Instant::now()))
     }
@@ -287,8 +297,10 @@ impl HostInputDecoder {
 
     fn flush_expired_at(&mut self, now: Instant) -> DecodedEvents {
         let expired = match &self.state {
-            DecodeState::Idle | DecodeState::Paste { .. } => false,
-            DecodeState::Prefix { deadline, .. } => now >= *deadline,
+            DecodeState::Idle => false,
+            DecodeState::Prefix { deadline, .. } | DecodeState::Paste { deadline, .. } => {
+                now >= *deadline
+            }
         };
         if !expired {
             return DecodedEvents::None;
@@ -296,7 +308,11 @@ impl HostInputDecoder {
         match std::mem::replace(&mut self.state, DecodeState::Idle) {
             DecodeState::Idle => DecodedEvents::None,
             DecodeState::Prefix { events, .. } => DecodedEvents::Many(events),
-            DecodeState::Paste { .. } => unreachable!("paste states do not expire"),
+            DecodeState::Paste {
+                mut text,
+                mut ending,
+                ..
+            } => finish_paste(&mut text, &mut ending),
         }
     }
 }
@@ -322,6 +338,7 @@ fn is_key_release(event: &Event) -> bool {
 fn paste_char(code: KeyCode) -> Option<char> {
     match code {
         KeyCode::Char(character) => Some(character),
+        KeyCode::Backspace => Some('\u{8}'),
         KeyCode::Enter => Some('\r'),
         KeyCode::Tab => Some('\t'),
         KeyCode::Esc => Some('\u{1b}'),
@@ -557,7 +574,7 @@ mod tests {
     }
 
     #[test]
-    fn unterminated_paste_waits_for_its_real_end_marker() {
+    fn unterminated_paste_flushes_content_without_markers() {
         let now = Instant::now();
         let mut decoder = HostInputDecoder::default();
         for event in marker(START_MARKER) {
@@ -567,22 +584,9 @@ mod tests {
         decoder.push_at(key(KeyCode::Enter), now);
         decoder.push_at(key(KeyCode::Char('b')), now);
 
-        assert!(decoder.wait_timeout().is_none());
         assert!(matches!(
-            decoder.flush_expired_at(now + Duration::from_secs(60)),
-            DecodedEvents::None
-        ));
-
-        let mut output = Vec::new();
-        for event in marker(END_MARKER) {
-            collect(
-                decoder.push_at(event, now + Duration::from_secs(60)),
-                &mut output,
-            );
-        }
-        assert!(matches!(
-            output.as_slice(),
-            [Event::Paste(text)] if text == "a\rb"
+            decoder.flush_expired_at(now + PASTE_IDLE_TIMEOUT),
+            DecodedEvents::One(Event::Paste(text)) if text == "a\rb"
         ));
     }
 

--- a/src/terminal/host_input.rs
+++ b/src/terminal/host_input.rs
@@ -10,10 +10,18 @@ use std::time::{Duration, Instant};
 
 use ratatui::crossterm::event::{Event, KeyCode, KeyEventKind};
 
+#[cfg(any(windows, test))]
+mod console;
+#[cfg(windows)]
+mod windows;
+
+#[cfg(windows)]
+pub use windows::run_input_loop;
+
 const START_MARKER: &[char] = &['\u{1b}', '[', '2', '0', '0', '~'];
 const END_MARKER: &[char] = &['\u{1b}', '[', '2', '0', '1', '~'];
 const PREFIX_TIMEOUT: Duration = Duration::from_millis(40);
-const PASTE_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+const NATIVE_PREFIX_TIMEOUT: Duration = Duration::from_secs(1);
 const MAX_PASTE_CHUNK_BYTES: usize = 8 * 1024 * 1024;
 
 /// Zero, one, or a rare batch of decoded terminal events.
@@ -67,7 +75,6 @@ enum DecodeState {
     Paste {
         text: String,
         ending: String,
-        deadline: Instant,
     },
 }
 
@@ -91,9 +98,38 @@ impl HostInputDecoder {
     }
 
     fn push_at(&mut self, event: Event, now: Instant) -> DecodedEvents {
+        self.push_at_with_policy(event, now, true, PREFIX_TIMEOUT)
+    }
+
+    /// Decode one event produced from a native Windows console record.
+    ///
+    /// A physical Escape key has a scan code and can bypass marker detection,
+    /// so it is delivered immediately. Synthetic scan-code-zero Escape records
+    /// may begin a terminal control sequence and receive a wider continuation
+    /// window than Crossterm's fallback path.
+    pub(super) fn push_native(
+        &mut self,
+        event: Event,
+        can_start_marker: bool,
+        now: Instant,
+    ) -> DecodedEvents {
+        self.push_at_with_policy(event, now, can_start_marker, NATIVE_PREFIX_TIMEOUT)
+    }
+
+    pub(super) fn is_pasting(&self) -> bool {
+        matches!(self.state, DecodeState::Paste { .. })
+    }
+
+    fn push_at_with_policy(
+        &mut self,
+        event: Event,
+        now: Instant,
+        can_start_marker: bool,
+        prefix_timeout: Duration,
+    ) -> DecodedEvents {
         let state = std::mem::replace(&mut self.state, DecodeState::Idle);
         match state {
-            DecodeState::Idle => self.push_idle(event, now),
+            DecodeState::Idle => self.push_idle(event, now, can_start_marker, prefix_timeout),
             DecodeState::Prefix {
                 mut events,
                 matched,
@@ -103,7 +139,7 @@ impl HostInputDecoder {
                     self.state = DecodeState::Prefix {
                         events,
                         matched,
-                        deadline: now + PREFIX_TIMEOUT,
+                        deadline: now + prefix_timeout,
                     };
                     return DecodedEvents::None;
                 }
@@ -125,35 +161,39 @@ impl HostInputDecoder {
                         self.state = DecodeState::Paste {
                             text: String::new(),
                             ending: String::new(),
-                            deadline: now + PASTE_IDLE_TIMEOUT,
                         };
                     } else {
                         self.state = DecodeState::Prefix {
                             events,
                             matched,
-                            deadline: now + PREFIX_TIMEOUT,
+                            deadline: now + prefix_timeout,
                         };
                     }
                     DecodedEvents::None
                 } else {
                     let replay = DecodedEvents::Many(events);
-                    replay.combine(self.push_idle(event, now))
+                    replay.combine(self.push_idle(event, now, can_start_marker, prefix_timeout))
                 }
             }
             DecodeState::Paste {
                 mut text,
                 mut ending,
-                deadline: _,
-            } => self.push_paste(event, now, &mut text, &mut ending),
+            } => self.push_paste(event, &mut text, &mut ending),
         }
     }
 
-    fn push_idle(&mut self, event: Event, now: Instant) -> DecodedEvents {
-        if marker_char(&event) == Some(START_MARKER[0]) {
+    fn push_idle(
+        &mut self,
+        event: Event,
+        now: Instant,
+        can_start_marker: bool,
+        prefix_timeout: Duration,
+    ) -> DecodedEvents {
+        if can_start_marker && marker_char(&event) == Some(START_MARKER[0]) {
             self.state = DecodeState::Prefix {
                 events: vec![event],
                 matched: 1,
-                deadline: now + PREFIX_TIMEOUT,
+                deadline: now + prefix_timeout,
             };
             DecodedEvents::None
         } else {
@@ -164,7 +204,6 @@ impl HostInputDecoder {
     fn push_paste(
         &mut self,
         event: Event,
-        now: Instant,
         text: &mut String,
         ending: &mut String,
     ) -> DecodedEvents {
@@ -172,14 +211,13 @@ impl HostInputDecoder {
             text.push_str(ending);
             ending.clear();
             text.push_str(&pasted);
-            return self.keep_or_chunk(text, ending, now);
+            return self.keep_or_chunk(text, ending);
         }
 
         let Event::Key(key) = &event else {
             self.state = DecodeState::Paste {
                 text: std::mem::take(text),
                 ending: std::mem::take(ending),
-                deadline: now + PASTE_IDLE_TIMEOUT,
             };
             return DecodedEvents::One(event);
         };
@@ -187,7 +225,6 @@ impl HostInputDecoder {
             self.state = DecodeState::Paste {
                 text: std::mem::take(text),
                 ending: std::mem::take(ending),
-                deadline: now + PASTE_IDLE_TIMEOUT,
             };
             return DecodedEvents::None;
         }
@@ -206,7 +243,6 @@ impl HostInputDecoder {
                 self.state = DecodeState::Paste {
                     text: std::mem::take(text),
                     ending: std::mem::take(ending),
-                    deadline: now + PASTE_IDLE_TIMEOUT,
                 };
                 return DecodedEvents::None;
             }
@@ -219,15 +255,10 @@ impl HostInputDecoder {
         } else {
             text.push(character);
         }
-        self.keep_or_chunk(text, ending, now)
+        self.keep_or_chunk(text, ending)
     }
 
-    fn keep_or_chunk(
-        &mut self,
-        text: &mut String,
-        ending: &mut String,
-        now: Instant,
-    ) -> DecodedEvents {
+    fn keep_or_chunk(&mut self, text: &mut String, ending: &mut String) -> DecodedEvents {
         let output = if text.len() >= MAX_PASTE_CHUNK_BYTES {
             DecodedEvents::One(Event::Paste(std::mem::take(text)))
         } else {
@@ -236,18 +267,16 @@ impl HostInputDecoder {
         self.state = DecodeState::Paste {
             text: std::mem::take(text),
             ending: std::mem::take(ending),
-            deadline: now + PASTE_IDLE_TIMEOUT,
         };
         output
     }
 
-    /// Time until held input must be released. Detection always uses explicit
-    /// markers; this deadline only prevents a lone Escape or damaged paste from
-    /// leaving the decoder stuck indefinitely.
+    /// Time until a possible start-marker prefix must be released. Once a full
+    /// start marker arrives, only its matching end marker closes the paste.
     pub fn wait_timeout(&self) -> Option<Duration> {
         let deadline = match &self.state {
-            DecodeState::Idle => return None,
-            DecodeState::Prefix { deadline, .. } | DecodeState::Paste { deadline, .. } => *deadline,
+            DecodeState::Idle | DecodeState::Paste { .. } => return None,
+            DecodeState::Prefix { deadline, .. } => *deadline,
         };
         Some(deadline.saturating_duration_since(Instant::now()))
     }
@@ -258,10 +287,8 @@ impl HostInputDecoder {
 
     fn flush_expired_at(&mut self, now: Instant) -> DecodedEvents {
         let expired = match &self.state {
-            DecodeState::Idle => false,
-            DecodeState::Prefix { deadline, .. } | DecodeState::Paste { deadline, .. } => {
-                now >= *deadline
-            }
+            DecodeState::Idle | DecodeState::Paste { .. } => false,
+            DecodeState::Prefix { deadline, .. } => now >= *deadline,
         };
         if !expired {
             return DecodedEvents::None;
@@ -269,11 +296,7 @@ impl HostInputDecoder {
         match std::mem::replace(&mut self.state, DecodeState::Idle) {
             DecodeState::Idle => DecodedEvents::None,
             DecodeState::Prefix { events, .. } => DecodedEvents::Many(events),
-            DecodeState::Paste {
-                mut text,
-                mut ending,
-                ..
-            } => finish_paste(&mut text, &mut ending),
+            DecodeState::Paste { .. } => unreachable!("paste states do not expire"),
         }
     }
 }
@@ -534,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn unterminated_paste_flushes_content_without_markers() {
+    fn unterminated_paste_waits_for_its_real_end_marker() {
         let now = Instant::now();
         let mut decoder = HostInputDecoder::default();
         for event in marker(START_MARKER) {
@@ -544,9 +567,22 @@ mod tests {
         decoder.push_at(key(KeyCode::Enter), now);
         decoder.push_at(key(KeyCode::Char('b')), now);
 
+        assert!(decoder.wait_timeout().is_none());
         assert!(matches!(
-            decoder.flush_expired_at(now + PASTE_IDLE_TIMEOUT),
-            DecodedEvents::One(Event::Paste(text)) if text == "a\rb"
+            decoder.flush_expired_at(now + Duration::from_secs(60)),
+            DecodedEvents::None
+        ));
+
+        let mut output = Vec::new();
+        for event in marker(END_MARKER) {
+            collect(
+                decoder.push_at(event, now + Duration::from_secs(60)),
+                &mut output,
+            );
+        }
+        assert!(matches!(
+            output.as_slice(),
+            [Event::Paste(text)] if text == "a\rb"
         ));
     }
 

--- a/src/terminal/host_input/console.rs
+++ b/src/terminal/host_input/console.rs
@@ -25,6 +25,7 @@ pub(super) const MOUSE_WHEELED: u32 = 0x0004;
 pub(super) const MOUSE_HWHEELED: u32 = 0x0008;
 
 const STREAM_TIMEOUT: Duration = Duration::from_millis(100);
+const MAX_STREAM_RECORDS: usize = 128;
 const START_MARKER: &str = "\u{1b}[200~";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -177,6 +178,9 @@ impl ConsoleStreamDecoder {
         }
         self.control.records.push(record);
         self.control.deadline = Some(now + STREAM_TIMEOUT);
+        if self.control.records.len() >= MAX_STREAM_RECORDS {
+            return self.flush_control(now);
+        }
         let text = record_text(&self.control.records);
 
         if text == START_MARKER {
@@ -225,6 +229,9 @@ impl Win32RecordFramer {
         }
         self.records.push(record);
         self.deadline = Some(now + STREAM_TIMEOUT);
+        if self.records.len() >= MAX_STREAM_RECORDS {
+            return self.flush();
+        }
 
         let text = record_text(&self.records);
         if text == "\u{1b}" || text == "\u{1b}[" {
@@ -934,5 +941,39 @@ mod tests {
                 control_state: 0,
             })
         );
+    }
+
+    #[test]
+    fn pending_win32_reports_are_bounded() {
+        let mut framer = Win32RecordFramer::default();
+        let now = Instant::now();
+        let mut output = Vec::new();
+        for ch in std::iter::once('\u{1b}')
+            .chain(std::iter::once('['))
+            .chain(std::iter::repeat_n('1', MAX_STREAM_RECORDS - 2))
+        {
+            output.extend(framer.push(key_char(ch), now));
+        }
+        assert_eq!(output.len(), 1);
+        assert!(matches!(&output[0], Win32Item::Raw(records)
+            if records.len() == MAX_STREAM_RECORDS));
+        assert!(framer.records.is_empty());
+        assert!(framer.deadline.is_none());
+    }
+
+    #[test]
+    fn pending_control_sequences_are_bounded() {
+        let mut decoder = ConsoleStreamDecoder::default();
+        let now = Instant::now();
+        let mut output = DecodedEvents::None;
+        for ch in std::iter::once('\u{1b}')
+            .chain("[<".chars())
+            .chain(std::iter::repeat_n('1', MAX_STREAM_RECORDS - 3))
+        {
+            output = output.combine(decoder.push_record(key_char(ch), now));
+        }
+        assert!(!matches!(output, DecodedEvents::None));
+        assert!(decoder.control.records.is_empty());
+        assert!(decoder.control.deadline.is_none());
     }
 }

--- a/src/terminal/host_input/console.rs
+++ b/src/terminal/host_input/console.rs
@@ -1,12 +1,9 @@
-//! Platform-neutral translation of Windows console records into Crossterm events.
+//! Decode Windows console input without losing native key or paste boundaries.
 //!
-//! The OS reader lives in `windows.rs`. Keeping the record model here lets the
-//! Windows behavior be regression-tested on every CI host without pretending a
-//! synthetic fixture is a live ConPTY test.
+//! The OS reader is Windows-only, while this record model and decoder stay
+//! platform-neutral so protocol fixtures run on every CI host.
 
-#[cfg(windows)]
-use std::time::Duration;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ratatui::crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
@@ -27,6 +24,9 @@ pub(super) const MOUSE_MOVED: u32 = 0x0001;
 pub(super) const MOUSE_WHEELED: u32 = 0x0004;
 pub(super) const MOUSE_HWHEELED: u32 = 0x0008;
 
+const STREAM_TIMEOUT: Duration = Duration::from_millis(100);
+const START_MARKER: &str = "\u{1b}[200~";
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(super) struct ConsoleKeyRecord {
     pub key_down: bool,
@@ -46,6 +46,384 @@ pub(super) struct ConsoleMouseRecord {
     pub event_flags: u32,
 }
 
+/// Restores Win32-input-mode reports before translating them into Crossterm's
+/// semantic event model.
+#[derive(Default)]
+pub(super) struct ConsoleStreamDecoder {
+    semantic: ConsoleInputDecoder,
+    win32: Win32RecordFramer,
+    control: RawControlFramer,
+}
+
+#[derive(Default)]
+struct Win32RecordFramer {
+    records: Vec<ConsoleKeyRecord>,
+    deadline: Option<Instant>,
+}
+
+#[derive(Default)]
+struct RawControlFramer {
+    records: Vec<ConsoleKeyRecord>,
+    deadline: Option<Instant>,
+}
+
+enum Win32Item {
+    Raw(Vec<ConsoleKeyRecord>),
+    Record(ConsoleKeyRecord),
+}
+
+impl ConsoleStreamDecoder {
+    pub(super) fn push_key(&mut self, record: ConsoleKeyRecord, now: Instant) -> DecodedEvents {
+        if self.win32.is_pending() || stream_record_candidate(record) {
+            let mut output = DecodedEvents::None;
+            if record.key_down {
+                let repeats = record.repeat_count.max(1);
+                for _ in 0..repeats {
+                    let mut stream_record = record;
+                    stream_record.repeat_count = 1;
+                    if stream_record.utf16 == 0
+                        && stream_record.virtual_key == VK_ESCAPE
+                        && stream_record.scan_code == 0
+                        && stream_record.control_state == 0
+                    {
+                        stream_record.utf16 = 0x1b;
+                    }
+                    for item in self.win32.push(stream_record, now) {
+                        output = output.combine(self.push_item(item, now));
+                    }
+                }
+            }
+            return output;
+        }
+
+        let mut output = DecodedEvents::None;
+        for item in self.win32.flush() {
+            output = output.combine(self.push_item(item, now));
+        }
+        output.combine(self.push_record(record, now))
+    }
+
+    pub(super) fn push_mouse(&mut self, record: ConsoleMouseRecord, now: Instant) -> DecodedEvents {
+        let pending = self.flush_stream(now);
+        pending.combine(self.semantic.push_mouse(record, now))
+    }
+
+    pub(super) fn push_event(&mut self, event: Event, now: Instant) -> DecodedEvents {
+        let pending = self.flush_stream(now);
+        pending.combine(self.semantic.push_event(event, now))
+    }
+
+    pub(super) fn flush_expired(&mut self, now: Instant) -> DecodedEvents {
+        let mut output = DecodedEvents::None;
+        if self.win32.expired(now) {
+            for item in self.win32.flush() {
+                output = output.combine(self.push_item(item, now));
+            }
+            output = output.combine(self.flush_control(now));
+        }
+        if self.control.expired(now) {
+            output = output.combine(self.flush_control(now));
+        }
+        output.combine(self.semantic.flush_expired())
+    }
+
+    pub(super) fn wait_timeout(&self, now: Instant) -> Option<Duration> {
+        [
+            self.win32.deadline,
+            self.control.deadline,
+            self.semantic.wait_timeout().map(|duration| now + duration),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .map(|deadline| deadline.saturating_duration_since(now))
+    }
+
+    fn flush_stream(&mut self, now: Instant) -> DecodedEvents {
+        let mut output = DecodedEvents::None;
+        for item in self.win32.flush() {
+            output = output.combine(self.push_item(item, now));
+        }
+        output.combine(self.flush_control(now))
+    }
+
+    fn push_item(&mut self, item: Win32Item, now: Instant) -> DecodedEvents {
+        match item {
+            Win32Item::Record(record) => self.push_record(record, now),
+            Win32Item::Raw(records) => records
+                .into_iter()
+                .fold(DecodedEvents::None, |output, record| {
+                    output.combine(self.push_record(record, now))
+                }),
+        }
+    }
+
+    fn push_record(&mut self, record: ConsoleKeyRecord, now: Instant) -> DecodedEvents {
+        if self.semantic.is_pasting() {
+            return self.semantic.push_key(record, now);
+        }
+
+        if self.control.records.is_empty() {
+            if raw_escape_candidate(record) {
+                self.control.records.push(record);
+                self.control.deadline = Some(now + STREAM_TIMEOUT);
+                return DecodedEvents::None;
+            }
+            return self.semantic.push_key(record, now);
+        }
+
+        if !record.key_down || record.utf16 == 0 {
+            return DecodedEvents::None;
+        }
+        self.control.records.push(record);
+        self.control.deadline = Some(now + STREAM_TIMEOUT);
+        let text = record_text(&self.control.records);
+
+        if text == START_MARKER {
+            let records = std::mem::take(&mut self.control.records);
+            self.control.deadline = None;
+            return records
+                .into_iter()
+                .flat_map(|record| record_chars(record).map(record_for_char))
+                .fold(DecodedEvents::None, |output, record| {
+                    output.combine(self.semantic.push_key(record, now))
+                });
+        }
+        if let Some(event) = complete_control_event(&text) {
+            self.control.records.clear();
+            self.control.deadline = None;
+            return self.semantic.push_event(event, now);
+        }
+        if control_prefix(&text) {
+            return DecodedEvents::None;
+        }
+        self.flush_control(now)
+    }
+
+    fn flush_control(&mut self, now: Instant) -> DecodedEvents {
+        self.control.deadline = None;
+        std::mem::take(&mut self.control.records)
+            .into_iter()
+            .fold(DecodedEvents::None, |output, record| {
+                output.combine(self.semantic.push_key(record, now))
+            })
+    }
+}
+
+impl Win32RecordFramer {
+    fn is_pending(&self) -> bool {
+        !self.records.is_empty()
+    }
+
+    fn expired(&self, now: Instant) -> bool {
+        self.deadline.is_some_and(|deadline| now >= deadline)
+    }
+
+    fn push(&mut self, record: ConsoleKeyRecord, now: Instant) -> Vec<Win32Item> {
+        if self.records.is_empty() && record.utf16 != 0x1b {
+            return vec![Win32Item::Raw(vec![record])];
+        }
+        self.records.push(record);
+        self.deadline = Some(now + STREAM_TIMEOUT);
+
+        let text = record_text(&self.records);
+        if text == "\u{1b}" || text == "\u{1b}[" {
+            return Vec::new();
+        }
+        if let Some(body) = text.strip_prefix("\u{1b}[") {
+            if let Some(body) = body.strip_suffix('_') {
+                let records = std::mem::take(&mut self.records);
+                self.deadline = None;
+                return vec![parse_win32_record(body)
+                    .map(Win32Item::Record)
+                    .unwrap_or(Win32Item::Raw(records))];
+            }
+            if body.chars().all(|ch| ch.is_ascii_digit() || ch == ';') {
+                return Vec::new();
+            }
+        }
+        self.flush()
+    }
+
+    fn flush(&mut self) -> Vec<Win32Item> {
+        self.deadline = None;
+        if self.records.is_empty() {
+            Vec::new()
+        } else {
+            vec![Win32Item::Raw(std::mem::take(&mut self.records))]
+        }
+    }
+}
+
+impl RawControlFramer {
+    fn expired(&self, now: Instant) -> bool {
+        self.deadline.is_some_and(|deadline| now >= deadline)
+    }
+}
+
+fn parse_win32_record(body: &str) -> Option<ConsoleKeyRecord> {
+    let mut fields = body.split(';');
+    let mut next = |default: u32| -> Option<u32> {
+        let field = fields.next()?;
+        if field.is_empty() {
+            Some(default)
+        } else {
+            field.parse().ok()
+        }
+    };
+    let record = ConsoleKeyRecord {
+        virtual_key: u16::try_from(next(0)?).ok()?,
+        scan_code: u16::try_from(next(0)?).ok()?,
+        utf16: u16::try_from(next(0)?).ok()?,
+        key_down: next(0)? != 0,
+        control_state: next(0)?,
+        repeat_count: u16::try_from(next(1)?).ok()?,
+    };
+    fields.next().is_none().then_some(record)
+}
+
+fn stream_record_candidate(record: ConsoleKeyRecord) -> bool {
+    record.key_down
+        && (record.virtual_key == 0
+            || record.scan_code == 0
+            || (record.utf16 == 0x1b && record.scan_code == 0 && record.control_state == 0))
+}
+
+fn record_for_char(ch: char) -> ConsoleKeyRecord {
+    ConsoleKeyRecord {
+        key_down: true,
+        repeat_count: 1,
+        utf16: ch as u32 as u16,
+        ..ConsoleKeyRecord::default()
+    }
+}
+
+fn record_chars(record: ConsoleKeyRecord) -> impl Iterator<Item = char> {
+    char::from_u32(u32::from(record.utf16)).into_iter()
+}
+
+fn record_text(records: &[ConsoleKeyRecord]) -> String {
+    records
+        .iter()
+        .filter_map(|record| char::from_u32(u32::from(record.utf16)))
+        .collect()
+}
+
+fn raw_escape_candidate(record: ConsoleKeyRecord) -> bool {
+    record.key_down
+        && record.scan_code == 0
+        && record.control_state == 0
+        && (record.utf16 == 0x1b || (record.virtual_key == VK_ESCAPE && record.scan_code == 0))
+}
+
+fn control_prefix(text: &str) -> bool {
+    if START_MARKER.starts_with(text)
+        || "\u{1b}[I".starts_with(text)
+        || "\u{1b}[O".starts_with(text)
+    {
+        return true;
+    }
+    if let Some(body) = text.strip_prefix("\u{1b}[<") {
+        return body.chars().all(|ch| ch.is_ascii_digit() || ch == ';');
+    }
+    for sequence in [
+        "\u{1b}[A",
+        "\u{1b}[B",
+        "\u{1b}[C",
+        "\u{1b}[D",
+        "\u{1b}[H",
+        "\u{1b}[F",
+        "\u{1b}[Z",
+        "\u{1b}[2~",
+        "\u{1b}[3~",
+        "\u{1b}[5~",
+        "\u{1b}[6~",
+    ] {
+        if sequence.starts_with(text) {
+            return true;
+        }
+    }
+    false
+}
+
+fn complete_control_event(text: &str) -> Option<Event> {
+    let code = match text {
+        "\u{1b}[A" => Some(KeyCode::Up),
+        "\u{1b}[B" => Some(KeyCode::Down),
+        "\u{1b}[C" => Some(KeyCode::Right),
+        "\u{1b}[D" => Some(KeyCode::Left),
+        "\u{1b}[H" => Some(KeyCode::Home),
+        "\u{1b}[F" => Some(KeyCode::End),
+        "\u{1b}[Z" => Some(KeyCode::BackTab),
+        "\u{1b}[2~" => Some(KeyCode::Insert),
+        "\u{1b}[3~" => Some(KeyCode::Delete),
+        "\u{1b}[5~" => Some(KeyCode::PageUp),
+        "\u{1b}[6~" => Some(KeyCode::PageDown),
+        _ => None,
+    };
+    if let Some(code) = code {
+        return Some(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)));
+    }
+    match text {
+        "\u{1b}[I" => return Some(Event::FocusGained),
+        "\u{1b}[O" => return Some(Event::FocusLost),
+        _ => {}
+    }
+    parse_sgr_mouse(text).map(Event::Mouse)
+}
+
+fn parse_sgr_mouse(text: &str) -> Option<MouseEvent> {
+    let body = text.strip_prefix("\u{1b}[<")?;
+    let final_byte = body.as_bytes().last().copied()?;
+    if !matches!(final_byte, b'M' | b'm') {
+        return None;
+    }
+    let mut fields = body[..body.len() - 1].split(';');
+    let code = fields.next()?.parse::<u16>().ok()?;
+    let column = fields.next()?.parse::<u16>().ok()?.saturating_sub(1);
+    let row = fields.next()?.parse::<u16>().ok()?.saturating_sub(1);
+    if fields.next().is_some() {
+        return None;
+    }
+    let mut modifiers = KeyModifiers::NONE;
+    if code & 4 != 0 {
+        modifiers.insert(KeyModifiers::SHIFT);
+    }
+    if code & 8 != 0 {
+        modifiers.insert(KeyModifiers::ALT);
+    }
+    if code & 16 != 0 {
+        modifiers.insert(KeyModifiers::CONTROL);
+    }
+    let button = match code & 3 {
+        0 => MouseButton::Left,
+        1 => MouseButton::Middle,
+        2 => MouseButton::Right,
+        _ => MouseButton::Left,
+    };
+    let kind = if code & 64 != 0 {
+        if code & 1 == 0 {
+            MouseEventKind::ScrollUp
+        } else {
+            MouseEventKind::ScrollDown
+        }
+    } else if code & 32 != 0 && code & 3 == 3 {
+        MouseEventKind::Moved
+    } else if final_byte == b'm' || code & 3 == 3 {
+        MouseEventKind::Up(button)
+    } else if code & 32 != 0 {
+        MouseEventKind::Drag(button)
+    } else {
+        MouseEventKind::Down(button)
+    };
+    Some(MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers,
+    })
+}
+
 #[derive(Default)]
 pub(super) struct ConsoleInputDecoder {
     paste: HostInputDecoder,
@@ -61,12 +439,15 @@ struct MouseButtons {
 }
 
 impl ConsoleInputDecoder {
+    fn is_pasting(&self) -> bool {
+        self.paste.is_pasting()
+    }
+
     pub(super) fn push_key(&mut self, record: ConsoleKeyRecord, now: Instant) -> DecodedEvents {
         if modifier_only(record.virtual_key, record.utf16) {
             self.pending_high_surrogate = None;
             return DecodedEvents::None;
         }
-
         let repeats = if record.key_down {
             record.repeat_count.max(1)
         } else {
@@ -75,8 +456,6 @@ impl ConsoleInputDecoder {
         let mut output = DecodedEvents::None;
         for index in 0..repeats {
             let kind = if !record.key_down {
-                // Alt+numpad characters are carried on the Alt release record.
-                // Treat that payload as text instead of dropping it as a release.
                 if record.virtual_key == VK_MENU && record.utf16 != 0 {
                     KeyEventKind::Press
                 } else {
@@ -92,11 +471,11 @@ impl ConsoleInputDecoder {
             };
             let modifiers = modifiers(record.control_state);
             let event = Event::Key(KeyEvent::new_with_kind(code, modifiers, kind));
-            let synthetic_marker_escape = record.key_down
+            let can_start_marker = record.key_down
                 && record.scan_code == 0
                 && modifiers.is_empty()
                 && matches!(event, Event::Key(ref key) if key.code == KeyCode::Esc);
-            output = output.combine(self.paste.push_native(event, synthetic_marker_escape, now));
+            output = output.combine(self.paste.push_native(event, can_start_marker, now));
         }
         output
     }
@@ -108,15 +487,13 @@ impl ConsoleInputDecoder {
             middle: record.button_state & FROM_LEFT_2ND_BUTTON_PRESSED != 0,
         };
         let kind = if record.event_flags & MOUSE_WHEELED != 0 {
-            let delta = (record.button_state >> 16) as u16 as i16;
-            if delta < 0 {
+            if ((record.button_state >> 16) as u16 as i16) < 0 {
                 MouseEventKind::ScrollDown
             } else {
                 MouseEventKind::ScrollUp
             }
         } else if record.event_flags & MOUSE_HWHEELED != 0 {
-            let delta = (record.button_state >> 16) as u16 as i16;
-            if delta < 0 {
+            if ((record.button_state >> 16) as u16 as i16) < 0 {
                 MouseEventKind::ScrollLeft
             } else {
                 MouseEventKind::ScrollRight
@@ -163,33 +540,26 @@ impl ConsoleInputDecoder {
         self.paste.push_native(event, false, now)
     }
 
-    #[cfg(windows)]
     pub(super) fn flush_expired(&mut self) -> DecodedEvents {
         self.paste.flush_expired()
     }
 
-    #[cfg(windows)]
     pub(super) fn wait_timeout(&self) -> Option<Duration> {
         self.paste.wait_timeout()
     }
 
     fn key_code(&mut self, record: ConsoleKeyRecord) -> Option<KeyCode> {
         let mods = modifiers(record.control_state);
-
-        // Once a bracketed paste has started, the Unicode payload is data, not
-        // keyboard intent. In particular, a pasted control character must not
-        // be reconstructed as Ctrl+letter, and a dead-key/layout fallback must
-        // not synthesize text that was not present in the clipboard stream.
         if self.paste.is_pasting() {
             return self.decode_utf16(record.utf16).map(|ch| match ch {
                 '\u{8}' => KeyCode::Backspace,
                 '\t' => KeyCode::Tab,
                 '\r' => KeyCode::Enter,
+                '\n' => KeyCode::Char('\n'),
                 '\u{1b}' => KeyCode::Esc,
                 _ => KeyCode::Char(ch),
             });
         }
-
         let special = match record.virtual_key {
             VK_BACK => Some(KeyCode::Backspace),
             VK_TAB if mods.contains(KeyModifiers::SHIFT) => Some(KeyCode::BackTab),
@@ -213,7 +583,6 @@ impl ConsoleInputDecoder {
             self.pending_high_surrogate = None;
             return special;
         }
-
         if let Some(ch) = self.decode_utf16(record.utf16) {
             return Some(match ch {
                 '\u{8}' => KeyCode::Backspace,
@@ -230,15 +599,14 @@ impl ConsoleInputDecoder {
                 _ => KeyCode::Char(ch),
             });
         }
-
         self.pending_high_surrogate = None;
         match record.virtual_key {
             VK_A..=VK_Z if mods.contains(KeyModifiers::CONTROL) => {
-                let mut ch = (record.virtual_key as u8).to_ascii_lowercase() as char;
-                if mods.contains(KeyModifiers::SHIFT) {
-                    ch = ch.to_ascii_uppercase();
-                }
-                Some(KeyCode::Char(ch))
+                Some(KeyCode::Char(if mods.contains(KeyModifiers::SHIFT) {
+                    record.virtual_key as u8 as char
+                } else {
+                    (record.virtual_key as u8).to_ascii_lowercase() as char
+                }))
             }
             VK_0..=VK_9 if mods.contains(KeyModifiers::CONTROL) => {
                 Some(KeyCode::Char(record.virtual_key as u8 as char))
@@ -249,34 +617,38 @@ impl ConsoleInputDecoder {
     }
 
     fn decode_utf16(&mut self, unit: u16) -> Option<char> {
-        if unit == 0 {
-            return None;
-        }
-        if (0xd800..=0xdbff).contains(&unit) {
-            self.pending_high_surrogate = Some(unit);
-            return None;
-        }
-        if (0xdc00..=0xdfff).contains(&unit) {
-            let high = self.pending_high_surrogate.take()?;
-            return char::decode_utf16([high, unit]).next()?.ok();
-        }
-        self.pending_high_surrogate = None;
-        char::from_u32(u32::from(unit))
+        decode_utf16_unit(&mut self.pending_high_surrogate, unit)
     }
 }
 
+fn decode_utf16_unit(pending: &mut Option<u16>, unit: u16) -> Option<char> {
+    if unit == 0 {
+        return None;
+    }
+    if (0xd800..=0xdbff).contains(&unit) {
+        *pending = Some(unit);
+        return None;
+    }
+    if (0xdc00..=0xdfff).contains(&unit) {
+        let high = pending.take()?;
+        return char::decode_utf16([high, unit]).next()?.ok();
+    }
+    *pending = None;
+    char::from_u32(u32::from(unit))
+}
+
 fn modifiers(state: u32) -> KeyModifiers {
-    let mut modifiers = KeyModifiers::NONE;
+    let mut value = KeyModifiers::NONE;
     if state & SHIFT_PRESSED != 0 {
-        modifiers.insert(KeyModifiers::SHIFT);
+        value.insert(KeyModifiers::SHIFT);
     }
     if state & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED) != 0 {
-        modifiers.insert(KeyModifiers::CONTROL);
+        value.insert(KeyModifiers::CONTROL);
     }
     if state & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED) != 0 {
-        modifiers.insert(KeyModifiers::ALT);
+        value.insert(KeyModifiers::ALT);
     }
-    modifiers
+    value
 }
 
 fn modifier_only(virtual_key: u16, utf16: u16) -> bool {
@@ -302,6 +674,7 @@ const VK_SHIFT: u16 = 0x10;
 const VK_CONTROL: u16 = 0x11;
 const VK_MENU: u16 = 0x12;
 const VK_ESCAPE: u16 = 0x1b;
+const VK_SPACE: u16 = 0x20;
 const VK_PRIOR: u16 = 0x21;
 const VK_NEXT: u16 = 0x22;
 const VK_END: u16 = 0x23;
@@ -312,7 +685,6 @@ const VK_RIGHT: u16 = 0x27;
 const VK_DOWN: u16 = 0x28;
 const VK_INSERT: u16 = 0x2d;
 const VK_DELETE: u16 = 0x2e;
-const VK_SPACE: u16 = 0x20;
 const VK_0: u16 = 0x30;
 const VK_9: u16 = 0x39;
 const VK_A: u16 = 0x41;
@@ -330,102 +702,134 @@ const VK_RMENU: u16 = 0xa5;
 mod tests {
     use super::*;
 
-    fn key(ch: char) -> ConsoleKeyRecord {
-        ConsoleKeyRecord {
-            key_down: true,
-            repeat_count: 1,
-            utf16: ch as u16,
-            ..ConsoleKeyRecord::default()
-        }
+    fn key_char(ch: char) -> ConsoleKeyRecord {
+        record_for_char(ch)
     }
 
-    fn collect(output: DecodedEvents) -> Vec<Event> {
+    fn encoded(record: ConsoleKeyRecord) -> Vec<ConsoleKeyRecord> {
+        format!(
+            "\u{1b}[{};{};{};{};{};{}_",
+            record.virtual_key,
+            record.scan_code,
+            record.utf16,
+            u8::from(record.key_down),
+            record.control_state,
+            record.repeat_count,
+        )
+        .chars()
+        .map(key_char)
+        .collect()
+    }
+
+    fn collect(records: impl IntoIterator<Item = ConsoleKeyRecord>) -> Vec<Event> {
+        let mut decoder = ConsoleStreamDecoder::default();
+        let now = Instant::now();
+        let mut events = Vec::new();
+        for record in records {
+            decoder
+                .push_key(record, now)
+                .for_each(|event| events.push(event));
+        }
+        events
+    }
+
+    fn decoded(output: DecodedEvents) -> Vec<Event> {
         let mut events = Vec::new();
         output.for_each(|event| events.push(event));
         events
     }
 
     #[test]
-    fn native_physical_escape_is_not_delayed() {
-        let mut decoder = ConsoleInputDecoder::default();
-        let output = decoder.push_key(
-            ConsoleKeyRecord {
+    fn win32_reports_restore_one_atomic_multiline_paste() {
+        let mut records = Vec::new();
+        for ch in "\u{1b}[200~first".chars() {
+            records.extend(encoded(ConsoleKeyRecord {
                 key_down: true,
                 repeat_count: 1,
-                virtual_key: VK_ESCAPE,
-                scan_code: 1,
-                utf16: 0x1b,
-                control_state: 0,
-            },
-            Instant::now(),
+                virtual_key: ch.to_ascii_uppercase() as u16,
+                utf16: ch as u16,
+                ..ConsoleKeyRecord::default()
+            }));
+        }
+        for key_down in [true, false] {
+            records.extend(encoded(ConsoleKeyRecord {
+                key_down,
+                repeat_count: 1,
+                virtual_key: VK_RETURN,
+                scan_code: 28,
+                utf16: '\r' as u16,
+                ..ConsoleKeyRecord::default()
+            }));
+        }
+        for ch in "second\u{1b}[201~".chars() {
+            records.extend(encoded(ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: ch.to_ascii_uppercase() as u16,
+                utf16: ch as u16,
+                ..ConsoleKeyRecord::default()
+            }));
+        }
+        assert!(
+            matches!(collect(records).as_slice(), [Event::Paste(text)] if text == "first\rsecond")
         );
+    }
+
+    #[test]
+    fn raw_vti_paste_and_ctrl_mouse_remain_semantic() {
+        let paste = collect("\u{1b}[200~one\r\ntwo\u{1b}[201~".chars().map(key_char));
+        assert!(matches!(paste.as_slice(), [Event::Paste(text)] if text == "one\r\ntwo"));
+
+        let mouse = collect("\u{1b}[<16;3;4M".chars().map(key_char));
+        assert!(matches!(mouse.as_slice(), [Event::Mouse(event)]
+            if event.kind == MouseEventKind::Down(MouseButton::Left)
+                && event.column == 2
+                && event.row == 3
+                && event.modifiers == KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn physical_escape_is_immediate() {
+        let mut decoder = ConsoleStreamDecoder::default();
+        let now = Instant::now();
+        let record = ConsoleKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            virtual_key: VK_ESCAPE,
+            scan_code: 1,
+            utf16: 0x1b,
+            ..ConsoleKeyRecord::default()
+        };
+        let output = decoder.push_key(record, now);
         assert!(matches!(output, DecodedEvents::One(Event::Key(key)) if key.code == KeyCode::Esc));
     }
 
     #[test]
-    fn native_records_form_one_complete_multiline_paste() {
-        let now = Instant::now();
+    fn native_paste_preserves_surrogate_pairs_repeats_and_control_data() {
         let mut decoder = ConsoleInputDecoder::default();
-        let mut events = Vec::new();
-        for ch in "\u{1b}[200~first\r\n\r\nsecond\u{1b}[201~".chars() {
-            decoder
-                .push_key(key(ch), now)
-                .for_each(|event| events.push(event));
-        }
-        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "first\r\n\r\nsecond"));
-    }
-
-    #[test]
-    fn native_paste_preserves_surrogate_pairs_and_repeats() {
         let now = Instant::now();
-        let mut decoder = ConsoleInputDecoder::default();
-        for ch in "\u{1b}[200~".chars() {
-            decoder.push_key(key(ch), now);
+        for ch in START_MARKER.chars() {
+            decoder.push_key(key_char(ch), now);
         }
-        decoder.push_key(
+        for record in [
             ConsoleKeyRecord {
                 key_down: true,
                 repeat_count: 1,
                 utf16: 0xd83d,
                 ..ConsoleKeyRecord::default()
             },
-            now,
-        );
-        decoder.push_key(
             ConsoleKeyRecord {
                 key_down: true,
                 repeat_count: 1,
                 utf16: 0xde00,
                 ..ConsoleKeyRecord::default()
             },
-            now,
-        );
-        decoder.push_key(
             ConsoleKeyRecord {
                 key_down: true,
                 repeat_count: 3,
                 utf16: 'x' as u16,
                 ..ConsoleKeyRecord::default()
             },
-            now,
-        );
-        let mut events = Vec::new();
-        for ch in "\u{1b}[201~".chars() {
-            decoder
-                .push_key(key(ch), now)
-                .for_each(|event| events.push(event));
-        }
-        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "😀xxx"));
-    }
-
-    #[test]
-    fn native_paste_preserves_literal_control_payload() {
-        let now = Instant::now();
-        let mut decoder = ConsoleInputDecoder::default();
-        for ch in "\u{1b}[200~".chars() {
-            decoder.push_key(key(ch), now);
-        }
-        decoder.push_key(
             ConsoleKeyRecord {
                 key_down: true,
                 repeat_count: 1,
@@ -434,38 +838,37 @@ mod tests {
                 control_state: LEFT_CTRL_PRESSED,
                 ..ConsoleKeyRecord::default()
             },
-            now,
-        );
+        ] {
+            decoder.push_key(record, now);
+        }
         let mut events = Vec::new();
         for ch in "\u{1b}[201~".chars() {
             decoder
-                .push_key(key(ch), now)
+                .push_key(key_char(ch), now)
                 .for_each(|event| events.push(event));
         }
-        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "\u{1}"));
+        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "😀xxx\u{1}"));
     }
 
     #[test]
-    fn native_zero_unicode_dead_key_does_not_invent_text() {
+    fn native_modifiers_dead_keys_and_ctrl_space_keep_their_meaning() {
         let mut decoder = ConsoleInputDecoder::default();
-        let output = decoder.push_key(
-            ConsoleKeyRecord {
-                key_down: true,
-                repeat_count: 1,
-                virtual_key: b'E' as u16,
-                scan_code: 0x12,
-                utf16: 0,
-                control_state: 0,
-            },
-            Instant::now(),
-        );
-        assert!(matches!(output, DecodedEvents::None));
-    }
-
-    #[test]
-    fn native_altgr_and_ctrl_mouse_keep_modifiers() {
-        let mut decoder = ConsoleInputDecoder::default();
-        let events = collect(decoder.push_key(
+        let now = Instant::now();
+        assert!(matches!(
+            decoder.push_key(
+                ConsoleKeyRecord {
+                    key_down: true,
+                    repeat_count: 1,
+                    virtual_key: b'E' as u16,
+                    scan_code: 0x12,
+                    utf16: 0,
+                    ..ConsoleKeyRecord::default()
+                },
+                now,
+            ),
+            DecodedEvents::None
+        ));
+        let altgr = decoded(decoder.push_key(
             ConsoleKeyRecord {
                 key_down: true,
                 repeat_count: 1,
@@ -474,43 +877,62 @@ mod tests {
                 utf16: '€' as u16,
                 control_state: LEFT_CTRL_PRESSED | RIGHT_ALT_PRESSED,
             },
-            Instant::now(),
+            now,
         ));
-        assert!(matches!(events.as_slice(), [Event::Key(key)]
+        assert!(matches!(altgr.as_slice(), [Event::Key(key)]
             if key.code == KeyCode::Char('€')
                 && key.modifiers == KeyModifiers::CONTROL | KeyModifiers::ALT));
 
-        let mouse = decoder.push_mouse(
-            ConsoleMouseRecord {
-                column: 12,
-                row: 7,
-                button_state: FROM_LEFT_1ST_BUTTON_PRESSED,
-                control_state: LEFT_CTRL_PRESSED,
-                event_flags: 0,
-            },
-            Instant::now(),
-        );
-        assert!(matches!(mouse, DecodedEvents::One(Event::Mouse(mouse))
-            if mouse.kind == MouseEventKind::Down(MouseButton::Left)
-                && mouse.modifiers == KeyModifiers::CONTROL));
-    }
-
-    #[test]
-    fn native_ctrl_space_preserves_the_default_prefix() {
-        let mut decoder = ConsoleInputDecoder::default();
-        let events = collect(decoder.push_key(
+        let ctrl_space = decoded(decoder.push_key(
             ConsoleKeyRecord {
                 key_down: true,
                 repeat_count: 1,
                 virtual_key: VK_SPACE,
                 scan_code: 0x39,
-                utf16: 0,
                 control_state: LEFT_CTRL_PRESSED,
+                ..ConsoleKeyRecord::default()
             },
-            Instant::now(),
+            now,
         ));
-        assert!(matches!(events.as_slice(), [Event::Key(key)]
+        assert!(matches!(ctrl_space.as_slice(), [Event::Key(key)]
             if key.code == KeyCode::Char(' ')
                 && key.modifiers == KeyModifiers::CONTROL));
+
+        let ctrl_shift = decoded(decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: b'V' as u16,
+                scan_code: 0x2f,
+                control_state: LEFT_CTRL_PRESSED | SHIFT_PRESSED,
+                ..ConsoleKeyRecord::default()
+            },
+            now,
+        ));
+        assert!(matches!(ctrl_shift.as_slice(), [Event::Key(key)]
+            if key.code == KeyCode::Char('V')
+                && key.modifiers == KeyModifiers::CONTROL | KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn literal_backspace_stays_inside_paste() {
+        let events = collect("\u{1b}[200~a\u{8}b\u{1b}[201~".chars().map(key_char));
+        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "a\u{8}b"));
+    }
+
+    #[test]
+    fn win32_report_rejects_extra_fields() {
+        assert!(parse_win32_record("65;30;97;1;0;1;9").is_none());
+        assert_eq!(
+            parse_win32_record("65;30;97;1;0;1"),
+            Some(ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: 65,
+                scan_code: 30,
+                utf16: 97,
+                control_state: 0,
+            })
+        );
     }
 }

--- a/src/terminal/host_input/console.rs
+++ b/src/terminal/host_input/console.rs
@@ -1,0 +1,516 @@
+//! Platform-neutral translation of Windows console records into Crossterm events.
+//!
+//! The OS reader lives in `windows.rs`. Keeping the record model here lets the
+//! Windows behavior be regression-tested on every CI host without pretending a
+//! synthetic fixture is a live ConPTY test.
+
+#[cfg(windows)]
+use std::time::Duration;
+use std::time::Instant;
+
+use ratatui::crossterm::event::{
+    Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
+
+use super::{DecodedEvents, HostInputDecoder};
+
+pub(super) const LEFT_ALT_PRESSED: u32 = 0x0002;
+pub(super) const RIGHT_ALT_PRESSED: u32 = 0x0001;
+pub(super) const LEFT_CTRL_PRESSED: u32 = 0x0008;
+pub(super) const RIGHT_CTRL_PRESSED: u32 = 0x0004;
+pub(super) const SHIFT_PRESSED: u32 = 0x0010;
+
+pub(super) const FROM_LEFT_1ST_BUTTON_PRESSED: u32 = 0x0001;
+pub(super) const RIGHTMOST_BUTTON_PRESSED: u32 = 0x0002;
+pub(super) const FROM_LEFT_2ND_BUTTON_PRESSED: u32 = 0x0004;
+pub(super) const MOUSE_MOVED: u32 = 0x0001;
+pub(super) const MOUSE_WHEELED: u32 = 0x0004;
+pub(super) const MOUSE_HWHEELED: u32 = 0x0008;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct ConsoleKeyRecord {
+    pub key_down: bool,
+    pub repeat_count: u16,
+    pub virtual_key: u16,
+    pub scan_code: u16,
+    pub utf16: u16,
+    pub control_state: u32,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct ConsoleMouseRecord {
+    pub column: u16,
+    pub row: u16,
+    pub button_state: u32,
+    pub control_state: u32,
+    pub event_flags: u32,
+}
+
+#[derive(Default)]
+pub(super) struct ConsoleInputDecoder {
+    paste: HostInputDecoder,
+    pending_high_surrogate: Option<u16>,
+    mouse_buttons: MouseButtons,
+}
+
+#[derive(Clone, Copy, Default)]
+struct MouseButtons {
+    left: bool,
+    right: bool,
+    middle: bool,
+}
+
+impl ConsoleInputDecoder {
+    pub(super) fn push_key(&mut self, record: ConsoleKeyRecord, now: Instant) -> DecodedEvents {
+        if modifier_only(record.virtual_key, record.utf16) {
+            self.pending_high_surrogate = None;
+            return DecodedEvents::None;
+        }
+
+        let repeats = if record.key_down {
+            record.repeat_count.max(1)
+        } else {
+            1
+        };
+        let mut output = DecodedEvents::None;
+        for index in 0..repeats {
+            let kind = if !record.key_down {
+                // Alt+numpad characters are carried on the Alt release record.
+                // Treat that payload as text instead of dropping it as a release.
+                if record.virtual_key == VK_MENU && record.utf16 != 0 {
+                    KeyEventKind::Press
+                } else {
+                    KeyEventKind::Release
+                }
+            } else if index == 0 {
+                KeyEventKind::Press
+            } else {
+                KeyEventKind::Repeat
+            };
+            let Some(code) = self.key_code(record) else {
+                continue;
+            };
+            let modifiers = modifiers(record.control_state);
+            let event = Event::Key(KeyEvent::new_with_kind(code, modifiers, kind));
+            let synthetic_marker_escape = record.key_down
+                && record.scan_code == 0
+                && modifiers.is_empty()
+                && matches!(event, Event::Key(ref key) if key.code == KeyCode::Esc);
+            output = output.combine(self.paste.push_native(event, synthetic_marker_escape, now));
+        }
+        output
+    }
+
+    pub(super) fn push_mouse(&mut self, record: ConsoleMouseRecord, now: Instant) -> DecodedEvents {
+        let next = MouseButtons {
+            left: record.button_state & FROM_LEFT_1ST_BUTTON_PRESSED != 0,
+            right: record.button_state & RIGHTMOST_BUTTON_PRESSED != 0,
+            middle: record.button_state & FROM_LEFT_2ND_BUTTON_PRESSED != 0,
+        };
+        let kind = if record.event_flags & MOUSE_WHEELED != 0 {
+            let delta = (record.button_state >> 16) as u16 as i16;
+            if delta < 0 {
+                MouseEventKind::ScrollDown
+            } else {
+                MouseEventKind::ScrollUp
+            }
+        } else if record.event_flags & MOUSE_HWHEELED != 0 {
+            let delta = (record.button_state >> 16) as u16 as i16;
+            if delta < 0 {
+                MouseEventKind::ScrollLeft
+            } else {
+                MouseEventKind::ScrollRight
+            }
+        } else if record.event_flags & MOUSE_MOVED != 0 {
+            if next.left {
+                MouseEventKind::Drag(MouseButton::Left)
+            } else if next.right {
+                MouseEventKind::Drag(MouseButton::Right)
+            } else if next.middle {
+                MouseEventKind::Drag(MouseButton::Middle)
+            } else {
+                MouseEventKind::Moved
+            }
+        } else if next.left && !self.mouse_buttons.left {
+            MouseEventKind::Down(MouseButton::Left)
+        } else if next.right && !self.mouse_buttons.right {
+            MouseEventKind::Down(MouseButton::Right)
+        } else if next.middle && !self.mouse_buttons.middle {
+            MouseEventKind::Down(MouseButton::Middle)
+        } else if !next.left && self.mouse_buttons.left {
+            MouseEventKind::Up(MouseButton::Left)
+        } else if !next.right && self.mouse_buttons.right {
+            MouseEventKind::Up(MouseButton::Right)
+        } else if !next.middle && self.mouse_buttons.middle {
+            MouseEventKind::Up(MouseButton::Middle)
+        } else {
+            self.mouse_buttons = next;
+            return DecodedEvents::None;
+        };
+        self.mouse_buttons = next;
+        self.push_event(
+            Event::Mouse(MouseEvent {
+                kind,
+                column: record.column,
+                row: record.row,
+                modifiers: modifiers(record.control_state),
+            }),
+            now,
+        )
+    }
+
+    pub(super) fn push_event(&mut self, event: Event, now: Instant) -> DecodedEvents {
+        self.paste.push_native(event, false, now)
+    }
+
+    #[cfg(windows)]
+    pub(super) fn flush_expired(&mut self) -> DecodedEvents {
+        self.paste.flush_expired()
+    }
+
+    #[cfg(windows)]
+    pub(super) fn wait_timeout(&self) -> Option<Duration> {
+        self.paste.wait_timeout()
+    }
+
+    fn key_code(&mut self, record: ConsoleKeyRecord) -> Option<KeyCode> {
+        let mods = modifiers(record.control_state);
+
+        // Once a bracketed paste has started, the Unicode payload is data, not
+        // keyboard intent. In particular, a pasted control character must not
+        // be reconstructed as Ctrl+letter, and a dead-key/layout fallback must
+        // not synthesize text that was not present in the clipboard stream.
+        if self.paste.is_pasting() {
+            return self.decode_utf16(record.utf16).map(|ch| match ch {
+                '\u{8}' => KeyCode::Backspace,
+                '\t' => KeyCode::Tab,
+                '\r' => KeyCode::Enter,
+                '\u{1b}' => KeyCode::Esc,
+                _ => KeyCode::Char(ch),
+            });
+        }
+
+        let special = match record.virtual_key {
+            VK_BACK => Some(KeyCode::Backspace),
+            VK_TAB if mods.contains(KeyModifiers::SHIFT) => Some(KeyCode::BackTab),
+            VK_TAB => Some(KeyCode::Tab),
+            VK_RETURN => Some(KeyCode::Enter),
+            VK_ESCAPE => Some(KeyCode::Esc),
+            VK_PRIOR => Some(KeyCode::PageUp),
+            VK_NEXT => Some(KeyCode::PageDown),
+            VK_END => Some(KeyCode::End),
+            VK_HOME => Some(KeyCode::Home),
+            VK_LEFT => Some(KeyCode::Left),
+            VK_UP => Some(KeyCode::Up),
+            VK_RIGHT => Some(KeyCode::Right),
+            VK_DOWN => Some(KeyCode::Down),
+            VK_INSERT => Some(KeyCode::Insert),
+            VK_DELETE => Some(KeyCode::Delete),
+            VK_F1..=VK_F24 => Some(KeyCode::F((record.virtual_key - VK_F1 + 1) as u8)),
+            _ => None,
+        };
+        if special.is_some() {
+            self.pending_high_surrogate = None;
+            return special;
+        }
+
+        if let Some(ch) = self.decode_utf16(record.utf16) {
+            return Some(match ch {
+                '\u{8}' => KeyCode::Backspace,
+                '\t' => KeyCode::Tab,
+                '\r' => KeyCode::Enter,
+                '\u{1b}' => KeyCode::Esc,
+                '\u{1}'..='\u{1a}' if mods.contains(KeyModifiers::CONTROL) => {
+                    KeyCode::Char((b'a' + ch as u8 - 1) as char)
+                }
+                '\u{1c}' if mods.contains(KeyModifiers::CONTROL) => KeyCode::Char('\\'),
+                '\u{1d}' if mods.contains(KeyModifiers::CONTROL) => KeyCode::Char(']'),
+                '\u{1e}' if mods.contains(KeyModifiers::CONTROL) => KeyCode::Char('^'),
+                '\u{1f}' if mods.contains(KeyModifiers::CONTROL) => KeyCode::Char('/'),
+                _ => KeyCode::Char(ch),
+            });
+        }
+
+        self.pending_high_surrogate = None;
+        match record.virtual_key {
+            VK_A..=VK_Z if mods.contains(KeyModifiers::CONTROL) => {
+                let mut ch = (record.virtual_key as u8).to_ascii_lowercase() as char;
+                if mods.contains(KeyModifiers::SHIFT) {
+                    ch = ch.to_ascii_uppercase();
+                }
+                Some(KeyCode::Char(ch))
+            }
+            VK_0..=VK_9 if mods.contains(KeyModifiers::CONTROL) => {
+                Some(KeyCode::Char(record.virtual_key as u8 as char))
+            }
+            VK_SPACE if mods.contains(KeyModifiers::CONTROL) => Some(KeyCode::Char(' ')),
+            _ => None,
+        }
+    }
+
+    fn decode_utf16(&mut self, unit: u16) -> Option<char> {
+        if unit == 0 {
+            return None;
+        }
+        if (0xd800..=0xdbff).contains(&unit) {
+            self.pending_high_surrogate = Some(unit);
+            return None;
+        }
+        if (0xdc00..=0xdfff).contains(&unit) {
+            let high = self.pending_high_surrogate.take()?;
+            return char::decode_utf16([high, unit]).next()?.ok();
+        }
+        self.pending_high_surrogate = None;
+        char::from_u32(u32::from(unit))
+    }
+}
+
+fn modifiers(state: u32) -> KeyModifiers {
+    let mut modifiers = KeyModifiers::NONE;
+    if state & SHIFT_PRESSED != 0 {
+        modifiers.insert(KeyModifiers::SHIFT);
+    }
+    if state & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED) != 0 {
+        modifiers.insert(KeyModifiers::CONTROL);
+    }
+    if state & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED) != 0 {
+        modifiers.insert(KeyModifiers::ALT);
+    }
+    modifiers
+}
+
+fn modifier_only(virtual_key: u16, utf16: u16) -> bool {
+    utf16 == 0
+        && matches!(
+            virtual_key,
+            VK_SHIFT
+                | VK_CONTROL
+                | VK_MENU
+                | VK_LSHIFT
+                | VK_RSHIFT
+                | VK_LCONTROL
+                | VK_RCONTROL
+                | VK_LMENU
+                | VK_RMENU
+        )
+}
+
+const VK_BACK: u16 = 0x08;
+const VK_TAB: u16 = 0x09;
+const VK_RETURN: u16 = 0x0d;
+const VK_SHIFT: u16 = 0x10;
+const VK_CONTROL: u16 = 0x11;
+const VK_MENU: u16 = 0x12;
+const VK_ESCAPE: u16 = 0x1b;
+const VK_PRIOR: u16 = 0x21;
+const VK_NEXT: u16 = 0x22;
+const VK_END: u16 = 0x23;
+const VK_HOME: u16 = 0x24;
+const VK_LEFT: u16 = 0x25;
+const VK_UP: u16 = 0x26;
+const VK_RIGHT: u16 = 0x27;
+const VK_DOWN: u16 = 0x28;
+const VK_INSERT: u16 = 0x2d;
+const VK_DELETE: u16 = 0x2e;
+const VK_SPACE: u16 = 0x20;
+const VK_0: u16 = 0x30;
+const VK_9: u16 = 0x39;
+const VK_A: u16 = 0x41;
+const VK_Z: u16 = 0x5a;
+const VK_F1: u16 = 0x70;
+const VK_F24: u16 = 0x87;
+const VK_LSHIFT: u16 = 0xa0;
+const VK_RSHIFT: u16 = 0xa1;
+const VK_LCONTROL: u16 = 0xa2;
+const VK_RCONTROL: u16 = 0xa3;
+const VK_LMENU: u16 = 0xa4;
+const VK_RMENU: u16 = 0xa5;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(ch: char) -> ConsoleKeyRecord {
+        ConsoleKeyRecord {
+            key_down: true,
+            repeat_count: 1,
+            utf16: ch as u16,
+            ..ConsoleKeyRecord::default()
+        }
+    }
+
+    fn collect(output: DecodedEvents) -> Vec<Event> {
+        let mut events = Vec::new();
+        output.for_each(|event| events.push(event));
+        events
+    }
+
+    #[test]
+    fn native_physical_escape_is_not_delayed() {
+        let mut decoder = ConsoleInputDecoder::default();
+        let output = decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: VK_ESCAPE,
+                scan_code: 1,
+                utf16: 0x1b,
+                control_state: 0,
+            },
+            Instant::now(),
+        );
+        assert!(matches!(output, DecodedEvents::One(Event::Key(key)) if key.code == KeyCode::Esc));
+    }
+
+    #[test]
+    fn native_records_form_one_complete_multiline_paste() {
+        let now = Instant::now();
+        let mut decoder = ConsoleInputDecoder::default();
+        let mut events = Vec::new();
+        for ch in "\u{1b}[200~first\r\n\r\nsecond\u{1b}[201~".chars() {
+            decoder
+                .push_key(key(ch), now)
+                .for_each(|event| events.push(event));
+        }
+        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "first\r\n\r\nsecond"));
+    }
+
+    #[test]
+    fn native_paste_preserves_surrogate_pairs_and_repeats() {
+        let now = Instant::now();
+        let mut decoder = ConsoleInputDecoder::default();
+        for ch in "\u{1b}[200~".chars() {
+            decoder.push_key(key(ch), now);
+        }
+        decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                utf16: 0xd83d,
+                ..ConsoleKeyRecord::default()
+            },
+            now,
+        );
+        decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                utf16: 0xde00,
+                ..ConsoleKeyRecord::default()
+            },
+            now,
+        );
+        decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 3,
+                utf16: 'x' as u16,
+                ..ConsoleKeyRecord::default()
+            },
+            now,
+        );
+        let mut events = Vec::new();
+        for ch in "\u{1b}[201~".chars() {
+            decoder
+                .push_key(key(ch), now)
+                .for_each(|event| events.push(event));
+        }
+        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "😀xxx"));
+    }
+
+    #[test]
+    fn native_paste_preserves_literal_control_payload() {
+        let now = Instant::now();
+        let mut decoder = ConsoleInputDecoder::default();
+        for ch in "\u{1b}[200~".chars() {
+            decoder.push_key(key(ch), now);
+        }
+        decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: b'A' as u16,
+                utf16: 0x01,
+                control_state: LEFT_CTRL_PRESSED,
+                ..ConsoleKeyRecord::default()
+            },
+            now,
+        );
+        let mut events = Vec::new();
+        for ch in "\u{1b}[201~".chars() {
+            decoder
+                .push_key(key(ch), now)
+                .for_each(|event| events.push(event));
+        }
+        assert!(matches!(events.as_slice(), [Event::Paste(text)] if text == "\u{1}"));
+    }
+
+    #[test]
+    fn native_zero_unicode_dead_key_does_not_invent_text() {
+        let mut decoder = ConsoleInputDecoder::default();
+        let output = decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: b'E' as u16,
+                scan_code: 0x12,
+                utf16: 0,
+                control_state: 0,
+            },
+            Instant::now(),
+        );
+        assert!(matches!(output, DecodedEvents::None));
+    }
+
+    #[test]
+    fn native_altgr_and_ctrl_mouse_keep_modifiers() {
+        let mut decoder = ConsoleInputDecoder::default();
+        let events = collect(decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: b'E' as u16,
+                scan_code: 0x12,
+                utf16: '€' as u16,
+                control_state: LEFT_CTRL_PRESSED | RIGHT_ALT_PRESSED,
+            },
+            Instant::now(),
+        ));
+        assert!(matches!(events.as_slice(), [Event::Key(key)]
+            if key.code == KeyCode::Char('€')
+                && key.modifiers == KeyModifiers::CONTROL | KeyModifiers::ALT));
+
+        let mouse = decoder.push_mouse(
+            ConsoleMouseRecord {
+                column: 12,
+                row: 7,
+                button_state: FROM_LEFT_1ST_BUTTON_PRESSED,
+                control_state: LEFT_CTRL_PRESSED,
+                event_flags: 0,
+            },
+            Instant::now(),
+        );
+        assert!(matches!(mouse, DecodedEvents::One(Event::Mouse(mouse))
+            if mouse.kind == MouseEventKind::Down(MouseButton::Left)
+                && mouse.modifiers == KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn native_ctrl_space_preserves_the_default_prefix() {
+        let mut decoder = ConsoleInputDecoder::default();
+        let events = collect(decoder.push_key(
+            ConsoleKeyRecord {
+                key_down: true,
+                repeat_count: 1,
+                virtual_key: VK_SPACE,
+                scan_code: 0x39,
+                utf16: 0,
+                control_state: LEFT_CTRL_PRESSED,
+            },
+            Instant::now(),
+        ));
+        assert!(matches!(events.as_slice(), [Event::Key(key)]
+            if key.code == KeyCode::Char(' ')
+                && key.modifiers == KeyModifiers::CONTROL));
+    }
+}

--- a/src/terminal/host_input/windows.rs
+++ b/src/terminal/host_input/windows.rs
@@ -305,8 +305,20 @@ fn input_trace_enabled() -> bool {
     })
 }
 
-// This diagnostic is deliberately opt-in because UTF-16 key units can reveal
-// typed or pasted text. It is never emitted during normal logging.
+/// Classifies a UTF-16 unit without retaining the character itself.
+///
+/// 0 = none, 1 = control, 2 = printable, 3 = surrogate half.
+fn utf16_class(unit: u16) -> u8 {
+    match unit {
+        0 => 0,
+        0x01..=0x1f | 0x7f => 1,
+        0xd800..=0xdfff => 3,
+        _ => 2,
+    }
+}
+
+// This diagnostic is deliberately opt-in and records only the UTF-16 unit
+// class, never the character itself. It is never emitted during normal logging.
 fn trace_key_record(record: ConsoleKeyRecord) {
     if !input_trace_enabled() {
         return;
@@ -318,7 +330,7 @@ fn trace_key_record(record: ConsoleKeyRecord) {
             crate::logging::Field::RepeatCount(u64::from(record.repeat_count)),
             crate::logging::Field::VirtualKey(u64::from(record.virtual_key)),
             crate::logging::Field::ScanCode(u64::from(record.scan_code)),
-            crate::logging::Field::Utf16(u64::from(record.utf16)),
+            crate::logging::Field::Utf16Class(u64::from(utf16_class(record.utf16))),
             crate::logging::Field::ControlState(u64::from(record.control_state)),
         ],
     );
@@ -362,6 +374,14 @@ fn std_handle(kind: u32) -> io::Result<HANDLE> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn input_trace_classification_does_not_retain_characters() {
+        assert_eq!(utf16_class(0), 0);
+        assert_eq!(utf16_class(b'\n' as u16), 1);
+        assert_eq!(utf16_class(b'a' as u16), 2);
+        assert_eq!(utf16_class(0xd83d), 3);
+    }
 
     #[test]
     fn virtual_terminal_input_preserves_existing_console_flags() {

--- a/src/terminal/host_input/windows.rs
+++ b/src/terminal/host_input/windows.rs
@@ -1,11 +1,7 @@
-//! Native Windows console input reader.
-//!
-//! Crossterm intentionally presents one semantic event at a time. Windows
-//! Terminal, however, injects a bracketed paste as a burst of console records.
-//! Reading those records directly preserves scan codes, UTF-16, modifiers,
-//! repeats, mouse state, and paste boundaries before they cross Luvus IPC.
+//! Windows console input setup and record reader.
 
-use std::io;
+use std::io::{self, Write};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use ratatui::crossterm::event::{poll, read, Event};
@@ -13,22 +9,94 @@ use windows_sys::Win32::Foundation::{
     HANDLE, INVALID_HANDLE_VALUE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows_sys::Win32::System::Console::{
-    GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, ReadConsoleInputW,
-    CONSOLE_SCREEN_BUFFER_INFO, FOCUS_EVENT, INPUT_RECORD, KEY_EVENT, MOUSE_EVENT,
-    STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, WINDOW_BUFFER_SIZE_EVENT,
+    GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, ReadConsoleInputW, SetConsoleMode,
+    CONSOLE_SCREEN_BUFFER_INFO, ENABLE_VIRTUAL_TERMINAL_INPUT, FOCUS_EVENT, INPUT_RECORD,
+    KEY_EVENT, MOUSE_EVENT, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, WINDOW_BUFFER_SIZE_EVENT,
 };
 use windows_sys::Win32::System::Threading::{WaitForSingleObject, INFINITE};
 
-use super::console::{ConsoleInputDecoder, ConsoleKeyRecord, ConsoleMouseRecord};
+use super::console::{ConsoleKeyRecord, ConsoleMouseRecord, ConsoleStreamDecoder};
 use super::{DecodedEvents, HostInputDecoder};
 
 const READ_BATCH: usize = 128;
+const WIN32_INPUT_ENABLE: &[u8] = b"\x1b[?9001h";
+const WIN32_INPUT_DISABLE: &[u8] = b"\x1b[?9001l";
+
+/// Restore the console and host-terminal input modes when a client detaches.
+pub struct WindowsInputModeGuard {
+    input: Option<HANDLE>,
+    restore_mode: Option<u32>,
+    win32_mode: bool,
+}
+
+impl WindowsInputModeGuard {
+    fn inactive() -> Self {
+        Self {
+            input: None,
+            restore_mode: None,
+            win32_mode: false,
+        }
+    }
+}
+
+impl Drop for WindowsInputModeGuard {
+    fn drop(&mut self) {
+        if self.win32_mode {
+            let _ = std::io::stdout().write_all(WIN32_INPUT_DISABLE);
+            let _ = std::io::stdout().flush();
+        }
+        if let (Some(input), Some(mode)) = (self.input, self.restore_mode) {
+            let _ = unsafe { SetConsoleMode(input, mode) };
+        }
+    }
+}
+
+/// Enable lossless VT input and the documented Win32 key-record protocol.
+///
+/// Crossterm raw mode does not set `ENABLE_VIRTUAL_TERMINAL_INPUT`. Without it,
+/// ConPTY translates a terminal paste back into legacy records and destroys
+/// the byte boundaries before Luvus can identify one bracketed paste.
+pub fn enable_input_mode() -> WindowsInputModeGuard {
+    if !native_backend_enabled() {
+        return WindowsInputModeGuard::inactive();
+    }
+    let Ok(input) = std_handle(STD_INPUT_HANDLE) else {
+        return WindowsInputModeGuard::inactive();
+    };
+    let mut original = 0;
+    if unsafe { GetConsoleMode(input, &mut original) } == 0 {
+        return WindowsInputModeGuard::inactive();
+    }
+    let desired = original | ENABLE_VIRTUAL_TERMINAL_INPUT;
+    if desired != original && unsafe { SetConsoleMode(input, desired) } == 0 {
+        return WindowsInputModeGuard::inactive();
+    }
+    let mut applied = 0;
+    if unsafe { GetConsoleMode(input, &mut applied) } == 0
+        || applied & ENABLE_VIRTUAL_TERMINAL_INPUT == 0
+    {
+        if desired != original {
+            let _ = unsafe { SetConsoleMode(input, original) };
+        }
+        return WindowsInputModeGuard::inactive();
+    }
+    if std::io::stdout().write_all(WIN32_INPUT_ENABLE).is_err()
+        || std::io::stdout().flush().is_err()
+    {
+        if desired != original {
+            let _ = unsafe { SetConsoleMode(input, original) };
+        }
+        return WindowsInputModeGuard::inactive();
+    }
+    WindowsInputModeGuard {
+        input: Some(input),
+        restore_mode: (desired != original).then_some(original),
+        win32_mode: true,
+    }
+}
 
 pub fn run_input_loop(mut pending: Vec<Event>, mut emit: impl FnMut(Event) -> bool) {
     for event in pending.drain(..) {
-        // Theme probing runs before bracketed paste is enabled, so these are
-        // ordinary user events rather than paste markers. Forward them exactly
-        // once before the native reader begins consuming console records.
         if !emit(event) {
             return;
         }
@@ -36,11 +104,12 @@ pub fn run_input_loop(mut pending: Vec<Event>, mut emit: impl FnMut(Event) -> bo
 
     if native_backend_enabled() {
         if let Ok(mut input) = NativeConsoleInput::open() {
-            input.run(&mut emit);
-            return;
+            if input.virtual_terminal_input {
+                input.run(&mut emit);
+                return;
+            }
         }
     }
-
     run_crossterm_fallback(&mut emit);
 }
 
@@ -78,6 +147,7 @@ fn emit_decoded(decoded: DecodedEvents, emit: &mut impl FnMut(Event) -> bool) ->
     let mut connected = true;
     decoded.for_each(|event| {
         if connected {
+            trace_decoded_event(&event);
             connected = emit(event);
         }
     });
@@ -87,7 +157,8 @@ fn emit_decoded(decoded: DecodedEvents, emit: &mut impl FnMut(Event) -> bool) ->
 struct NativeConsoleInput {
     input: HANDLE,
     output: Option<HANDLE>,
-    decoder: ConsoleInputDecoder,
+    virtual_terminal_input: bool,
+    decoder: ConsoleStreamDecoder,
     records: [INPUT_RECORD; READ_BATCH],
 }
 
@@ -101,27 +172,28 @@ impl NativeConsoleInput {
         Ok(Self {
             input,
             output: std_handle(STD_OUTPUT_HANDLE).ok(),
-            decoder: ConsoleInputDecoder::default(),
+            virtual_terminal_input: mode & ENABLE_VIRTUAL_TERMINAL_INPUT != 0,
+            decoder: ConsoleStreamDecoder::default(),
             records: [INPUT_RECORD::default(); READ_BATCH],
         })
     }
 
     fn run(&mut self, emit: &mut impl FnMut(Event) -> bool) {
         loop {
-            let timeout = self.decoder.wait_timeout();
+            let now = Instant::now();
+            let timeout = self.decoder.wait_timeout(now);
             match self.read_batch(timeout) {
                 Ok(Some(read_count)) => {
                     let now = Instant::now();
                     for index in 0..read_count {
-                        let record = self.records[index];
-                        let decoded = self.decode_record(record, now);
+                        let decoded = self.decode_record(self.records[index], now);
                         if !emit_decoded(decoded, emit) {
                             return;
                         }
                     }
                 }
                 Ok(None) => {
-                    if !emit_decoded(self.decoder.flush_expired(), emit) {
+                    if !emit_decoded(self.decoder.flush_expired(Instant::now()), emit) {
                         return;
                     }
                 }
@@ -159,24 +231,24 @@ impl NativeConsoleInput {
         match u32::from(record.EventType) {
             KEY_EVENT => {
                 let key = unsafe { record.Event.KeyEvent };
-                self.decoder.push_key(
-                    ConsoleKeyRecord {
-                        key_down: key.bKeyDown != 0,
-                        repeat_count: key.wRepeatCount,
-                        virtual_key: key.wVirtualKeyCode,
-                        scan_code: key.wVirtualScanCode,
-                        utf16: unsafe { key.uChar.UnicodeChar },
-                        control_state: key.dwControlKeyState,
-                    },
-                    now,
-                )
+                let key = ConsoleKeyRecord {
+                    key_down: key.bKeyDown != 0,
+                    repeat_count: key.wRepeatCount,
+                    virtual_key: key.wVirtualKeyCode,
+                    scan_code: key.wVirtualScanCode,
+                    utf16: unsafe { key.uChar.UnicodeChar },
+                    control_state: key.dwControlKeyState,
+                };
+                trace_key_record(key);
+                self.decoder.push_key(key, now)
             }
             MOUSE_EVENT => {
                 let mouse = unsafe { record.Event.MouseEvent };
-                let row = self.relative_mouse_row(mouse.dwMousePosition.Y);
+                let (column, row) =
+                    self.relative_mouse_position(mouse.dwMousePosition.X, mouse.dwMousePosition.Y);
                 self.decoder.push_mouse(
                     ConsoleMouseRecord {
-                        column: mouse.dwMousePosition.X.max(0) as u16,
+                        column,
                         row,
                         button_state: mouse.dwButtonState,
                         control_state: mouse.dwControlKeyState,
@@ -190,27 +262,89 @@ impl NativeConsoleInput {
                 .unwrap_or(DecodedEvents::None),
             FOCUS_EVENT => {
                 let focus = unsafe { record.Event.FocusEvent };
-                let event = if focus.bSetFocus != 0 {
-                    Event::FocusGained
-                } else {
-                    Event::FocusLost
-                };
-                self.decoder.push_event(event, now)
+                self.decoder.push_event(
+                    if focus.bSetFocus != 0 {
+                        Event::FocusGained
+                    } else {
+                        Event::FocusLost
+                    },
+                    now,
+                )
             }
             _ => DecodedEvents::None,
         }
     }
 
-    fn relative_mouse_row(&self, absolute: i16) -> u16 {
+    fn relative_mouse_position(&self, column: i16, row: i16) -> (u16, u16) {
+        let fallback = (column.max(0) as u16, row.max(0) as u16);
         let Some(output) = self.output else {
-            return absolute.max(0) as u16;
+            return fallback;
         };
         let mut info = CONSOLE_SCREEN_BUFFER_INFO::default();
         if unsafe { GetConsoleScreenBufferInfo(output, &mut info) } == 0 {
-            return absolute.max(0) as u16;
+            return fallback;
         }
-        absolute.saturating_sub(info.srWindow.Top).max(0) as u16
+        (
+            column.saturating_sub(info.srWindow.Left).max(0) as u16,
+            row.saturating_sub(info.srWindow.Top).max(0) as u16,
+        )
     }
+}
+
+fn input_trace_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("LUVUS_WINDOWS_INPUT_TRACE")
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes"
+                )
+            })
+            .unwrap_or(false)
+    })
+}
+
+// This diagnostic is deliberately opt-in because UTF-16 key units can reveal
+// typed or pasted text. It is never emitted during normal logging.
+fn trace_key_record(record: ConsoleKeyRecord) {
+    if !input_trace_enabled() {
+        return;
+    }
+    crate::logging::event(
+        crate::logging::EventKind::ClientInputRecord,
+        &[
+            crate::logging::Field::KeyDown(record.key_down),
+            crate::logging::Field::RepeatCount(u64::from(record.repeat_count)),
+            crate::logging::Field::VirtualKey(u64::from(record.virtual_key)),
+            crate::logging::Field::ScanCode(u64::from(record.scan_code)),
+            crate::logging::Field::Utf16(u64::from(record.utf16)),
+            crate::logging::Field::ControlState(u64::from(record.control_state)),
+        ],
+    );
+}
+
+fn trace_decoded_event(event: &Event) {
+    if !input_trace_enabled() {
+        return;
+    }
+    let (kind, bytes) = match event {
+        Event::Paste(text) => ("paste", text.len() as u64),
+        Event::Key(_) => ("key", 0),
+        Event::Mouse(_) => ("mouse", 0),
+        Event::Resize(_, _) => ("resize", 0),
+        Event::FocusGained => ("focus_gained", 0),
+        Event::FocusLost => ("focus_lost", 0),
+    };
+    crate::logging::event(
+        crate::logging::EventKind::ClientInputDecoded,
+        &[
+            crate::logging::Field::InputKind(
+                crate::logging::SafeId::new(kind).expect("static input kind is safe"),
+            ),
+            crate::logging::Field::Bytes(bytes),
+        ],
+    );
 }
 
 fn std_handle(kind: u32) -> io::Result<HANDLE> {
@@ -222,5 +356,19 @@ fn std_handle(kind: u32) -> io::Result<HANDLE> {
         ))
     } else {
         Ok(handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn virtual_terminal_input_preserves_existing_console_flags() {
+        let original = 0x0010 | 0x0080;
+        assert_eq!(
+            original | ENABLE_VIRTUAL_TERMINAL_INPUT,
+            0x0010 | 0x0080 | 0x0200
+        );
     }
 }

--- a/src/terminal/host_input/windows.rs
+++ b/src/terminal/host_input/windows.rs
@@ -1,0 +1,226 @@
+//! Native Windows console input reader.
+//!
+//! Crossterm intentionally presents one semantic event at a time. Windows
+//! Terminal, however, injects a bracketed paste as a burst of console records.
+//! Reading those records directly preserves scan codes, UTF-16, modifiers,
+//! repeats, mouse state, and paste boundaries before they cross Luvus IPC.
+
+use std::io;
+use std::time::{Duration, Instant};
+
+use ratatui::crossterm::event::{poll, read, Event};
+use windows_sys::Win32::Foundation::{
+    HANDLE, INVALID_HANDLE_VALUE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows_sys::Win32::System::Console::{
+    GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, ReadConsoleInputW,
+    CONSOLE_SCREEN_BUFFER_INFO, FOCUS_EVENT, INPUT_RECORD, KEY_EVENT, MOUSE_EVENT,
+    STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, WINDOW_BUFFER_SIZE_EVENT,
+};
+use windows_sys::Win32::System::Threading::{WaitForSingleObject, INFINITE};
+
+use super::console::{ConsoleInputDecoder, ConsoleKeyRecord, ConsoleMouseRecord};
+use super::{DecodedEvents, HostInputDecoder};
+
+const READ_BATCH: usize = 128;
+
+pub fn run_input_loop(mut pending: Vec<Event>, mut emit: impl FnMut(Event) -> bool) {
+    for event in pending.drain(..) {
+        // Theme probing runs before bracketed paste is enabled, so these are
+        // ordinary user events rather than paste markers. Forward them exactly
+        // once before the native reader begins consuming console records.
+        if !emit(event) {
+            return;
+        }
+    }
+
+    if native_backend_enabled() {
+        if let Ok(mut input) = NativeConsoleInput::open() {
+            input.run(&mut emit);
+            return;
+        }
+    }
+
+    run_crossterm_fallback(&mut emit);
+}
+
+fn native_backend_enabled() -> bool {
+    std::env::var("LUVUS_WINDOWS_INPUT_BACKEND")
+        .map(|value| !value.eq_ignore_ascii_case("crossterm"))
+        .unwrap_or(true)
+}
+
+fn run_crossterm_fallback(emit: &mut impl FnMut(Event) -> bool) {
+    let mut decoder = HostInputDecoder::default();
+    loop {
+        if let Some(timeout) = decoder.wait_timeout() {
+            match poll(timeout) {
+                Ok(false) => {
+                    if !emit_decoded(decoder.flush_expired(), emit) {
+                        return;
+                    }
+                    continue;
+                }
+                Ok(true) => {}
+                Err(_) => return,
+            }
+        }
+        let Ok(event) = read() else {
+            return;
+        };
+        if !emit_decoded(decoder.push(event), emit) {
+            return;
+        }
+    }
+}
+
+fn emit_decoded(decoded: DecodedEvents, emit: &mut impl FnMut(Event) -> bool) -> bool {
+    let mut connected = true;
+    decoded.for_each(|event| {
+        if connected {
+            connected = emit(event);
+        }
+    });
+    connected
+}
+
+struct NativeConsoleInput {
+    input: HANDLE,
+    output: Option<HANDLE>,
+    decoder: ConsoleInputDecoder,
+    records: [INPUT_RECORD; READ_BATCH],
+}
+
+impl NativeConsoleInput {
+    fn open() -> io::Result<Self> {
+        let input = std_handle(STD_INPUT_HANDLE)?;
+        let mut mode = 0;
+        if unsafe { GetConsoleMode(input, &mut mode) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            input,
+            output: std_handle(STD_OUTPUT_HANDLE).ok(),
+            decoder: ConsoleInputDecoder::default(),
+            records: [INPUT_RECORD::default(); READ_BATCH],
+        })
+    }
+
+    fn run(&mut self, emit: &mut impl FnMut(Event) -> bool) {
+        loop {
+            let timeout = self.decoder.wait_timeout();
+            match self.read_batch(timeout) {
+                Ok(Some(read_count)) => {
+                    let now = Instant::now();
+                    for index in 0..read_count {
+                        let record = self.records[index];
+                        let decoded = self.decode_record(record, now);
+                        if !emit_decoded(decoded, emit) {
+                            return;
+                        }
+                    }
+                }
+                Ok(None) => {
+                    if !emit_decoded(self.decoder.flush_expired(), emit) {
+                        return;
+                    }
+                }
+                Err(_) => return,
+            }
+        }
+    }
+
+    fn read_batch(&mut self, timeout: Option<Duration>) -> io::Result<Option<usize>> {
+        let wait_ms = timeout
+            .map(|timeout| u32::try_from(timeout.as_millis()).unwrap_or(INFINITE - 1))
+            .unwrap_or(INFINITE);
+        match unsafe { WaitForSingleObject(self.input, wait_ms) } {
+            WAIT_TIMEOUT => return Ok(None),
+            WAIT_OBJECT_0 => {}
+            WAIT_FAILED => return Err(io::Error::last_os_error()),
+            _ => return Err(io::Error::other("unexpected console wait result")),
+        }
+        let mut read_count = 0;
+        if unsafe {
+            ReadConsoleInputW(
+                self.input,
+                self.records.as_mut_ptr(),
+                self.records.len() as u32,
+                &mut read_count,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Some(read_count as usize))
+    }
+
+    fn decode_record(&mut self, record: INPUT_RECORD, now: Instant) -> DecodedEvents {
+        match u32::from(record.EventType) {
+            KEY_EVENT => {
+                let key = unsafe { record.Event.KeyEvent };
+                self.decoder.push_key(
+                    ConsoleKeyRecord {
+                        key_down: key.bKeyDown != 0,
+                        repeat_count: key.wRepeatCount,
+                        virtual_key: key.wVirtualKeyCode,
+                        scan_code: key.wVirtualScanCode,
+                        utf16: unsafe { key.uChar.UnicodeChar },
+                        control_state: key.dwControlKeyState,
+                    },
+                    now,
+                )
+            }
+            MOUSE_EVENT => {
+                let mouse = unsafe { record.Event.MouseEvent };
+                let row = self.relative_mouse_row(mouse.dwMousePosition.Y);
+                self.decoder.push_mouse(
+                    ConsoleMouseRecord {
+                        column: mouse.dwMousePosition.X.max(0) as u16,
+                        row,
+                        button_state: mouse.dwButtonState,
+                        control_state: mouse.dwControlKeyState,
+                        event_flags: mouse.dwEventFlags,
+                    },
+                    now,
+                )
+            }
+            WINDOW_BUFFER_SIZE_EVENT => crossterm::terminal::size()
+                .map(|(columns, rows)| self.decoder.push_event(Event::Resize(columns, rows), now))
+                .unwrap_or(DecodedEvents::None),
+            FOCUS_EVENT => {
+                let focus = unsafe { record.Event.FocusEvent };
+                let event = if focus.bSetFocus != 0 {
+                    Event::FocusGained
+                } else {
+                    Event::FocusLost
+                };
+                self.decoder.push_event(event, now)
+            }
+            _ => DecodedEvents::None,
+        }
+    }
+
+    fn relative_mouse_row(&self, absolute: i16) -> u16 {
+        let Some(output) = self.output else {
+            return absolute.max(0) as u16;
+        };
+        let mut info = CONSOLE_SCREEN_BUFFER_INFO::default();
+        if unsafe { GetConsoleScreenBufferInfo(output, &mut info) } == 0 {
+            return absolute.max(0) as u16;
+        }
+        absolute.saturating_sub(info.srWindow.Top).max(0) as u16
+    }
+}
+
+fn std_handle(kind: u32) -> io::Result<HANDLE> {
+    let handle = unsafe { GetStdHandle(kind) };
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Windows console handle unavailable",
+        ))
+    } else {
+        Ok(handle)
+    }
+}

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -86,7 +86,7 @@ panes / agents:
   pane focus <id>            focus a pane (jumps to its workspace/tab)
   pane move [<id>] (--tab <n> | --new-tab)  move a pane within its workspace
   pane run [<id>] <cmd...>   run a command in a pane
-  pane send [<id>] <text>    send raw text to a pane
+  pane send [<id>] <text>    paste text into a pane
   pane read [<id>]           print a pane's recent output
   pane status [<id>]         print a pane's agent status and history metrics (any workspace)
   pane processes [<id>]      list cached executable identities without exposing arguments


### PR DESCRIPTION
## Summary

The live Windows report disproved the earlier implementation. Reading legacy `INPUT_RECORD` values directly was not enough because Luvus never enabled virtual terminal input or requested the Windows Terminal Win32 input record protocol. The decoder was therefore waiting for a stream the terminal had not been asked to send.

This revision negotiates that protocol, decodes the documented six-field key reports, reconstructs bracketed paste before IPC, and fixes the independent multiline `luvus pane send` path.

## What changed

- Enable `ENABLE_VIRTUAL_TERMINAL_INPUT` while a Windows client is attached and restore the original console mode on exit.
- Request Win32 input records with `CSI ? 9001 h` and disable the mode on detach.
- Decode the documented `CSI Vk;Sc;Uc;Kd;Cs;Rc _` reports before translating keyboard input.
- Reconstruct one bracketed paste while preserving CRLF, blank lines, UTF-16 surrogate pairs, repeats, literal control data, and backspace.
- Preserve Ctrl, Alt, Shift, AltGr, Ctrl+Shift letters, navigation keys, function keys, focus events, resize events, and mouse modifiers.
- Keep physical Escape immediate and bound incomplete control sequences and damaged pastes with explicit recovery deadlines.
- Correct both row and column offsets for native mouse records.
- Make `luvus pane send` request paste semantics so multiline CLI text uses the child pane bracketed-paste mode instead of raw typing semantics.
- Add an opt-in Windows input trace for live diagnosis. Set `LUVUS_WINDOWS_INPUT_TRACE=1` with `LUVUS_LOG=debug`. The trace is off by default. Raw UTF-16 key units can reveal typed or pasted content, so traces must be reviewed before sharing.
- Retain the Crossterm fallback when native Windows input mode cannot be established.

## Scope

This changes only the Windows host-input reader plus the CLI multiline send path. macOS and Linux keep their existing interactive input path. No dependency was added.

The record path preserves Ctrl+V and Ctrl+mouse input needed by child applications and Luvus hyperlink handling. It does not introduce a separate image clipboard transport. Live Windows verification is still required before claiming image clipboard behavior or closing #225.

## Verification

- `cargo test terminal::host_input -- --nocapture`
- `cargo test pane_send_requests_atomic_paste_semantics -- --nocapture`
- `cargo test pane_input_methods_report_rejection_and_run_is_one_action -- --nocapture`
- `cargo clippy --locked --target x86_64-pc-windows-gnu --all-targets -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo build --release --locked`
- Isolated debug server check under `~/.luvus-dev` confirmed multiline `pane send` retained line order and content without touching the production server.

The full local suite passed with 1,615 tests, 0 failures, and 3 ignored tests. The Windows target compiles cleanly with strict Clippy. A live Windows Terminal test remains required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Windows terminal input handling for keyboard, mouse, focus, Unicode, modifiers, control characters, and paste events.
  * Added native Windows console input with automatic fallback when unavailable.
  * `pane send` now pastes text atomically, including multiline content.

* **Bug Fixes**
  * Incomplete paste sequences now expire instead of blocking input.
  * Improved decoding of incomplete input sequences and backspace characters during paste.
  * Invalid values for the paste option are now rejected with a clear error.

* **Documentation**
  * Updated CLI help and documentation to describe text pasting consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->