### PR TITLE
feat(automation): expose agent access capabilities

### DIFF
--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -2067,6 +2067,15 @@ pub fn automation_agent_choices_for(
     })
 }
 
+/// Whether one built-in automation agent has a reviewed launch profile for the
+/// requested access level. The creation form uses this for presentation only;
+/// submission repeats the same descriptor-owned validation before mutation.
+pub fn automation_agent_supports(agent: &str, access: crate::automation::AutomationAccess) -> bool {
+    crate::agent::registry::find(agent)
+        .and_then(|descriptor| descriptor.automation)
+        .is_some_and(|operations| operations.supports(access))
+}
+
 fn task_tab_name(task: &crate::orch::Task) -> String {
     let value = format!("{} · {}", task.id, task.title.trim());
     value.chars().take(crate::app::TAB_NAME_MAX).collect()
@@ -3762,7 +3771,8 @@ mod tests {
         app.handle_orch_form_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
         let form = app.orch_form.as_ref().unwrap();
         assert_eq!(form.access, crate::automation::AutomationAccess::ReadOnly);
-        assert!(automation_agent_choices_for(form.access).contains(&form.agent.as_str()));
+        assert_eq!(form.agent, "fx");
+        assert!(!automation_agent_supports(&form.agent, form.access));
 
         app.orch_activate_hit(crate::app::OrchHit::FormField(
             crate::app::OrchFormField::Access,
@@ -3771,6 +3781,64 @@ mod tests {
             app.orch_form.as_ref().unwrap().access,
             crate::automation::AutomationAccess::Workspace
         );
+    }
+
+    #[test]
+    fn automation_agent_picker_keeps_all_launch_capable_agents_visible() {
+        use crate::automation::AutomationAccess;
+
+        assert_eq!(automation_agent_choices().len(), 19);
+        assert!(automation_agent_choices().contains(&"kilo"));
+        assert!(automation_agent_choices().contains(&"pi"));
+        assert!(!automation_agent_choices().contains(&"antigravity"));
+        assert!(!automation_agent_choices().contains(&"amp"));
+
+        let mut form = crate::app::OrchForm::for_kind(crate::app::OrchFormKind::Automation);
+        form.access = AutomationAccess::ReadOnly;
+        form.agent = "opencode".into();
+        form.field = crate::app::OrchFormField::Agent;
+        form.cycle_choice(false);
+
+        assert_eq!(form.agent, "opencode2");
+        assert_eq!(form.access, AutomationAccess::ReadOnly);
+        assert!(!automation_agent_supports(&form.agent, form.access));
+        assert!(automation_agent_supports(
+            &form.agent,
+            AutomationAccess::FullAccess
+        ));
+    }
+
+    #[test]
+    fn automation_form_rejects_an_incompatible_visible_agent() {
+        let _env = crate::persist::test_env("orch-automation-access-mismatch");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(100, 30, tx).unwrap();
+        app.open_orch_board();
+        app.orch_form = Some(crate::app::OrchForm {
+            kind: crate::app::OrchFormKind::Automation,
+            title: "OpenCode 2 review".into(),
+            prompt: "Review the workspace.".into(),
+            agent: "opencode2".into(),
+            access: crate::automation::AutomationAccess::ReadOnly,
+            start: crate::app::OrchFormStart::Daily,
+            schedule: "08:00".into(),
+            timezone: "Asia/Makassar".into(),
+            mode: TaskWorkerMode::Workspace,
+            ..crate::app::OrchForm::default()
+        });
+
+        app.submit_orch_form();
+
+        let form = app
+            .orch_form
+            .as_ref()
+            .expect("an invalid access choice keeps the form open");
+        assert!(form
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("does not support read only")));
+        assert!(app.automation.automations.is_empty());
+        assert!(app.orch.tasks.is_empty());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,7 +29,8 @@ mod board;
 mod config_persistence;
 mod cwd;
 pub use board::{
-    agent_choices, automation_agent_choices, automation_agent_choices_for, task_agent_choices,
+    agent_choices, automation_agent_choices, automation_agent_choices_for,
+    automation_agent_supports, task_agent_choices,
 };
 pub(crate) mod diff;
 mod dispatch;
@@ -1460,7 +1461,7 @@ impl OrchForm {
             }
             OrchFormField::Agent => {
                 let choices = if self.kind == OrchFormKind::Automation {
-                    crate::app::automation_agent_choices_for(self.access)
+                    crate::app::automation_agent_choices()
                 } else {
                     crate::app::task_agent_choices()
                 };
@@ -1493,13 +1494,6 @@ impl OrchForm {
                     .unwrap_or(0);
                 self.access = choices
                     [(index + if backwards { choices.len() - 1 } else { 1 }) % choices.len()];
-                let agents = crate::app::automation_agent_choices_for(self.access);
-                if !agents
-                    .iter()
-                    .any(|agent| agent.eq_ignore_ascii_case(&self.agent))
-                {
-                    self.agent = agents.first().copied().unwrap_or_default().to_string();
-                }
             }
             _ => {}
         }

--- a/src/ui/board.rs
+++ b/src/ui/board.rs
@@ -1862,6 +1862,15 @@ pub(super) fn draw_form(
             crate::app::OrchFormStart::Daily => cat.automation_daily,
             crate::app::OrchFormStart::Weekly => cat.automation_weekly,
         };
+        let access_label = |access| match access {
+            crate::automation::AutomationAccess::ReadOnly => cat.automation_access_read_only,
+            crate::automation::AutomationAccess::Workspace => cat.automation_access_workspace,
+            crate::automation::AutomationAccess::FullAccess => cat.automation_access_full,
+        };
+        let agent_access_mismatch = field == crate::app::OrchFormField::Agent
+            && form.kind == crate::app::OrchFormKind::Automation
+            && form.automation_target == crate::app::OrchAutomationTarget::NewWorker
+            && !crate::app::automation_agent_supports(&form.agent, form.access);
         let value = if field == crate::app::OrchFormField::Target {
             match form.automation_target {
                 crate::app::OrchAutomationTarget::NewWorker => {
@@ -1883,17 +1892,25 @@ pub(super) fn draw_form(
                 crate::orch::TaskWorkerMode::Workspace => cat.board_workspace.to_string(),
             }
         } else if field == crate::app::OrchFormField::Access {
-            match form.access {
-                crate::automation::AutomationAccess::ReadOnly => {
-                    cat.automation_access_read_only.to_string()
-                }
-                crate::automation::AutomationAccess::Workspace => {
-                    cat.automation_access_workspace.to_string()
-                }
-                crate::automation::AutomationAccess::FullAccess => {
-                    cat.automation_access_full.to_string()
+            access_label(form.access).to_string()
+        } else if field == crate::app::OrchFormField::Agent
+            && form.kind == crate::app::OrchFormKind::Automation
+            && form.automation_target == crate::app::OrchAutomationTarget::NewWorker
+        {
+            let mut value = form.agent.clone();
+            let mut separator = "  ·  ";
+            for access in [
+                crate::automation::AutomationAccess::ReadOnly,
+                crate::automation::AutomationAccess::Workspace,
+                crate::automation::AutomationAccess::FullAccess,
+            ] {
+                if crate::app::automation_agent_supports(&form.agent, access) {
+                    value.push_str(separator);
+                    value.push_str(access_label(access));
+                    separator = "/";
                 }
             }
+            value
         } else {
             form.value(field).to_string()
         };
@@ -1977,15 +1994,20 @@ pub(super) fn draw_form(
             );
             let cursor_width = usize::from(active && body_rect.width > 0);
             let available = body_rect.width as usize - cursor_width;
+            let value_style = if agent_access_mismatch {
+                Style::new().fg(t.coral)
+            } else {
+                Style::new().fg(t.text)
+            };
             let body = if value.is_empty() && !active {
                 Span::styled(
                     super::truncate(hint, available),
                     Style::new().fg(t.overlay0),
                 )
             } else if active {
-                Span::styled(input_tail(&value, available), Style::new().fg(t.text))
+                Span::styled(input_tail(&value, available), value_style)
             } else {
-                Span::styled(super::truncate(&value, available), Style::new().fg(t.text))
+                Span::styled(super::truncate(&value, available), value_style)
             };
             f.render_widget(
                 Paragraph::new(Line::from(vec![
@@ -3265,6 +3287,32 @@ mod tests {
         assert!(rendered.contains("…"));
         assert!(rendered.contains("ending stays visible▏"));
         assert!(!rendered.contains("A long descriptive task title"));
+    }
+
+    #[test]
+    fn automation_form_shows_each_agents_supported_access_profiles() {
+        let area = Rect::new(0, 0, 90, 30);
+        let mut buffer = Buffer::empty(area);
+        let mut target = RenderTarget::new(&mut buffer, area);
+        let mut form = OrchForm::for_kind(crate::app::OrchFormKind::Automation);
+        form.agent = "opencode2".into();
+        form.access = crate::automation::AutomationAccess::ReadOnly;
+        form.field = crate::app::OrchFormField::Agent;
+
+        draw_form(
+            &mut target,
+            area,
+            &form,
+            &crate::i18n::EN,
+            &Theme::quattro_rally(),
+        );
+
+        let rendered = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("opencode2  ·  Full access▏"));
     }
 
     #[test]

--- a/website/src/content/docs/docs/guides/automation.mdx
+++ b/website/src/content/docs/docs/guides/automation.mdx
@@ -204,6 +204,39 @@ agent/access combinations fail before Luvus creates a task, lease, worktree, or
 pane. Luvus never edits the agent's permanent configuration or types approval
 answers into an unknown prompt.
 
+The TUI keeps every launch-capable built-in agent visible in the Agent field.
+The access profiles beside its name show what that adapter supports. An
+incompatible selection is highlighted and cannot be submitted until you choose
+one of those profiles. Luvus never changes a selection to Full access on your
+behalf.
+
+| Agent | Read-only | Workspace | Full access |
+|---|:---:|:---:|:---:|
+| Claude Code | yes | yes | yes |
+| Codex | yes | yes | yes |
+| Gemini | no | yes | yes |
+| Aider | yes | no | yes |
+| opencode | no | yes | no |
+| OpenCode 2 Preview | no | no | yes |
+| GitHub Copilot CLI | yes | yes | yes |
+| Kimi Code CLI | no | yes | yes |
+| Qwen Code | yes | yes | yes |
+| Kilo Code | no | no | yes |
+| Kiro | yes | no | yes |
+| Cursor | yes | yes | yes |
+| Droid | yes | yes | yes |
+| Grok Build | yes | yes | yes |
+| Hermes CLI | no | no | yes |
+| Muse Code | yes | yes | yes |
+| Oh My Pi | yes | yes | yes |
+| Pi | yes | no | no |
+| fx | no | yes | yes |
+
+Luvus also detects Antigravity and Amp, but their current CLIs do not expose a
+reviewed unattended permission profile, so they are not available as new
+automation workers. They can still appear when an automation targets a live
+agent that is already running in a pane.
+
 Kilo Code currently exposes one reviewed unattended profile: **Full access**,
 launched as `kilo run --auto`. Kilo documents that `--auto` may approve actions
 not explicitly denied, so Luvus does not present it as read-only or workspace


### PR DESCRIPTION
## Summary

- keep Workspace as the default automation access while exposing all 19 launch-capable built-in agents
- show each selected agent’s supported access profiles in the creation form
- highlight incompatible agent and access combinations without silently replacing the agent
- require users to select Full access explicitly when an agent only supports that profile
- document the complete per-agent automation access matrix

## Safety

The existing descriptor-owned validation remains authoritative. Unsupported combinations fail before Luvus creates an automation, ORCH task, lease, worktree, or pane.

## Verification

- `cargo test app::board::tests -- --nocapture`
- `cargo test ui::board::tests -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `npm run build` in `website/`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation agent selection now displays each agent’s supported access profiles.
  * Agents remain visible while changing access levels, with unsupported combinations clearly marked.
  * Submitting an incompatible agent and access combination now shows an error without creating an automation or task.

* **Documentation**
  * Added guidance and a compatibility table covering built-in agents and their supported access profiles.
  * Documented that Antigravity and Amp cannot be used as new automation workers without a reviewed unattended profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->