### PR TITLE
feat(input): add dedicated Windows image paste

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,9 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Console",
+    "Win32_System_DataExchange",
     "Win32_System_Kernel",
+    "Win32_System_Memory",
     "Win32_System_Threading",
 ] }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -674,6 +674,17 @@ impl App {
                 self.paste_into_focused_pane(&s);
                 false // goes to the pane; its echo (PtyData) renders it
             }
+            AppEvent::PasteImage(path) => {
+                // Image paths are terminal input, never modal text. Restrict
+                // delivery to the same normal focused-pane state that accepts
+                // ordinary typing so an image cannot leak through an overlay,
+                // native view, dashboard, or navigation mode.
+                if !self.focused_pane_accepts_image_paste() {
+                    return false;
+                }
+                self.paste_into_focused_pane(&path.to_string_lossy());
+                false // the pane's echo is the event that changes the frame
+            }
             AppEvent::Resize => {
                 // A resize (or a same-size resize event a terminal emits on a
                 // move/expose) may have damaged the screen — force a full repaint.
@@ -3677,6 +3688,50 @@ impl App {
         target
     }
 
+    /// Whether the current input owner is the normal focused terminal pane.
+    /// Dedicated image paste is intentionally stricter than text paste because
+    /// a Luvus modal has no meaningful image value to accept.
+    fn focused_pane_accepts_image_paste(&self) -> bool {
+        self.mode == Mode::Normal
+            && self.bar.overflow.is_none()
+            && self.cmd_inspect.is_none()
+            && !self.help_open
+            && !self.changelog_open
+            && self.module_setting_edit.is_none()
+            && self.named_session_menu.is_none()
+            && self.settings.is_none()
+            && self.search.is_none()
+            && self.picker.is_none()
+            && self.worktree_prompt.is_none()
+            && self.worktree_open.is_none()
+            && self.tab_rename.is_none()
+            && self.tab_menu.is_none()
+            && self.ws_menu.is_none()
+            && self.pane_menu.is_none()
+            && self.agent_menu.is_none()
+            && self.file_prompt.is_none()
+            && self.file_delete.is_none()
+            && self.worktree_delete.is_none()
+            && self.file_menu.is_none()
+            && self.diff_menu.is_none()
+            && self.orch_menu.is_none()
+            && self.dock_menu.is_none()
+            && !self.switcher
+            && self.pane_rename.is_none()
+            && self.ws_rename.is_none()
+            && self.orch_form.is_none()
+            && self.orch_start.is_none()
+            && self.orch_detail.is_none()
+            && self.scroll_pane.is_none()
+            && self.copy_mode.is_none()
+            && self.sidebar_focus.is_none()
+            && !self.files_focused
+            && !self.active_is_git()
+            && !self.active_is_orch()
+            && !self.active_is_mission()
+            && self.focused().is_some()
+    }
+
     /// Record that the user just typed into the focused pane, so detection can
     /// tell typing (whose echo is PTY output) apart from the agent generating
     /// (docs/07). Only the focused pane receives typed input.
@@ -4537,6 +4592,31 @@ mod tests {
             app.orch_form.as_ref().unwrap().prompt,
             "first\nsecond\nthirdline"
         );
+    }
+
+    #[test]
+    fn image_path_paste_reaches_only_a_normal_focused_pane() {
+        let _env = crate::persist::test_env("image-path-paste-route");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        let focus = app.layout().focus;
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&focus)
+            .unwrap()
+            .replace_input_sender_for_test(input_tx);
+
+        let path = std::path::PathBuf::from("clipboard-images/example.png");
+        assert!(!app.handle_event(AppEvent::PasteImage(path.clone())));
+        let crate::terminal::pty::InputAction::Bytes(bytes) = input_rx.try_recv().unwrap() else {
+            panic!("image path should use the ordinary paste queue");
+        };
+        assert_eq!(bytes, path.to_string_lossy().as_bytes());
+
+        app.help_open = true;
+        assert!(!app.handle_event(AppEvent::PasteImage("clipboard-images/blocked.png".into())));
+        assert!(input_rx.try_recv().is_err());
+        assert!(app.help_open, "the image gesture must not dismiss help");
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -680,6 +680,7 @@ impl App {
                 // ordinary typing so an image cannot leak through an overlay,
                 // native view, dashboard, or navigation mode.
                 if !self.focused_pane_accepts_image_paste() {
+                    crate::clipboard_image::discard_staged_png(&path);
                     return false;
                 }
                 self.paste_into_focused_pane(&path.to_string_lossy());
@@ -4614,9 +4615,13 @@ mod tests {
         assert_eq!(bytes, path.to_string_lossy().as_bytes());
 
         app.help_open = true;
-        assert!(!app.handle_event(AppEvent::PasteImage("clipboard-images/blocked.png".into())));
+        let png = crate::clipboard_image::encode_rgba_png(1, 1, |_, _| [1, 2, 3, 255])
+            .expect("fixture PNG");
+        let blocked = crate::clipboard_image::stage_png(&png).expect("staged image");
+        assert!(!app.handle_event(AppEvent::PasteImage(blocked.clone())));
         assert!(input_rx.try_recv().is_err());
         assert!(app.help_open, "the image gesture must not dismiss help");
+        assert!(!blocked.exists(), "rejected image must not remain staged");
     }
 
     #[test]

--- a/src/clipboard_image.rs
+++ b/src/clipboard_image.rs
@@ -160,6 +160,47 @@ pub(crate) fn validate_png(bytes: &[u8]) -> Result<PngInfo, &'static str> {
     info.ok_or("PNG is missing its header")
 }
 
+/// Return the exact PNG range from a bounded clipboard allocation.
+///
+/// Windows reports the allocation capacity through `GlobalSize`, which may be
+/// larger than the PNG placed on the clipboard. Walk structural chunk
+/// boundaries to the first IEND, then run the strict validator on only that
+/// range so allocator padding is never staged as image data.
+#[cfg(any(windows, test))]
+pub(crate) fn validated_png_prefix(bytes: &[u8]) -> Result<&[u8], &'static str> {
+    if bytes.len() > MAX_PNG_BYTES {
+        return Err("PNG exceeds clipboard image limit");
+    }
+    if !bytes.starts_with(PNG_SIGNATURE) {
+        return Err("invalid PNG signature");
+    }
+
+    let mut cursor = PNG_SIGNATURE.len();
+    while cursor < bytes.len() {
+        let header_end = cursor.checked_add(8).ok_or("PNG chunk overflow")?;
+        if header_end > bytes.len() {
+            return Err("truncated PNG chunk header");
+        }
+        let length = u32::from_be_bytes(
+            bytes[cursor..cursor + 4]
+                .try_into()
+                .map_err(|_| "invalid PNG chunk length")?,
+        ) as usize;
+        let data_end = header_end.checked_add(length).ok_or("PNG chunk overflow")?;
+        let chunk_end = data_end.checked_add(4).ok_or("PNG chunk overflow")?;
+        if chunk_end > bytes.len() {
+            return Err("truncated PNG chunk");
+        }
+        if &bytes[cursor + 4..header_end] == b"IEND" {
+            let exact = &bytes[..chunk_end];
+            validate_png(exact)?;
+            return Ok(exact);
+        }
+        cursor = chunk_end;
+    }
+    Err("PNG is missing its end marker")
+}
+
 /// Encode RGBA pixels without a compression dependency or a second full image
 /// buffer. Stored DEFLATE blocks are larger than compressed output but keep the
 /// transient memory bound predictable on the explicit paste path.
@@ -440,6 +481,19 @@ pub(crate) fn stage_png(bytes: &[u8]) -> io::Result<PathBuf> {
     ))
 }
 
+/// Remove a staged clipboard image that could not reach its input owner.
+/// Refuse every path outside the selected session's owned staging directory.
+pub(crate) fn discard_staged_png(path: &Path) {
+    let expected_dir = crate::persist::session_dir().join("clipboard-images");
+    let owned_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with(STAGED_PREFIX) && name.ends_with(STAGED_SUFFIX));
+    if path.parent() == Some(expected_dir.as_path()) && owned_name {
+        let _ = fs::remove_file(path);
+    }
+}
+
 fn cleanup_staged(dir: &Path) {
     let now = SystemTime::now();
     let Ok(entries) = fs::read_dir(dir) else {
@@ -638,6 +692,16 @@ mod tests {
     }
 
     #[test]
+    fn registered_png_trims_allocator_padding_at_the_valid_end_marker() {
+        let png = encode_rgba_png(1, 1, |_, _| [7, 8, 9, 255]).unwrap();
+        let mut allocation = png.clone();
+        allocation.extend_from_slice(&[0xaa; 32]);
+
+        assert_eq!(validate_png(&allocation), Err("trailing PNG data"));
+        assert_eq!(validated_png_prefix(&allocation).unwrap(), png);
+    }
+
+    #[test]
     fn validator_rejects_dimensions_that_imply_excessive_decode_memory() {
         let png = encode_rgba_png(1, 1, |_, _| [0, 0, 0, 255]).unwrap();
         let mut oversized = png;
@@ -743,6 +807,25 @@ mod tests {
                 0o600
             );
         }
+    }
+
+    #[test]
+    fn discarded_staged_images_are_removed_without_touching_other_files() {
+        let _env = crate::persist::test_env("clipboard-image-discard");
+        crate::persist::ensure_session_dir();
+        let png = encode_rgba_png(1, 1, |_, _| [1, 2, 3, 255]).unwrap();
+        let staged = stage_png(&png).unwrap();
+        let unrelated = staged.parent().unwrap().join("keep.png");
+        fs::write(&unrelated, b"not owned by clipboard staging").unwrap();
+
+        discard_staged_png(&unrelated);
+        discard_staged_png(&staged);
+
+        assert!(!staged.exists());
+        assert_eq!(
+            fs::read(unrelated).unwrap(),
+            b"not owned by clipboard staging"
+        );
     }
 
     #[test]

--- a/src/clipboard_image.rs
+++ b/src/clipboard_image.rs
@@ -1,0 +1,773 @@
+//! Bounded clipboard-image validation, PNG normalization, and private staging.
+//!
+//! Clipboard access belongs to the display client. This module contains only
+//! platform-neutral data handling and server-side publication, so malformed
+//! image data crosses neither the filesystem nor the app-loop boundary.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+pub(crate) const MAX_PNG_BYTES: usize = 48 * 1024 * 1024;
+pub(crate) const MAX_DIMENSION: u32 = 8192;
+pub(crate) const MAX_PIXELS: u64 = 12_000_000;
+
+const PNG_SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+const STAGED_PREFIX: &str = "luvus-image-";
+const STAGED_SUFFIX: &str = ".png";
+const STALE_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
+const MAX_STAGING_SCAN: usize = 1024;
+const MAX_FRESH_STAGED: usize = 128;
+#[cfg(any(windows, test))]
+const STORED_BLOCK_BYTES: usize = u16::MAX as usize;
+#[cfg(any(windows, test))]
+const BI_RGB: u32 = 0;
+#[cfg(any(windows, test))]
+const BI_BITFIELDS: u32 = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PngInfo {
+    pub width: u32,
+    pub height: u32,
+}
+
+/// An exact image-paste gesture. Alt is deliberately excluded so AltGr text
+/// can never become a clipboard action, and repeats cannot stage duplicates.
+pub(crate) fn is_image_paste_key(key: &KeyEvent) -> bool {
+    key.kind == KeyEventKind::Press
+        && matches!(key.code, KeyCode::Char('v' | 'V'))
+        && (key.modifiers == KeyModifiers::CONTROL
+            || key.modifiers == KeyModifiers::CONTROL | KeyModifiers::SHIFT)
+}
+
+/// Validate the PNG container and the decoded allocation implied by IHDR.
+/// This intentionally does not decompress IDAT. Chunk CRCs and strict bounds
+/// make the file safe to stage while the downstream agent remains responsible
+/// for decoding its own input.
+pub(crate) fn validate_png(bytes: &[u8]) -> Result<PngInfo, &'static str> {
+    if bytes.len() > MAX_PNG_BYTES {
+        return Err("PNG exceeds clipboard image limit");
+    }
+    if !bytes.starts_with(PNG_SIGNATURE) {
+        return Err("invalid PNG signature");
+    }
+
+    let mut cursor = PNG_SIGNATURE.len();
+    let mut info = None;
+    let mut saw_idat = false;
+    let mut saw_iend = false;
+    while cursor < bytes.len() {
+        let header_end = cursor.checked_add(8).ok_or("PNG chunk overflow")?;
+        if header_end > bytes.len() {
+            return Err("truncated PNG chunk header");
+        }
+        let length = u32::from_be_bytes(
+            bytes[cursor..cursor + 4]
+                .try_into()
+                .map_err(|_| "invalid PNG chunk length")?,
+        ) as usize;
+        let kind = &bytes[cursor + 4..cursor + 8];
+        if !kind.iter().all(|byte| byte.is_ascii_alphabetic()) {
+            return Err("invalid PNG chunk type");
+        }
+        let data_start = cursor + 8;
+        let data_end = data_start.checked_add(length).ok_or("PNG chunk overflow")?;
+        let chunk_end = data_end.checked_add(4).ok_or("PNG chunk overflow")?;
+        if chunk_end > bytes.len() {
+            return Err("truncated PNG chunk");
+        }
+        let expected_crc = u32::from_be_bytes(
+            bytes[data_end..chunk_end]
+                .try_into()
+                .map_err(|_| "invalid PNG checksum")?,
+        );
+        if crc32(&bytes[cursor + 4..data_end]) != expected_crc {
+            return Err("invalid PNG checksum");
+        }
+
+        match kind {
+            b"IHDR" => {
+                if info.is_some() || cursor != PNG_SIGNATURE.len() || length != 13 {
+                    return Err("invalid PNG header");
+                }
+                let width = read_be_u32(bytes, data_start)?;
+                let height = read_be_u32(bytes, data_start + 4)?;
+                let bit_depth = bytes[data_start + 8];
+                let color_type = bytes[data_start + 9];
+                if width == 0
+                    || height == 0
+                    || width > MAX_DIMENSION
+                    || height > MAX_DIMENSION
+                    || u64::from(width) * u64::from(height) > MAX_PIXELS
+                {
+                    return Err("PNG dimensions exceed clipboard image limit");
+                }
+                let channels = match (color_type, bit_depth) {
+                    (0, 1 | 2 | 4 | 8 | 16) => 1u64,
+                    (2, 8 | 16) => 3,
+                    (3, 1 | 2 | 4 | 8) => 1,
+                    (4, 8 | 16) => 2,
+                    (6, 8 | 16) => 4,
+                    _ => return Err("unsupported PNG pixel format"),
+                };
+                let row_bits = u64::from(width)
+                    .checked_mul(channels)
+                    .and_then(|value| value.checked_mul(u64::from(bit_depth)))
+                    .ok_or("PNG dimensions overflow")?;
+                let decoded = row_bits
+                    .div_ceil(8)
+                    .checked_add(1)
+                    .and_then(|row| row.checked_mul(u64::from(height)))
+                    .ok_or("PNG dimensions overflow")?;
+                if decoded > MAX_PNG_BYTES as u64 {
+                    return Err("decoded PNG exceeds clipboard image limit");
+                }
+                if bytes[data_start + 10] != 0
+                    || bytes[data_start + 11] != 0
+                    || bytes[data_start + 12] > 1
+                {
+                    return Err("unsupported PNG encoding");
+                }
+                info = Some(PngInfo { width, height });
+            }
+            b"IDAT" => {
+                if info.is_none() || saw_iend {
+                    return Err("PNG image data is out of order");
+                }
+                saw_idat = true;
+            }
+            b"IEND" => {
+                if length != 0 || info.is_none() || !saw_idat || saw_iend {
+                    return Err("invalid PNG end marker");
+                }
+                saw_iend = true;
+                if chunk_end != bytes.len() {
+                    return Err("trailing PNG data");
+                }
+            }
+            _ if info.is_none() || saw_iend => return Err("PNG chunk is out of order"),
+            _ => {}
+        }
+        cursor = chunk_end;
+    }
+
+    if !saw_iend {
+        return Err("PNG is missing its end marker");
+    }
+    info.ok_or("PNG is missing its header")
+}
+
+/// Encode RGBA pixels without a compression dependency or a second full image
+/// buffer. Stored DEFLATE blocks are larger than compressed output but keep the
+/// transient memory bound predictable on the explicit paste path.
+#[cfg(any(windows, test))]
+pub(crate) fn encode_rgba_png(
+    width: u32,
+    height: u32,
+    mut pixel: impl FnMut(u32, u32) -> [u8; 4],
+) -> Result<Vec<u8>, &'static str> {
+    let pixels = u64::from(width)
+        .checked_mul(u64::from(height))
+        .ok_or("image dimensions overflow")?;
+    if width == 0
+        || height == 0
+        || width > MAX_DIMENSION
+        || height > MAX_DIMENSION
+        || pixels > MAX_PIXELS
+    {
+        return Err("image dimensions exceed clipboard image limit");
+    }
+    let raw_len = u64::from(height)
+        .checked_mul(
+            u64::from(width)
+                .checked_mul(4)
+                .and_then(|row| row.checked_add(1))
+                .ok_or("image dimensions overflow")?,
+        )
+        .ok_or("image dimensions overflow")?;
+    let block_count = raw_len.div_ceil(STORED_BLOCK_BYTES as u64);
+    let estimated = raw_len
+        .checked_add(block_count * 5)
+        .and_then(|value| value.checked_add(128))
+        .ok_or("PNG size overflow")?;
+    if estimated > MAX_PNG_BYTES as u64 {
+        return Err("encoded PNG exceeds clipboard image limit");
+    }
+
+    let mut output = Vec::with_capacity(estimated as usize);
+    output.extend_from_slice(PNG_SIGNATURE);
+    let mut ihdr = [0u8; 13];
+    ihdr[..4].copy_from_slice(&width.to_be_bytes());
+    ihdr[4..8].copy_from_slice(&height.to_be_bytes());
+    ihdr[8] = 8;
+    ihdr[9] = 6;
+    append_chunk(&mut output, b"IHDR", &ihdr)?;
+
+    let length_at = output.len();
+    output.extend_from_slice(&[0; 4]);
+    output.extend_from_slice(b"IDAT");
+    let data_at = output.len();
+    {
+        let mut zlib = StoredZlib::new(&mut output);
+        for y in 0..height {
+            zlib.push(0);
+            for x in 0..width {
+                for channel in pixel(x, y) {
+                    zlib.push(channel);
+                }
+            }
+        }
+        zlib.finish();
+    }
+    let idat_len = output.len() - data_at;
+    let idat_len_u32 = u32::try_from(idat_len).map_err(|_| "PNG chunk exceeds limit")?;
+    output[length_at..length_at + 4].copy_from_slice(&idat_len_u32.to_be_bytes());
+    let checksum = crc32(&output[length_at + 4..]);
+    output.extend_from_slice(&checksum.to_be_bytes());
+    append_chunk(&mut output, b"IEND", &[])?;
+    if output.len() > MAX_PNG_BYTES {
+        return Err("encoded PNG exceeds clipboard image limit");
+    }
+    validate_png(&output)?;
+    Ok(output)
+}
+
+/// Convert a bounded Windows DIB into the narrow RGBA PNG representation used
+/// by Luvus. Clipboard access remains in the Windows adapter; keeping this byte
+/// parser platform-neutral lets malformed Windows fixtures run in every CI job.
+#[cfg(any(windows, test))]
+pub(crate) fn dib_to_png(bytes: &[u8]) -> Result<Vec<u8>, &'static str> {
+    let header_size = read_le_u32(bytes, 0)? as usize;
+    if !matches!(header_size, 40 | 52 | 56 | 108 | 124) || header_size > bytes.len() {
+        return Err("unsupported DIB header");
+    }
+    let width = read_le_i32(bytes, 4)?;
+    let signed_height = read_le_i32(bytes, 8)?;
+    if width <= 0 || signed_height == 0 || signed_height == i32::MIN {
+        return Err("invalid DIB dimensions");
+    }
+    let width = width as u32;
+    let height = signed_height.unsigned_abs();
+    let planes = read_le_u16(bytes, 12)?;
+    let bits = read_le_u16(bytes, 14)?;
+    let compression = read_le_u32(bytes, 16)?;
+    let colors_used = read_le_u32(bytes, 32)?;
+    if planes != 1 || colors_used != 0 {
+        return Err("unsupported DIB planes or palette");
+    }
+    if !matches!(
+        (bits, compression),
+        (24, BI_RGB) | (32, BI_RGB) | (32, BI_BITFIELDS)
+    ) {
+        return Err("unsupported DIB pixel format");
+    }
+    if header_size >= 124 && (read_le_u32(bytes, 112)? != 0 || read_le_u32(bytes, 116)? != 0) {
+        return Err("embedded DIB profiles are unsupported");
+    }
+
+    let (red_mask, green_mask, blue_mask, alpha_mask, pixel_offset) = if compression == BI_BITFIELDS
+    {
+        let masks_at = if header_size >= 52 { 40 } else { header_size };
+        let red = read_le_u32(bytes, masks_at)?;
+        let green = read_le_u32(bytes, masks_at + 4)?;
+        let blue = read_le_u32(bytes, masks_at + 8)?;
+        let alpha = if header_size >= 56 {
+            read_le_u32(bytes, masks_at + 12)?
+        } else {
+            0
+        };
+        validate_dib_masks(red, green, blue, alpha)?;
+        let offset = if header_size >= 52 {
+            header_size
+        } else {
+            header_size.checked_add(12).ok_or("DIB offset overflow")?
+        };
+        (red, green, blue, alpha, offset)
+    } else {
+        (0x00ff_0000, 0x0000_ff00, 0x0000_00ff, 0, header_size)
+    };
+
+    let row_bits = usize::try_from(width)
+        .map_err(|_| "DIB width overflow")?
+        .checked_mul(bits as usize)
+        .ok_or("DIB row overflow")?;
+    let row_stride = row_bits
+        .checked_add(31)
+        .map(|value| value / 32 * 4)
+        .ok_or("DIB row overflow")?;
+    let pixel_bytes = row_stride
+        .checked_mul(height as usize)
+        .ok_or("DIB storage overflow")?;
+    let pixel_end = pixel_offset
+        .checked_add(pixel_bytes)
+        .ok_or("DIB storage overflow")?;
+    if pixel_end > bytes.len() {
+        return Err("truncated DIB pixels");
+    }
+    let top_down = signed_height < 0;
+    encode_rgba_png(width, height, |x, y| {
+        let source_y = if top_down { y } else { height - 1 - y };
+        let row = pixel_offset + source_y as usize * row_stride;
+        if bits == 24 {
+            let offset = row + x as usize * 3;
+            [bytes[offset + 2], bytes[offset + 1], bytes[offset], 255]
+        } else {
+            let offset = row + x as usize * 4;
+            let value = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
+            [
+                dib_channel(value, red_mask),
+                dib_channel(value, green_mask),
+                dib_channel(value, blue_mask),
+                if alpha_mask == 0 {
+                    255
+                } else {
+                    dib_channel(value, alpha_mask)
+                },
+            ]
+        }
+    })
+}
+
+#[cfg(any(windows, test))]
+fn validate_dib_masks(red: u32, green: u32, blue: u32, alpha: u32) -> Result<(), &'static str> {
+    if red == 0
+        || green == 0
+        || blue == 0
+        || !contiguous_mask(red)
+        || !contiguous_mask(green)
+        || !contiguous_mask(blue)
+        || (alpha != 0 && !contiguous_mask(alpha))
+        || red & green != 0
+        || red & blue != 0
+        || green & blue != 0
+        || alpha & (red | green | blue) != 0
+    {
+        return Err("invalid DIB channel masks");
+    }
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+fn contiguous_mask(mask: u32) -> bool {
+    if mask == 0 {
+        return false;
+    }
+    let shifted = mask >> mask.trailing_zeros();
+    shifted & shifted.wrapping_add(1) == 0
+}
+
+#[cfg(any(windows, test))]
+fn dib_channel(value: u32, mask: u32) -> u8 {
+    let shift = mask.trailing_zeros();
+    let maximum = mask >> shift;
+    let component = (value & mask) >> shift;
+    ((u64::from(component) * 255 + u64::from(maximum) / 2) / u64::from(maximum)) as u8
+}
+
+#[cfg(any(windows, test))]
+fn read_le_u16(bytes: &[u8], offset: usize) -> Result<u16, &'static str> {
+    let end = offset.checked_add(2).ok_or("DIB integer overflow")?;
+    Ok(u16::from_le_bytes(
+        bytes
+            .get(offset..end)
+            .ok_or("truncated DIB integer")?
+            .try_into()
+            .map_err(|_| "invalid DIB integer")?,
+    ))
+}
+
+#[cfg(any(windows, test))]
+fn read_le_u32(bytes: &[u8], offset: usize) -> Result<u32, &'static str> {
+    let end = offset.checked_add(4).ok_or("DIB integer overflow")?;
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..end)
+            .ok_or("truncated DIB integer")?
+            .try_into()
+            .map_err(|_| "invalid DIB integer")?,
+    ))
+}
+
+#[cfg(any(windows, test))]
+fn read_le_i32(bytes: &[u8], offset: usize) -> Result<i32, &'static str> {
+    Ok(read_le_u32(bytes, offset)? as i32)
+}
+
+/// Publish a validated image beneath the selected server session. The caller
+/// runs on a client receiver or local input thread, never on the app loop.
+pub(crate) fn stage_png(bytes: &[u8]) -> io::Result<PathBuf> {
+    validate_png(bytes).map_err(|message| io::Error::new(io::ErrorKind::InvalidData, message))?;
+    let dir = crate::persist::ensure_clipboard_image_dir()?;
+    cleanup_staged(&dir);
+
+    for _ in 0..8 {
+        let mut random = [0u8; 16];
+        getrandom::fill(&mut random).map_err(|error| io::Error::other(error.to_string()))?;
+        let mut name = String::with_capacity(STAGED_PREFIX.len() + 32 + STAGED_SUFFIX.len());
+        name.push_str(STAGED_PREFIX);
+        for byte in random {
+            use std::fmt::Write as _;
+            let _ = write!(&mut name, "{byte:02x}");
+        }
+        name.push_str(STAGED_SUFFIX);
+        let path = dir.join(name);
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&path) {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(bytes) {
+                    drop(file);
+                    let _ = fs::remove_file(&path);
+                    return Err(error);
+                }
+                return Ok(path);
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique clipboard image path",
+    ))
+}
+
+fn cleanup_staged(dir: &Path) {
+    let now = SystemTime::now();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut fresh = Vec::new();
+    for entry in entries.take(MAX_STAGING_SCAN).flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !name.starts_with(STAGED_PREFIX) || !name.ends_with(STAGED_SUFFIX) {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+        let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        let stale = now
+            .duration_since(modified)
+            .is_ok_and(|age| age >= STALE_AFTER);
+        if stale {
+            let _ = fs::remove_file(path);
+        } else {
+            fresh.push((modified, path));
+        }
+    }
+    if fresh.len() >= MAX_FRESH_STAGED {
+        fresh.sort_by_key(|(modified, _)| *modified);
+        let remove = fresh.len() - (MAX_FRESH_STAGED - 1);
+        for (_, path) in fresh.into_iter().take(remove) {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn read_be_u32(bytes: &[u8], offset: usize) -> Result<u32, &'static str> {
+    let end = offset.checked_add(4).ok_or("PNG integer overflow")?;
+    Ok(u32::from_be_bytes(
+        bytes
+            .get(offset..end)
+            .ok_or("truncated PNG integer")?
+            .try_into()
+            .map_err(|_| "invalid PNG integer")?,
+    ))
+}
+
+#[cfg(any(windows, test))]
+fn append_chunk(output: &mut Vec<u8>, kind: &[u8; 4], data: &[u8]) -> Result<(), &'static str> {
+    let length = u32::try_from(data.len()).map_err(|_| "PNG chunk exceeds limit")?;
+    output.extend_from_slice(&length.to_be_bytes());
+    let checksum_at = output.len();
+    output.extend_from_slice(kind);
+    output.extend_from_slice(data);
+    let checksum = crc32(&output[checksum_at..]);
+    output.extend_from_slice(&checksum.to_be_bytes());
+    Ok(())
+}
+
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = u32::MAX;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            crc = (crc >> 1) ^ (0xedb8_8320 & 0u32.wrapping_sub(crc & 1));
+        }
+    }
+    !crc
+}
+
+#[cfg(any(windows, test))]
+struct StoredZlib<'a> {
+    output: &'a mut Vec<u8>,
+    block: Vec<u8>,
+    adler_a: u32,
+    adler_b: u32,
+}
+
+#[cfg(any(windows, test))]
+impl<'a> StoredZlib<'a> {
+    fn new(output: &'a mut Vec<u8>) -> Self {
+        output.extend_from_slice(&[0x78, 0x01]);
+        Self {
+            output,
+            block: Vec::with_capacity(STORED_BLOCK_BYTES),
+            adler_a: 1,
+            adler_b: 0,
+        }
+    }
+
+    fn push(&mut self, byte: u8) {
+        self.adler_a = (self.adler_a + u32::from(byte)) % 65_521;
+        self.adler_b = (self.adler_b + self.adler_a) % 65_521;
+        self.block.push(byte);
+        if self.block.len() == STORED_BLOCK_BYTES {
+            self.flush(false);
+        }
+    }
+
+    fn flush(&mut self, final_block: bool) {
+        self.output.push(u8::from(final_block));
+        let length = self.block.len() as u16;
+        self.output.extend_from_slice(&length.to_le_bytes());
+        self.output.extend_from_slice(&(!length).to_le_bytes());
+        self.output.extend_from_slice(&self.block);
+        self.block.clear();
+    }
+
+    fn finish(mut self) {
+        self.flush(true);
+        let adler = (self.adler_b << 16) | self.adler_a;
+        self.output.extend_from_slice(&adler.to_be_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stored_rgba(png: &[u8]) -> Vec<u8> {
+        let mut cursor = PNG_SIGNATURE.len();
+        let mut zlib = None;
+        while cursor < png.len() {
+            let length = u32::from_be_bytes(png[cursor..cursor + 4].try_into().unwrap()) as usize;
+            let data = cursor + 8..cursor + 8 + length;
+            if &png[cursor + 4..cursor + 8] == b"IDAT" {
+                zlib = Some(&png[data]);
+                break;
+            }
+            cursor += 12 + length;
+        }
+        let zlib = zlib.expect("IDAT chunk");
+        let mut cursor = 2;
+        let mut raw = Vec::new();
+        loop {
+            let header = zlib[cursor];
+            cursor += 1;
+            assert_eq!(header & 0xfe, 0, "fixture uses stored DEFLATE blocks");
+            let length = u16::from_le_bytes(zlib[cursor..cursor + 2].try_into().unwrap());
+            let inverse = u16::from_le_bytes(zlib[cursor + 2..cursor + 4].try_into().unwrap());
+            assert_eq!(length, !inverse);
+            cursor += 4;
+            raw.extend_from_slice(&zlib[cursor..cursor + length as usize]);
+            cursor += length as usize;
+            if header & 1 != 0 {
+                break;
+            }
+        }
+        assert_eq!(cursor + 4, zlib.len(), "four-byte Adler32 trailer");
+        raw
+    }
+
+    #[test]
+    fn exact_image_paste_chords_exclude_alt_and_repeats() {
+        let key = |modifiers, kind| KeyEvent::new_with_kind(KeyCode::Char('v'), modifiers, kind);
+        assert!(is_image_paste_key(&key(
+            KeyModifiers::CONTROL,
+            KeyEventKind::Press
+        )));
+        assert!(is_image_paste_key(&key(
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            KeyEventKind::Press
+        )));
+        assert!(!is_image_paste_key(&key(
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+            KeyEventKind::Press
+        )));
+        assert!(!is_image_paste_key(&key(
+            KeyModifiers::CONTROL,
+            KeyEventKind::Repeat
+        )));
+    }
+
+    #[test]
+    fn rgba_encoder_produces_a_bounded_structural_png() {
+        let pixels = [
+            [255, 0, 0, 255],
+            [0, 255, 0, 255],
+            [0, 0, 255, 255],
+            [255, 255, 255, 128],
+        ];
+        let png = encode_rgba_png(2, 2, |x, y| pixels[(y * 2 + x) as usize]).unwrap();
+        assert_eq!(
+            validate_png(&png),
+            Ok(PngInfo {
+                width: 2,
+                height: 2
+            })
+        );
+        let mut corrupt = png;
+        corrupt[20] ^= 1;
+        assert_eq!(validate_png(&corrupt), Err("invalid PNG checksum"));
+    }
+
+    #[test]
+    fn validator_rejects_dimensions_that_imply_excessive_decode_memory() {
+        let png = encode_rgba_png(1, 1, |_, _| [0, 0, 0, 255]).unwrap();
+        let mut oversized = png;
+        oversized[16..20].copy_from_slice(&(MAX_DIMENSION + 1).to_be_bytes());
+        let checksum = crc32(&oversized[12..29]);
+        oversized[29..33].copy_from_slice(&checksum.to_be_bytes());
+        assert_eq!(
+            validate_png(&oversized),
+            Err("PNG dimensions exceed clipboard image limit")
+        );
+    }
+
+    #[test]
+    fn bottom_up_24_bit_dib_preserves_rows_and_colors() {
+        let mut dib = vec![0u8; 40 + 16];
+        dib[0..4].copy_from_slice(&40u32.to_le_bytes());
+        dib[4..8].copy_from_slice(&2i32.to_le_bytes());
+        dib[8..12].copy_from_slice(&2i32.to_le_bytes());
+        dib[12..14].copy_from_slice(&1u16.to_le_bytes());
+        dib[14..16].copy_from_slice(&24u16.to_le_bytes());
+        // DIB storage is bottom-up and each 24-bit row is padded to four bytes.
+        dib[40..48].copy_from_slice(&[255, 0, 0, 255, 255, 255, 0, 0]);
+        dib[48..56].copy_from_slice(&[0, 0, 255, 0, 255, 0, 0, 0]);
+
+        let png = dib_to_png(&dib).unwrap();
+        assert_eq!(
+            validate_png(&png),
+            Ok(PngInfo {
+                width: 2,
+                height: 2
+            })
+        );
+        assert_eq!(
+            stored_rgba(&png),
+            [
+                0, 255, 0, 0, 255, 0, 255, 0, 255, // top: red, green
+                0, 0, 0, 255, 255, 255, 255, 255, 255, // bottom: blue, white
+            ]
+        );
+    }
+
+    #[test]
+    fn top_down_v5_bitfields_preserve_alpha() {
+        let mut dib = vec![0u8; 124 + 4];
+        dib[0..4].copy_from_slice(&124u32.to_le_bytes());
+        dib[4..8].copy_from_slice(&1i32.to_le_bytes());
+        dib[8..12].copy_from_slice(&(-1i32).to_le_bytes());
+        dib[12..14].copy_from_slice(&1u16.to_le_bytes());
+        dib[14..16].copy_from_slice(&32u16.to_le_bytes());
+        dib[16..20].copy_from_slice(&BI_BITFIELDS.to_le_bytes());
+        dib[40..44].copy_from_slice(&0x00ff_0000u32.to_le_bytes());
+        dib[44..48].copy_from_slice(&0x0000_ff00u32.to_le_bytes());
+        dib[48..52].copy_from_slice(&0x0000_00ffu32.to_le_bytes());
+        dib[52..56].copy_from_slice(&0xff00_0000u32.to_le_bytes());
+        dib[124..128].copy_from_slice(&0x8040_2010u32.to_le_bytes());
+
+        let png = dib_to_png(&dib).unwrap();
+        assert_eq!(
+            validate_png(&png),
+            Ok(PngInfo {
+                width: 1,
+                height: 1
+            })
+        );
+        assert_eq!(stored_rgba(&png), [0, 64, 32, 16, 128]);
+    }
+
+    #[test]
+    fn malformed_or_compressed_dib_fails_closed() {
+        assert_eq!(dib_to_png(&[0; 12]), Err("unsupported DIB header"));
+        let mut dib = vec![0u8; 44];
+        dib[0..4].copy_from_slice(&40u32.to_le_bytes());
+        dib[4..8].copy_from_slice(&1i32.to_le_bytes());
+        dib[8..12].copy_from_slice(&1i32.to_le_bytes());
+        dib[12..14].copy_from_slice(&1u16.to_le_bytes());
+        dib[14..16].copy_from_slice(&32u16.to_le_bytes());
+        dib[16..20].copy_from_slice(&1u32.to_le_bytes());
+        assert_eq!(dib_to_png(&dib), Err("unsupported DIB pixel format"));
+    }
+
+    #[test]
+    fn staging_uses_selected_private_session_storage() {
+        let _env = crate::persist::test_env("clipboard-image-stage");
+        crate::persist::ensure_session_dir();
+        let png = encode_rgba_png(1, 1, |_, _| [1, 2, 3, 255]).unwrap();
+        let path = stage_png(&png).unwrap();
+        let expected = crate::persist::session_dir().join("clipboard-images");
+        assert_eq!(path.parent(), Some(expected.as_path()));
+        assert_eq!(fs::read(&path).unwrap(), png);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(path.parent().unwrap())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn staging_cleanup_is_bounded_and_preserves_unowned_files() {
+        let _env = crate::persist::test_env("clipboard-image-cleanup");
+        crate::persist::ensure_session_dir();
+        let png = encode_rgba_png(1, 1, |_, _| [1, 2, 3, 255]).unwrap();
+        let dir = crate::persist::ensure_clipboard_image_dir().unwrap();
+        let unrelated = dir.join("keep.txt");
+        fs::write(&unrelated, b"not owned by image staging").unwrap();
+
+        for _ in 0..MAX_FRESH_STAGED + 3 {
+            stage_png(&png).unwrap();
+        }
+        let owned = fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with(STAGED_PREFIX))
+            })
+            .count();
+        assert_eq!(owned, MAX_FRESH_STAGED);
+        assert_eq!(fs::read(unrelated).unwrap(), b"not owned by image staging");
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,7 @@
 //! Messages flowing into the main loop from input/PTY threads and (in server
 //! mode) from client connections.
 
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
@@ -18,6 +19,7 @@ pub enum ClientInput {
     Key(KeyEvent),
     Mouse(MouseEvent),
     Paste(String),
+    PasteImage(PathBuf),
     Resize(u16, u16),
 }
 
@@ -26,6 +28,8 @@ pub enum AppEvent {
     Key(KeyEvent),
     Mouse(MouseEvent),
     Paste(String),
+    /// A validated PNG staged in the selected server's private directory.
+    PasteImage(PathBuf),
     Resize,
     /// The given pane produced output; the screen changed.
     PtyData(PaneId),

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -376,7 +376,17 @@ fn write_input_event(writer: &mut impl Write, event: Event) -> bool {
 }
 
 fn event_message(event: Event) -> Option<ClientMessage> {
+    event_message_with_image(event, crate::platform::clipboard_image)
+}
+
+fn event_message_with_image(
+    event: Event,
+    image: impl FnOnce() -> Option<Vec<u8>>,
+) -> Option<ClientMessage> {
     match crate::terminal::host_key::normalize_platform_modifiers(event) {
+        Event::Key(k) if crate::clipboard_image::is_image_paste_key(&k) => image()
+            .map(ClientMessage::ClipboardImage)
+            .or(Some(ClientMessage::Key(k))),
         Event::Key(k) => Some(ClientMessage::Key(k)),
         Event::Mouse(m) => Some(ClientMessage::Mouse(m)),
         Event::Resize(cols, rows) => {
@@ -968,6 +978,22 @@ mod render_tests {
         assert!(matches!(
             message,
             Some(ClientMessage::Paste(text)) if text == command
+        ));
+    }
+
+    #[test]
+    fn image_paste_chord_uses_binary_data_and_falls_back_to_the_key() {
+        let key = ratatui::crossterm::event::KeyEvent::new(
+            ratatui::crossterm::event::KeyCode::Char('v'),
+            ratatui::crossterm::event::KeyModifiers::CONTROL,
+        );
+        assert!(matches!(
+            event_message_with_image(Event::Key(key), || Some(vec![1, 2, 3])),
+            Some(ClientMessage::ClipboardImage(bytes)) if bytes == [1, 2, 3]
+        ));
+        assert!(matches!(
+            event_message_with_image(Event::Key(key), || None),
+            Some(ClientMessage::Key(fallback)) if fallback == key
         ));
     }
 

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -7,7 +7,7 @@ use std::io::{self, Read, Write};
 use ratatui::buffer::Buffer;
 use ratatui::crossterm::event::{KeyEvent, MouseEvent};
 use ratatui::style::{Color, Modifier};
-use serde::de::DeserializeOwned;
+use serde::de::{DeserializeOwned, Error as _, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
 use crate::sound::SoundSignal;
@@ -28,7 +28,7 @@ pub enum ClientMessage {
     Paste(String),
     /// PNG bytes read from the display client's local clipboard after an
     /// explicit image-paste gesture. The server validates and stages them.
-    ClipboardImage(Vec<u8>),
+    ClipboardImage(#[serde(deserialize_with = "deserialize_clipboard_image")] Vec<u8>),
     Resize {
         cols: u16,
         rows: u16,
@@ -36,6 +36,48 @@ pub enum ClientMessage {
     Detach,
     /// Response to [`ServerMessage::Ready`] when terminal colors were requested.
     TerminalColors(Option<TerminalColors>),
+}
+
+fn deserialize_clipboard_image<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct ClipboardImageVisitor;
+
+    impl<'de> Visitor<'de> for ClipboardImageVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                formatter,
+                "at most {} clipboard image bytes",
+                crate::clipboard_image::MAX_PNG_BYTES
+            )
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let length = sequence.size_hint().unwrap_or(0);
+            if length > crate::clipboard_image::MAX_PNG_BYTES {
+                return Err(A::Error::custom("clipboard image exceeds size limit"));
+            }
+            let mut bytes = Vec::new();
+            bytes
+                .try_reserve_exact(length)
+                .map_err(|_| A::Error::custom("clipboard image allocation failed"))?;
+            while let Some(byte) = sequence.next_element()? {
+                if bytes.len() == crate::clipboard_image::MAX_PNG_BYTES {
+                    return Err(A::Error::custom("clipboard image exceeds size limit"));
+                }
+                bytes.push(byte);
+            }
+            Ok(bytes)
+        }
+    }
+
+    deserializer.deserialize_seq(ClipboardImageVisitor)
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -212,7 +254,8 @@ pub fn read_message<R: Read, M: DeserializeOwned>(r: &mut R) -> io::Result<M> {
     }
     let mut buf = vec![0u8; len];
     r.read_exact(&mut buf)?;
-    let (msg, _) = bincode::serde::decode_from_slice(&buf, bincode::config::standard())
+    let config = bincode::config::standard().with_limit::<MAX_FRAME>();
+    let (msg, _) = bincode::serde::decode_from_slice(&buf, config)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     Ok(msg)
 }
@@ -504,6 +547,35 @@ mod tests {
             read_message::<_, ClientMessage>(&mut &bytes[..]).unwrap(),
             ClientMessage::ClipboardImage(decoded) if decoded == png
         ));
+    }
+
+    #[test]
+    fn clipboard_image_rejects_an_oversized_declared_length_before_allocation() {
+        let config = bincode::config::standard();
+        let mut encoded =
+            bincode::serde::encode_to_vec(ClientMessage::ClipboardImage(Vec::new()), config)
+                .unwrap();
+        assert_eq!(
+            encoded.pop(),
+            Some(0),
+            "empty image ends with a zero length"
+        );
+        encoded.extend(
+            bincode::serde::encode_to_vec(crate::clipboard_image::MAX_PNG_BYTES + 1, config)
+                .unwrap(),
+        );
+
+        let mut frame = Vec::with_capacity(encoded.len() + 4);
+        frame.extend_from_slice(&(encoded.len() as u32).to_le_bytes());
+        frame.extend_from_slice(&encoded);
+        let error = match read_message::<_, ClientMessage>(&mut &frame[..]) {
+            Ok(_) => panic!("oversized clipboard image length must be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error
+            .to_string()
+            .contains("clipboard image exceeds size limit"));
     }
 
     /// A wide glyph written through ratatui's own `set_string` (the path modals,

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::sound::SoundSignal;
 use crate::terminal::theme_probe::TerminalColors;
 
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 const MAX_FRAME: usize = 64 * 1024 * 1024;
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -26,6 +26,9 @@ pub enum ClientMessage {
     Key(KeyEvent),
     Mouse(MouseEvent),
     Paste(String),
+    /// PNG bytes read from the display client's local clipboard after an
+    /// explicit image-paste gesture. The server validates and stages them.
+    ClipboardImage(Vec<u8>),
     Resize {
         cols: u16,
         rows: u16,
@@ -488,6 +491,18 @@ mod tests {
         assert!(matches!(
             read_message::<_, ServerMessage>(&mut &bytes[..]).unwrap(),
             ServerMessage::SwitchSession { name } if name == "api"
+        ));
+    }
+
+    #[test]
+    fn clipboard_image_roundtrips_as_binary_png_data() {
+        let png = crate::clipboard_image::encode_rgba_png(1, 1, |_, _| [1, 2, 3, 255])
+            .expect("fixture PNG");
+        let mut bytes = Vec::new();
+        write_message(&mut bytes, &ClientMessage::ClipboardImage(png.clone())).unwrap();
+        assert!(matches!(
+            read_message::<_, ClientMessage>(&mut &bytes[..]).unwrap(),
+            ClientMessage::ClipboardImage(decoded) if decoded == png
         ));
     }
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -788,6 +788,7 @@ fn apply(
                 ClientInput::Key(key) => AppEvent::Key(key),
                 ClientInput::Mouse(mouse) => AppEvent::Mouse(mouse),
                 ClientInput::Paste(text) => AppEvent::Paste(text),
+                ClientInput::PasteImage(path) => AppEvent::PasteImage(path),
                 ClientInput::Resize(..) => unreachable!("handled above"),
             };
             app.handle_event(event)
@@ -1348,6 +1349,21 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
                     })
                     .is_err()
                 {
+                    break;
+                }
+            }
+            Ok(ClientMessage::ClipboardImage(png)) => {
+                let Ok(path) = crate::clipboard_image::stage_png(&png) else {
+                    continue;
+                };
+                if app_tx
+                    .send(AppEvent::ClientInput {
+                        id,
+                        input: ClientInput::PasteImage(path.clone()),
+                    })
+                    .is_err()
+                {
+                    let _ = std::fs::remove_file(path);
                     break;
                 }
             }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -738,6 +738,7 @@ fn apply(
         }
         AppEvent::ClientInput { id, input } => {
             let Some(client) = clients.get_mut(&id) else {
+                discard_client_input(input);
                 return false;
             };
             client.last_activity = *next_activity;
@@ -777,6 +778,7 @@ fn apply(
                     clients.remove(&id);
                     *foreground = latest_client(clients);
                     apply_foreground_theme(app, clients, *foreground);
+                    discard_client_input(input);
                     return true;
                 }
                 if let Some(size) = target_size {
@@ -796,6 +798,12 @@ fn apply(
         // Redraw only if the event actually changed the UI — a plain keystroke
         // forwarded to a pane does not (its echo arrives as a separate `PtyData`).
         other => app.handle_event(other),
+    }
+}
+
+fn discard_client_input(input: ClientInput) {
+    if let ClientInput::PasteImage(path) = input {
+        crate::clipboard_image::discard_staged_png(&path);
     }
 }
 
@@ -1363,7 +1371,7 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
                     })
                     .is_err()
                 {
-                    let _ = std::fs::remove_file(path);
+                    crate::clipboard_image::discard_staged_png(&path);
                     break;
                 }
             }
@@ -1956,6 +1964,33 @@ mod tests {
             ),
             "clipboard control data cannot be dropped behind a frame"
         );
+    }
+
+    #[test]
+    fn image_staged_for_a_removed_client_is_discarded() {
+        let _env = crate::persist::test_env("removed-client-image");
+        let (app_tx, _app_rx) = mpsc::channel();
+        let mut app = App::new(80, 24, app_tx).expect("app starts");
+        let png = crate::clipboard_image::encode_rgba_png(1, 1, |_, _| [1, 2, 3, 255])
+            .expect("fixture PNG");
+        let staged = crate::clipboard_image::stage_png(&png).expect("staged image");
+        let mut clients = HashMap::new();
+        let mut foreground = None;
+        let mut interactive_size = (80, 24);
+        let mut next_activity = 1;
+
+        assert!(!apply(
+            AppEvent::ClientInput {
+                id: 7,
+                input: ClientInput::PasteImage(staged.clone()),
+            },
+            &mut app,
+            &mut clients,
+            &mut foreground,
+            &mut interactive_size,
+            &mut next_activity,
+        ));
+        assert!(!staged.exists());
     }
 
     /// Explicit client detach is carried by the same reliable control path and

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod automation;
 mod bar;
 mod changelog;
 mod cli;
+mod clipboard_image;
 mod config;
 mod detect;
 mod diff;
@@ -1436,7 +1437,20 @@ fn send_input_event(tx: &Sender<AppEvent>, event: Event) -> bool {
 }
 
 fn app_event(event: Event) -> Option<AppEvent> {
+    app_event_with_image(event, || {
+        crate::platform::clipboard_image()
+            .and_then(|png| crate::clipboard_image::stage_png(&png).ok())
+    })
+}
+
+fn app_event_with_image(
+    event: Event,
+    image: impl FnOnce() -> Option<std::path::PathBuf>,
+) -> Option<AppEvent> {
     match crate::terminal::host_key::normalize_platform_modifiers(event) {
+        Event::Key(k) if crate::clipboard_image::is_image_paste_key(&k) => {
+            image().map(AppEvent::PasteImage).or(Some(AppEvent::Key(k)))
+        }
         Event::Key(k) => Some(AppEvent::Key(k)),
         Event::Mouse(m) => Some(AppEvent::Mouse(m)),
         Event::Resize(_, _) => Some(AppEvent::Resize),
@@ -1459,6 +1473,23 @@ mod tests {
         let _env = crate::persist::test_env("stop-absent");
         crate::persist::ensure_session_dir();
         assert!(!send_server_stop().expect("absent server is not an error"));
+    }
+
+    #[test]
+    fn local_image_paste_uses_a_staged_path_and_falls_back_to_the_key() {
+        let key = ratatui::crossterm::event::KeyEvent::new(
+            ratatui::crossterm::event::KeyCode::Char('v'),
+            ratatui::crossterm::event::KeyModifiers::CONTROL,
+        );
+        let path = std::path::PathBuf::from("clipboard-images/example.png");
+        assert!(matches!(
+            app_event_with_image(Event::Key(key), || Some(path.clone())),
+            Some(AppEvent::PasteImage(staged)) if staged == path
+        ));
+        assert!(matches!(
+            app_event_with_image(Event::Key(key), || None),
+            Some(AppEvent::Key(fallback)) if fallback == key
+        ));
     }
 
     #[test]

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -332,6 +332,35 @@ pub fn ensure_server_session_dir() -> std::io::Result<PathBuf> {
     Ok(dir)
 }
 
+/// Create the selected server's private clipboard-image directory.
+///
+/// Image data arrives from an authenticated display client, but the server
+/// still owns the final path. Reusing the server directory validation keeps a
+/// malicious symlink or permissive directory from redirecting staged input.
+pub fn ensure_clipboard_image_dir() -> std::io::Result<PathBuf> {
+    let session = ensure_server_session_dir()?;
+    let dir = session.join("clipboard-images");
+    ensure_private_server_dir(&dir)?;
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        let metadata = fs::symlink_metadata(&dir)?;
+        if !metadata.file_type().is_dir()
+            || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "Luvus clipboard storage must be a real directory: {}",
+                    dir.display()
+                ),
+            ));
+        }
+    }
+    Ok(dir)
+}
+
 fn ensure_private_server_dir(dir: &std::path::Path) -> std::io::Result<()> {
     fs::create_dir_all(dir)?;
     #[cfg(unix)]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -40,6 +40,19 @@ pub fn option_modifier_pressed() -> bool {
     false
 }
 
+/// Read and normalize a local Windows clipboard image after an explicit paste
+/// gesture. Other platforms preserve their existing terminal and agent-native
+/// clipboard behavior and never probe the clipboard here.
+#[cfg(windows)]
+pub fn clipboard_image() -> Option<Vec<u8>> {
+    windows::clipboard_image()
+}
+
+#[cfg(not(windows))]
+pub fn clipboard_image() -> Option<Vec<u8>> {
+    None
+}
+
 /// Do two paths name the same folder? (docs/43 WIN-6.)
 ///
 /// Node lookup used to compare `PathBuf`s with `==`, so any difference in

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -27,6 +27,12 @@ use windows_sys::Win32::System::Threading::{
     PROCESS_VM_READ, RTL_USER_PROCESS_PARAMETERS,
 };
 
+mod clipboard;
+
+pub(super) fn clipboard_image() -> Option<Vec<u8>> {
+    clipboard::clipboard_image()
+}
+
 const MAX_PROCESS_ENTRIES: usize = 16_384;
 const MAX_DESCENDANTS_PER_ROOT: usize = 64;
 const MAX_COMMAND_LINE_BYTES: usize = 64 * 1024;

--- a/src/platform/windows/clipboard.rs
+++ b/src/platform/windows/clipboard.rs
@@ -9,7 +9,7 @@ use windows_sys::Win32::System::DataExchange::{
 };
 use windows_sys::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
 
-use crate::clipboard_image::{dib_to_png, validate_png, MAX_PNG_BYTES};
+use crate::clipboard_image::{dib_to_png, validated_png_prefix, MAX_PNG_BYTES};
 
 const CF_DIB: u32 = 8;
 const CF_DIBV5: u32 = 17;
@@ -60,7 +60,7 @@ pub(super) fn clipboard_image() -> Option<Vec<u8>> {
     let png_format = unsafe { RegisterClipboardFormatW(png_name.as_ptr()) };
     if png_format != 0 {
         if let Some(png) = with_format(png_format, |bytes| {
-            validate_png(bytes).ok().map(|_| bytes.to_vec())
+            validated_png_prefix(bytes).ok().map(|png| png.to_vec())
         })
         .flatten()
         {

--- a/src/platform/windows/clipboard.rs
+++ b/src/platform/windows/clipboard.rs
@@ -1,0 +1,106 @@
+//! Explicit, bounded Windows clipboard-image access.
+
+use std::time::Duration;
+
+use windows_sys::Win32::Foundation::{HANDLE, HWND};
+use windows_sys::Win32::System::DataExchange::{
+    CloseClipboard, GetClipboardData, IsClipboardFormatAvailable, OpenClipboard,
+    RegisterClipboardFormatW,
+};
+use windows_sys::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
+
+use crate::clipboard_image::{dib_to_png, validate_png, MAX_PNG_BYTES};
+
+const CF_DIB: u32 = 8;
+const CF_DIBV5: u32 = 17;
+const MAX_OPEN_ATTEMPTS: usize = 3;
+
+struct ClipboardGuard;
+
+impl ClipboardGuard {
+    fn open() -> Option<Self> {
+        for attempt in 0..MAX_OPEN_ATTEMPTS {
+            // SAFETY: a null owner is documented for read-only clipboard use.
+            if unsafe { OpenClipboard(std::ptr::null_mut::<core::ffi::c_void>() as HWND) } != 0 {
+                return Some(Self);
+            }
+            if attempt + 1 < MAX_OPEN_ATTEMPTS {
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        }
+        None
+    }
+}
+
+impl Drop for ClipboardGuard {
+    fn drop(&mut self) {
+        // SAFETY: this guard exists only after one successful OpenClipboard.
+        unsafe {
+            CloseClipboard();
+        }
+    }
+}
+
+struct GlobalLockGuard(HANDLE);
+
+impl Drop for GlobalLockGuard {
+    fn drop(&mut self) {
+        // SAFETY: this handle was locked successfully and remains owned by the
+        // clipboard. Unlocking does not free or transfer it.
+        unsafe {
+            GlobalUnlock(self.0);
+        }
+    }
+}
+
+pub(super) fn clipboard_image() -> Option<Vec<u8>> {
+    let _clipboard = ClipboardGuard::open()?;
+    let png_name = ['P' as u16, 'N' as u16, 'G' as u16, 0];
+    // SAFETY: `png_name` is a live null-terminated UTF-16 string.
+    let png_format = unsafe { RegisterClipboardFormatW(png_name.as_ptr()) };
+    if png_format != 0 {
+        if let Some(png) = with_format(png_format, |bytes| {
+            validate_png(bytes).ok().map(|_| bytes.to_vec())
+        })
+        .flatten()
+        {
+            return Some(png);
+        }
+    }
+    for format in [CF_DIBV5, CF_DIB] {
+        if let Some(png) = with_format(format, dib_to_png).and_then(Result::ok) {
+            return Some(png);
+        }
+    }
+    None
+}
+
+fn with_format<T>(format: u32, read: impl FnOnce(&[u8]) -> T) -> Option<T> {
+    // SAFETY: querying an integer clipboard format has no pointer preconditions.
+    if unsafe { IsClipboardFormatAvailable(format) } == 0 {
+        return None;
+    }
+    // SAFETY: the clipboard is open for this thread and `format` was reported
+    // available. Luvus never takes ownership of the returned handle.
+    let handle = unsafe { GetClipboardData(format) };
+    if handle.is_null() {
+        return None;
+    }
+    // SAFETY: clipboard memory for PNG and DIB formats is an HGLOBAL. Size is
+    // queried before lock and bounded before constructing the borrowed slice.
+    let size = unsafe { GlobalSize(handle) };
+    if size == 0 || size > MAX_PNG_BYTES {
+        return None;
+    }
+    // SAFETY: a successful GlobalLock returns at least `size` readable bytes
+    // which remain valid until the matching unlock below.
+    let pointer = unsafe { GlobalLock(handle) };
+    if pointer.is_null() {
+        return None;
+    }
+    let _lock = GlobalLockGuard(handle);
+    // SAFETY: established by GlobalSize and GlobalLock above. The clipboard is
+    // held open and the handle stays locked for the closure call.
+    let bytes = unsafe { std::slice::from_raw_parts(pointer.cast::<u8>(), size) };
+    Some(read(bytes))
+}

--- a/website/src/content/docs/docs/guides/layout.mdx
+++ b/website/src/content/docs/docs/guides/layout.mdx
@@ -231,6 +231,21 @@ Unicode character counts; wide glyphs such as CJK and many emoji consume two.
 Drag across any pane to select, and releasing **auto-copies** to your clipboard. Full
 details, plus scrollback, are in [Scrollback & Copy](/docs/guides/scrollback/).
 
+## Pasting images on Windows
+
+Copy a screenshot or image, focus an agent pane, then press `Ctrl+V` or
+`Ctrl+Shift+V` if that is the paste chord your terminal sends. Luvus reads the
+clipboard only for that explicit gesture. A supported PNG or bitmap is staged
+as a private PNG and its path is pasted into the focused pane without submitting
+the prompt. Agents that accept image paths can then attach or inspect it.
+
+If the clipboard has text, is unavailable, or contains an unsupported image,
+Luvus forwards the original key unchanged. Image paste is ignored while a Luvus
+modal, native file view, dashboard, copy mode, or navigation mode owns input, so
+the private path cannot leak into a pane behind it. This dedicated reader is
+currently available in Windows display clients. Text paste and the existing
+terminal-native behavior on macOS and Linux are unchanged.
+
 ## Opening links and files
 
 Agents print references all day: the PR they opened, the doc they read, the file

--- a/website/src/content/docs/docs/guides/remote.mdx
+++ b/website/src/content/docs/docs/guides/remote.mdx
@@ -238,9 +238,16 @@ With `luvus --remote`, the local attached client owns effects that should happen
 where you are sitting:
 
 - copied text goes to the local clipboard
+- on Windows, an explicit image paste reads the local clipboard and stages the
+  private PNG on the remote Luvus server before pasting that remote path into
+  the focused pane
 - notifications and sounds play locally
 - detected links open in the local browser
 - each attached client uses its own terminal size and mobile or desktop layout
+
+Image bytes travel inside the existing encrypted SSH connection. Luvus does not
+open another port or write the image to the local machine's Luvus server. If no
+supported image is present, the original paste key continues unchanged.
 
 The global finder searches the selected remote Luvus home. It does not mix
 local workspaces or sessions into remote results.


### PR DESCRIPTION
## Summary

This adds a dedicated Windows clipboard image path while preserving the existing text input behavior.

- Read registered PNG, CF_DIBV5, and CF_DIB data only after an explicit Ctrl+V or Ctrl+Shift+V gesture
- Normalize common 24-bit and 32-bit Windows bitmaps into PNG without adding an image or compression dependency
- Carry the bounded PNG through the existing binary client transport
- Stage the image under private selected-session storage and paste its path into the originating client's focused terminal pane
- Keep text paste and unsupported clipboard content on the existing key path
- Document local and remote image paste behavior

## Safety and resource bounds

Clipboard access remains client-owned, so a Windows client attached over SSH reads the clipboard on the machine in front of the user. The server chooses the destination path and never accepts a client-provided filename.

The implementation validates PNG structure and checksums on both sides, caps payloads at 48 MiB, limits dimensions to 8192 pixels and 12 million total pixels, uses random create-new filenames, and performs bounded cleanup only during an explicit image paste. It adds no timer, watcher, polling loop, network endpoint, or new dependency.

Image paths are delivered only when a normal terminal pane owns input. Luvus modals, dashboards, native file views, copy mode, and navigation modes reject the delivery instead of leaking it into the pane underneath. The prompt is not submitted automatically.

## Verification

- `cargo fmt --all --check`
- `cargo test clipboard_image -- --nocapture`
- focused client, local-mode, protocol, and pane-routing tests
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --target x86_64-pc-windows-gnu --tests`
- `cargo clippy --target x86_64-pc-windows-gnu --all-targets -- -D warnings`
- `cargo test --locked` with 1632 passed and 3 ignored benchmarks
- `cargo build --release --locked`
- `npm run build` in `website/`
- isolated debug server lifecycle under `~/.luvus-dev` using the `image-paste-test` named session

A live Windows Terminal clipboard test was not available on this macOS development machine. The Windows implementation was cross-compiled and linted, while the platform-neutral DIB fixtures run on every host and verify row order, color channels, alpha, malformed input rejection, bounds, staging permissions, and cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows image pasting from the system clipboard with Ctrl+V or Ctrl+Shift+V.
  - Images are securely transferred and pasted as file paths without submitting the prompt.
  - Remote sessions support image pasting without opening additional ports.
  - Unsupported or unavailable images continue using normal paste behavior.

- **Bug Fixes**
  - Image pasting is ignored while modals, dashboards, file views, navigation, or copy mode control input.

- **Documentation**
  - Added guides covering Windows image pasting and remote-session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->