### PR TITLE
feat(agent): add Kilo Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Keyboard → Keyboard Shortcuts → Input Sources** to free `Ctrl+Space`.
 | Muse Code | ✓ | ✓ | No |
 | Fx | ✓ | ✓ | No |
 | Cursor | ✓ | resume command | No |
+| Kilo Code | ✓ | exact-ID resume | No |
 | Gemini · Aider · Amp · Droid · Qwen · Kiro | ✓ | No | No |
 
 Live status needs no agent integration. See the

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -317,7 +317,7 @@ luvus agent get <target>
 luvus agent fork <target> [--name <alias>] [--no-focus]
 ```
 
-Native forks currently support Claude, Grok, Codex, Pi, and OMP. Report
+Native forks currently support Claude, Grok, Codex, Kilo Code, Pi, and OMP. Report
 `unsupported_agent`, `session_unknown`, or `spawn_failed` exactly when returned.
 Do not approximate a failed fork with `pane split`, `agent start`, or `resume`,
 because those paths do not guarantee an independent copy of the conversation.

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -94,6 +94,9 @@ read current state and reconcile instead of blindly retrying.
     `full_access`; omitted access defaults to `workspace`. This is independent
     of `task.mode`. Never retry an unsupported agent/access pair with broader
     access unless the user explicitly selected it.
+  - Kilo Code new-worker schedules support only an explicitly selected
+    `full_access` profile because its reviewed unattended command is
+    `kilo run --auto`. Never broaden a Kilo schedule automatically.
   - `target` defaults to `new_worker`. Use `active_agent` only with the exact
     live `pane_id`, `terminal_id`, `task.agent_id`, and `task.workspace_id`
     returned by discovery. Its `if_busy` policy is `wait` or `skip`; it creates

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -317,7 +317,7 @@ luvus agent get <target>
 luvus agent fork <target> [--name <alias>] [--no-focus]
 ```
 
-Native forks currently support Claude, Grok, Codex, Pi, and OMP. Report
+Native forks currently support Claude, Grok, Codex, Kilo Code, Pi, and OMP. Report
 `unsupported_agent`, `session_unknown`, or `spawn_failed` exactly when returned.
 Do not approximate a failed fork with `pane split`, `agent start`, or `resume`,
 because those paths do not guarantee an independent copy of the conversation.

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -94,6 +94,9 @@ read current state and reconcile instead of blindly retrying.
     `full_access`; omitted access defaults to `workspace`. This is independent
     of `task.mode`. Never retry an unsupported agent/access pair with broader
     access unless the user explicitly selected it.
+  - Kilo Code new-worker schedules support only an explicitly selected
+    `full_access` profile because its reviewed unattended command is
+    `kilo run --auto`. Never broaden a Kilo schedule automatically.
   - `target` defaults to `new_worker`. Use `active_agent` only with the exact
     live `pane_id`, `terminal_id`, `task.agent_id`, and `task.workspace_id`
     returned by discovery. Its `if_busy` policy is `wait` or `skip`; it creates

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -27,6 +27,7 @@ pub(crate) mod fx;
 pub(crate) mod gemini;
 pub(crate) mod grok;
 pub(crate) mod hermes;
+pub(crate) mod kilo;
 pub(crate) mod kimi;
 pub(crate) mod kiro;
 pub(crate) mod muse;
@@ -392,7 +393,11 @@ mod tests {
         assert!(resume_command("cursor-agent", "z")
             .unwrap()
             .contains("cursor-agent --resume"));
-        assert!(is_resumable("opencode") && is_resumable("cursor-agent"));
+        assert_eq!(
+            resume_command("kilocode", "ses_123").as_deref(),
+            Some("kilo --session 'ses_123'\r")
+        );
+        assert!(is_resumable("opencode") && is_resumable("cursor-agent") && is_resumable("kilo"));
         assert_eq!(
             resume_command("gemini", "g1").as_deref(),
             Some("gemini --resume 'g1'\r")
@@ -817,7 +822,17 @@ mod tests {
             .contains("pi --fork"));
         let grok = fork_command("grok", "g1").unwrap();
         assert!(grok.contains("grok --resume") && grok.contains("--fork-session"));
-        assert!(can_fork("claude") && can_fork("codex") && can_fork("pi") && can_fork("grok"));
+        assert_eq!(
+            fork_command("kilocode", "ses_123").as_deref(),
+            Some("kilo --session 'ses_123' --fork\r")
+        );
+        assert!(
+            can_fork("claude")
+                && can_fork("codex")
+                && can_fork("kilo")
+                && can_fork("pi")
+                && can_fork("grok")
+        );
         assert!(
             !can_fork("muse"),
             "Muse has no external native fork entrypoint"

--- a/src/agent/kilo/mod.rs
+++ b/src/agent/kilo/mod.rs
@@ -1,0 +1,38 @@
+use super::types::{
+    AgentDescriptor, AutomationLaunch, AutomationOperations, IdentityDescriptor, SessionOperations,
+};
+
+pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
+    id: "kilo",
+    aliases: &["kilocode"],
+    launch_command: "kilo",
+    task_prompt_args: &["--prompt"],
+    automation: Some(AutomationOperations {
+        read_only: None,
+        workspace: None,
+        // Kilo's non-interactive runner rejects permission requests unless
+        // --auto is present. That switch can approve unrestricted actions, so
+        // it maps only to Luvus's explicit full-access policy.
+        full_access: Some(AutomationLaunch {
+            args: &["run", "--auto"],
+        }),
+    }),
+    identity: IdentityDescriptor {
+        // Both executable names are official. Keep the ordinary word "kilo"
+        // out of screen-text matching while still accepting it as an exact
+        // process, launch command, or OSC-title token.
+        distinct: &["kilocode"],
+        ambiguous: &["kilo"],
+        binary_matcher: None,
+        interpreter_packages: &["@kilocode/cli"],
+        overlap_priority: 0,
+    },
+    sessions: Some(SessionOperations {
+        // Kilo exposes exact session resume and fork commands, but its current
+        // durable store has no reviewed bounded offline reader in Luvus.
+        discovery: None,
+        resume: |session| format!("kilo --session {session}\r"),
+        fork: Some(|session| format!("kilo --session {session} --fork\r")),
+    }),
+    integration: None,
+};

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -10,6 +10,7 @@ pub(crate) static BUILTINS: &[&AgentDescriptor] = &[
     &super::copilot::DESCRIPTOR,
     &super::kimi::DESCRIPTOR,
     &super::qwen::DESCRIPTOR,
+    &super::kilo::DESCRIPTOR,
     &super::kiro::DESCRIPTOR,
     &super::cursor::DESCRIPTOR,
     &super::amp::DESCRIPTOR,
@@ -144,6 +145,11 @@ mod tests {
         assert!(pi.supports(AutomationAccess::ReadOnly));
         assert!(!pi.supports(AutomationAccess::Workspace));
         assert!(!pi.supports(AutomationAccess::FullAccess));
+
+        let kilo = find("kilo").unwrap().automation.unwrap();
+        assert!(!kilo.supports(AutomationAccess::ReadOnly));
+        assert!(!kilo.supports(AutomationAccess::Workspace));
+        assert!(kilo.supports(AutomationAccess::FullAccess));
     }
 
     #[test]
@@ -182,6 +188,7 @@ mod tests {
         assert_eq!(find("cursor-agent").map(|agent| agent.id), Some("cursor"));
         assert_eq!(find("CURSOR").map(|agent| agent.id), Some("cursor"));
         assert_eq!(find("agy").map(|agent| agent.id), Some("antigravity"));
+        assert_eq!(find("KILOCODE").map(|agent| agent.id), Some("kilo"));
         assert_eq!(
             find("ANTIGRAVITY-CLI").map(|agent| agent.id),
             Some("antigravity")
@@ -211,6 +218,7 @@ mod tests {
             ("copilot", &["copilot"][..], &[][..]),
             ("kimi", &["kimi"][..], &[][..]),
             ("qwen", &["qwen"][..], &[][..]),
+            ("kilo", &["kilocode"][..], &["kilo"][..]),
             ("kiro", &["kiro"][..], &[][..]),
             ("cursor", &["cursor-agent"][..], &["cursor"][..]),
             ("amp", &[][..], &["amp"][..]),
@@ -256,6 +264,7 @@ mod tests {
                 "copilot",
                 "kimi",
                 "qwen",
+                "kilo",
                 "cursor",
                 "grok",
                 "hermes",
@@ -307,7 +316,7 @@ mod tests {
             })
             .map(|descriptor| descriptor.id)
             .collect();
-        assert_eq!(forkable, ["claude", "codex", "grok", "omp", "pi"]);
+        assert_eq!(forkable, ["claude", "codex", "kilo", "grok", "omp", "pi"]);
 
         assert_eq!(
             integrations()

--- a/src/agent/usage.rs
+++ b/src/agent/usage.rs
@@ -186,7 +186,7 @@ pub fn session_usage(agent: &str, cwd: &Path, session_id: &str) -> Option<AgentU
         "fx" => fx_usage(&fx_dir(&fx::sessions::base(), session_id)),
         // These agents currently expose identity/state but no stable,
         // structured, per-session usage store Luvus can read safely.
-        "aider" | "antigravity" | "kiro" | "cursor" | "amp" | "droid" | "opencode" => None,
+        "aider" | "antigravity" | "kilo" | "kiro" | "cursor" | "amp" | "droid" | "opencode" => None,
         _ => None, // manifest-defined agents degrade honestly too.
     }
 }
@@ -878,6 +878,8 @@ mod tests {
             "aider",
             "antigravity",
             "agy",
+            "kilo",
+            "kilocode",
             "kiro",
             "cursor",
             "cursor-agent",

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -3314,6 +3314,7 @@ mod tests {
             ("grok", "grok"),
             ("hermes", "hermes --oneshot"),
             ("kimi", "kimi --prompt"),
+            ("kilo", "kilo --prompt"),
             ("kiro", "kiro-cli"),
             ("muse", "muse"),
             ("omp", "omp"),
@@ -3339,6 +3340,12 @@ mod tests {
             agent_automation_command("fx", AutomationAccess::Workspace).unwrap(),
             "fx ask --auto"
         );
+        assert_eq!(
+            agent_automation_command("kilo", AutomationAccess::FullAccess).unwrap(),
+            "kilo run --auto"
+        );
+        assert!(agent_automation_command("kilo", AutomationAccess::ReadOnly).is_err());
+        assert!(agent_automation_command("kilo", AutomationAccess::Workspace).is_err());
         assert!(agent_automation_command("aider", AutomationAccess::Workspace).is_err());
         assert!(agent_automation_command("antigravity", AutomationAccess::Workspace).is_err());
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -1968,6 +1968,75 @@ Would you like to proceed?
             m.launch_args_for(&[antigravity_windows.into()], "antigravity"),
             Some(vec!["-p".into(), "fix the tests".into()])
         );
+
+        let kilo_unix = "/opt/homebrew/bin/kilo --session ses_123 --model anthropic/claude";
+        assert_eq!(
+            m.agent_in_processes(&[kilo_unix.into()]),
+            Some("kilo".into())
+        );
+        assert_eq!(
+            m.launch_args_for(&[kilo_unix.into()], "kilo"),
+            Some(vec![
+                "--session".into(),
+                "ses_123".into(),
+                "--model".into(),
+                "anthropic/claude".into(),
+            ])
+        );
+        assert_eq!(
+            m.agent_in_processes(&[r#"C:\Users\me\bin\kilocode.exe --continue"#.into()]),
+            Some("kilo".into())
+        );
+        assert_eq!(
+            m.agent_in_processes(&[
+                r#"node C:\Users\me\AppData\Roaming\npm\node_modules\@kilocode\cli\bin\kilo --prompt "review""#.into()
+            ]),
+            Some("kilo".into()),
+            "the exact scoped npm package identifies Kilo on Windows"
+        );
+    }
+
+    #[test]
+    fn kilo_uses_process_identity_and_generic_state_rules() {
+        let manifests = Manifests::builtin();
+        let running = ["/usr/local/bin/kilo".to_string()];
+        let detect = |screen: &str| {
+            classify(
+                Some("zsh"),
+                screen,
+                false,
+                false,
+                "zsh",
+                "",
+                &running,
+                &manifests,
+            )
+        };
+
+        let blocked = detect("Run this command? [y/n]");
+        assert_eq!(blocked.agent, "kilo");
+        assert_eq!(blocked.identity_source, "process_tree");
+        assert_eq!(blocked.state, State::Blocked);
+        assert_eq!(
+            detect("⠹ Thinking… (esc to interrupt)").state,
+            State::Working
+        );
+        assert_eq!(detect("Ready").state, State::Idle);
+
+        let incidental = classify(
+            Some("zsh"),
+            "this archive weighs one kilo",
+            false,
+            false,
+            "zsh",
+            "",
+            &[],
+            &manifests,
+        );
+        assert_eq!(
+            incidental.agent, "zsh",
+            "the ordinary word kilo is never trusted from terminal prose"
+        );
     }
 
     #[test]

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -54,7 +54,7 @@ static INSTALL_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 pub enum SkillHost {
     Claude,
     /// The open `~/.agents/skills` location shared by Codex, Copilot, Gemini,
-    /// Pi, Cursor, Amp, Droid, and fx.
+    /// Pi, Cursor, Amp, Droid, fx, and Kilo Code.
     Shared,
     Opencode,
     Kimi,
@@ -541,6 +541,8 @@ fn host_commands(host: SkillHost) -> &'static [&'static str] {
             "amp",
             "droid",
             "fx",
+            "kilo",
+            "kilocode",
         ],
         SkillHost::Opencode => &["opencode"],
         SkillHost::Kimi => &["kimi"],
@@ -580,6 +582,7 @@ fn host_config_dirs(
             xdg.join("amp"),
             home.join(".factory"),
             home.join(".fx"),
+            home.join(".kilo"),
         ],
         SkillHost::Opencode => vec![xdg.join("opencode")],
         SkillHost::Kimi => vec![kimi_home
@@ -1171,6 +1174,8 @@ mod tests {
             "amp",
             "droid",
             "fx",
+            "kilo",
+            "kilocode",
         ] {
             assert!(
                 shared.contains(&agent),

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -84,7 +84,7 @@ for an agent to receive it:
 `luvus skill enable` makes no network request. It installs the same bundled
 skill into detected native skill locations without overwriting external or
 modified content. The shared `~/.agents/skills/luvus/` copy serves Codex,
-GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx. Dedicated
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code. Dedicated
 adapters serve Claude Code, OpenCode, Kimi Code CLI, Grok Build, Hermes CLI,
 Qwen Code, and Kiro. Aider has no native Agent Skills installation surface, so
 use `luvus skill show` when an Aider conversation needs the instructions.
@@ -305,6 +305,11 @@ discovery rather than inferring support from an agent name.
   `luvus integration install opencode` adds a TUI-local plugin that reports
   only the root session selected in that pane plus structured usage. Without
   it, Mission Control leaves OpenCode usage unavailable instead of guessing.
+- Kilo Code is detected through the official `kilo` and `kilocode` commands.
+  Resume and fork use Kilo's native commands only when Luvus already has the
+  exact session ID; Luvus does not scan or guess sessions from Kilo's database.
+  A scheduled Kilo worker requires the user's explicit `full_access` selection
+  because its reviewed unattended command is `kilo run --auto`.
 - `luvus integration install hermes` adds exact per-pane session ownership for
   restart resume. Hermes detection still works without it, but Luvus does not
   scan Hermes's private history database or guess a session.

--- a/website/public/manifests/index.json
+++ b/website/public/manifests/index.json
@@ -2,6 +2,7 @@
   "files": [
     "antigravity.toml",
     "claude.toml",
-    "gemini.toml"
+    "gemini.toml",
+    "kilo.toml"
   ]
 }

--- a/website/public/manifests/kilo.toml
+++ b/website/public/manifests/kilo.toml
@@ -1,0 +1,9 @@
+# Official Luvus detection manifest for Kilo Code CLI.
+# This provides detection-only compatibility to older identity-enabled Luvus
+# versions. Native launch, automation, resume, and fork support ships in the
+# Luvus binary.
+agent = "kilo"
+
+[identity]
+distinct = ["kilocode"]
+ambiguous = ["kilo"]

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -29,8 +29,8 @@ Run `luvus doctor`. Local views need `git`. PRs/issues need an authenticated
 
 luvus identifies an agent by the program running in the pane, matched against a
 list of names it knows (Claude Code, Copilot, Codex, opencode, Kimi, Cursor,
-Gemini, Aider, Amp, Droid, Grok, Hermes, Muse, Qwen, Kiro). If your agent runs
-under a name luvus does not know, teach it one in
+Gemini, Aider, Amp, Droid, Grok, Hermes, Muse, Qwen, Kilo Code, Kiro). If your
+agent runs under a name luvus does not know, teach it one in
 `~/.luvus/manifests/<agent>.toml`:
 
 ```toml

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -156,6 +156,7 @@ skill through their native adapters:
 
 - **Claude Code:** `~/.claude/skills/luvus/`
 - **Codex:** `~/.agents/skills/luvus/`
+- **Kilo Code:** `~/.agents/skills/luvus/`
 - **opencode:** `${XDG_CONFIG_HOME:-~/.config}/opencode/skills/luvus/`
 
 The command makes no network request and never replaces a skill directory it

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -11,7 +11,7 @@ back after a restart, all without wrapping or modifying the agents themselves.
 
 Every pane running a recognized agent (Claude Code, Copilot, Codex, opencode,
 Kimi, Grok, Hermes CLI, Muse Code, Pi, Oh My Pi (OMP), Cursor, Gemini, Qwen,
-Kiro, Aider, Amp, Droid, or fx) appears in the sidebar with a live state:
+Kilo Code, Kiro, Aider, Amp, Droid, or fx) appears in the sidebar with a live state:
 
 | State | Meaning | How it's detected |
 |---|---|---|
@@ -77,7 +77,7 @@ Click a session row to select it and update the Selected Agent panel. Use
 | Gemini and Qwen | project chat records |
 | fx | session usage snapshot |
 
-Aider, Kiro, Cursor, Amp, Droid, Muse, and manifest-defined agents still receive live
+Aider, Kilo Code, Kiro, Cursor, Amp, Droid, Muse, and manifest-defined agents still receive live
 identity and state detection, but show `—` for usage until they expose a stable
 per-session counter or report one through an integration. Luvus never estimates
 tokens from transcript text.
@@ -143,6 +143,7 @@ not sufficient, and Luvus runs the agent's own resume command:
 | Qwen | its project chat store (`~/.qwen/tmp`) |
 | fx | its session store (`~/.fx/sessions`) |
 | Cursor | resume command (when the session id is known) |
+| Kilo Code | `kilo --session <id>` (when the exact session id is known) |
 
 You'll also see **recent sessions** listed at the bottom of the AGENTS sidebar
 (toggle *All*): click one to reopen it into a new pane, even sessions from
@@ -177,6 +178,7 @@ support it natively:
 | Claude Code | `claude --resume <id> --fork-session` |
 | Grok Build | `grok --resume <id> --fork-session` |
 | Codex | `codex fork <id>` |
+| Kilo Code | `kilo --session <id> --fork` |
 | Pi | `pi --fork <id>` |
 | Oh My Pi (OMP) | `omp --fork <id>` |
 
@@ -190,6 +192,10 @@ rollout in a shared folder, because that could fork another pane's active
 conversation. Install or refresh the Codex hook with
 `luvus integration install codex`; its SessionStart and prompt hooks bind new
 and resumed Codex panes to their exact rollout.
+
+Kilo Code also requires an exact session ID for resume or fork. Luvus detects
+the `kilo` and `kilocode` executables natively, but it does not scan Kilo's
+current database or guess which session belongs to a pane.
 
 Muse Code supports native detection and resume, but not **Fork to New Pane**.
 Its `/fork` command exists only inside the active TUI, and its CLI refuses to

--- a/website/src/content/docs/docs/guides/automation.mdx
+++ b/website/src/content/docs/docs/guides/automation.mdx
@@ -204,6 +204,11 @@ agent/access combinations fail before Luvus creates a task, lease, worktree, or
 pane. Luvus never edits the agent's permanent configuration or types approval
 answers into an unknown prompt.
 
+Kilo Code currently exposes one reviewed unattended profile: **Full access**,
+launched as `kilo run --auto`. Kilo documents that `--auto` may approve actions
+not explicitly denied, so Luvus does not present it as read-only or workspace
+access and rejects those combinations before creating worker resources.
+
 ## Schedule types
 
 Pass exactly one trigger to `automation create`, `automation update`, or

--- a/website/src/content/docs/docs/guides/codex-plugin.mdx
+++ b/website/src/content/docs/docs/guides/codex-plugin.mdx
@@ -41,7 +41,7 @@ luvus skill enable
 The command makes no network request. It detects supported coding-agent
 environments and installs the one bundled Luvus skill through their native
 skill directories. The shared `~/.agents/skills/luvus/` destination serves
-Codex, GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx.
+Codex, GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code.
 Claude Code, OpenCode, Kimi Code CLI, Grok Build, Hermes CLI, Qwen Code, and
 Kiro use their native dedicated destinations. It does not add an always-on
 pointer to `~/.codex/AGENTS.md`, and it never overwrites an installation it
@@ -176,7 +176,7 @@ luvus agent fork reviewer --name experiment --no-focus
 ```
 
 The fork inherits the source conversation and receives its own new session.
-Native forks currently support Claude, Grok, Codex, Pi, and OMP. If the target is
+Native forks currently support Claude, Grok, Codex, Kilo Code, Pi, and OMP. If the target is
 unsupported, its session cannot be resolved, or its pane cannot start, the
 skill reports Luvus's structured error instead of substituting a split, new
 agent, or resume operation that could lose or reuse the wrong context.

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -18,6 +18,7 @@ description: What luvus supports per agent, covering live status, session resume
 | Muse Code | ✓ | ✓ | no | no |
 | fx | ✓ | ✓ | no | no |
 | Cursor | ✓ | resume command | no | no |
+| Kilo Code | ✓ | with exact session ID | with exact session ID | no |
 | Gemini | ✓ | no | no | no |
 | Aider | ✓ | no | no | no |
 | Amp | ✓ | no | no | no |
@@ -36,7 +37,8 @@ description: What luvus supports per agent, covering live status, session resume
   original keeps running. It needs an agent with a native fork command, so today
   that is **Claude** (`claude --resume <id> --fork-session`), **Grok**
   (`grok --resume <id> --fork-session`), **Codex** (`codex fork <id>`),
-  **Pi** (`pi --fork <id>`), and **Oh My Pi (omp)** (`omp --fork <id>`).
+  **Kilo Code** (`kilo --session <id> --fork`), **Pi** (`pi --fork <id>`),
+  and **Oh My Pi (omp)** (`omp --fork <id>`).
   Right-click the pane and choose **Fork to New Pane**, or press `Ctrl+Space f`.
   The action only appears when Luvus can resolve the source session safely.
 - **Hook**, via `luvus integration install <agent>`, makes the agent report its
@@ -70,6 +72,13 @@ description: What luvus supports per agent, covering live status, session resume
   OpenCode detection and legacy JSON session discovery still work while usage
   remains unavailable.
 
+  Kilo Code is detected through either official executable (`kilo` or
+  `kilocode`) and the exact `@kilocode/cli` package identity. Luvus can resume
+  and fork a Kilo session when it already has the exact session ID, but does not
+  scan or guess IDs from Kilo's current database. Scheduled Kilo workers are
+  available only with explicit **Full access**, which maps to Kilo's documented
+  `kilo run --auto` contract; read-only and workspace automation are rejected.
+
   Hermes installs `~/.hermes/plugins/luvus-agent-state`, or the equivalent
   directory under `HERMES_HOME`, and enables only that plugin in
   `config.yaml`. Its callbacks report each exact CLI session once. Native
@@ -96,7 +105,7 @@ Print the release-matched instructions for one conversation with
 `luvus skill show`, or install them persistently with `luvus skill enable`.
 
 The shared `~/.agents/skills/luvus/` destination is understood by Codex,
-GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, and fx. Luvus uses
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code. Luvus uses
 dedicated native destinations for Claude Code, OpenCode, Kimi Code CLI, Grok
 Build, Hermes CLI, Qwen Code, Oh My Pi (omp), and Kiro. Aider does not expose a
 native Agent Skills installation directory, so use `luvus skill show` when an

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -678,8 +678,10 @@ when false, the current workspace, tab, pane focus, and zoom state are preserved
 Unsupported agents return `unsupported_agent`; a supported agent whose session
 ID cannot be resolved returns `session_unknown`; and PTY launch failure returns
 `spawn_failed`. Codex requires a hook-reported or Luvus-resumed exact session
-identity and never falls back to the newest rollout in the workspace. Validation
-completes before a new pane is spawned.
+identity and never falls back to the newest rollout in the workspace. Kilo Code
+also requires an exact session identity because Luvus does not scan or guess
+sessions from Kilo's current database. Validation completes before a new pane
+is spawned.
 
 ## Files
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -91,6 +91,7 @@ const AGENTS = [
   { name: 'Copilot', Icon: IconCopilot, mono: true, hook: true },
   { name: 'Kimi', Icon: IconKimi, hook: true },
   { name: 'Qwen', Icon: IconQwen },
+  { name: 'Kilo Code', letter: 'K' },
   { name: 'Kiro', Icon: IconKiro },
   { name: 'Cursor', Icon: IconCursor, mono: true },
   { name: 'Amp', Icon: IconAmp },


### PR DESCRIPTION
Adds Kilo Code CLI as a first-class built-in Luvus agent with native detection, ORCH launch behavior, bounded automation authority, exact-session commands, skill discovery, and public documentation.

## What

- Add an isolated `src/agent/kilo/` descriptor for the official `kilo` and `kilocode` executables and exact `@kilocode/cli` interpreter-package identity.
- Launch interactive ORCH tasks with `kilo --prompt`.
- Support scheduled Kilo workers only under explicit Full access through the documented `kilo run --auto` command. Read-only and workspace access fail before resources are created.
- Add native resume and fork commands for cases where Luvus already owns an exact Kilo session ID. Luvus does not scan or guess identities from the Kilo database.
- Reuse the supported `.agents/skills/luvus/` destination for Kilo skill discovery.
- Publish a detection-only managed manifest for compatible older Luvus binaries.
- Update the supported-agent reference, automation and UHP guidance, bundled skill copies, README, FAQ, and homepage grid.
- Add Unix, Windows, npm package, alias, false-positive prose, state, automation, session-command, skill-host, and usage-degradation regression coverage.

## Why

Kilo Code exposes a terminal-native coding agent with official interactive, non-interactive, resume, fork, and Agent Skills interfaces. Registering those reviewed contracts centrally makes Kilo available to the sidebar, ORCH, CLI and UHP-backed agent operations without UI name checks, polling, dependencies, or permanent agent configuration changes.

## Verification

- [x] `cargo test --locked` — 1,596 passed, 3 ignored
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --locked`
- [x] Focused registry, detection, ORCH, automation, resume, fork, manifest, skill parity, and usage tests
- [x] `npm run build` in `website/`
- [x] Installed Kilo Code 7.5.15: version, top-level help, `run --help`, and workspace-scoped JSON session listing

## Notes

The installed Kilo Code 7.5.15 CLI confirms the interactive `--prompt`, unattended `run --auto`, exact `--session`, and `--fork` contracts. No paid or authenticated model prompt was submitted. Workspace-scoped JSON session listing exits cleanly with no sessions in this checkout. Kilo global session listing currently crashes inside the upstream CLI on a local record without `time.updated`; Luvus does not depend on that command or database and keeps offline discovery disabled. Exact-session resume and fork remain fail-closed until a trusted session identity is available.