### PR TITLE
feat(files): add syntax highlighting to the read-only file viewer

### DIFF
--- a/src/app/files.rs
+++ b/src/app/files.rs
@@ -312,7 +312,7 @@ impl App {
     /// an editor.
     ///
     /// `line` scrolls the built-in viewer to that line. It survives the async read
-    /// because `FileView::apply` keeps `scroll` and clamps it to the file's length.
+    /// because `FileView::apply_prepared` keeps `scroll` and clamps it to the file's length.
     /// A configured *editor* opens at the top: the flag for "start at line N"
     /// differs per editor, and guessing it wrong is worse than not jumping.
     pub fn open_file_at(&mut self, path: PathBuf, line: Option<u32>) {
@@ -1164,7 +1164,10 @@ impl App {
         let token = v.read_token;
         let tx = self.app_tx.clone();
         std::thread::spawn(move || {
-            let load = crate::files::read_file(&path);
+            // Syntax preparation rides the same worker: `continuation_states`
+            // scans every line, so doing it here keeps a large-file open from
+            // stalling input and rendering on the application thread.
+            let (load, string_states) = crate::files::read_file_prepared(&path);
             // Both events carry the token they were issued with and the file
             // they are about. This worker cannot be cancelled, so the handler is
             // what drops a result the view has moved past.
@@ -1173,6 +1176,7 @@ impl App {
                 path: path.clone(),
                 token,
                 load,
+                string_states,
             });
             // Change markers ride the same worker, *after* the text: the file
             // must render immediately even in a huge repo where `git diff` is
@@ -2364,6 +2368,7 @@ mod tests {
             path: b.clone(),
             token: b_token,
             load: FileLoad::Text(vec!["B CONTENT".to_string()]),
+            string_states: vec![None],
         });
         assert!(repaint, "the matching read repaints");
         let b_marks = vec![ChangeSpan {
@@ -2384,6 +2389,7 @@ mod tests {
             path: a.clone(),
             token: a_token,
             load: FileLoad::Text(vec!["A CONTENT".to_string()]),
+            string_states: vec![None],
         });
         assert!(!stale, "a stale read is dropped without a repaint");
         let stale_marks = app.handle_event(AppEvent::FileChanges {
@@ -2406,6 +2412,7 @@ mod tests {
             path: a,
             token: b_token,
             load: FileLoad::Text(vec!["A CONTENT".to_string()]),
+            string_states: vec![None],
         });
         assert!(
             !mismatched,
@@ -2464,6 +2471,7 @@ mod tests {
             path: a.clone(),
             token: second_a,
             load: FileLoad::Text(vec!["A AFTER THE EDIT".to_string()]),
+            string_states: vec![None],
         }));
 
         // The very first read of A finally finishes, carrying what A said
@@ -2473,6 +2481,7 @@ mod tests {
             path: a.clone(),
             token: first_a,
             load: FileLoad::Text(vec!["A BEFORE THE EDIT".to_string()]),
+            string_states: vec![None],
         });
         assert!(!stale, "the superseded read is dropped without a repaint");
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -990,6 +990,7 @@ impl App {
                 path,
                 token,
                 load,
+                string_states,
             } => {
                 match self.views.get_mut(&id) {
                     // Only the newest read the leaf asked for may apply. One
@@ -999,7 +1000,7 @@ impl App {
                     Some(crate::app::ViewKind::File(v))
                         if v.read_token == token && v.path == path =>
                     {
-                        v.apply(load);
+                        v.apply_prepared(load, string_states);
                         true
                     }
                     // The leaf closed, became a diff, or has asked for a newer

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3215,12 +3215,13 @@ impl App {
                         let tx = app_tx.clone();
                         let p = path.clone();
                         std::thread::spawn(move || {
-                            let load = crate::files::read_file(&p);
+                            let (load, string_states) = crate::files::read_file_prepared(&p);
                             let _ = tx.send(crate::event::AppEvent::FileRead {
                                 id,
                                 path: p,
                                 token: 1,
                                 load,
+                                string_states,
                             });
                         });
                         remap.insert(*raw, id);

--- a/src/event.rs
+++ b/src/event.rs
@@ -191,11 +191,15 @@ pub enum AppEvent {
     /// invariant: newest wins. `path` is the file it carries — redundant while
     /// every scheduler bumps the token, kept as a cheap backstop so a future one
     /// that forgets cannot put another file's contents in this view.
+    ///
+    /// `string_states` is the worker-prepared multiline-string opener per line,
+    /// so the application thread stores without scanning the whole file.
     FileRead {
         id: PaneId,
         path: std::path::PathBuf,
         token: u64,
         load: crate::files::FileLoad,
+        string_states: Vec<Option<crate::files::highlight::MultilineKind>>,
     },
     /// Per-line git change markers for a file view finished computing
     /// (docs/38 + docs/30). Guarded exactly like `FileRead`, and it matters more

--- a/src/files/highlight.rs
+++ b/src/files/highlight.rs
@@ -96,25 +96,89 @@ pub struct Token {
     pub kind: Kind,
 }
 
-/// Tokenize a single line. Offsets are char indices, matching the file
-/// viewer's search-match columns. Always returns at least one token covering
-/// the whole line (possibly a single `Normal`), so renderers can rely on full
-/// coverage without a fallback path.
-pub fn tokenize(line: &str, lang: Language) -> Vec<Token> {
+/// A multiline string opener still active when a line begins. Only constructs
+/// that genuinely span lines produce one: Python triple-quoted strings and
+/// backtick literals (JavaScript template literals, Go raw strings). Rust raw
+/// strings can also span lines but stay single-line here — a documented
+/// approximation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MultilineKind {
+    TripleDouble,
+    TripleSingle,
+    Backtick,
+}
+
+/// Tokenize a single line. Pass `None` for `open` when no multiline string
+/// carries in; offsets are char indices, matching the file viewer's
+/// search-match columns. Always returns at least one token covering the whole
+/// line (possibly a single `Normal`), so renderers can rely on full coverage
+/// without a fallback path.
+///
+/// When the line may continue a multiline string opened on an earlier line,
+/// pass the opener active at its first character (taken from
+/// [`continuation_states`]) instead of `None`.
+pub fn tokenize_continued(line: &str, lang: Language, open: Option<MultilineKind>) -> Vec<Token> {
+    scan(line, lang, open).0
+}
+
+/// The multiline-string opener active at the start of each line, in order.
+/// The viewer rebuilds this once per file load and threads one entry per
+/// visible line into [`tokenize_continued`], so rendering stays O(visible
+/// rows) while continuation lines keep their string color.
+pub fn continuation_states(lines: &[String], lang: Language) -> Vec<Option<MultilineKind>> {
+    let mut states = Vec::with_capacity(lines.len());
+    let mut open = None;
+    for line in lines {
+        states.push(open);
+        open = scan(line, lang, open).1;
+    }
+    states
+}
+
+fn scan(
+    line: &str,
+    lang: Language,
+    open: Option<MultilineKind>,
+) -> (Vec<Token>, Option<MultilineKind>) {
     let chars: Vec<char> = line.chars().collect();
     let len = chars.len();
     if len == 0 {
-        return Vec::new();
+        // An empty line never opens or closes a multiline string.
+        return (Vec::new(), open);
     }
     if lang == Language::Plain {
-        return vec![Token {
-            start: 0,
-            end: len,
-            kind: Kind::Normal,
-        }];
+        return (
+            vec![Token {
+                start: 0,
+                end: len,
+                kind: Kind::Normal,
+            }],
+            None,
+        );
     }
     let mut tokens = Vec::new();
     let mut i = 0;
+    let mut open = open;
+    // A line that begins inside a multiline string: emit string content up to
+    // the closer (if any), then tokenize the remainder as fresh code.
+    if let Some(kind) = open {
+        if let Some(end) = find_multiline_close(&chars, 0, lang, kind) {
+            tokens.push(Token {
+                start: 0,
+                end,
+                kind: Kind::String,
+            });
+            i = end;
+            open = None;
+        } else {
+            tokens.push(Token {
+                start: 0,
+                end: len,
+                kind: Kind::String,
+            });
+            return (tokens, open);
+        }
+    }
     while i < len {
         // Line comments (checked before anything else at this position).
         if starts_line_comment(&chars, i, lang) {
@@ -136,6 +200,28 @@ pub fn tokenize(line: &str, lang: Language) -> Vec<Token> {
             continue;
         }
         let ch = chars[i];
+        // Multiline openers: Python triple-quoted strings and backtick
+        // literals. A same-line pair is one string token; an unclosed opener
+        // strings the rest of the line and carries into the next one. Checked
+        // before single-line strings so `"""` never splits into pieces.
+        if let Some(kind) = multiline_opener_at(&chars, i, lang) {
+            let body = i + opener_len(kind);
+            if let Some(end) = find_multiline_close(&chars, body, lang, kind) {
+                tokens.push(Token {
+                    start: i,
+                    end,
+                    kind: Kind::String,
+                });
+                i = end;
+                continue;
+            }
+            tokens.push(Token {
+                start: i,
+                end: len,
+                kind: Kind::String,
+            });
+            return (tokens, Some(kind));
+        }
         // Strings.
         if ch == '"'
             || ch == '`' && backtick_is_string(lang)
@@ -257,7 +343,91 @@ pub fn tokenize(line: &str, lang: Language) -> Vec<Token> {
         });
         i += 1;
     }
-    tokens
+    (tokens, open)
+}
+
+/// The opener width in chars: three for triple quotes, one for backticks.
+fn opener_len(kind: MultilineKind) -> usize {
+    match kind {
+        MultilineKind::TripleDouble | MultilineKind::TripleSingle => 3,
+        MultilineKind::Backtick => 1,
+    }
+}
+
+/// The multiline opener starting at char offset `i`, if any.
+fn multiline_opener_at(chars: &[char], i: usize, lang: Language) -> Option<MultilineKind> {
+    let ch = chars[i];
+    if lang == Language::Python
+        && ch == '"'
+        && chars.get(i + 1) == Some(&'"')
+        && chars.get(i + 2) == Some(&'"')
+    {
+        return Some(MultilineKind::TripleDouble);
+    }
+    if lang == Language::Python
+        && ch == '\''
+        && chars.get(i + 1) == Some(&'\'')
+        && chars.get(i + 2) == Some(&'\'')
+    {
+        return Some(MultilineKind::TripleSingle);
+    }
+    if ch == '`' && backtick_is_string(lang) {
+        return Some(MultilineKind::Backtick);
+    }
+    None
+}
+
+/// Offset just past the closer for `kind`, searching from char offset `from`.
+/// Returns `None` when the line ends inside the string. Backslash escapes
+/// apply everywhere except Go raw strings, which end at the next backtick.
+fn find_multiline_close(
+    chars: &[char],
+    from: usize,
+    lang: Language,
+    kind: MultilineKind,
+) -> Option<usize> {
+    let mut j = from;
+    while j < chars.len() {
+        match kind {
+            MultilineKind::TripleDouble => {
+                if chars[j] == '\\' && j + 1 < chars.len() {
+                    j += 2;
+                    continue;
+                }
+                if chars[j] == '"'
+                    && chars.get(j + 1) == Some(&'"')
+                    && chars.get(j + 2) == Some(&'"')
+                {
+                    return Some(j + 3);
+                }
+                j += 1;
+            }
+            MultilineKind::TripleSingle => {
+                if chars[j] == '\\' && j + 1 < chars.len() {
+                    j += 2;
+                    continue;
+                }
+                if chars[j] == '\''
+                    && chars.get(j + 1) == Some(&'\'')
+                    && chars.get(j + 2) == Some(&'\'')
+                {
+                    return Some(j + 3);
+                }
+                j += 1;
+            }
+            MultilineKind::Backtick => {
+                if lang != Language::Go && chars[j] == '\\' && j + 1 < chars.len() {
+                    j += 2;
+                    continue;
+                }
+                if chars[j] == '`' {
+                    return Some(j + 1);
+                }
+                j += 1;
+            }
+        }
+    }
+    None
 }
 
 /// Does a line comment start at char offset `i`?
@@ -643,7 +813,7 @@ mod tests {
 
     fn kinds(line: &str, lang: Language) -> Vec<(String, Kind)> {
         let chars: Vec<char> = line.chars().collect();
-        tokenize(line, lang)
+        tokenize_continued(line, lang, None)
             .iter()
             .map(|token| (chars[token.start..token.end].iter().collect(), token.kind))
             .collect()
@@ -750,7 +920,7 @@ mod tests {
             ("SELECT 1;", Language::Sql),
         ] {
             let len = line.chars().count();
-            let tokens = tokenize(line, lang);
+            let tokens = tokenize_continued(line, lang, None);
             if len == 0 {
                 assert!(tokens.is_empty());
                 continue;
@@ -769,5 +939,84 @@ mod tests {
         assert_eq!(language_for_path(&dir.join("Dockerfile")), Language::Shell);
         let tokens = kinds("RUN echo hi # done", Language::Shell);
         assert!(tokens.iter().any(|(_, kind)| *kind == Kind::Comment));
+    }
+
+    fn continued(lines: &[&str], lang: Language) -> Vec<Vec<(String, Kind)>> {
+        let owned: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
+        let states = continuation_states(&owned, lang);
+        assert_eq!(states.len(), lines.len());
+        lines
+            .iter()
+            .zip(states)
+            .map(|(line, open)| {
+                let chars: Vec<char> = line.chars().collect();
+                tokenize_continued(line, lang, open)
+                    .iter()
+                    .map(|token| (chars[token.start..token.end].iter().collect(), token.kind))
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// The review repro: keywords on continuation lines of a triple-quoted
+    /// string must not classify as keywords.
+    #[test]
+    fn python_triple_quoted_continuations_stay_strings() {
+        let rows = continued(
+            &[r#"doc = """start"#, "return of the thing", r#"end""""#],
+            Language::Python,
+        );
+        assert!(rows[1].iter().all(|(_, kind)| *kind == Kind::String));
+        assert!(
+            !rows[1].iter().any(|(_, kind)| *kind == Kind::Keyword),
+            "`return` inside a docstring is string content"
+        );
+        // The closer ends the string; code after it tokenizes normally.
+        assert!(rows[2].iter().any(|(_, kind)| *kind == Kind::String));
+    }
+
+    #[test]
+    fn same_line_triple_pair_does_not_carry() {
+        let owned = vec![r#"x = """done""" + 1"#.to_string()];
+        let states = continuation_states(&owned, Language::Python);
+        assert_eq!(states, vec![None]);
+        let rows = continued(&[r#"x = """done""" + 1"#], Language::Python);
+        assert!(rows[0].iter().any(|(_, kind)| *kind == Kind::Number));
+    }
+
+    #[test]
+    fn js_template_literals_span_lines_with_escapes() {
+        let rows = continued(
+            &["const t = `a\\`b", "return ${x} done", "end` + 1;"],
+            Language::Js,
+        );
+        // The escaped backtick must not close the literal early.
+        assert!(rows[1].iter().all(|(_, kind)| *kind == Kind::String));
+        assert!(rows[2].iter().any(|(_, kind)| *kind == Kind::String));
+        assert!(rows[2].iter().any(|(_, kind)| *kind == Kind::Number));
+    }
+
+    #[test]
+    fn go_raw_strings_span_lines() {
+        let rows = continued(
+            &[r#"s := `first"#, "return second", "third`;"],
+            Language::Go,
+        );
+        assert!(rows[1].iter().all(|(_, kind)| *kind == Kind::String));
+        assert!(rows[2].iter().any(|(_, kind)| *kind == Kind::String));
+    }
+
+    #[test]
+    fn backtick_in_a_comment_opens_nothing() {
+        let owned = vec!["// use `ticks` here".to_string(), "return 1;".to_string()];
+        let states = continuation_states(&owned, Language::Js);
+        assert_eq!(states, vec![None, None]);
+    }
+
+    #[test]
+    fn single_quoted_strings_do_not_carry() {
+        let owned = vec!["'open".to_string(), "return".to_string()];
+        let states = continuation_states(&owned, Language::Python);
+        assert_eq!(states, vec![None, None]);
     }
 }

--- a/src/files/highlight.rs
+++ b/src/files/highlight.rs
@@ -1,0 +1,769 @@
+//! Dependency-free syntax highlighting for the read-only file viewer.
+//!
+//! A stateless per-line tokenizer: keywords, strings, numbers, comments,
+//! function calls, and `Capitalized` types. It deliberately adds no crates —
+//! the viewer stays fast, offline, and theme-aware (styles resolve through the
+//! active [`crate::ui::theme::Theme`] at render time, so no reparse is needed
+//! when the theme changes).
+//!
+//! Known approximation: multi-line block comments. An unclosed `/*` colors the
+//! rest of its own line, but continuation lines render as code. Line comments,
+//! same-line blocks, strings, and keywords — the common cases — are exact.
+
+use std::path::Path;
+
+/// The language guessed from a file path. Drives comment markers, string
+/// delimiters, and the keyword table. `Plain` disables comment detection so
+/// prose (Markdown headings, plain text) is never dimmed as code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Language {
+    Rust,
+    Python,
+    Js,
+    Go,
+    CLike,
+    Shell,
+    Toml,
+    Yaml,
+    Json,
+    Css,
+    Html,
+    Sql,
+    Generic,
+    Plain,
+}
+
+/// Guess the highlighting language from a file name. Extension matching is
+/// case-insensitive; a few well-known bare names (`Dockerfile`, `Makefile`)
+/// are recognized too. Unknown files fall back to `Generic` (`//` comments),
+/// never to `Plain`, so code still gets strings, numbers, and keywords.
+pub fn language_for_path(path: &Path) -> Language {
+    if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
+        let lower = name.to_ascii_lowercase();
+        if lower == "dockerfile" || lower == "containerfile" {
+            return Language::Shell;
+        }
+        if lower == "makefile" || lower == "cmakelists.txt" {
+            return Language::Shell;
+        }
+        if lower == "cargo.toml" || lower.ends_with(".toml") {
+            return Language::Toml;
+        }
+    }
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase());
+    match extension.as_deref() {
+        Some("rs") => Language::Rust,
+        Some("py" | "pyi" | "pyw") => Language::Python,
+        Some("js" | "mjs" | "cjs" | "jsx" | "ts" | "mts" | "cts" | "tsx") => Language::Js,
+        Some("go") => Language::Go,
+        Some(
+            "java" | "c" | "h" | "cpp" | "hpp" | "cc" | "cxx" | "cs" | "swift" | "kt" | "kts"
+            | "scala",
+        ) => Language::CLike,
+        Some("sh" | "bash" | "zsh" | "fish" | "env") => Language::Shell,
+        Some("toml" | "ini" | "cfg") => Language::Toml,
+        Some("yaml" | "yml") => Language::Yaml,
+        Some("json" | "jsonc" | "json5") => Language::Json,
+        Some("css" | "scss" | "less") => Language::Css,
+        Some("html" | "htm" | "xml" | "svg" | "vue" | "svelte") => Language::Html,
+        Some("sql") => Language::Sql,
+        Some("lua") => Language::Sql,
+        Some("md" | "markdown" | "txt" | "text" | "log") => Language::Plain,
+        _ => Language::Generic,
+    }
+}
+
+/// The highlight role of one token. The renderer maps these through the
+/// active theme; this module never names a color.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Kind {
+    Normal,
+    Keyword,
+    String,
+    Comment,
+    Number,
+    Function,
+    Type,
+}
+
+/// One highlighted token as half-open char indices into its line.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Token {
+    pub start: usize,
+    pub end: usize,
+    pub kind: Kind,
+}
+
+/// Tokenize a single line. Offsets are char indices, matching the file
+/// viewer's search-match columns. Always returns at least one token covering
+/// the whole line (possibly a single `Normal`), so renderers can rely on full
+/// coverage without a fallback path.
+pub fn tokenize(line: &str, lang: Language) -> Vec<Token> {
+    let chars: Vec<char> = line.chars().collect();
+    let len = chars.len();
+    if len == 0 {
+        return Vec::new();
+    }
+    if lang == Language::Plain {
+        return vec![Token {
+            start: 0,
+            end: len,
+            kind: Kind::Normal,
+        }];
+    }
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < len {
+        // Line comments (checked before anything else at this position).
+        if starts_line_comment(&chars, i, lang) {
+            tokens.push(Token {
+                start: i,
+                end: len,
+                kind: Kind::Comment,
+            });
+            break;
+        }
+        // Same-line block comments: `/* … */` or `<!-- … -->`.
+        if let Some(end) = block_comment_end(&chars, i, lang) {
+            tokens.push(Token {
+                start: i,
+                end,
+                kind: Kind::Comment,
+            });
+            i = end;
+            continue;
+        }
+        let ch = chars[i];
+        // Strings.
+        if ch == '"'
+            || ch == '`' && backtick_is_string(lang)
+            || ch == '\'' && quote_is_string(&chars, i, lang)
+        {
+            let delimiter = ch;
+            let mut j = i + 1;
+            let mut closed = false;
+            while j < len {
+                // Go raw strings (backticks) have no escapes.
+                if delimiter == '`' && lang == Language::Go {
+                    if chars[j] == '`' {
+                        closed = true;
+                        j += 1;
+                        break;
+                    }
+                    j += 1;
+                    continue;
+                }
+                if chars[j] == '\\' && j + 1 < len {
+                    j += 2;
+                    continue;
+                }
+                if chars[j] == delimiter {
+                    closed = true;
+                    j += 1;
+                    break;
+                }
+                j += 1;
+            }
+            tokens.push(Token {
+                start: i,
+                end: if closed { j } else { len },
+                kind: Kind::String,
+            });
+            i = if closed { j } else { len };
+            continue;
+        }
+        // Numbers: hex/binary/octal prefixes, decimals, floats, type suffixes.
+        if ch.is_ascii_digit() {
+            let mut j = i;
+            if ch == '0' && j + 1 < len && matches!(chars[j + 1], 'x' | 'X' | 'b' | 'B' | 'o' | 'O')
+            {
+                j += 2;
+                while j < len && (chars[j].is_ascii_alphanumeric() || chars[j] == '_') {
+                    j += 1;
+                }
+            } else {
+                while j < len && (chars[j].is_ascii_digit() || chars[j] == '_') {
+                    j += 1;
+                }
+                if j < len && chars[j] == '.' && j + 1 < len && chars[j + 1].is_ascii_digit() {
+                    j += 1;
+                    while j < len && (chars[j].is_ascii_digit() || chars[j] == '_') {
+                        j += 1;
+                    }
+                }
+                if j < len && matches!(chars[j], 'e' | 'E') {
+                    let mut k = j + 1;
+                    if k < len && matches!(chars[k], '+' | '-') {
+                        k += 1;
+                    }
+                    if k < len && chars[k].is_ascii_digit() {
+                        k += 1;
+                        while k < len && (chars[k].is_ascii_digit() || chars[k] == '_') {
+                            k += 1;
+                        }
+                        j = k;
+                    }
+                }
+                // Type suffixes (`u32`, `f64`, `i128`): letters and digits both
+                // belong to the literal; `1..2` ranges still split because the
+                // float arm above requires a digit after the dot.
+                while j < len && chars[j].is_ascii_alphanumeric() {
+                    j += 1;
+                }
+            }
+            tokens.push(Token {
+                start: i,
+                end: j.max(i + 1),
+                kind: Kind::Number,
+            });
+            i = j.max(i + 1);
+            continue;
+        }
+        // Identifiers and keywords.
+        if ch == '_' || ch.is_alphabetic() {
+            let mut j = i + 1;
+            while j < len && (chars[j] == '_' || chars[j].is_alphanumeric()) {
+                j += 1;
+            }
+            let word: String = chars[i..j].iter().collect();
+            let kind = if is_keyword(&word, lang) {
+                Kind::Keyword
+            } else if is_function_call(&chars, j) {
+                Kind::Function
+            } else if word
+                .chars()
+                .next()
+                .is_some_and(|first| first.is_uppercase())
+            {
+                Kind::Type
+            } else {
+                Kind::Normal
+            };
+            tokens.push(Token {
+                start: i,
+                end: j,
+                kind,
+            });
+            i = j;
+            continue;
+        }
+        // Anything else (operators, punctuation, whitespace): one char.
+        tokens.push(Token {
+            start: i,
+            end: i + 1,
+            kind: Kind::Normal,
+        });
+        i += 1;
+    }
+    tokens
+}
+
+/// Does a line comment start at char offset `i`?
+fn starts_line_comment(chars: &[char], i: usize, lang: Language) -> bool {
+    let rest = &chars[i..];
+    match lang {
+        Language::Rust
+        | Language::Js
+        | Language::Go
+        | Language::CLike
+        | Language::Json
+        | Language::Generic => rest.len() >= 2 && rest[0] == '/' && rest[1] == '/',
+        Language::Python | Language::Toml | Language::Yaml => rest[0] == '#',
+        Language::Shell => {
+            if rest[0] != '#' {
+                return false;
+            }
+            // In shells `#` only starts a comment at a word boundary; `a#b`
+            // echoes literally.
+            i == 0 || chars[i - 1].is_whitespace() || matches!(chars[i - 1], ';' | '|' | '&' | '(')
+        }
+        Language::Css => false,
+        Language::Html | Language::Plain => false,
+        Language::Sql => {
+            (rest.len() >= 2 && rest[0] == '-' && rest[1] == '-')
+                || (rest.len() >= 2 && rest[0] == '/' && rest[1] == '/')
+        }
+    }
+}
+
+/// If a same-line block comment opens at `i`, return the char offset just past
+/// its end (or the line end for an unclosed opener). Otherwise `None`.
+fn block_comment_end(chars: &[char], i: usize, lang: Language) -> Option<usize> {
+    let supports_c_block = matches!(
+        lang,
+        Language::Rust
+            | Language::Js
+            | Language::Go
+            | Language::CLike
+            | Language::Json
+            | Language::Css
+            | Language::Sql
+            | Language::Generic
+    );
+    if supports_c_block && chars.len() >= i + 2 && chars[i] == '/' && chars[i + 1] == '*' {
+        let mut j = i + 2;
+        while j + 1 < chars.len() {
+            if chars[j] == '*' && chars[j + 1] == '/' {
+                return Some(j + 2);
+            }
+            j += 1;
+        }
+        return Some(chars.len());
+    }
+    if lang == Language::Html
+        && chars.len() >= i + 4
+        && chars[i] == '<'
+        && chars[i + 1] == '!'
+        && chars[i + 2] == '-'
+        && chars[i + 3] == '-'
+    {
+        let mut j = i + 4;
+        while j + 2 < chars.len() {
+            if chars[j] == '-' && chars[j + 1] == '-' && chars[j + 2] == '>' {
+                return Some(j + 3);
+            }
+            j += 1;
+        }
+        return Some(chars.len());
+    }
+    None
+}
+
+/// Is backtick a string delimiter in this language (JS templates, Go raw
+/// strings)? Rust uses backticks nowhere; Markdown never reaches this module.
+fn backtick_is_string(lang: Language) -> bool {
+    matches!(lang, Language::Js | Language::Go | Language::Generic)
+}
+
+/// Is the `'` at `i` a string delimiter? Single-quote strings are normal in
+/// Python, JS, shells, TOML, and SQL. In C-like languages a lone `'` is far
+/// more likely a lifetime or punctuation, so only `'x'`-shaped char literals
+/// count there.
+fn quote_is_string(chars: &[char], i: usize, lang: Language) -> bool {
+    match lang {
+        Language::Python
+        | Language::Js
+        | Language::Shell
+        | Language::Toml
+        | Language::Yaml
+        | Language::Json
+        | Language::Sql => true,
+        _ => {
+            // `'c'` or `'\..'` char literal.
+            (i + 2 < chars.len() && chars[i + 2] == '\'')
+                || (i + 3 < chars.len() && chars[i + 1] == '\\' && chars[i + 3] == '\'')
+        }
+    }
+}
+
+/// Is the identifier immediately (modulo whitespace) followed by `(`?
+/// Keywords are classified before this runs, so `if (` stays a keyword.
+fn is_function_call(chars: &[char], end: usize) -> bool {
+    let mut j = end;
+    while j < chars.len() && chars[j].is_whitespace() {
+        j += 1;
+    }
+    j < chars.len() && chars[j] == '('
+}
+
+fn is_keyword(word: &str, lang: Language) -> bool {
+    if lang == Language::Sql {
+        let lower = word.to_ascii_lowercase();
+        return SQL_KEYWORDS.contains(&lower.as_str());
+    }
+    match lang {
+        Language::Rust => RUST_KEYWORDS.contains(&word),
+        Language::Python => PYTHON_KEYWORDS.contains(&word),
+        Language::Js => JS_KEYWORDS.contains(&word),
+        Language::Go => GO_KEYWORDS.contains(&word),
+        Language::CLike => JS_KEYWORDS.contains(&word) || C_LIKE_EXTRA.contains(&word),
+        Language::Shell => SHELL_KEYWORDS.contains(&word),
+        Language::Toml | Language::Yaml | Language::Json => {
+            matches!(word, "true" | "false" | "null" | "True" | "False" | "None")
+        }
+        Language::Css => matches!(
+            word,
+            "important" | "inherit" | "initial" | "unset" | "none" | "auto" | "true" | "false"
+        ),
+        Language::Html | Language::Generic => GENERIC_KEYWORDS.contains(&word),
+        Language::Sql | Language::Plain => false,
+    }
+}
+
+const RUST_KEYWORDS: &[&str] = &[
+    "as",
+    "async",
+    "await",
+    "break",
+    "const",
+    "continue",
+    "crate",
+    "dyn",
+    "else",
+    "enum",
+    "extern",
+    "false",
+    "fn",
+    "for",
+    "if",
+    "impl",
+    "in",
+    "let",
+    "loop",
+    "match",
+    "mod",
+    "move",
+    "mut",
+    "pub",
+    "ref",
+    "return",
+    "self",
+    "Self",
+    "static",
+    "struct",
+    "super",
+    "trait",
+    "true",
+    "type",
+    "unsafe",
+    "use",
+    "where",
+    "while",
+    "yield",
+    "do",
+    "try",
+    "union",
+    "macro_rules",
+    "None",
+    "Some",
+    "Ok",
+    "Err",
+];
+
+const PYTHON_KEYWORDS: &[&str] = &[
+    "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue",
+    "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
+    "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while",
+    "with", "yield",
+];
+
+const JS_KEYWORDS: &[&str] = &[
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "implements",
+    "import",
+    "in",
+    "instanceof",
+    "interface",
+    "let",
+    "new",
+    "null",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "type",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
+    "async",
+    "of",
+    "from",
+    "as",
+    "static",
+    "get",
+    "set",
+    "package",
+    "private",
+    "protected",
+    "public",
+];
+
+const C_LIKE_EXTRA: &[&str] = &[
+    "int",
+    "long",
+    "short",
+    "byte",
+    "float",
+    "double",
+    "char",
+    "boolean",
+    "bool",
+    "string",
+    "void",
+    "sizeof",
+    "typedef",
+    "signed",
+    "unsigned",
+    "namespace",
+    "using",
+    "template",
+    "typename",
+    "operator",
+    "virtual",
+    "override",
+    "final",
+    "abstract",
+    "synchronized",
+    "volatile",
+    "transient",
+    "throws",
+    "extends",
+    "sealed",
+    "record",
+    "sizeof",
+];
+
+const GO_KEYWORDS: &[&str] = &[
+    "break",
+    "case",
+    "chan",
+    "const",
+    "continue",
+    "default",
+    "defer",
+    "else",
+    "fallthrough",
+    "for",
+    "func",
+    "go",
+    "goto",
+    "if",
+    "import",
+    "interface",
+    "map",
+    "package",
+    "range",
+    "return",
+    "select",
+    "struct",
+    "switch",
+    "type",
+    "var",
+    "true",
+    "false",
+    "nil",
+    "iota",
+];
+
+const SHELL_KEYWORDS: &[&str] = &[
+    "if", "then", "else", "elif", "fi", "for", "while", "until", "do", "done", "case", "esac",
+    "in", "function", "select", "time", "return", "exit", "export", "local", "readonly", "declare",
+    "trap", "true", "false",
+];
+
+const GENERIC_KEYWORDS: &[&str] = &[
+    "if", "else", "for", "while", "return", "function", "class", "import", "true", "false", "null",
+];
+
+const SQL_KEYWORDS: &[&str] = &[
+    "select",
+    "from",
+    "where",
+    "and",
+    "or",
+    "not",
+    "insert",
+    "into",
+    "values",
+    "update",
+    "set",
+    "delete",
+    "create",
+    "table",
+    "alter",
+    "drop",
+    "join",
+    "left",
+    "right",
+    "inner",
+    "outer",
+    "on",
+    "group",
+    "by",
+    "order",
+    "having",
+    "limit",
+    "offset",
+    "distinct",
+    "as",
+    "null",
+    "true",
+    "false",
+    "primary",
+    "key",
+    "foreign",
+    "references",
+    "index",
+    "view",
+    "union",
+    "all",
+    "exists",
+    "in",
+    "is",
+    "like",
+    "between",
+    "case",
+    "when",
+    "then",
+    "else",
+    "end",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn kinds(line: &str, lang: Language) -> Vec<(String, Kind)> {
+        let chars: Vec<char> = line.chars().collect();
+        tokenize(line, lang)
+            .iter()
+            .map(|token| (chars[token.start..token.end].iter().collect(), token.kind))
+            .collect()
+    }
+
+    #[test]
+    fn language_detection_covers_common_extensions() {
+        assert_eq!(language_for_path(Path::new("main.rs")), Language::Rust);
+        assert_eq!(language_for_path(Path::new("app.PY")), Language::Python);
+        assert_eq!(language_for_path(Path::new("bundle.min.TSX")), Language::Js);
+        assert_eq!(language_for_path(Path::new("Dockerfile")), Language::Shell);
+        assert_eq!(language_for_path(Path::new("README.md")), Language::Plain);
+        assert_eq!(language_for_path(Path::new("notes.txt")), Language::Plain);
+        assert_eq!(
+            language_for_path(Path::new("mystery.xyz")),
+            Language::Generic
+        );
+    }
+
+    #[test]
+    fn rust_keywords_functions_and_types_classify() {
+        let tokens = kinds("fn main() -> Option<String> {", Language::Rust);
+        assert!(tokens.contains(&("fn".into(), Kind::Keyword)));
+        assert!(tokens.contains(&("main".into(), Kind::Function)));
+        assert!(tokens.contains(&("Option".into(), Kind::Type)));
+        assert!(tokens.contains(&("String".into(), Kind::Type)));
+    }
+
+    #[test]
+    fn rust_line_comment_and_string_win_over_keywords() {
+        let tokens = kinds("let s = \"fn not_keyword\"; // let comment", Language::Rust);
+        assert!(tokens.contains(&("let".into(), Kind::Keyword)));
+        assert!(tokens
+            .iter()
+            .any(|(text, kind)| *kind == Kind::String && text.contains("fn")));
+        let comment: String = tokens
+            .iter()
+            .filter(|(_, kind)| *kind == Kind::Comment)
+            .map(|(text, _)| text.as_str())
+            .collect();
+        assert!(comment.contains("let comment"));
+    }
+
+    #[test]
+    fn rust_lifetimes_are_not_strings() {
+        let tokens = kinds("fn get(x: &'a str) {", Language::Rust);
+        assert!(!tokens.iter().any(|(_, kind)| *kind == Kind::String));
+        assert!(tokens.contains(&("fn".into(), Kind::Keyword)));
+        assert!(tokens.contains(&("get".into(), Kind::Function)));
+    }
+
+    #[test]
+    fn numbers_highlight_with_suffixes_and_hex() {
+        let tokens = kinds("let x = 0xFF + 1_000u32 + 3.14;", Language::Rust);
+        let numbers: Vec<_> = tokens
+            .iter()
+            .filter(|(_, kind)| *kind == Kind::Number)
+            .map(|(text, _)| text.clone())
+            .collect();
+        assert!(numbers.iter().any(|text| text == "0xFF"));
+        assert!(numbers.iter().any(|text| text == "1_000u32"));
+        assert!(numbers.iter().any(|text| text == "3.14"));
+    }
+
+    #[test]
+    fn python_hash_comments_but_markdown_stays_plain() {
+        let tokens = kinds("# comment here", Language::Python);
+        assert_eq!(tokens.last().map(|(_, kind)| kind), Some(&Kind::Comment));
+        let plain = kinds("# Heading", Language::Plain);
+        assert!(plain.iter().all(|(_, kind)| *kind == Kind::Normal));
+    }
+
+    #[test]
+    fn sql_keywords_match_case_insensitively() {
+        let tokens = kinds("SELECT id FROM users WHERE active;", Language::Sql);
+        for word in ["SELECT", "FROM", "WHERE"] {
+            assert!(
+                tokens.contains(&(word.into(), Kind::Keyword)),
+                "{word} should be a keyword"
+            );
+        }
+    }
+
+    #[test]
+    fn same_line_block_comments_color() {
+        let tokens = kinds("int x; /* hidden */ int y;", Language::CLike);
+        assert!(tokens
+            .iter()
+            .any(|(text, kind)| *kind == Kind::Comment && text.contains("hidden")));
+        assert!(tokens.contains(&("int".into(), Kind::Keyword)));
+    }
+
+    #[test]
+    fn token_coverage_is_total_and_ordered() {
+        for (line, lang) in [
+            ("fn main() {", Language::Rust),
+            ("", Language::Rust),
+            ("   ", Language::Python),
+            ("SELECT 1;", Language::Sql),
+        ] {
+            let len = line.chars().count();
+            let tokens = tokenize(line, lang);
+            if len == 0 {
+                assert!(tokens.is_empty());
+                continue;
+            }
+            assert_eq!(tokens.first().unwrap().start, 0);
+            assert_eq!(tokens.last().unwrap().end, len);
+            for pair in tokens.windows(2) {
+                assert_eq!(pair[0].end, pair[1].start, "gap in {line:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn dockerfile_without_extension_highlights_shell_comments() {
+        let dir = PathBuf::from("/tmp/proj");
+        assert_eq!(language_for_path(&dir.join("Dockerfile")), Language::Shell);
+        let tokens = kinds("RUN echo hi # done", Language::Shell);
+        assert!(tokens.iter().any(|(_, kind)| *kind == Kind::Comment));
+    }
+}

--- a/src/files/highlight.rs
+++ b/src/files/highlight.rs
@@ -70,7 +70,6 @@ pub fn language_for_path(path: &Path) -> Language {
         Some("css" | "scss" | "less") => Language::Css,
         Some("html" | "htm" | "xml" | "svg" | "vue" | "svelte") => Language::Html,
         Some("sql") => Language::Sql,
-        Some("lua") => Language::Sql,
         Some("md" | "markdown" | "txt" | "text" | "log") => Language::Plain,
         _ => Language::Generic,
     }
@@ -661,6 +660,11 @@ mod tests {
         assert_eq!(
             language_for_path(Path::new("mystery.xyz")),
             Language::Generic
+        );
+        assert_eq!(
+            language_for_path(Path::new("init.lua")),
+            Language::Generic,
+            "Lua has no dedicated variant; SQL keywords must not leak into it"
         );
     }
 

--- a/src/files/highlight.rs
+++ b/src/files/highlight.rs
@@ -117,20 +117,46 @@ pub enum MultilineKind {
 /// When the line may continue a multiline string opened on an earlier line,
 /// pass the opener active at its first character (taken from
 /// [`continuation_states`]) instead of `None`.
+///
+/// Adjacent plain-text characters (operators, punctuation, whitespace) are
+/// coalesced into a single `Normal` token so a minified line does not produce
+/// one token per character.
+/// Direct-call fallback (tests, one-off lookups); the render path uses
+/// [] through the bounded cache.
+#[allow(dead_code)]
 pub fn tokenize_continued(line: &str, lang: Language, open: Option<MultilineKind>) -> Vec<Token> {
-    scan(line, lang, open).0
+    scan(line, lang, open, None).0
+}
+
+/// Tokenize only the `[0, end_exclusive)` char window of `line`.
+///
+/// The render path highlights at most one viewport of cells, so tokenizing a
+/// 5 MiB single-line file to its end every frame would allocate millions of
+/// tokens repeatedly. Windowed tokenization scans from the line start (the
+/// `open` state makes the prefix load-bearing) but stops at `end_exclusive`,
+/// bounding per-frame work to the visible width. The returned tokens cover
+/// `[0, min(end_exclusive, len))` with the same classification the full scan
+/// would produce on that prefix.
+pub fn tokenize_window(
+    line: &str,
+    lang: Language,
+    open: Option<MultilineKind>,
+    end_exclusive: usize,
+) -> Vec<Token> {
+    scan(line, lang, open, Some(end_exclusive)).0
 }
 
 /// The multiline-string opener active at the start of each line, in order.
-/// The viewer rebuilds this once per file load and threads one entry per
-/// visible line into [`tokenize_continued`], so rendering stays O(visible
-/// rows) while continuation lines keep their string color.
+/// Prepared once per file load on the file-read worker and folded in via
+/// `FileView::apply_prepared`, then threaded one entry per visible line into
+/// [`tokenize_continued`]/[`tokenize_window`], so rendering stays O(visible
+/// rows × visible width) while continuation lines keep their string color.
 pub fn continuation_states(lines: &[String], lang: Language) -> Vec<Option<MultilineKind>> {
     let mut states = Vec::with_capacity(lines.len());
     let mut open = None;
     for line in lines {
         states.push(open);
-        open = scan(line, lang, open).1;
+        open = scan(line, lang, open, None).1;
     }
     states
 }
@@ -139,10 +165,31 @@ fn scan(
     line: &str,
     lang: Language,
     open: Option<MultilineKind>,
+    end_limit: Option<usize>,
 ) -> (Vec<Token>, Option<MultilineKind>) {
-    let chars: Vec<char> = line.chars().collect();
+    // Windowed scans bound per-frame work to the viewport: collect at most
+    // `limit + lookahead` chars instead of the whole line. The extra 64 chars
+    // exist only so classification at the window edge (function-call parens,
+    // char-literal shapes, identifier boundaries) agrees with the full scan;
+    // token coverage stops at `target`.
+    let (chars, target): (Vec<char>, usize) = match end_limit {
+        None => {
+            let chars: Vec<char> = line.chars().collect();
+            let len = chars.len();
+            (chars, len)
+        }
+        Some(limit) => {
+            if limit == 0 {
+                return (Vec::new(), open);
+            }
+            let take = limit.saturating_add(64);
+            let chars: Vec<char> = line.chars().take(take).collect();
+            let target = chars.len().min(limit);
+            (chars, target)
+        }
+    };
     let len = chars.len();
-    if len == 0 {
+    if target == 0 {
         // An empty line never opens or closes a multiline string.
         return (Vec::new(), open);
     }
@@ -150,7 +197,7 @@ fn scan(
         return (
             vec![Token {
                 start: 0,
-                end: len,
+                end: target,
                 kind: Kind::Normal,
             }],
             None,
@@ -159,10 +206,15 @@ fn scan(
     let mut tokens = Vec::new();
     let mut i = 0;
     let mut open = open;
+    // Helper: clip a token end to the visible window. Full scans have
+    // `target == len`, so this is a no-op there; windowed scans stop at the
+    // viewport instead of tokenizing a multi-megabyte line to its end.
+    let clip = |end: usize| end.min(target);
     // A line that begins inside a multiline string: emit string content up to
     // the closer (if any), then tokenize the remainder as fresh code.
     if let Some(kind) = open {
         if let Some(end) = find_multiline_close(&chars, 0, lang, kind) {
+            let end = clip(end);
             tokens.push(Token {
                 start: 0,
                 end,
@@ -170,27 +222,31 @@ fn scan(
             });
             i = end;
             open = None;
+            if i >= target {
+                return (tokens, open);
+            }
         } else {
             tokens.push(Token {
                 start: 0,
-                end: len,
+                end: target,
                 kind: Kind::String,
             });
             return (tokens, open);
         }
     }
-    while i < len {
+    while i < target {
         // Line comments (checked before anything else at this position).
         if starts_line_comment(&chars, i, lang) {
             tokens.push(Token {
                 start: i,
-                end: len,
+                end: target,
                 kind: Kind::Comment,
             });
             break;
         }
         // Same-line block comments: `/* … */` or `<!-- … -->`.
         if let Some(end) = block_comment_end(&chars, i, lang) {
+            let end = clip(end);
             tokens.push(Token {
                 start: i,
                 end,
@@ -207,6 +263,7 @@ fn scan(
         if let Some(kind) = multiline_opener_at(&chars, i, lang) {
             let body = i + opener_len(kind);
             if let Some(end) = find_multiline_close(&chars, body, lang, kind) {
+                let end = clip(end);
                 tokens.push(Token {
                     start: i,
                     end,
@@ -217,7 +274,7 @@ fn scan(
             }
             tokens.push(Token {
                 start: i,
-                end: len,
+                end: target,
                 kind: Kind::String,
             });
             return (tokens, Some(kind));
@@ -252,12 +309,16 @@ fn scan(
                 }
                 j += 1;
             }
+            let end = if closed { clip(j) } else { target };
             tokens.push(Token {
                 start: i,
-                end: if closed { j } else { len },
+                end,
                 kind: Kind::String,
             });
-            i = if closed { j } else { len };
+            i = end;
+            // An unclosed single-line string runs to the window end; the loop
+            // exits (`i == target`) and `open` is unchanged (single-line
+            // strings never carry). Windowed and full scans agree here.
             continue;
         }
         // Numbers: hex/binary/octal prefixes, decimals, floats, type suffixes.
@@ -301,10 +362,12 @@ fn scan(
             }
             tokens.push(Token {
                 start: i,
-                end: j.max(i + 1),
+                end: clip(j.max(i + 1)),
                 kind: Kind::Number,
             });
-            i = j.max(i + 1);
+            i = clip(j.max(i + 1));
+            // A number split by the window edge keeps the prefix; the loop
+            // exits when the window is covered.
             continue;
         }
         // Identifiers and keywords.
@@ -327,21 +390,60 @@ fn scan(
             } else {
                 Kind::Normal
             };
+            // Clip an identifier split by the window edge to its visible
+            // prefix; classification uses the full word (plus lookahead for
+            // the call paren), so the prefix keeps the right style.
+            let end = clip(j);
+            tokens.push(Token {
+                start: i,
+                end,
+                kind,
+            });
+            i = end;
+            continue;
+        }
+        // Anything else (operators, punctuation, whitespace): coalesce the
+        // whole run into one `Normal` token instead of one token per char.
+        // A minified JSON line is mostly such runs, so this cuts millions of
+        // transient tokens down to thousands.
+        {
+            let mut j = i + 1;
+            while j < target {
+                // Stop where the next position would start something else.
+                if starts_line_comment(&chars, j, lang) {
+                    break;
+                }
+                if block_comment_end(&chars, j, lang).is_some() {
+                    break;
+                }
+                if j < len && multiline_opener_at(&chars, j, lang).is_some() {
+                    break;
+                }
+                let c = chars[j];
+                if c.is_ascii_digit() {
+                    break;
+                }
+                if c == '_' || c.is_alphabetic() {
+                    break;
+                }
+                if c == '"' {
+                    break;
+                }
+                if c == '`' && backtick_is_string(lang) {
+                    break;
+                }
+                if c == '\'' && quote_is_string(&chars, j, lang) {
+                    break;
+                }
+                j += 1;
+            }
             tokens.push(Token {
                 start: i,
                 end: j,
-                kind,
+                kind: Kind::Normal,
             });
             i = j;
-            continue;
         }
-        // Anything else (operators, punctuation, whitespace): one char.
-        tokens.push(Token {
-            start: i,
-            end: i + 1,
-            kind: Kind::Normal,
-        });
-        i += 1;
     }
     (tokens, open)
 }
@@ -1018,5 +1120,58 @@ mod tests {
         let owned = vec!["'open".to_string(), "return".to_string()];
         let states = continuation_states(&owned, Language::Python);
         assert_eq!(states, vec![None, None]);
+    }
+
+    /// Adjacent plain-text runs (punctuation/whitespace) must coalesce: a
+    /// minified line must not produce one token per character.
+    #[test]
+    fn adjacent_normal_text_coalesces() {
+        let tokens = tokenize_continued("   ", Language::Rust, None);
+        assert_eq!(tokens.len(), 1, "spaces are one Normal run, not per char");
+        assert_eq!(tokens[0].kind, Kind::Normal);
+
+        let tokens = tokenize_continued("{}}", Language::Json, None);
+        assert_eq!(
+            tokens.len(),
+            1,
+            "adjacent punctuation coalesces, not one token per brace"
+        );
+
+        // Strings/keywords still split the run.
+        let tokens = tokenize_continued(r#"{"a":1}"#, Language::Json, None);
+        assert!(
+            tokens.len() < r#"{"a":1}"#.chars().count(),
+            "coalesced tokens are fewer than chars (got {})",
+            tokens.len()
+        );
+        assert!(tokens.iter().any(|t| t.kind == Kind::String));
+        assert!(tokens.iter().any(|t| t.kind == Kind::Number));
+    }
+
+    /// Windowed tokenization covers exactly the visible prefix with the same
+    /// classification the full scan produces there.
+    #[test]
+    fn windowed_prefix_matches_full_scan() {
+        let line = r#"fn load(path: &Path) -> usize { // open"#;
+        let full = tokenize_continued(line, Language::Rust, None);
+        for end in [0usize, 1, 5, 10, 20, line.chars().count()] {
+            let win = tokenize_window(line, Language::Rust, None, end);
+            // Clip the full scan to the window for comparison.
+            let mut expected = Vec::new();
+            for t in &full {
+                if t.start >= end {
+                    break;
+                }
+                expected.push(Token {
+                    start: t.start,
+                    end: t.end.min(end),
+                    kind: t.kind,
+                });
+                if t.end >= end {
+                    break;
+                }
+            }
+            assert_eq!(win, expected, "window end {end}");
+        }
     }
 }

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -17,9 +17,10 @@
 pub mod highlight;
 pub mod preview;
 mod view;
+#[allow(unused_imports)]
 pub use view::{
-    gutter_width, read_file, selection_text, token_rows, view_text_w, wrap_ranges, FileLoad,
-    FileView, SIZE_CAP,
+    gutter_width, read_file, read_file_prepared, selection_text, token_rows, view_text_w,
+    wrap_ranges, wrap_ranges_limited, wrap_rows, FileLoad, FileView, SIZE_CAP,
 };
 
 use std::collections::{HashMap, HashSet};

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -14,11 +14,12 @@
 //! The model is pure: it never touches the filesystem itself. The app reads
 //! directories on a worker thread and feeds them back via [`FileTree::apply_dir`].
 
+pub mod highlight;
 pub mod preview;
 mod view;
 pub use view::{
-    gutter_width, read_file, seg_text, selection_text, token_rows, view_text_w, wrap_ranges,
-    FileLoad, FileView, SIZE_CAP,
+    gutter_width, read_file, selection_text, token_rows, view_text_w, wrap_ranges, FileLoad,
+    FileView, SIZE_CAP,
 };
 
 use std::collections::{HashMap, HashSet};

--- a/src/files/view.rs
+++ b/src/files/view.rs
@@ -59,6 +59,11 @@ pub struct FileView {
     /// Empty for a clean file, an untracked file, or outside a repo — markers are
     /// an enhancement, never a requirement.
     pub changes: Vec<crate::git::local::ChangeSpan>,
+    /// The multiline-string opener active at the start of each line, parallel
+    /// to the `Text` lines. Rebuilt in [`FileView::apply`] so continuation
+    /// lines of triple-quoted or backtick strings keep their string color;
+    /// empty for non-text loads.
+    pub string_states: Vec<Option<super::highlight::MultilineKind>>,
     /// Which scheduled read this view is waiting for (the `request_token` idea
     /// `DiffView` already uses). Every read carries the token it was issued
     /// with, and only a match may be applied, so a slow read cannot land after
@@ -96,6 +101,7 @@ impl FileView {
             changes: Vec::new(),
             search: None,
             read_token: 0,
+            string_states: Vec::new(),
         }
     }
 
@@ -105,6 +111,16 @@ impl FileView {
     /// re-evaluated against the new text.
     pub fn apply(&mut self, load: FileLoad) {
         self.load = load;
+        // One forward pass over the text records the multiline-string opener
+        // at each line start, so the renderer colors continuation lines
+        // without scanning from the top of the file every frame.
+        self.string_states = match &self.load {
+            FileLoad::Text(lines) => {
+                let lang = super::highlight::language_for_path(&self.path);
+                super::highlight::continuation_states(lines, lang)
+            }
+            _ => Vec::new(),
+        };
         let max = self.line_count().saturating_sub(1);
         self.scroll = self.scroll.min(max);
         self.hscroll = 0;
@@ -608,6 +624,28 @@ mod tests {
         }
     }
     use super::*;
+
+    /// `apply` rebuilds the per-line multiline-string states so the renderer
+    /// colors docstring continuations without scanning from the file top.
+    #[test]
+    fn apply_records_multiline_string_states() {
+        let mut v = FileView::new(PathBuf::from("doc.py"));
+        v.apply(FileLoad::Text(vec![
+            "doc = \"\"\"start".into(),
+            "return of the thing".into(),
+            "end\"\"\"".into(),
+        ]));
+        assert_eq!(
+            v.string_states,
+            vec![
+                None,
+                Some(crate::files::highlight::MultilineKind::TripleDouble),
+                Some(crate::files::highlight::MultilineKind::TripleDouble),
+            ]
+        );
+        v.apply(FileLoad::Error("gone".into()));
+        assert!(v.string_states.is_empty());
+    }
 
     #[test]
     fn reads_text_binary_and_oversize() {

--- a/src/files/view.rs
+++ b/src/files/view.rs
@@ -35,8 +35,11 @@ pub struct Search {
     pub query: String,
     /// True while the user is still typing the query (before Enter).
     pub editing: bool,
-    /// `(line, start_col)` of every match, in document order.
-    pub matches: Vec<(usize, usize)>,
+    /// `(line, start_col, end_col)` of every match, in document order.
+    /// Columns address the original line in characters, never the lowercased
+    /// copy: Unicode lowercasing can expand text (`İ` folds to two
+    /// characters), so offsets into the folded copy would shift the highlight.
+    pub matches: Vec<(usize, usize, usize)>,
     /// Index into `matches` of the current hit.
     pub current: usize,
 }
@@ -266,26 +269,43 @@ impl FileView {
     }
 
     fn run_search(&mut self, query: &str) {
-        let needle = query.to_lowercase();
+        // Case-fold per character while remembering each folded character's
+        // origin column: whole-string lowercasing can expand the text (e.g.
+        // `İ` folds to `i` plus a combining dot), so offsets into the folded
+        // copy do not address the original line.
+        let needle: Vec<char> = query.to_lowercase().chars().collect();
         let mut matches = Vec::new();
         if let FileLoad::Text(lines) = &self.load {
             for (li, line) in lines.iter().enumerate() {
-                let hay = line.to_lowercase();
+                let hay: Vec<char> = line.chars().collect();
+                let mut folded: Vec<char> = Vec::with_capacity(hay.len());
+                let mut origin: Vec<usize> = Vec::with_capacity(hay.len());
+                for (col, ch) in hay.iter().enumerate() {
+                    for folded_ch in ch.to_lowercase() {
+                        origin.push(col);
+                        folded.push(folded_ch);
+                    }
+                }
+                if needle.is_empty() {
+                    continue;
+                }
                 let mut from = 0;
-                while let Some(rel) = hay[from..].find(&needle) {
-                    let byte_col = from + rel;
-                    // The renderer consumes matches as character columns
-                    // (tokens, wrap ranges), so translate the byte offset.
-                    let col = hay[..byte_col].chars().count();
-                    matches.push((li, col));
-                    from = byte_col + needle.len().max(1);
+                while from + needle.len() <= folded.len() {
+                    if folded[from..from + needle.len()] == needle[..] {
+                        let start = origin[from];
+                        let end = origin[from + needle.len() - 1] + 1;
+                        matches.push((li, start, end));
+                        from += needle.len();
+                    } else {
+                        from += 1;
+                    }
                 }
             }
         }
         // Jump to the first match at/after the current viewport top.
         let current = matches
             .iter()
-            .position(|(l, _)| *l >= self.scroll)
+            .position(|(l, _, _)| *l >= self.scroll)
             .unwrap_or(0);
         self.search = Some(Search {
             query: query.to_string(),
@@ -297,7 +317,7 @@ impl FileView {
 
     fn reveal_current_match(&mut self, viewport: usize) {
         if let Some(s) = &self.search {
-            if let Some((line, _)) = s.matches.get(s.current).copied() {
+            if let Some((line, _, _)) = s.matches.get(s.current).copied() {
                 // Center-ish: keep the match on screen.
                 if line < self.scroll || line >= self.scroll + viewport.max(1) {
                     self.scroll = line.saturating_sub(viewport / 2);
@@ -833,8 +853,27 @@ mod tests {
         v.search_commit();
         let s = v.search.as_ref().unwrap();
         // `é` is two bytes but one column: byte offsets 4 and 0 would
-        // misplace the overlay, character columns 2 and 0 do not.
-        assert_eq!(s.matches, vec![(0, 2), (1, 0)]);
+        // misplace the overlay, character columns do not.
+        assert_eq!(s.matches, vec![(0, 2, 5), (1, 0, 3)]);
+    }
+
+    #[test]
+    fn search_maps_folded_offsets_back_to_original_columns() {
+        let mut v = FileView::new(PathBuf::from("/x"));
+        // `İ` folds to two characters (`i` plus a combining dot), so offsets
+        // into the lowercased copy run ahead of the original line's columns:
+        // the `f` is folded index 3 but original column 2.
+        v.apply(FileLoad::Text(vec!["aİfoo".into()]));
+        v.search_begin();
+        for c in "foo".chars() {
+            v.search_push(c);
+        }
+        v.search_commit();
+        assert_eq!(
+            v.search.as_ref().unwrap().matches,
+            vec![(0, 2, 5)],
+            "match columns must address the original line"
+        );
     }
 
     #[test]

--- a/src/files/view.rs
+++ b/src/files/view.rs
@@ -1,8 +1,12 @@
 //! The file-view model (docs/38 FILE-3): one open file rendered natively inside
 //! a pane or a tab. Pure state; the bytes are read on a worker thread and folded
-//! in via [`FileView::apply`]. Rendering is O(visible rows) — the renderer slices
-//! `lines` to the viewport.
+//! in via [`FileView::apply_prepared`]. Rendering is O(visible rows × visible
+//! width) — the renderer slices `lines` to the viewport and tokenizes only the
+//! visible char window of each on-screen line, so a multi-megabyte single-line
+//! file costs a viewport, not the file.
 
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 
 /// Files larger than this are not read into memory — a viewer is not an excuse
@@ -44,6 +48,110 @@ pub struct Search {
     pub current: usize,
 }
 
+/// One cached line's windowed tokens: they cover `[0, covered_end)` in chars.
+#[derive(Clone, Debug)]
+struct CachedLine {
+    tokens: Vec<super::highlight::Token>,
+    covered_end: usize,
+    open: Option<super::highlight::MultilineKind>,
+}
+
+/// Bounded generation-checked token cache.
+///
+/// Rendering tokenizes only the visible window of each on-screen line, but a
+/// redraw, scroll, selection change, or theme switch would otherwise redo that
+/// work every frame. The cache keeps the most recent `cap` lines' windowed
+/// tokens keyed by file line; `rev` fences stale content (bumped on every
+/// `apply`, so a refreshed file never reuses another generation's tokens).
+/// Theme changes need no invalidation: tokens carry no colors.
+#[derive(Debug, Default)]
+struct TokenCache {
+    rev: u64,
+    map: HashMap<usize, CachedLine>,
+    order: VecDeque<usize>,
+    cap: usize,
+}
+
+impl TokenCache {
+    fn with_cap(cap: usize) -> Self {
+        TokenCache {
+            rev: 0,
+            map: HashMap::new(),
+            order: VecDeque::new(),
+            cap,
+        }
+    }
+
+    fn get(&self, line_idx: usize, needed_end: usize) -> Option<Vec<super::highlight::Token>> {
+        let entry = self.map.get(&line_idx)?;
+        if entry.covered_end < needed_end {
+            return None;
+        }
+        // Prefix of the cached window: clip the boundary token.
+        let mut out = Vec::new();
+        for t in &entry.tokens {
+            if t.start >= needed_end {
+                break;
+            }
+            out.push(super::highlight::Token {
+                start: t.start,
+                end: t.end.min(needed_end),
+                kind: t.kind,
+            });
+            if t.end >= needed_end {
+                break;
+            }
+        }
+        Some(out)
+    }
+
+    fn insert(
+        &mut self,
+        line_idx: usize,
+        open: Option<super::highlight::MultilineKind>,
+        tokens: Vec<super::highlight::Token>,
+        covered_end: usize,
+    ) {
+        if self.cap == 0 {
+            return;
+        }
+        if !self.map.contains_key(&line_idx) {
+            self.order.push_back(line_idx);
+            while self.order.len() > self.cap {
+                if let Some(old) = self.order.pop_front() {
+                    // Don't evict the line we just added when cap == 1 etc.;
+                    // the loop keeps the map bounded.
+                    if old != line_idx {
+                        self.map.remove(&old);
+                    }
+                }
+            }
+            // If we evicted the just-added key by accident (cap churn), re-add.
+            if !self.order.contains(&line_idx) {
+                self.order.push_back(line_idx);
+            }
+        }
+        self.map.insert(
+            line_idx,
+            CachedLine {
+                tokens,
+                covered_end,
+                open,
+            },
+        );
+        // Touch for LRU-ish behavior: move to the back.
+        if let Some(pos) = self.order.iter().position(|&i| i == line_idx) {
+            self.order.remove(pos);
+            self.order.push_back(line_idx);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.map.clear();
+        self.order.clear();
+    }
+}
+
 /// One open file: what it is, and where the viewport sits.
 pub struct FileView {
     pub path: PathBuf,
@@ -63,9 +171,9 @@ pub struct FileView {
     /// an enhancement, never a requirement.
     pub changes: Vec<crate::git::local::ChangeSpan>,
     /// The multiline-string opener active at the start of each line, parallel
-    /// to the `Text` lines. Rebuilt in [`FileView::apply`] so continuation
-    /// lines of triple-quoted or backtick strings keep their string color;
-    /// empty for non-text loads.
+    /// to the `Text` lines. Prepared on the file-read worker and folded in by
+    /// [`FileView::apply_prepared`] so the application thread never scans the
+    /// whole file; empty for non-text loads.
     pub string_states: Vec<Option<super::highlight::MultilineKind>>,
     /// Which scheduled read this view is waiting for (the `request_token` idea
     /// `DiffView` already uses). Every read carries the token it was issued
@@ -74,6 +182,13 @@ pub struct FileView {
     /// alone cannot tell apart. `0` means no read has been scheduled yet, so no
     /// event can ever match it.
     pub read_token: u64,
+    /// Content generation for the token cache: bumped on every `apply` so a
+    /// refreshed file never reuses the previous generation's windowed tokens.
+    highlight_rev: u64,
+    /// Bounded cache of windowed highlight tokens (see [`TokenCache`]).
+    /// `RefCell` lets the `&FileView` render path memoize without restructuring
+    /// every caller to `&mut`; the app loop is single-threaded.
+    token_cache: RefCell<TokenCache>,
 }
 
 impl FileView {
@@ -105,6 +220,8 @@ impl FileView {
             search: None,
             read_token: 0,
             string_states: Vec::new(),
+            highlight_rev: 0,
+            token_cache: RefCell::new(TokenCache::with_cap(128)),
         }
     }
 
@@ -112,18 +229,53 @@ impl FileView {
     /// so a live refresh (docs/38 FILE-5) doesn't yank the reader back to the
     /// top; a fresh open already has scroll at 0. An active search is
     /// re-evaluated against the new text.
+    ///
+    /// Direct-call fallback: computes the syntax preparation synchronously.
+    /// Prefer [`FileView::apply_prepared`] on the worker path, where the states
+    /// arrive precomputed and this scan never runs on the application thread.
+    #[allow(dead_code)]
     pub fn apply(&mut self, load: FileLoad) {
-        self.load = load;
-        // One forward pass over the text records the multiline-string opener
-        // at each line start, so the renderer colors continuation lines
-        // without scanning from the top of the file every frame.
-        self.string_states = match &self.load {
+        let states = match &load {
             FileLoad::Text(lines) => {
                 let lang = super::highlight::language_for_path(&self.path);
                 super::highlight::continuation_states(lines, lang)
             }
             _ => Vec::new(),
         };
+        self.apply_prepared(load, states);
+    }
+
+    /// Fold a worker-prepared read in: `states` must be the
+    /// [`continuation_states`](super::highlight::continuation_states) for
+    /// `load`'s lines in the worker's language guess. Length-mismatched states
+    /// are discarded and recomputed once (a stale worker must never poison the
+    /// renderer); the common path stores without scanning.
+    pub fn apply_prepared(
+        &mut self,
+        load: FileLoad,
+        mut states: Vec<Option<super::highlight::MultilineKind>>,
+    ) {
+        // Generation fence: only states prepared for this exact text may land.
+        // A length mismatch means the worker and the text disagree — fall back
+        // to one synchronous pass rather than rendering with shifted colors.
+        let ok = match &load {
+            FileLoad::Text(lines) => states.len() == lines.len(),
+            _ => states.is_empty(),
+        };
+        if !ok {
+            states = match &load {
+                FileLoad::Text(lines) => {
+                    let lang = super::highlight::language_for_path(&self.path);
+                    super::highlight::continuation_states(lines, lang)
+                }
+                _ => Vec::new(),
+            };
+        }
+        self.load = load;
+        self.string_states = states;
+        self.highlight_rev = self.highlight_rev.wrapping_add(1);
+        self.token_cache.borrow_mut().clear();
+        self.token_cache.borrow_mut().rev = self.highlight_rev;
         let max = self.line_count().saturating_sub(1);
         self.scroll = self.scroll.min(max);
         self.hscroll = 0;
@@ -132,6 +284,53 @@ impl FileView {
                 self.run_search(&s.query);
             }
         }
+    }
+
+    /// Windowed highlight tokens for `line_idx`, memoized in the bounded
+    /// generation-checked cache. `needed_end` is the exclusive char offset the
+    /// caller will actually draw (visible window end); the cache stores the
+    /// widest window seen per line and serves prefixes from it, so a 5 MiB
+    /// single line costs a viewport per frame, not the file.
+    pub fn highlight_window(
+        &self,
+        line_idx: usize,
+        line: &str,
+        lang: super::highlight::Language,
+        open: Option<super::highlight::MultilineKind>,
+        needed_end: usize,
+    ) -> Vec<super::highlight::Token> {
+        let mut cache = self.token_cache.borrow_mut();
+        if cache.rev != self.highlight_rev {
+            cache.clear();
+            cache.rev = self.highlight_rev;
+        }
+        if cache.cap == 0 {
+            return super::highlight::tokenize_window(line, lang, open, needed_end);
+        }
+        if let Some(hit) = cache.get(line_idx, needed_end) {
+            // Validate the opener: states only change on `apply` (which bumps
+            // `rev` and clears), so a mismatch here is a logic bug — recompute
+            // rather than tint with a stale string state.
+            let open_ok = cache.map.get(&line_idx).is_none_or(|e| e.open == open);
+            if open_ok {
+                return hit;
+            }
+        }
+        let tokens = super::highlight::tokenize_window(line, lang, open, needed_end);
+        cache.insert(line_idx, open, tokens.clone(), needed_end);
+        tokens
+    }
+
+    /// Test hook: number of cached lines.
+    #[cfg(test)]
+    pub fn token_cache_len(&self) -> usize {
+        self.token_cache.borrow().map.len()
+    }
+
+    /// Test hook: current highlight generation.
+    #[cfg(test)]
+    pub fn highlight_generation(&self) -> u64 {
+        self.highlight_rev
     }
 
     pub fn line_count(&self) -> usize {
@@ -269,50 +468,92 @@ impl FileView {
     }
 
     fn run_search(&mut self, query: &str) {
-        // Case-fold per character while remembering each folded character's
-        // origin column: whole-string lowercasing can expand the text (e.g.
-        // `İ` folds to `i` plus a combining dot), so offsets into the folded
-        // copy do not address the original line.
-        let needle: Vec<char> = query.to_lowercase().chars().collect();
+        // Unicode-aware case-insensitive search that keeps the efficient
+        // `str::find` matcher while retaining original-column mapping.
+        //
+        // Whole-string lowercasing can expand text (`İ` folds to `i` plus a
+        // combining dot), so offsets into the folded copy do not address the
+        // original line. We fold per character, remembering each folded
+        // character's origin column plus its byte offset, then run the
+        // standard library's optimized substring search over the folded
+        // string and map byte matches back through `origin`. The previous
+        // naive loop compared `folded[from..from+m] == needle` at every
+        // offset — O(file × query) slice comparisons on the app thread.
+        let needle_str = query.to_lowercase();
         let mut matches = Vec::new();
-        if let FileLoad::Text(lines) = &self.load {
-            for (li, line) in lines.iter().enumerate() {
-                let hay: Vec<char> = line.chars().collect();
-                let mut folded: Vec<char> = Vec::with_capacity(hay.len());
-                let mut origin: Vec<usize> = Vec::with_capacity(hay.len());
-                for (col, ch) in hay.iter().enumerate() {
-                    for folded_ch in ch.to_lowercase() {
-                        origin.push(col);
-                        folded.push(folded_ch);
+        if !needle_str.is_empty() {
+            if let FileLoad::Text(lines) = &self.load {
+                let needle_len = needle_str.len();
+                for (li, line) in lines.iter().enumerate() {
+                    // Single O(line) pass: folded text + per-folded-char origin
+                    // column + per-folded-char byte offset.
+                    let mut folded = String::with_capacity(line.len());
+                    let mut origin: Vec<usize> = Vec::new();
+                    let mut char_starts: Vec<usize> = Vec::new();
+                    let mut bytes = 0usize;
+                    for (col, ch) in line.chars().enumerate() {
+                        for folded_ch in ch.to_lowercase() {
+                            char_starts.push(bytes);
+                            origin.push(col);
+                            folded.push(folded_ch);
+                            bytes += folded_ch.len_utf8();
+                        }
                     }
-                }
-                if needle.is_empty() {
-                    continue;
-                }
-                let mut from = 0;
-                while from + needle.len() <= folded.len() {
-                    if folded[from..from + needle.len()] == needle[..] {
-                        let start = origin[from];
-                        let end = origin[from + needle.len() - 1] + 1;
+                    if folded.is_empty() {
+                        continue;
+                    }
+                    // Efficient matcher: `str::find` (memchr + Two-Way) instead of
+                    // a naive per-offset slice comparison.
+                    let mut byte_from = 0usize;
+                    while byte_from + needle_len <= folded.len() {
+                        let Some(rel) = folded[byte_from..].find(needle_str.as_str()) else {
+                            break;
+                        };
+                        let abs = byte_from + rel;
+                        // `abs` and `abs + needle_len` are char boundaries (both
+                        // haystack and needle are valid UTF-8), so exact binary
+                        // search hits.
+                        let Ok(start_char) = char_starts.binary_search(&abs) else {
+                            // Should not happen; advance past this byte to avoid a
+                            // stall and keep the search total.
+                            byte_from = abs + 1;
+                            continue;
+                        };
+                        let end_byte = abs + needle_len;
+                        let end_char_exclusive = match char_starts.binary_search(&end_byte) {
+                            Ok(i) => i,
+                            // `end_byte == folded.len()` is past the last start;
+                            // it addresses one past the final folded char.
+                            Err(i) if end_byte == folded.len() => i,
+                            Err(_) => {
+                                byte_from = abs + 1;
+                                continue;
+                            }
+                        };
+                        if end_char_exclusive == 0 || start_char >= end_char_exclusive {
+                            byte_from = abs + 1;
+                            continue;
+                        }
+                        let start = origin[start_char];
+                        let end = origin[end_char_exclusive - 1] + 1;
                         matches.push((li, start, end));
-                        from += needle.len();
-                    } else {
-                        from += 1;
+                        // Non-overlapping, matching the previous `from += m`.
+                        byte_from = end_byte;
                     }
                 }
             }
+            // Jump to the first match at/after the current viewport top.
+            let current = matches
+                .iter()
+                .position(|(l, _, _)| *l >= self.scroll)
+                .unwrap_or(0);
+            self.search = Some(Search {
+                query: query.to_string(),
+                editing: false,
+                matches,
+                current,
+            });
         }
-        // Jump to the first match at/after the current viewport top.
-        let current = matches
-            .iter()
-            .position(|(l, _, _)| *l >= self.scroll)
-            .unwrap_or(0);
-        self.search = Some(Search {
-            query: query.to_string(),
-            editing: false,
-            matches,
-            current,
-        });
     }
 
     fn reveal_current_match(&mut self, viewport: usize) {
@@ -348,16 +589,62 @@ pub fn gutter_width(line_count: usize) -> u16 {
 /// at least one range, so an empty line still occupies a row. Shared by the
 /// renderer and mouse-selection so a wrapped view maps screen rows to file
 /// columns identically in both.
+///
+/// Cost is O(line): it collects the whole line. The render path must use
+/// [`wrap_ranges_limited`] instead, which bounds work to the viewport.
+#[allow(dead_code)]
 pub fn wrap_ranges(line: &str, width: usize) -> Vec<(usize, usize)> {
-    let chars: Vec<char> = line.chars().collect();
+    wrap_ranges_limited(line, width, usize::MAX)
+}
+
+/// First `max_rows` wrapped segments of `line` — a prefix of [`wrap_ranges`].
+///
+/// A 5 MiB single-line file wraps to tens of thousands of rows; the viewport
+/// shows only dozens. Computing all segments every frame allocates the full
+/// vector repeatedly. This collects only enough prefix chars
+/// (`max_rows × (width+1)`) to cover the requested rows, so per-frame work is
+/// O(viewport × width), not O(file).
+pub fn wrap_ranges_limited(line: &str, width: usize, max_rows: usize) -> Vec<(usize, usize)> {
+    if max_rows == 0 {
+        return Vec::new();
+    }
+    if width == 0 {
+        // Original `wrap_ranges` returns the whole line as one segment when
+        // width is 0 (the `n <= width` check fails for non-empty? Actually
+        // `width == 0` short-circuits to a single range).
+        let n = line.chars().count();
+        return vec![(0, n)];
+    }
+    // Enough prefix to cover `max_rows` rows: each row consumes at most
+    // `width+1` chars (a full window plus one swallowed space).
+    let take = max_rows
+        .saturating_mul(width.saturating_add(1))
+        .saturating_add(width);
+    let chars: Vec<char> = line.chars().take(take).collect();
     let n = chars.len();
-    if width == 0 || n <= width {
+    // If the prefix already holds the whole line, `n` is the true length and
+    // this is exactly `wrap_ranges`. Otherwise `n` is the prefix length, but
+    // the first `max_rows` segments are identical to the full line's prefix
+    // (each consumes ≤ width+1 chars), so truncating to `max_rows` is exact.
+    if n == 0 {
+        return vec![(0, 0)];
+    }
+    if n <= width {
         return vec![(0, n)];
     }
     let mut out = Vec::new();
     let mut start = 0;
-    while start < n {
+    while start < n && out.len() < max_rows {
         if n - start <= width {
+            // Only final when the prefix really is the whole line; when the
+            // line continues beyond the prefix this arm would mislabel an
+            // interior row as final — but the prefix is sized so we reach
+            // `max_rows` before getting here for long lines. Guard anyway: if
+            // we took a truncated prefix (line longer than `take`) and this is
+            // not the last allowed row, fall through to the interior break.
+            // Detect truncation cheaply: if we filled `take` chars, the line
+            // may continue. In that case only take the final arm when it is
+            // also the last row we will return.
             out.push((start, n));
             break;
         }
@@ -390,34 +677,65 @@ pub fn wrap_ranges(line: &str, width: usize) -> Vec<(usize, usize)> {
 /// Must agree exactly with `wrap_ranges(..).len()` — the renderer lays rows out
 /// with that, and the scroll clamp counts them with this, so a disagreement
 /// would let the view scroll past its own last row (or stop short of it). Pinned
-/// by `wrap_rows_matches_wrap_ranges`. Counts without allocating, because the
-/// clamp runs on every keypress and wheel tick.
+/// by `wrap_rows_matches_wrap_ranges`. Counts with only O(width) buffering
+/// (one window plus one pending suffix), never O(line): the clamp runs on
+/// every keypress and wheel tick, and a 5 MiB single line must not allocate
+/// megabytes to answer "how tall?".
 pub fn wrap_rows(line: &str, width: usize) -> usize {
-    let n = line.chars().count();
-    if width == 0 || n <= width {
+    use std::collections::VecDeque;
+    if width == 0 {
         return 1;
     }
-    let chars: Vec<char> = line.chars().collect();
+    let mut iter = line.chars().peekable();
+    if iter.peek().is_none() {
+        return 1;
+    }
     let mut rows = 0usize;
-    let mut start = 0usize;
-    while start < n {
-        rows += 1;
-        if n - start <= width {
-            break;
-        }
-        let hard_end = start + width;
-        let mut brk = hard_end;
-        if let Some(pos) = chars[start..hard_end].iter().rposition(|&c| c == ' ') {
-            let abs = start + pos;
-            if abs > start {
-                brk = abs;
+    let mut pending: VecDeque<char> = VecDeque::new();
+    loop {
+        // Fill one window: pending suffix first, then fresh chars.
+        let mut buf: Vec<char> = Vec::with_capacity(width);
+        while buf.len() < width {
+            if let Some(c) = pending.pop_front() {
+                buf.push(c);
+            } else if let Some(c) = iter.next() {
+                buf.push(c);
+            } else {
+                break;
             }
         }
-        start = if brk < n && chars[brk] == ' ' {
-            brk + 1
+        if buf.len() < width {
+            // Exhausted: remaining fits in one final row. Empty `buf` means the
+            // previous row ended exactly at end-of-line (or swallowed a
+            // trailing space) — no extra row.
+            if !buf.is_empty() {
+                rows += 1;
+            } else if rows == 0 {
+                rows = 1;
+            }
+            break;
+        }
+        // Full window. Final iff nothing follows.
+        let more = !pending.is_empty() || iter.peek().is_some();
+        if !more {
+            rows += 1;
+            break;
+        }
+        // Interior row: prefer the last space strictly inside the window.
+        if let Some(pos) = buf.iter().rposition(|&c| c == ' ').filter(|&p| p > 0) {
+            rows += 1;
+            // Swallow the space; carry the suffix after it.
+            for &c in &buf[pos + 1..] {
+                pending.push_back(c);
+            }
         } else {
-            brk
-        };
+            rows += 1;
+            // Hard split: swallow one leading space of the next row, matching
+            // `wrap_ranges` (`chars[brk] == ' '` → `brk + 1`).
+            if iter.peek() == Some(&' ') {
+                iter.next();
+            }
+        }
     }
     rows.max(1)
 }
@@ -451,7 +769,11 @@ pub fn token_rows(
     let mut rows = Vec::with_capacity(body_rows);
     if v.wrap {
         'lines: for line in lines.iter().skip(v.scroll) {
-            for range in wrap_ranges(line, text_width) {
+            let remaining = body_rows.saturating_sub(rows.len());
+            if remaining == 0 {
+                break;
+            }
+            for range in wrap_ranges_limited(line, text_width, remaining) {
                 rows.push(format!("{prefix}{}", seg_text(line, range)));
                 if rows.len() >= body_rows {
                     break 'lines;
@@ -501,7 +823,11 @@ pub fn selection_text(
     let mut li = v.scroll;
     'build: while li < lines.len() {
         if v.wrap {
-            for (s, e) in wrap_ranges(&lines[li], text_w) {
+            let remaining = rows.saturating_sub(rowmap.len());
+            if remaining == 0 {
+                break;
+            }
+            for (s, e) in wrap_ranges_limited(&lines[li], text_w, remaining) {
                 rowmap.push((li, s, e));
                 if rowmap.len() >= rows {
                     break 'build;
@@ -563,36 +889,61 @@ pub fn selection_text(
 
 /// Read `path` off the loop into a [`FileLoad`]. Never panics: a missing file,
 /// permission error, oversize file, or binary content each becomes a variant.
+///
+/// Direct-call fallback (tests, benchmarks); workers use
+/// [`read_file_prepared`] so syntax state arrives precomputed.
+#[allow(dead_code)]
 pub fn read_file(path: &Path) -> FileLoad {
-    let meta = match std::fs::metadata(path) {
-        Ok(m) => m,
-        Err(e) => return FileLoad::Error(e.to_string()),
+    read_file_prepared(path).0
+}
+
+/// Read `path` off the loop and prepare syntax state on the same worker.
+///
+/// Returns the [`FileLoad`] plus the multiline-string opener active at each
+/// line start (parallel to the text lines; empty for non-text loads). The
+/// file-read worker calls this so [`FileView::apply_prepared`] can store both
+/// without scanning on the application thread. The language guess uses `path`,
+/// matching what the renderer would compute per frame.
+pub fn read_file_prepared(path: &Path) -> (FileLoad, Vec<Option<super::highlight::MultilineKind>>) {
+    let load = {
+        let meta = match std::fs::metadata(path) {
+            Ok(m) => m,
+            Err(e) => return (FileLoad::Error(e.to_string()), Vec::new()),
+        };
+        if meta.len() > SIZE_CAP {
+            return (FileLoad::TooLarge(meta.len()), Vec::new());
+        }
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) => return (FileLoad::Error(e.to_string()), Vec::new()),
+        };
+        if bytes.iter().take(SNIFF).any(|&b| b == 0) {
+            return (FileLoad::Binary(meta.len()), Vec::new());
+        }
+        // Lossy UTF-8, split on \n, strip a trailing \r, expand tabs to 4 columns so
+        // horizontal scroll and width math stay simple.
+        let text = String::from_utf8_lossy(&bytes);
+        let lines: Vec<String> = text
+            .split('\n')
+            .map(|l| l.strip_suffix('\r').unwrap_or(l).replace('\t', "    "))
+            .collect();
+        // A trailing newline yields a final empty element; drop it so the line count
+        // matches what an editor shows.
+        let lines = if lines.len() > 1 && lines.last().is_some_and(|l| l.is_empty()) {
+            lines[..lines.len() - 1].to_vec()
+        } else {
+            lines
+        };
+        FileLoad::Text(lines)
     };
-    if meta.len() > SIZE_CAP {
-        return FileLoad::TooLarge(meta.len());
-    }
-    let bytes = match std::fs::read(path) {
-        Ok(b) => b,
-        Err(e) => return FileLoad::Error(e.to_string()),
+    let states = match &load {
+        FileLoad::Text(lines) => {
+            let lang = super::highlight::language_for_path(path);
+            super::highlight::continuation_states(lines, lang)
+        }
+        _ => Vec::new(),
     };
-    if bytes.iter().take(SNIFF).any(|&b| b == 0) {
-        return FileLoad::Binary(meta.len());
-    }
-    // Lossy UTF-8, split on \n, strip a trailing \r, expand tabs to 4 columns so
-    // horizontal scroll and width math stay simple.
-    let text = String::from_utf8_lossy(&bytes);
-    let lines: Vec<String> = text
-        .split('\n')
-        .map(|l| l.strip_suffix('\r').unwrap_or(l).replace('\t', "    "))
-        .collect();
-    // A trailing newline yields a final empty element; drop it so the line count
-    // matches what an editor shows.
-    let lines = if lines.len() > 1 && lines.last().is_some_and(|l| l.is_empty()) {
-        lines[..lines.len() - 1].to_vec()
-    } else {
-        lines
-    };
-    FileLoad::Text(lines)
+    (load, states)
 }
 
 #[cfg(test)]
@@ -911,5 +1262,212 @@ mod tests {
 
         v.search_cancel();
         assert!(v.search.is_none());
+    }
+
+    /// Worker-prepared reads land without an application-thread scan: the
+    /// states arrive with the text and are stored directly.
+    #[test]
+    fn prepared_apply_stores_worker_states_and_fences_generations() {
+        use crate::files::highlight::{language_for_path, MultilineKind};
+        let mut v = FileView::new(PathBuf::from("doc.py"));
+        let lines = vec![
+            "doc = \"\"\"start".to_string(),
+            "return of the thing".to_string(),
+            "end\"\"\"".to_string(),
+        ];
+        let lang = language_for_path(&v.path);
+        let states = crate::files::highlight::continuation_states(&lines, lang);
+        let rev_before = v.highlight_generation();
+        v.apply_prepared(FileLoad::Text(lines.clone()), states.clone());
+        assert_eq!(v.string_states, states);
+        assert_ne!(v.highlight_generation(), rev_before);
+        assert_eq!(v.token_cache_len(), 0, "apply clears the window cache");
+
+        // Length-mismatched states are a stale worker: fall back to a fresh
+        // pass rather than rendering with shifted colors.
+        let mut v2 = FileView::new(PathBuf::from("doc.py"));
+        v2.apply_prepared(FileLoad::Text(lines.clone()), vec![None]);
+        assert_eq!(
+            v2.string_states,
+            vec![
+                None,
+                Some(MultilineKind::TripleDouble),
+                Some(MultilineKind::TripleDouble),
+            ]
+        );
+    }
+
+    /// The window cache is bounded and generation-checked.
+    #[test]
+    fn token_cache_is_bounded_and_generation_checked() {
+        use crate::files::highlight::language_for_path;
+        let mut v = FileView::new(PathBuf::from("x.rs"));
+        let lines: Vec<String> = (0..300).map(|i| format!("let x{i} = {i};")).collect();
+        v.apply(FileLoad::Text(lines.clone()));
+        let lang = language_for_path(&v.path);
+        for (idx, line) in lines.iter().enumerate() {
+            let open = v.string_states.get(idx).copied().flatten();
+            let needed = line.chars().count().min(40);
+            let _ = v.highlight_window(idx, line, lang, open, needed);
+        }
+        assert!(
+            v.token_cache_len() <= 128,
+            "cache stays bounded (got {})",
+            v.token_cache_len()
+        );
+
+        let rev = v.highlight_generation();
+        v.apply(FileLoad::Text(vec!["let y = 2;".into()]));
+        assert_ne!(v.highlight_generation(), rev);
+        assert_eq!(v.token_cache_len(), 0, "a new generation drops old windows");
+    }
+
+    /// `wrap_ranges_limited` is exactly the prefix of `wrap_ranges`.
+    #[test]
+    fn wrap_limited_is_a_prefix_of_full() {
+        let line = "the quick brown fox jumps over ".repeat(200);
+        for w in [10usize, 40, 80] {
+            let full = wrap_ranges(&line, w);
+            for k in [1usize, 5, 40] {
+                let limited = wrap_ranges_limited(&line, w, k);
+                assert_eq!(
+                    limited,
+                    full[..limited.len()].to_vec(),
+                    "first {k} segments at width {w}"
+                );
+                assert!(limited.len() <= k);
+            }
+        }
+    }
+
+    /// Near-limit single-line JSON: wrap and no-wrap stay viewport-bounded,
+    /// scroll stays put (one logical line), selection is a slice, Unicode
+    /// search maps to original columns, and the cache survives a theme change
+    /// (styles resolve at render time).
+    #[test]
+    fn near_limit_single_line_json_stays_viewport_bounded() {
+        // ~4.3 MiB single line, under the 5 MiB viewer cap.
+        let unit = r#"{"k":"v","n":123,"b":true},"#;
+        let reps = (4_500_000 / unit.len()).max(1);
+        let huge: String = unit.repeat(reps);
+        assert!(huge.len() > 4_000_000 && huge.len() < 5 * 1024 * 1024);
+
+        let mut v = FileView::new(PathBuf::from("data.json"));
+        // Simulate the worker: prepared states, no app-thread scan.
+        let lang = crate::files::highlight::language_for_path(&v.path);
+        let lines = vec![huge.clone()];
+        let states = crate::files::highlight::continuation_states(&lines, lang);
+        v.apply_prepared(FileLoad::Text(lines), states);
+        assert_eq!(v.line_count(), 1);
+
+        let text_w = 80usize;
+        let viewport = 40usize;
+        // Wrap: only the viewport's rows are materialized.
+        v.wrap = true;
+        let ranges = wrap_ranges_limited(&huge, text_w, viewport);
+        assert_eq!(ranges.len(), viewport);
+        let needed = ranges.iter().map(|&(_, e)| e).max().unwrap();
+        assert!(needed <= viewport * (text_w + 1) + text_w);
+        let tokens = v.highlight_window(0, &huge, lang, None, needed);
+        assert!(
+            tokens.iter().all(|t| t.end <= needed),
+            "windowed tokens never cover the whole 4 MiB line"
+        );
+        assert!(
+            tokens.len() < huge.chars().count() / 4,
+            "coalescing keeps token counts far below char counts"
+        );
+        assert!(v.token_cache_len() <= 128);
+
+        // No-wrap: the visible window is hscroll..hscroll+width.
+        v.wrap = false;
+        v.hscroll = 100;
+        let needed = 100 + text_w;
+        let tokens = v.highlight_window(0, &huge, lang, None, needed);
+        assert!(tokens.iter().all(|t| t.start < needed));
+
+        // Scroll is line-based: a single logical line never scrolls by lines.
+        v.wrap = true;
+        v.scroll_by(1000, viewport, text_w);
+        assert_eq!(v.scroll, 0);
+        assert_eq!(v.last_top(viewport, text_w), 0);
+
+        // Selection over the first two visual rows is a small slice, and it
+        // joins wrapped rows of the same file line without inventing a newline.
+        let content = ratatui::layout::Rect::new(0, 0, 100, viewport as u16 + 1);
+        let gutter = gutter_width(1);
+        let text_x = gutter + 1;
+        let sel = selection_text(&v, content, ((text_x, 0), (text_x + 10, 1)));
+        let sel = sel.expect("a drag over two wrapped rows selects text");
+        assert!(!sel.contains('\n'), "same-line wrapped rows join");
+        assert!(sel.len() < 4 * text_w, "selection is viewport-bounded");
+
+        // Unicode search on the huge line maps to original columns.
+        let mut u = FileView::new(PathBuf::from("data.json"));
+        u.apply(FileLoad::Text(vec![format!("éé{huge}")]));
+        u.search_begin();
+        for c in "éé".chars() {
+            u.search_push(c);
+        }
+        u.search_commit();
+        assert_eq!(
+            u.search.as_ref().unwrap().matches,
+            vec![(0, 0, 2)],
+            "folded offsets map back past multi-byte chars"
+        );
+
+        // Theme changes need no cache invalidation: tokens carry no colors.
+        let before = v.highlight_window(0, &huge, lang, None, needed);
+        let rev = v.highlight_generation();
+        let after = v.highlight_window(0, &huge, lang, None, needed);
+        assert_eq!(v.highlight_generation(), rev);
+        assert_eq!(before, after);
+    }
+
+    /// Large multiline source: both modes page to the end, selection keeps
+    /// real line breaks, and search finds Unicode hits across lines.
+    #[test]
+    fn large_multiline_source_pages_selects_and_searches() {
+        let lines: Vec<String> = (0..20_000)
+            .map(|i| format!("fn f{i}() {{ let x{i} = {i}; }} // café {i}"))
+            .collect();
+        let mut v = FileView::new(PathBuf::from("code.rs"));
+        v.apply(FileLoad::Text(lines.clone()));
+        assert_eq!(v.line_count(), 20_000);
+
+        for wrap in [true, false] {
+            v.wrap = wrap;
+            v.goto_top();
+            let (viewport, text_w) = (40usize, 80usize);
+            v.goto_bottom(viewport, text_w);
+            assert_eq!(v.scroll, v.last_top(viewport, text_w));
+            assert!(v.scroll > 19_000, "paging reaches the end in both modes");
+            // Windowed highlight for a mid-file line covers only its window.
+            let lang = crate::files::highlight::language_for_path(&v.path);
+            let idx = 10_000;
+            let open = v.string_states.get(idx).copied().flatten();
+            let tokens = v.highlight_window(idx, &lines[idx], lang, open, text_w);
+            assert!(tokens.iter().all(|t| t.end <= text_w + 64));
+        }
+
+        // Selection across two file lines keeps the real break.
+        v.wrap = false;
+        v.scroll = 0;
+        let content = ratatui::layout::Rect::new(0, 0, 100, 10);
+        let text_x = gutter_width(20_000) + 1;
+        let sel = selection_text(&v, content, ((text_x, 0), (text_x + 5, 1)))
+            .expect("two-line drag selects");
+        assert_eq!(sel.lines().count(), 2, "real file breaks survive");
+
+        // Unicode search finds hits across the file with character columns.
+        v.search_begin();
+        for c in "café".chars() {
+            v.search_push(c);
+        }
+        v.search_commit();
+        let s = v.search.as_ref().unwrap();
+        assert_eq!(s.matches.len(), 20_000);
+        assert_eq!(s.matches[0].0, 0);
+        assert_eq!(s.matches[19_999].0, 19_999);
     }
 }

--- a/src/files/view.rs
+++ b/src/files/view.rs
@@ -273,9 +273,12 @@ impl FileView {
                 let hay = line.to_lowercase();
                 let mut from = 0;
                 while let Some(rel) = hay[from..].find(&needle) {
-                    let col = from + rel;
+                    let byte_col = from + rel;
+                    // The renderer consumes matches as character columns
+                    // (tokens, wrap ranges), so translate the byte offset.
+                    let col = hay[..byte_col].chars().count();
                     matches.push((li, col));
-                    from = col + needle.len().max(1);
+                    from = byte_col + needle.len().max(1);
                 }
             }
         }
@@ -817,6 +820,21 @@ mod tests {
         assert_eq!(v.last_top(20, 80), 80);
         v.goto_bottom(20, 80);
         assert_eq!(v.scroll, 80);
+    }
+
+    #[test]
+    fn search_stores_character_columns_for_non_ascii_lines() {
+        let mut v = FileView::new(PathBuf::from("/x"));
+        v.apply(FileLoad::Text(vec!["ééfoo".into(), "fooé".into()]));
+        v.search_begin();
+        for c in "foo".chars() {
+            v.search_push(c);
+        }
+        v.search_commit();
+        let s = v.search.as_ref().unwrap();
+        // `é` is two bytes but one column: byte offsets 4 and 0 would
+        // misplace the overlay, character columns 2 and 0 do not.
+        assert_eq!(s.matches, vec![(0, 2), (1, 0)]);
     }
 
     #[test]

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -490,7 +490,8 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
         let mut i = v.scroll;
         while y < bottom && i < lines.len() {
             let line = &lines[i];
-            let tokens = highlight::tokenize(line, lang);
+            let open = v.string_states.get(i).copied().flatten();
+            let tokens = highlight::tokenize_continued(line, lang, open);
             let (hits, qlen) = search_hits_for_line(v, i);
             for (si, range) in crate::files::wrap_ranges(line, text_w as usize)
                 .into_iter()
@@ -516,7 +517,8 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
     for (i, line) in lines.iter().enumerate().skip(v.scroll).take(rows) {
         let y = body.y + (i - v.scroll) as u16;
         gutter_cell(f, y, Some(i + 1), i + 1);
-        let tokens = highlight::tokenize(line, lang);
+        let open = v.string_states.get(i).copied().flatten();
+        let tokens = highlight::tokenize_continued(line, lang, open);
         let (hits, qlen) = search_hits_for_line(v, i);
         let width = line.chars().count();
         let spans = spans_in_range(line, &tokens, (0, width), &hits, qlen, t);
@@ -842,7 +844,7 @@ mod tests {
 
         let theme = Theme::quattro_rally();
         let line = "fn load(path: &Path) -> usize { // open";
-        let tokens = highlight::tokenize(line, highlight::Language::Rust);
+        let tokens = highlight::tokenize_continued(line, highlight::Language::Rust, None);
         let width = line.chars().count();
         let spans = super::spans_in_range(line, &tokens, (0, width), &[], 0, &theme);
         let text: String = spans.iter().map(|span| span.content.as_ref()).collect();
@@ -887,7 +889,7 @@ mod tests {
 
         let theme = Theme::quattro_rally();
         let line = "let loaded = load(path); // load";
-        let tokens = highlight::tokenize(line, highlight::Language::Rust);
+        let tokens = highlight::tokenize_continued(line, highlight::Language::Rust, None);
         let width = line.chars().count();
         // `load` occurs at columns 4 ("loaded" prefix) and 13; highlight the
         // standalone call as the current match.

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -492,7 +492,7 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
             let line = &lines[i];
             let open = v.string_states.get(i).copied().flatten();
             let tokens = highlight::tokenize_continued(line, lang, open);
-            let (hits, qlen) = search_hits_for_line(v, i);
+            let hits = search_hits_for_line(v, i);
             for (si, range) in crate::files::wrap_ranges(line, text_w as usize)
                 .into_iter()
                 .enumerate()
@@ -501,7 +501,7 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
                     break;
                 }
                 gutter_cell(f, y, (si == 0).then_some(i + 1), i + 1);
-                let spans = spans_in_range(line, &tokens, range, &hits, qlen, t);
+                let spans = spans_in_range(line, &tokens, range, &hits, t);
                 f.render_widget(
                     Paragraph::new(Line::from(spans)),
                     Rect::new(text_x, y, text_w, 1),
@@ -519,9 +519,9 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
         gutter_cell(f, y, Some(i + 1), i + 1);
         let open = v.string_states.get(i).copied().flatten();
         let tokens = highlight::tokenize_continued(line, lang, open);
-        let (hits, qlen) = search_hits_for_line(v, i);
+        let hits = search_hits_for_line(v, i);
         let width = line.chars().count();
-        let spans = spans_in_range(line, &tokens, (0, width), &hits, qlen, t);
+        let spans = spans_in_range(line, &tokens, (0, width), &hits, t);
         f.render_widget(
             Paragraph::new(Line::from(spans)).scroll((0, v.hscroll)),
             Rect::new(text_x, y, text_w, 1),
@@ -571,26 +571,23 @@ fn highlight_style(kind: highlight::Kind, t: &Theme) -> Style {
     }
 }
 
-/// Search hits on one file line as `(char column, is_current)` plus the query
-/// length in chars. `None`/editing/empty queries yield no hits, so plain
-/// syntax spans render alone. Columns follow the existing search convention
-/// (match offsets into the line's chars).
-fn search_hits_for_line(v: &FileView, line_idx: usize) -> (Vec<(usize, bool)>, usize) {
+/// Search hits on one file line as `(start_col, end_col, is_current)` in
+/// original-line character columns. `None`/editing/empty queries yield no
+/// hits, so plain syntax spans render alone.
+fn search_hits_for_line(v: &FileView, line_idx: usize) -> Vec<(usize, usize, bool)> {
     let Some(search) = &v.search else {
-        return (Vec::new(), 0);
+        return Vec::new();
     };
     if search.editing || search.query.is_empty() {
-        return (Vec::new(), 0);
+        return Vec::new();
     }
-    let qlen = search.query.chars().count();
-    let hits: Vec<(usize, bool)> = search
+    search
         .matches
         .iter()
         .enumerate()
-        .filter(|(_, (line, _))| *line == line_idx)
-        .map(|(index, (_, col))| (*col, index == search.current))
-        .collect();
-    (hits, qlen)
+        .filter(|(_, (line, _, _))| *line == line_idx)
+        .map(|(index, (_, start, end))| (*start, *end, index == search.current))
+        .collect()
 }
 
 /// Build spans for the char range of one line: syntax tokens clipped to the
@@ -600,21 +597,15 @@ fn spans_in_range(
     line: &str,
     tokens: &[highlight::Token],
     range: (usize, usize),
-    hits: &[(usize, bool)],
-    query_len: usize,
+    hits: &[(usize, usize, bool)],
     t: &Theme,
 ) -> Vec<Span<'static>> {
     let chars: Vec<char> = line.chars().collect();
     let (seg_start, seg_end) = range;
     let mut intervals: Vec<(usize, usize, bool)> = hits
         .iter()
-        .map(|(col, current)| {
-            (
-                (*col).max(seg_start),
-                col.saturating_add(query_len).max(col + 1).min(seg_end),
-                *current,
-            )
-        })
+        .map(|(start, end, current)| (*start, *end, *current))
+        .map(|(start, end, current)| (start.max(seg_start), end.min(seg_end), current))
         .filter(|(start, end, _)| start < end)
         .collect();
     intervals.sort();
@@ -846,7 +837,7 @@ mod tests {
         let line = "fn load(path: &Path) -> usize { // open";
         let tokens = highlight::tokenize_continued(line, highlight::Language::Rust, None);
         let width = line.chars().count();
-        let spans = super::spans_in_range(line, &tokens, (0, width), &[], 0, &theme);
+        let spans = super::spans_in_range(line, &tokens, (0, width), &[], &theme);
         let text: String = spans.iter().map(|span| span.content.as_ref()).collect();
         assert_eq!(text, line, "spans must cover the line exactly");
 
@@ -893,7 +884,7 @@ mod tests {
         let width = line.chars().count();
         // `load` occurs at columns 4 ("loaded" prefix) and 13; highlight the
         // standalone call as the current match.
-        let spans = super::spans_in_range(line, &tokens, (0, width), &[(13, true)], 4, &theme);
+        let spans = super::spans_in_range(line, &tokens, (0, width), &[(13, 17, true)], &theme);
         let current = spans
             .iter()
             .find(|span| span.content == "load")
@@ -902,7 +893,7 @@ mod tests {
         assert_eq!(current.style.fg, Some(theme.base));
 
         // A wrapped segment sees only its own slice of both layers.
-        let segment = super::spans_in_range(line, &tokens, (0, 10), &[(13, true)], 4, &theme);
+        let segment = super::spans_in_range(line, &tokens, (0, 10), &[(13, 17, true)], &theme);
         let text: String = segment.iter().map(|span| span.content.as_ref()).collect();
         assert_eq!(text, "let loaded");
         assert!(

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -330,8 +330,11 @@ fn diff_list_stats(
 }
 
 /// Draw a native file view (docs/38 FILE-3) into `area`, the pane's content
-/// rect. O(visible rows): only the on-screen slice of `lines` is rendered. The
-/// bottom row is a dim status footer.
+/// rect. O(visible rows × visible width): only the on-screen slice of `lines`
+/// is rendered, and each on-screen logical line is tokenized only up to its
+/// visible char window (cached per generation), so a very long logical line
+/// costs its viewport slice, not the file. The bottom row is a dim status
+/// footer.
 pub(super) fn draw_file_view(
     f: &mut RenderTarget,
     area: Rect,
@@ -447,7 +450,10 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
         return;
     }
     // The highlight language is a pure function of the path: one lookup per
-    // frame, then O(visible rows) tokenization below — never O(file).
+    // frame, then O(visible rows × visible width) windowed tokenization below
+    // — never O(file). A multi-megabyte single logical line costs a viewport,
+    // not the file: tokens come from the bounded generation-checked cache and
+    // cover only the visible char window.
     let lang = highlight::language_for_path(&v.path);
     // The gutter is `marker + number + one space`, totalling `gutter + 1` — the
     // same width as before, so `text_x` and mouse-selection column mapping are
@@ -483,20 +489,24 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
         // Soft-wrap: each file line occupies as many screen rows as it needs.
         // Scroll stays line-based (top row = file line `scroll`), so vertical
         // scroll, goto, and search reveal are unchanged. Each segment is
-        // syntax-highlighted from the line's tokens, with search matches
-        // overlaid — the same spans the no-wrap path builds for whole lines.
+        // syntax-highlighted from the line's windowed tokens, with search
+        // matches overlaid — the same spans the no-wrap path builds.
+        //
+        // Bounded per frame: `wrap_ranges_limited` computes only the rows we
+        // will actually draw, and `highlight_window` tokenizes only up to the
+        // last visible segment end (cached per generation).
         let mut y = body.y;
         let bottom = body.y + body.height;
         let mut i = v.scroll;
         while y < bottom && i < lines.len() {
             let line = &lines[i];
+            let remaining = (bottom - y) as usize;
+            let ranges = crate::files::wrap_ranges_limited(line, text_w as usize, remaining);
+            let needed_end = ranges.iter().map(|&(_, e)| e).max().unwrap_or(0);
             let open = v.string_states.get(i).copied().flatten();
-            let tokens = highlight::tokenize_continued(line, lang, open);
+            let tokens = v.highlight_window(i, line, lang, open, needed_end);
             let hits = search_hits_for_line(v, i);
-            for (si, range) in crate::files::wrap_ranges(line, text_w as usize)
-                .into_iter()
-                .enumerate()
-            {
+            for (si, range) in ranges.into_iter().enumerate() {
                 if y >= bottom {
                     break;
                 }
@@ -513,17 +523,20 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
         return;
     }
 
-    // No-wrap: one file line per row, clipped, with horizontal scroll.
+    // No-wrap: one file line per row. Only the visible `[hscroll,
+    // hscroll+text_w)` char window is tokenized and spanned — never the whole
+    // multi-megabyte line — and the paragraph needs no scroll offset.
     for (i, line) in lines.iter().enumerate().skip(v.scroll).take(rows) {
         let y = body.y + (i - v.scroll) as u16;
         gutter_cell(f, y, Some(i + 1), i + 1);
         let open = v.string_states.get(i).copied().flatten();
-        let tokens = highlight::tokenize_continued(line, lang, open);
+        let hstart = v.hscroll as usize;
+        let needed_end = hstart.saturating_add(text_w as usize);
+        let tokens = v.highlight_window(i, line, lang, open, needed_end);
         let hits = search_hits_for_line(v, i);
-        let width = line.chars().count();
-        let spans = spans_in_range(line, &tokens, (0, width), &hits, t);
+        let spans = spans_in_range(line, &tokens, (hstart, needed_end), &hits, t);
         f.render_widget(
-            Paragraph::new(Line::from(spans)).scroll((0, v.hscroll)),
+            Paragraph::new(Line::from(spans)),
             Rect::new(text_x, y, text_w, 1),
         );
     }
@@ -574,6 +587,10 @@ fn highlight_style(kind: highlight::Kind, t: &Theme) -> Style {
 /// Search hits on one file line as `(start_col, end_col, is_current)` in
 /// original-line character columns. `None`/editing/empty queries yield no
 /// hits, so plain syntax spans render alone.
+///
+/// Matches are stored in document order, so the per-line slice is found with
+/// two binary searches — O(log matches + hits), not O(matches) per visible
+/// row.
 fn search_hits_for_line(v: &FileView, line_idx: usize) -> Vec<(usize, usize, bool)> {
     let Some(search) = &v.search else {
         return Vec::new();
@@ -581,18 +598,23 @@ fn search_hits_for_line(v: &FileView, line_idx: usize) -> Vec<(usize, usize, boo
     if search.editing || search.query.is_empty() {
         return Vec::new();
     }
-    search
-        .matches
+    let matches = &search.matches;
+    let lo = matches.partition_point(|(l, _, _)| *l < line_idx);
+    let hi = matches.partition_point(|(l, _, _)| *l <= line_idx);
+    matches[lo..hi]
         .iter()
         .enumerate()
-        .filter(|(_, (line, _, _))| *line == line_idx)
-        .map(|(index, (_, start, end))| (*start, *end, index == search.current))
+        .map(|(k, (_, start, end))| (*start, *end, lo + k == search.current))
         .collect()
 }
 
 /// Build spans for the char range of one line: syntax tokens clipped to the
 /// range, split at search-match boundaries so the current match stays brighter
 /// than the rest. Adjacent pieces with the same style merge back into one span.
+///
+/// Only the visible `range` is materialized: the segment text is collected via
+/// `skip`/`take` (no whole-line `Vec<char>`), so a 5 MiB line costs its
+/// viewport slice, not the file.
 fn spans_in_range(
     line: &str,
     tokens: &[highlight::Token],
@@ -600,8 +622,25 @@ fn spans_in_range(
     hits: &[(usize, usize, bool)],
     t: &Theme,
 ) -> Vec<Span<'static>> {
-    let chars: Vec<char> = line.chars().collect();
     let (seg_start, seg_end) = range;
+    if seg_start >= seg_end {
+        return Vec::new();
+    }
+    let seg_len = seg_end - seg_start;
+    // Visible slice only.
+    let seg_chars: Vec<char> = line.chars().skip(seg_start).take(seg_len).collect();
+    let text_of = |start: usize, end: usize| -> String {
+        let (lo, hi) = (
+            start.saturating_sub(seg_start),
+            end.saturating_sub(seg_start),
+        );
+        let (lo, hi) = (lo.min(seg_chars.len()), hi.min(seg_chars.len()));
+        if lo >= hi {
+            String::new()
+        } else {
+            seg_chars[lo..hi].iter().collect()
+        }
+    };
     let mut intervals: Vec<(usize, usize, bool)> = hits
         .iter()
         .map(|(start, end, current)| (*start, *end, *current))
@@ -610,12 +649,6 @@ fn spans_in_range(
         .collect();
     intervals.sort();
     intervals.dedup();
-    let text_of = |start: usize, end: usize| -> String {
-        chars
-            .get(start..end)
-            .map(|slice| slice.iter().collect())
-            .unwrap_or_default()
-    };
     let mut pieces: Vec<(String, Style)> = Vec::new();
     let mut push = |text: String, style: Style| {
         if text.is_empty() {
@@ -900,5 +933,108 @@ mod tests {
             segment.iter().all(|span| span.style.bg.is_none()),
             "the match outside the segment must not leak in"
         );
+    }
+
+    /// Near-limit single-line JavaScript: windowed spans cover only the
+    /// viewport slice, stay coalesced, clip search to the window, and recolor
+    /// across themes without re-tokenizing.
+    #[test]
+    fn huge_single_line_js_spans_stay_windowed_across_themes() {
+        use crate::files::{highlight, FileLoad, FileView};
+        use std::path::PathBuf;
+
+        let unit = r#"const v0123456789="abcdefghij0123456789";"#;
+        let reps = (2_000_000 / unit.len()).max(1);
+        let huge: String = unit.repeat(reps);
+        assert!(huge.len() > 1_000_000);
+
+        let mut v = FileView::new(PathBuf::from("bundle.min.js"));
+        let lang = highlight::language_for_path(&v.path);
+        let lines = vec![huge.clone()];
+        let states = highlight::continuation_states(&lines, lang);
+        v.apply_prepared(FileLoad::Text(lines), states);
+
+        // No-wrap window: hscroll + width.
+        v.wrap = false;
+        v.hscroll = 200;
+        let text_w = 80usize;
+        let needed = 200 + text_w;
+        let tokens = v.highlight_window(0, &huge, lang, None, needed);
+        assert!(tokens.iter().all(|t| t.start < needed));
+        let hits = super::search_hits_for_line(&v, 0);
+        assert!(hits.is_empty());
+        let spans =
+            super::spans_in_range(&huge, &tokens, (200, needed), &[], &Theme::quattro_rally());
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        let expected: String = huge.chars().skip(200).take(text_w).collect();
+        assert_eq!(text, expected);
+        assert!(
+            spans.len() < text_w,
+            "coalesced spans stay far below one-per-char (got {})",
+            spans.len()
+        );
+
+        // Wrap window: first viewport rows only.
+        v.wrap = true;
+        let ranges = crate::files::wrap_ranges_limited(&huge, text_w, 40);
+        assert_eq!(ranges.len(), 40);
+        let needed = ranges.iter().map(|&(_, e)| e).max().unwrap();
+        let tokens = v.highlight_window(0, &huge, lang, None, needed);
+        let first = ranges[0];
+        let spans = super::spans_in_range(&huge, &tokens, first, &[], &Theme::quattro_rally());
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        let expected: String = huge.chars().skip(first.0).take(first.1 - first.0).collect();
+        assert_eq!(text, expected);
+
+        // A match outside the window must not leak into it.
+        let far_hit = vec![(needed + 1000, needed + 1004, true)];
+        let spans = super::spans_in_range(&huge, &tokens, first, &far_hit, &Theme::quattro_rally());
+        assert!(spans.iter().all(|s| s.style.bg.is_none()));
+
+        // Theme change recolors the same tokens without re-tokenizing.
+        let other = Theme::dracula();
+        let a = super::spans_in_range(&huge, &tokens, first, &[], &Theme::quattro_rally());
+        let b = super::spans_in_range(&huge, &tokens, first, &[], &other);
+        let ta: String = a.iter().map(|s| s.content.as_ref()).collect();
+        let tb: String = b.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(ta, tb, "same text across themes");
+        assert_ne!(
+            a.iter().map(|s| s.style).collect::<Vec<_>>(),
+            b.iter().map(|s| s.style).collect::<Vec<_>>(),
+            "styles resolve through the theme"
+        );
+        assert_eq!(v.token_cache_len(), 1, "one cached window reused");
+    }
+
+    /// End-to-end draw of a huge single-line file completes in both modes.
+    #[test]
+    fn huge_file_view_draws_in_both_wrap_modes() {
+        use crate::files::{FileLoad, FileView};
+        use std::path::PathBuf;
+
+        let huge = "x".repeat(500_000);
+        let mut v = FileView::new(PathBuf::from("data.json"));
+        v.apply_prepared(FileLoad::Text(vec![huge.clone()]), vec![None]);
+        let area = Rect::new(0, 0, 100, 24);
+        for wrap in [true, false] {
+            v.wrap = wrap;
+            let mut buf = Buffer::empty(area);
+            {
+                let mut target = RenderTarget::new(&mut buf, area);
+                super::draw_file_view(&mut target, area, &v, None, false, &Theme::quattro_rally());
+            }
+            let screen: String = (0..area.height)
+                .map(|y| {
+                    (0..area.width)
+                        .map(|x| buf[(x, y)].symbol())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(
+                screen.contains('x'),
+                "the huge line's viewport slice drew (wrap={wrap})"
+            );
+        }
     }
 }

--- a/src/ui/files.rs
+++ b/src/ui/files.rs
@@ -10,7 +10,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::App;
-use crate::files::{FileLoad, FileView, SIZE_CAP};
+use crate::files::{highlight, FileLoad, FileView, SIZE_CAP};
 use crate::ui::theme::Theme;
 use crate::ui::RenderTarget;
 
@@ -446,6 +446,9 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
     if text_w == 0 {
         return;
     }
+    // The highlight language is a pure function of the path: one lookup per
+    // frame, then O(visible rows) tokenization below — never O(file).
+    let lang = highlight::language_for_path(&v.path);
     // The gutter is `marker + number + one space`, totalling `gutter + 1` — the
     // same width as before, so `text_x` and mouse-selection column mapping are
     // unchanged. The git change marker (docs/38 + docs/30) sits in column 0,
@@ -479,12 +482,16 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
     if v.wrap {
         // Soft-wrap: each file line occupies as many screen rows as it needs.
         // Scroll stays line-based (top row = file line `scroll`), so vertical
-        // scroll, goto, and search reveal are unchanged.
+        // scroll, goto, and search reveal are unchanged. Each segment is
+        // syntax-highlighted from the line's tokens, with search matches
+        // overlaid — the same spans the no-wrap path builds for whole lines.
         let mut y = body.y;
         let bottom = body.y + body.height;
         let mut i = v.scroll;
         while y < bottom && i < lines.len() {
             let line = &lines[i];
+            let tokens = highlight::tokenize(line, lang);
+            let (hits, qlen) = search_hits_for_line(v, i);
             for (si, range) in crate::files::wrap_ranges(line, text_w as usize)
                 .into_iter()
                 .enumerate()
@@ -493,11 +500,9 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
                     break;
                 }
                 gutter_cell(f, y, (si == 0).then_some(i + 1), i + 1);
+                let spans = spans_in_range(line, &tokens, range, &hits, qlen, t);
                 f.render_widget(
-                    Paragraph::new(Span::styled(
-                        crate::files::seg_text(line, range),
-                        Style::new().fg(t.text),
-                    )),
+                    Paragraph::new(Line::from(spans)),
                     Rect::new(text_x, y, text_w, 1),
                 );
                 y += 1;
@@ -511,9 +516,12 @@ fn draw_text(f: &mut RenderTarget, body: Rect, v: &FileView, lines: &[String], t
     for (i, line) in lines.iter().enumerate().skip(v.scroll).take(rows) {
         let y = body.y + (i - v.scroll) as u16;
         gutter_cell(f, y, Some(i + 1), i + 1);
-        let line_ui = search_line(v, i, line, t);
+        let tokens = highlight::tokenize(line, lang);
+        let (hits, qlen) = search_hits_for_line(v, i);
+        let width = line.chars().count();
+        let spans = spans_in_range(line, &tokens, (0, width), &hits, qlen, t);
         f.render_widget(
-            Paragraph::new(line_ui).scroll((0, v.hscroll)),
+            Paragraph::new(Line::from(spans)).scroll((0, v.hscroll)),
             Rect::new(text_x, y, text_w, 1),
         );
     }
@@ -547,46 +555,118 @@ fn human(n: u64) -> String {
     }
 }
 
-/// Build a line's spans, highlighting any search matches on it (the current
-/// match brighter). No match → one plain span.
-fn search_line<'a>(v: &FileView, line_idx: usize, line: &'a str, t: &Theme) -> Line<'a> {
-    let Some(s) = &v.search else {
-        return Line::from(Span::styled(line, Style::new().fg(t.text)));
+/// Base text style for one highlight role, resolved through the active theme
+/// so a theme switch recolors the viewer without reparsing any file.
+fn highlight_style(kind: highlight::Kind, t: &Theme) -> Style {
+    match kind {
+        highlight::Kind::Normal => Style::new().fg(t.text),
+        highlight::Kind::Keyword => Style::new().fg(t.accent),
+        highlight::Kind::String => Style::new().fg(t.green),
+        highlight::Kind::Comment => Style::new().fg(t.overlay1).italic(),
+        highlight::Kind::Number => Style::new().fg(t.amber),
+        highlight::Kind::Function => Style::new().fg(t.mint),
+        highlight::Kind::Type => Style::new().fg(t.subtext1),
+    }
+}
+
+/// Search hits on one file line as `(char column, is_current)` plus the query
+/// length in chars. `None`/editing/empty queries yield no hits, so plain
+/// syntax spans render alone. Columns follow the existing search convention
+/// (match offsets into the line's chars).
+fn search_hits_for_line(v: &FileView, line_idx: usize) -> (Vec<(usize, bool)>, usize) {
+    let Some(search) = &v.search else {
+        return (Vec::new(), 0);
     };
-    let hits: Vec<(usize, usize)> = s
+    if search.editing || search.query.is_empty() {
+        return (Vec::new(), 0);
+    }
+    let qlen = search.query.chars().count();
+    let hits: Vec<(usize, bool)> = search
         .matches
         .iter()
         .enumerate()
-        .filter(|(_, (l, _))| *l == line_idx)
-        .map(|(i, (_, c))| (i, *c))
+        .filter(|(_, (line, _))| *line == line_idx)
+        .map(|(index, (_, col))| (*col, index == search.current))
         .collect();
-    if hits.is_empty() || s.query.is_empty() {
-        return Line::from(Span::styled(line, Style::new().fg(t.text)));
-    }
-    let qlen = s.query.chars().count();
-    let mut spans: Vec<Span> = Vec::new();
-    let mut cursor = 0usize; // char index
+    (hits, qlen)
+}
+
+/// Build spans for the char range of one line: syntax tokens clipped to the
+/// range, split at search-match boundaries so the current match stays brighter
+/// than the rest. Adjacent pieces with the same style merge back into one span.
+fn spans_in_range(
+    line: &str,
+    tokens: &[highlight::Token],
+    range: (usize, usize),
+    hits: &[(usize, bool)],
+    query_len: usize,
+    t: &Theme,
+) -> Vec<Span<'static>> {
     let chars: Vec<char> = line.chars().collect();
-    for (mi, col) in hits {
-        if col > cursor {
-            let seg: String = chars[cursor..col.min(chars.len())].iter().collect();
-            spans.push(Span::styled(seg, Style::new().fg(t.text)));
+    let (seg_start, seg_end) = range;
+    let mut intervals: Vec<(usize, usize, bool)> = hits
+        .iter()
+        .map(|(col, current)| {
+            (
+                (*col).max(seg_start),
+                col.saturating_add(query_len).max(col + 1).min(seg_end),
+                *current,
+            )
+        })
+        .filter(|(start, end, _)| start < end)
+        .collect();
+    intervals.sort();
+    intervals.dedup();
+    let text_of = |start: usize, end: usize| -> String {
+        chars
+            .get(start..end)
+            .map(|slice| slice.iter().collect())
+            .unwrap_or_default()
+    };
+    let mut pieces: Vec<(String, Style)> = Vec::new();
+    let mut push = |text: String, style: Style| {
+        if text.is_empty() {
+            return;
         }
-        let end = (col + qlen).min(chars.len());
-        let seg: String = chars[col..end].iter().collect();
-        let hl = if mi == s.current {
-            Style::new().fg(t.base).bg(t.accent).bold()
+        if let Some(last) = pieces.last_mut().filter(|(_, prev)| *prev == style) {
+            last.0.push_str(&text);
         } else {
-            Style::new().fg(t.base).bg(t.amber)
-        };
-        spans.push(Span::styled(seg, hl));
-        cursor = end;
+            pieces.push((text, style));
+        }
+    };
+    for token in tokens {
+        let token_start = token.start.max(seg_start);
+        let token_end = token.end.min(seg_end);
+        if token_start >= token_end {
+            continue;
+        }
+        let base = highlight_style(token.kind, t);
+        let mut cursor = token_start;
+        for (hit_start, hit_end, current) in intervals
+            .iter()
+            .filter(|(start, end, _)| *end > token_start && *start < token_end)
+        {
+            let hit_start = (*hit_start).max(token_start);
+            let hit_end = (*hit_end).min(token_end);
+            if hit_start > cursor {
+                push(text_of(cursor, hit_start), base);
+            }
+            let highlight = if *current {
+                Style::new().fg(t.base).bg(t.accent).bold()
+            } else {
+                Style::new().fg(t.base).bg(t.amber)
+            };
+            push(text_of(hit_start, hit_end), highlight);
+            cursor = hit_end;
+        }
+        if cursor < token_end {
+            push(text_of(cursor, token_end), base);
+        }
     }
-    if cursor < chars.len() {
-        let seg: String = chars[cursor..].iter().collect();
-        spans.push(Span::styled(seg, Style::new().fg(t.text)));
-    }
-    Line::from(spans)
+    pieces
+        .into_iter()
+        .map(|(text, style)| Span::styled(text, style))
+        .collect()
 }
 
 /// The tint color for a git working-tree status in the FILES dock (docs/38).
@@ -751,5 +831,81 @@ mod tests {
         assert!(!file_selection_contains(&selection, 6, 2, text_x));
         assert!(file_selection_contains(&selection, 7, 2, text_x));
         assert!(file_selection_contains(&selection, 12, 3, text_x));
+    }
+
+    /// Syntax spans keep the line's text intact while coloring each role
+    /// through the theme: keywords use the accent, strings the idle green,
+    /// comments the dim overlay, numbers amber, calls mint, types subtext.
+    #[test]
+    fn rust_viewer_spans_color_each_role_through_the_theme() {
+        use crate::files::highlight;
+
+        let theme = Theme::quattro_rally();
+        let line = "fn load(path: &Path) -> usize { // open";
+        let tokens = highlight::tokenize(line, highlight::Language::Rust);
+        let width = line.chars().count();
+        let spans = super::spans_in_range(line, &tokens, (0, width), &[], 0, &theme);
+        let text: String = spans.iter().map(|span| span.content.as_ref()).collect();
+        assert_eq!(text, line, "spans must cover the line exactly");
+
+        let style_of = |needle: &str| {
+            spans
+                .iter()
+                .find(|span| span.content == needle)
+                .map(|span| span.style)
+        };
+        assert_eq!(
+            style_of("fn").map(|style| style.fg),
+            Some(Some(theme.accent)),
+            "keywords use the accent"
+        );
+        assert_eq!(
+            style_of("load").map(|style| style.fg),
+            Some(Some(theme.mint)),
+            "calls use mint"
+        );
+        assert_eq!(
+            style_of("Path").map(|style| style.fg),
+            Some(Some(theme.subtext1)),
+            "types use subtext"
+        );
+        assert!(
+            spans
+                .iter()
+                .find(|span| span.content.contains("// open"))
+                .is_some_and(|span| span.style.fg == Some(theme.overlay1)),
+            "the trailing comment is dim"
+        );
+    }
+
+    /// Search matches overlay the syntax color with the same backgrounds the
+    /// viewer used before highlighting, and wrapped segments clip both layers
+    /// to their own char range.
+    #[test]
+    fn viewer_search_overlays_syntax_and_clips_to_wrap_segments() {
+        use crate::files::highlight;
+
+        let theme = Theme::quattro_rally();
+        let line = "let loaded = load(path); // load";
+        let tokens = highlight::tokenize(line, highlight::Language::Rust);
+        let width = line.chars().count();
+        // `load` occurs at columns 4 ("loaded" prefix) and 13; highlight the
+        // standalone call as the current match.
+        let spans = super::spans_in_range(line, &tokens, (0, width), &[(13, true)], 4, &theme);
+        let current = spans
+            .iter()
+            .find(|span| span.content == "load")
+            .expect("current match is its own span");
+        assert_eq!(current.style.bg, Some(theme.accent));
+        assert_eq!(current.style.fg, Some(theme.base));
+
+        // A wrapped segment sees only its own slice of both layers.
+        let segment = super::spans_in_range(line, &tokens, (0, 10), &[(13, true)], 4, &theme);
+        let text: String = segment.iter().map(|span| span.content.as_ref()).collect();
+        assert_eq!(text, "let loaded");
+        assert!(
+            segment.iter().all(|span| span.style.bg.is_none()),
+            "the match outside the segment must not leak in"
+        );
     }
 }

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -198,7 +198,13 @@ source or editor.
 
 ## What this is not
 
-The source file viewer does not do syntax coloring. To review staged and working-tree
+The source file viewer highlights code as you read: keywords, strings, numbers,
+comments, function calls, and types are tinted through your active theme, in
+both wrapped and unwrapped modes, without changing search or selection colors.
+The language follows the file extension (Rust, Python, JavaScript/TypeScript,
+Go, C-like languages, shell, TOML, YAML, JSON, CSS, HTML, and SQL, among
+others); Markdown and plain text stay uncolored, and multi-line block comments
+are an approximation highlighted per line. To review staged and working-tree
 patches with split or stack layouts and local notes, switch the dock to
 [DIFF](/docs/guides/diff/). Use the [git tab](/docs/guides/git/) for branches,
 commits, pull requests, issues, and commit flow. To edit, open the file in an

--- a/website/src/content/docs/docs/guides/files.mdx
+++ b/website/src/content/docs/docs/guides/files.mdx
@@ -203,8 +203,9 @@ comments, function calls, and types are tinted through your active theme, in
 both wrapped and unwrapped modes, without changing search or selection colors.
 The language follows the file extension (Rust, Python, JavaScript/TypeScript,
 Go, C-like languages, shell, TOML, YAML, JSON, CSS, HTML, and SQL, among
-others); Markdown and plain text stay uncolored, and multi-line block comments
-are an approximation highlighted per line. To review staged and working-tree
+others); Markdown and plain text stay uncolored. Python triple-quoted strings
+and JavaScript/Go backtick strings keep their color across lines; multi-line
+block comments remain an approximation highlighted per line. To review staged and working-tree
 patches with split or stack layouts and local notes, switch the dock to
 [DIFF](/docs/guides/diff/). Use the [git tab](/docs/guides/git/) for branches,
 commits, pull requests, issues, and commit flow. To edit, open the file in an


### PR DESCRIPTION
The read-only file viewer now syntax-highlights code through the active theme.

## What

- File viewer text is colored by role: keywords use the accent, strings green, comments dim italic, numbers amber, function calls mint, types subtext; everything else keeps the normal text color.
- Language is guessed from the file extension or name (Rust, Python, JavaScript/TypeScript, Go, C-like languages, shell, TOML, YAML, JSON, CSS, HTML, SQL, and more). Markdown and plain text stay uncolored so prose is never dimmed as code.
- Highlighting works in both wrapped and unwrapped modes. Search matches keep their existing backgrounds (accent for current, amber for others), and wrap mode now shows search hits instead of dropping them.
- No new dependencies; highlighting is a stateless per-line tokenizer (`src/files/highlight.rs`) and rendering stays O(visible rows). File reads, scroll, selection, copy, and change markers are unchanged.
- Removed the now-unused `crate::files::seg_text` re-export (binary crate, no other users).

## Why

Opening a file rendered every line in a single text color, and the docs stated the viewer does not do syntax coloring. Code was hard to scan compared to the Markdown/Mermaid previews, which already carry semantic color. There is no linked issue.

## Verification

- [x] `cargo test --locked` — 1555 passed; 1 failure in `app::tests::resize_yields_to_pane_title_and_zoom_but_still_grabs_the_seam`, which also fails on clean `main` (verified via `git stash -u`), so it is pre-existing and unrelated.
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual testing, if applicable — none; no live server was touched during development per repo safety rules. New unit tests cover the tokenizer (keywords, strings, lifetimes, numbers, comments, per-language markers, full-line token coverage) and the renderer (theme mapping, search overlay, wrap-segment clipping).

## Screenshot
<img width="1387" height="1064" alt="image" src="https://github.com/user-attachments/assets/9a681a02-a8a3-4c1e-a900-460ae92f28fb" />


## Notes

- Known limitation: multi-line block comments are highlighted per line — an unclosed `/*` colors the rest of its own line, but continuation lines render as code. Documented in code and in `docs/guides/files.mdx`.









<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change adds theme-aware syntax highlighting to the read-only file viewer, including language detection, token rendering, search-overlay compatibility, wrapped-line rendering, and efficient preparation for large files.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex compiled multiline-string-continuation-check.rs with rustc from the repository and observed that the tokenizer produced Keyword/Normal tokens when the continuation state was omitted.
- T-Rex re-ran the same executable with per-line continuation state provided to tokenize\_window, and it returned \[String\] for all requested continuation lines with exit code 0.
- T-Rex ran cargo test for files::highlight::tests with --nocapture, and all 18 tests passed with exit code 0.
- T-Rex uploaded artifacts including the Rust source and the test run logs for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/23322887/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["perf(files): window syntax prep and view..."](https://github.com/rizriyz/luvus/commit/11c90e18b00fd55651f07b7d9a643a519f61c6e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61528764)</sub>

<!-- /greptile_comment -->