### PR TITLE
feat(agent): add OpenCode 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Keyboard → Keyboard Shortcuts → Input Sources** to free `Ctrl+Space`.
 | Codex | ✓ | ✓ | ✓ |
 | Antigravity CLI | ✓ | ✓ | session only |
 | opencode | ✓ | ✓ | ✓ |
+| OpenCode 2 Preview | ✓ | exact-ID resume | No |
 | Kimi | ✓ | ✓ | ✓ |
 | Grok | ✓ | ✓ | ✓ |
 | Hermes CLI | ✓ | ✓ with integration | session only |

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -432,6 +432,8 @@ surface:
   detection remains authoritative for agent state.
 - For OpenCode, `luvus integration install opencode` adds exact TUI-local root
   session ownership and structured usage. Without it, usage stays unavailable.
+- OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
+  OpenCode V1 integration for it or infer session IDs from its live database.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership for restart resume. Detection remains native, but Luvus does not
   scan Hermes's private history store.

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -432,6 +432,8 @@ surface:
   detection remains authoritative for agent state.
 - For OpenCode, `luvus integration install opencode` adds exact TUI-local root
   session ownership and structured usage. Without it, usage stays unavailable.
+- OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
+  OpenCode V1 integration for it or infer session IDs from its live database.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership for restart resume. Detection remains native, but Luvus does not
   scan Hermes's private history store.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -33,6 +33,7 @@ pub(crate) mod kiro;
 pub(crate) mod muse;
 pub(crate) mod omp;
 pub(crate) mod opencode;
+pub(crate) mod opencode2;
 pub(crate) mod pi;
 pub(crate) mod qwen;
 pub(crate) mod registry;
@@ -369,6 +370,10 @@ mod tests {
         assert!(resume_command("opencode", "ses_1")
             .unwrap()
             .contains("opencode --session"));
+        assert_eq!(
+            resume_command("opencode2", "ses_2").as_deref(),
+            Some("opencode2 --session 'ses_2'\r")
+        );
         // Aliases + resume-only agents resolve through the registry.
         assert!(resume_command("codex", "c1")
             .unwrap()
@@ -397,7 +402,12 @@ mod tests {
             resume_command("kilocode", "ses_123").as_deref(),
             Some("kilo --session 'ses_123'\r")
         );
-        assert!(is_resumable("opencode") && is_resumable("cursor-agent") && is_resumable("kilo"));
+        assert!(
+            is_resumable("opencode")
+                && is_resumable("opencode2")
+                && is_resumable("cursor-agent")
+                && is_resumable("kilo")
+        );
         assert_eq!(
             resume_command("gemini", "g1").as_deref(),
             Some("gemini --resume 'g1'\r")
@@ -695,6 +705,10 @@ mod tests {
             f("grok", &["--resume", "old-id", "--fork-session", "--yolo"]),
             vec!["--yolo"]
         );
+        assert_eq!(
+            f("opencode2", &["--session", "old-id", "--standalone"]),
+            vec!["--standalone"]
+        );
         // Codex selects a session with positional resume/fork subcommands.
         assert_eq!(
             f("codex", &["resume", "sess_9", "--model", "o3"]),
@@ -747,6 +761,15 @@ mod tests {
         assert!(cmd.ends_with('\r'));
         // The stale captured --resume was filtered: exactly one resume id remains.
         assert_eq!(cmd.matches("--resume").count(), 1);
+
+        let opencode2_launch = ["--session", "old", "--standalone"]
+            .iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            resume_command_with_flags("opencode2", "ses_2", &opencode2_launch).as_deref(),
+            Some("opencode2 --session 'ses_2' '--standalone'\r")
+        );
 
         // All-filtered input and empty input both fall back to the plain command.
         let base = resume_command("claude", "abc").unwrap();

--- a/src/agent/opencode2/mod.rs
+++ b/src/agent/opencode2/mod.rs
@@ -1,0 +1,41 @@
+use super::types::{
+    AgentDescriptor, AutomationLaunch, AutomationOperations, IdentityDescriptor, SessionOperations,
+};
+
+pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
+    id: "opencode2",
+    aliases: &[],
+    launch_command: "opencode2",
+    task_prompt_args: &["--prompt"],
+    automation: Some(AutomationOperations {
+        read_only: None,
+        workspace: None,
+        // OpenCode 2's unattended runner can auto-approve every permission not
+        // explicitly denied by the user's configuration. Luvus therefore
+        // exposes it only behind an explicit full-access automation policy.
+        full_access: Some(AutomationLaunch {
+            args: &["run", "--auto"],
+        }),
+    }),
+    identity: IdentityDescriptor {
+        distinct: &["opencode2"],
+        ambiguous: &[],
+        binary_matcher: None,
+        // V1 and the V2 beta use the same npm package identity. The package
+        // alone cannot distinguish which executable and protocol is active.
+        interpreter_packages: &[],
+        overlap_priority: 0,
+    },
+    sessions: Some(SessionOperations {
+        // V2 stores sessions in its shared service's SQLite database. Do not
+        // open that live database or spawn the service from background
+        // discovery; resume only when Luvus already has an exact session ID.
+        discovery: None,
+        resume: |session| format!("opencode2 --session {session}\r"),
+        // The full TUI does not currently expose a native fork flag. The
+        // similarly named `mini` and `run` commands are different surfaces.
+        fork: None,
+    }),
+    // OpenCode V1's TUI plugin contract is not compatible with the V2 beta.
+    integration: None,
+};

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -7,6 +7,7 @@ pub(crate) static BUILTINS: &[&AgentDescriptor] = &[
     &super::antigravity::DESCRIPTOR,
     &super::aider::DESCRIPTOR,
     &super::opencode::DESCRIPTOR,
+    &super::opencode2::DESCRIPTOR,
     &super::copilot::DESCRIPTOR,
     &super::kimi::DESCRIPTOR,
     &super::qwen::DESCRIPTOR,
@@ -150,6 +151,11 @@ mod tests {
         assert!(!kilo.supports(AutomationAccess::ReadOnly));
         assert!(!kilo.supports(AutomationAccess::Workspace));
         assert!(kilo.supports(AutomationAccess::FullAccess));
+
+        let opencode2 = find("opencode2").unwrap().automation.unwrap();
+        assert!(!opencode2.supports(AutomationAccess::ReadOnly));
+        assert!(!opencode2.supports(AutomationAccess::Workspace));
+        assert!(opencode2.supports(AutomationAccess::FullAccess));
     }
 
     #[test]
@@ -215,6 +221,7 @@ mod tests {
             ("antigravity", &["antigravity-cli"][..], &["agy"][..]),
             ("aider", &["aider"][..], &[][..]),
             ("opencode", &["opencode"][..], &[][..]),
+            ("opencode2", &["opencode2"][..], &[][..]),
             ("copilot", &["copilot"][..], &[][..]),
             ("kimi", &["kimi"][..], &[][..]),
             ("qwen", &["qwen"][..], &[][..]),
@@ -261,6 +268,7 @@ mod tests {
                 "gemini",
                 "antigravity",
                 "opencode",
+                "opencode2",
                 "copilot",
                 "kimi",
                 "qwen",

--- a/src/agent/usage.rs
+++ b/src/agent/usage.rs
@@ -186,7 +186,8 @@ pub fn session_usage(agent: &str, cwd: &Path, session_id: &str) -> Option<AgentU
         "fx" => fx_usage(&fx_dir(&fx::sessions::base(), session_id)),
         // These agents currently expose identity/state but no stable,
         // structured, per-session usage store Luvus can read safely.
-        "aider" | "antigravity" | "kilo" | "kiro" | "cursor" | "amp" | "droid" | "opencode" => None,
+        "aider" | "antigravity" | "kilo" | "kiro" | "cursor" | "amp" | "droid" | "opencode"
+        | "opencode2" => None,
         _ => None, // manifest-defined agents degrade honestly too.
     }
 }
@@ -885,6 +886,7 @@ mod tests {
             "cursor-agent",
             "amp",
             "droid",
+            "opencode2",
             "custom",
         ] {
             assert!(session_usage(agent, Path::new("/work"), "session").is_none());

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -3319,6 +3319,7 @@ mod tests {
             ("muse", "muse"),
             ("omp", "omp"),
             ("opencode", "opencode --prompt"),
+            ("opencode2", "opencode2 --prompt"),
             ("pi", "pi"),
             ("qwen", "qwen --prompt-interactive"),
         ];
@@ -3346,6 +3347,12 @@ mod tests {
         );
         assert!(agent_automation_command("kilo", AutomationAccess::ReadOnly).is_err());
         assert!(agent_automation_command("kilo", AutomationAccess::Workspace).is_err());
+        assert_eq!(
+            agent_automation_command("opencode2", AutomationAccess::FullAccess).unwrap(),
+            "opencode2 run --auto"
+        );
+        assert!(agent_automation_command("opencode2", AutomationAccess::ReadOnly).is_err());
+        assert!(agent_automation_command("opencode2", AutomationAccess::Workspace).is_err());
         assert!(agent_automation_command("aider", AutomationAccess::Workspace).is_err());
         assert!(agent_automation_command("antigravity", AutomationAccess::Workspace).is_err());
 

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -2836,4 +2836,43 @@ Would you like to proceed?
         // which must keep working rather than reporting "no agents at all".
         assert_eq!(named("claude\n", &[]), "claude");
     }
+
+    #[test]
+    fn opencode_versions_have_distinct_process_identity() {
+        let manifests = Manifests::builtin();
+
+        assert_eq!(
+            manifests.agent_in_processes(&["/Users/me/.opencode/bin/opencode2 --auto".into()]),
+            Some("opencode2".into())
+        );
+        assert_eq!(
+            manifests.agent_in_processes(&[
+                r#"C:\Users\me\.opencode\bin\opencode2.exe --session ses_123"#.into()
+            ]),
+            Some("opencode2".into())
+        );
+        assert_eq!(
+            manifests.agent_in_processes(&["/usr/local/bin/opencode --session ses_v1".into()]),
+            Some("opencode".into())
+        );
+        assert_eq!(
+            manifests.launch_args_for(
+                &["/Users/me/.opencode/bin/opencode2 --session ses_2".into()],
+                "opencode2"
+            ),
+            Some(vec!["--session".into(), "ses_2".into()])
+        );
+
+        let prose = classify(
+            Some("zsh"),
+            "OpenCode 2 is available in beta\n",
+            true,
+            false,
+            "zsh",
+            "",
+            &["-zsh".into()],
+            &manifests,
+        );
+        assert_eq!(prose.agent, "zsh");
+    }
 }

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -544,7 +544,7 @@ fn host_commands(host: SkillHost) -> &'static [&'static str] {
             "kilo",
             "kilocode",
         ],
-        SkillHost::Opencode => &["opencode"],
+        SkillHost::Opencode => &["opencode", "opencode2"],
         SkillHost::Kimi => &["kimi"],
         SkillHost::Grok => &["grok"],
         SkillHost::Qwen => &["qwen"],
@@ -1125,6 +1125,10 @@ mod tests {
         assert_eq!(
             target_dir_at(SkillHost::Opencode, home, Some(Path::new("/xdg/config"))),
             PathBuf::from("/xdg/config/opencode/skills/luvus")
+        );
+        assert_eq!(
+            host_commands(SkillHost::Opencode),
+            ["opencode", "opencode2"]
         );
         assert_eq!(
             target_dir_at(SkillHost::Kimi, home, None),

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -84,10 +84,11 @@ for an agent to receive it:
 `luvus skill enable` makes no network request. It installs the same bundled
 skill into detected native skill locations without overwriting external or
 modified content. The shared `~/.agents/skills/luvus/` copy serves Codex,
-GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code. Dedicated
-adapters serve Claude Code, OpenCode, Kimi Code CLI, Grok Build, Hermes CLI,
-Qwen Code, and Kiro. Aider has no native Agent Skills installation surface, so
-use `luvus skill show` when an Aider conversation needs the instructions.
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code.
+Dedicated adapters serve Claude Code, OpenCode, OpenCode 2 Preview, Kimi Code
+CLI, Grok Build, Hermes CLI, Qwen Code, and Kiro. Aider has no native Agent
+Skills installation surface, so use `luvus skill show` when an Aider
+conversation needs the instructions.
 
 Start a new agent conversation after installation, or use that agent's skill
 reload command when it provides one. To remove unchanged Luvus-managed copies:
@@ -305,6 +306,11 @@ discovery rather than inferring support from an agent name.
   `luvus integration install opencode` adds a TUI-local plugin that reports
   only the root session selected in that pane plus structured usage. Without
   it, Mission Control leaves OpenCode usage unavailable instead of guessing.
+- OpenCode 2 Preview is detected separately as `opencode2`. Luvus can launch it
+  and resume an exact known ID with `opencode2 --session <id>`, but does not
+  scan its live SQLite database or reuse the OpenCode V1 integration. Its
+  reviewed unattended command, `opencode2 run --auto`, is available only for
+  an explicit `full_access` automation.
 - Kilo Code is detected through the official `kilo` and `kilocode` commands.
   Resume and fork use Kilo's native commands only when Luvus already has the
   exact session ID; Luvus does not scan or guess sessions from Kilo's database.

--- a/website/public/manifests/index.json
+++ b/website/public/manifests/index.json
@@ -3,6 +3,7 @@
     "antigravity.toml",
     "claude.toml",
     "gemini.toml",
-    "kilo.toml"
+    "kilo.toml",
+    "opencode2.toml"
   ]
 }

--- a/website/public/manifests/opencode2.toml
+++ b/website/public/manifests/opencode2.toml
@@ -1,0 +1,8 @@
+# Official Luvus detection manifest for the OpenCode 2 preview CLI.
+# This provides detection-only compatibility to older identity-enabled Luvus
+# versions. Native launch, exact-ID resume, and automation support ship in the
+# Luvus binary.
+agent = "opencode2"
+
+[identity]
+distinct = ["opencode2"]

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -28,9 +28,10 @@ Run `luvus doctor`. Local views need `git`. PRs/issues need an authenticated
 ## An agent shows as plain `zsh` / isn't detected
 
 luvus identifies an agent by the program running in the pane, matched against a
-list of names it knows (Claude Code, Copilot, Codex, opencode, Kimi, Cursor,
-Gemini, Aider, Amp, Droid, Grok, Hermes, Muse, Qwen, Kilo Code, Kiro). If your
-agent runs under a name luvus does not know, teach it one in
+list of names it knows (Claude Code, Copilot, Codex, opencode, OpenCode 2
+Preview, Kimi, Cursor, Gemini, Aider, Amp, Droid, Grok, Hermes, Muse, Qwen,
+Kilo Code, Kiro). If your agent runs under a name luvus does not know, teach it
+one in
 `~/.luvus/manifests/<agent>.toml`:
 
 ```toml

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -158,6 +158,7 @@ skill through their native adapters:
 - **Codex:** `~/.agents/skills/luvus/`
 - **Kilo Code:** `~/.agents/skills/luvus/`
 - **opencode:** `${XDG_CONFIG_HOME:-~/.config}/opencode/skills/luvus/`
+- **OpenCode 2 Preview:** `${XDG_CONFIG_HOME:-~/.config}/opencode/skills/luvus/`
 
 The command makes no network request and never replaces a skill directory it
 does not own. Luvus does not add a global `AGENTS.md` pointer. Supported agents
@@ -171,7 +172,7 @@ detection, sidebar visibility, and ordinary resume need no hook. Enabling either
 one never enables the other.
 
 The messaging **commands themselves work with every agent luvus detects**
-(claude, codex, gemini, opencode, kimi, grok, aider, and more), whether or not
+(claude, codex, gemini, opencode, opencode2, kimi, grok, aider, and more), whether or not
 that agent has the skill installed. The skill just teaches an agent to reach for
 them on its own.
 

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -10,8 +10,9 @@ back after a restart, all without wrapping or modifying the agents themselves.
 ## The AGENTS sidebar
 
 Every pane running a recognized agent (Claude Code, Copilot, Codex, opencode,
-Kimi, Grok, Hermes CLI, Muse Code, Pi, Oh My Pi (OMP), Cursor, Gemini, Qwen,
-Kilo Code, Kiro, Aider, Amp, Droid, or fx) appears in the sidebar with a live state:
+OpenCode 2 Preview, Kimi, Grok, Hermes CLI, Muse Code, Pi, Oh My Pi (OMP),
+Cursor, Gemini, Qwen, Kilo Code, Kiro, Aider, Amp, Droid, or fx) appears in the
+sidebar with a live state:
 
 | State | Meaning | How it's detected |
 |---|---|---|
@@ -70,6 +71,7 @@ Click a session row to select it and update the Selected Agent panel. Use
 | Codex | rollout token counters |
 | GitHub Copilot CLI | session shutdown metrics |
 | opencode | selected-session integration events |
+| OpenCode 2 Preview | unavailable until an exact structured counter is exposed |
 | Kimi | session status records |
 | Grok | completed-turn usage records |
 | Pi | assistant message usage |
@@ -77,10 +79,10 @@ Click a session row to select it and update the Selected Agent panel. Use
 | Gemini and Qwen | project chat records |
 | fx | session usage snapshot |
 
-Aider, Kilo Code, Kiro, Cursor, Amp, Droid, Muse, and manifest-defined agents still receive live
-identity and state detection, but show `—` for usage until they expose a stable
-per-session counter or report one through an integration. Luvus never estimates
-tokens from transcript text.
+Aider, OpenCode 2 Preview, Kilo Code, Kiro, Cursor, Amp, Droid, Muse, and
+manifest-defined agents still receive live identity and state detection, but
+show `—` for usage until they expose a stable per-session counter or report one
+through an integration. Luvus never estimates tokens from transcript text.
 
 Usage parsing runs off the render path only when Mission Control becomes active,
 its scope changes, or you choose **Refresh**. A hidden dashboard schedules no
@@ -133,6 +135,7 @@ not sufficient, and Luvus runs the agent's own resume command:
 | Codex | its rollout files |
 | Antigravity CLI | its workspace conversation cache (`~/.gemini/antigravity-cli/cache/last_conversations.json`) |
 | opencode | its session storage, plus exact live ownership from the optional integration |
+| OpenCode 2 Preview | `opencode2 --session <id>` when the exact ID is already known |
 | Kimi | its session index (`~/.kimi-code/session_index.jsonl`) |
 | Grok | its session directory (`~/.grok/sessions`) |
 | Hermes CLI | its exact session report from the optional integration |
@@ -144,6 +147,11 @@ not sufficient, and Luvus runs the agent's own resume command:
 | fx | its session store (`~/.fx/sessions`) |
 | Cursor | resume command (when the session id is known) |
 | Kilo Code | `kilo --session <id>` (when the exact session id is known) |
+
+OpenCode 2 Preview runs beside OpenCode V1 under the distinct `opencode2`
+executable. Luvus does not scan the V2 service's live SQLite database or reuse
+the V1 TUI plugin. Exact-ID resume remains available, and scheduled V2 work is
+offered only for explicit **Full access** through `opencode2 run --auto`.
 
 You'll also see **recent sessions** listed at the bottom of the AGENTS sidebar
 (toggle *All*): click one to reopen it into a new pane, even sessions from

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -10,6 +10,7 @@ description: What luvus supports per agent, covering live status, session resume
 | Codex | ✓ | ✓ | ✓ | ✓ |
 | Antigravity CLI (`agy`) | ✓ | ✓ | no | session only |
 | opencode | ✓ | ✓ | no | ✓ |
+| OpenCode 2 Preview (`opencode2`) | ✓ | with exact session ID | no | no |
 | Kimi Code CLI | ✓ | ✓ | no | ✓ |
 | Grok Build | ✓ | ✓ | ✓ | ✓ |
 | Hermes CLI | ✓ | ✓ with integration | no | session only |
@@ -72,6 +73,15 @@ description: What luvus supports per agent, covering live status, session resume
   OpenCode detection and legacy JSON session discovery still work while usage
   remains unavailable.
 
+  OpenCode 2 Preview is a separate built-in agent because its `opencode2`
+  executable can run beside OpenCode V1 and uses a different service, database,
+  plugin, and permission contract. Luvus detects and launches it natively and
+  can resume `opencode2 --session <id>` when an exact session ID is already
+  known. Luvus does not open its live SQLite database, start its service for
+  background discovery, reuse the V1 integration, or claim native TUI forking.
+  Scheduled OpenCode 2 workers require explicit **Full access**, mapped to its
+  documented `opencode2 run --auto` command.
+
   Kilo Code is detected through either official executable (`kilo` or
   `kilocode`) and the exact `@kilocode/cli` package identity. Luvus can resume
   and fork a Kilo session when it already has the exact session ID, but does not
@@ -105,11 +115,11 @@ Print the release-matched instructions for one conversation with
 `luvus skill show`, or install them persistently with `luvus skill enable`.
 
 The shared `~/.agents/skills/luvus/` destination is understood by Codex,
-GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code. Luvus uses
-dedicated native destinations for Claude Code, OpenCode, Kimi Code CLI, Grok
-Build, Hermes CLI, Qwen Code, Oh My Pi (omp), and Kiro. Aider does not expose a
-native Agent Skills installation directory, so use `luvus skill show` when an
-Aider conversation needs the instructions.
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code. Luvus
+uses dedicated native destinations for Claude Code, OpenCode, OpenCode 2
+Preview, Kimi Code CLI, Grok Build, Hermes CLI, Qwen Code, Oh My Pi (omp), and
+Kiro. Aider does not expose a native Agent Skills installation directory, so
+use `luvus skill show` when an Aider conversation needs the instructions.
 
 `luvus skill status` reports the bundled release separately from its managed
 filesystem installations. Codex marketplace plugins are managed by Codex and

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -88,6 +88,7 @@ const AGENTS = [
   { name: 'Antigravity', letter: 'A', hook: true },
   { name: 'Aider', Icon: IconAider },
   { name: 'opencode', Icon: IconOpencode, mono: true, hook: true },
+  { name: 'OpenCode 2', Icon: IconOpencode, mono: true },
   { name: 'Copilot', Icon: IconCopilot, mono: true, hook: true },
   { name: 'Kimi', Icon: IconKimi, hook: true },
   { name: 'Qwen', Icon: IconQwen },


### PR DESCRIPTION
Adds first-class OpenCode 2 Preview support while keeping it separate from the existing OpenCode V1 adapter.

## What

- register `opencode2` as a distinct built-in agent with native process detection on Unix and Windows-style paths
- launch interactive sessions with the exact `opencode2` executable and send ORCH prompts through its documented `--prompt` surface
- resume only when Luvus already owns an exact session ID via `opencode2 --session <id>`
- expose the reviewed `opencode2 run --auto` command only for explicit `full_access` automations; read-only and workspace policies remain unsupported
- reuse the OpenCode skill destination while keeping V1 session discovery, integration hooks, and usage parsing isolated from V2
- publish a detection manifest for older identity-enabled Luvus versions
- document the supported capabilities and current preview limitations across the README, agent guides/reference, bundled skill, and homepage

## Why

OpenCode 2 can run beside OpenCode V1 under a separate executable and uses a different service, SQLite store, plugin surface, and permission contract. Treating it as its own adapter prevents false V1 identity, unsafe database discovery, and unsupported capability claims while still providing reliable detection, launch, ORCH, exact-ID resume, skills, and reviewed automation support.

## Verification

- [x] `cargo test --locked` — 1,636 passed, 3 intentional ignores
- [x] `cargo clippy --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --locked`
- [x] `npm --prefix website run build`
- [x] focused registry, detection, ORCH prompt, automation policy, resume, usage, and skill-path tests
- [x] locally launched the installed `opencode2 --standalone`, observed its TUI/private service process, and confirmed both stopped cleanly

## Notes

OpenCode 2 is currently upstream preview software. This PR deliberately does not scan its live SQLite database, reuse the V1 integration, infer usage, or advertise full-TUI fork support. A full visual OpenCode 2 session inside an isolated Luvus TUI and native Windows execution remain untested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenCode 2 Preview as a distinct agent.
  - Added exact-ID session resume using `opencode2 --session <id>`.
  - Added full-access automation support through `opencode2 run --auto`.
  - Added OpenCode 2 Preview detection, skill installation, messaging, and scheduling support.

- **Documentation**
  - Updated the website, FAQ, agent guides, reference matrix, README, and manifests with OpenCode 2 Preview details.
  - Clarified that OpenCode 2 uses a separate integration and does not provide usage counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->