### PR TITLE
fix(agent): guard prompts until Codex is ready

### DIFF
--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -253,6 +253,10 @@ Without `--wait`, the immediate `submitted:true`, `evidence:"queued"` response i
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
+If the current screen is a detected startup, sign-in, selection, or approval
+surface, prompt submission returns `agent_not_ready` and queues no input. Read
+the visible screen before deciding whether an explicit `agent keys` action is
+authorized.
 
 When waiting was requested, keep it bounded and read a bounded result:
 

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -253,10 +253,14 @@ Without `--wait`, the immediate `submitted:true`, `evidence:"queued"` response i
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
-If the current screen is a detected startup, sign-in, selection, or approval
-surface, prompt submission returns `agent_not_ready` and queues no input. Read
-the visible screen before deciding whether an explicit `agent keys` action is
-authorized.
+For `agent.send` and `agent.prompt`, detected blocked prompt evidence—including
+in non-Codex panes—returns `agent_not_ready` and queues no input. Startup,
+sign-in, selection, and approval screens are examples, not an exhaustive list.
+A server-launched or restored Codex pane with an `agent_session` also returns
+`agent_not_ready` when prompt evidence is Unknown, unless live Codex composer
+geometry reports Ready. Existing Codex panes without that requirement retain the
+permissive Unknown-evidence fallback. Read the visible screen before deciding
+whether an explicit `agent keys` action is authorized.
 
 When waiting was requested, keep it bounded and read a bounded result:
 

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -182,6 +182,11 @@ Without `wait:true`, the immediate `submitted:true`, `evidence:"queued"` respons
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
-Detected startup, sign-in, selection, and approval screens return
-`agent_not_ready` before text or Enter is queued. Inspect the visible screen and
+For `agent.send` and `agent.prompt`, detected blocked prompt evidence—including
+in non-Codex panes—returns `agent_not_ready` before text or Enter is queued.
+Startup, sign-in, selection, and approval screens are examples, not an
+exhaustive list. A server-launched or restored Codex pane with an `agent_session`
+also returns `agent_not_ready` when prompt evidence is Unknown, unless live Codex
+composer geometry reports Ready. Existing Codex panes without that requirement
+retain the permissive Unknown-evidence fallback. Inspect the visible screen and
 use `agent.keys` only for an explicitly authorized interaction.

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -182,3 +182,6 @@ Without `wait:true`, the immediate `submitted:true`, `evidence:"queued"` respons
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
+Detected startup, sign-in, selection, and approval screens return
+`agent_not_ready` before text or Enter is queued. Inspect the visible screen and
+use `agent.keys` only for an explicitly authorized interaction.

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -253,6 +253,10 @@ Without `--wait`, the immediate `submitted:true`, `evidence:"queued"` response i
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
+If the current screen is a detected startup, sign-in, selection, or approval
+surface, prompt submission returns `agent_not_ready` and queues no input. Read
+the visible screen before deciding whether an explicit `agent keys` action is
+authorized.
 
 When waiting was requested, keep it bounded and read a bounded result:
 

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -253,10 +253,14 @@ Without `--wait`, the immediate `submitted:true`, `evidence:"queued"` response i
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
-If the current screen is a detected startup, sign-in, selection, or approval
-surface, prompt submission returns `agent_not_ready` and queues no input. Read
-the visible screen before deciding whether an explicit `agent keys` action is
-authorized.
+For `agent.send` and `agent.prompt`, detected blocked prompt evidence—including
+in non-Codex panes—returns `agent_not_ready` and queues no input. Startup,
+sign-in, selection, and approval screens are examples, not an exhaustive list.
+A server-launched or restored Codex pane with an `agent_session` also returns
+`agent_not_ready` when prompt evidence is Unknown, unless live Codex composer
+geometry reports Ready. Existing Codex panes without that requirement retain the
+permissive Unknown-evidence fallback. Read the visible screen before deciding
+whether an explicit `agent keys` action is authorized.
 
 When waiting was requested, keep it bounded and read a bounded result:
 

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -182,6 +182,11 @@ Without `wait:true`, the immediate `submitted:true`, `evidence:"queued"` respons
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
-Detected startup, sign-in, selection, and approval screens return
-`agent_not_ready` before text or Enter is queued. Inspect the visible screen and
+For `agent.send` and `agent.prompt`, detected blocked prompt evidence—including
+in non-Codex panes—returns `agent_not_ready` before text or Enter is queued.
+Startup, sign-in, selection, and approval screens are examples, not an
+exhaustive list. A server-launched or restored Codex pane with an `agent_session`
+also returns `agent_not_ready` when prompt evidence is Unknown, unless live Codex
+composer geometry reports Ready. Existing Codex panes without that requirement
+retain the permissive Unknown-evidence fallback. Inspect the visible screen and
 use `agent.keys` only for an explicitly authorized interaction.

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -182,3 +182,6 @@ Without `wait:true`, the immediate `submitted:true`, `evidence:"queued"` respons
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
+Detected startup, sign-in, selection, and approval screens return
+`agent_not_ready` before text or Enter is queued. Inspect the visible screen and
+use `agent.keys` only for an explicitly authorized interaction.

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1440,6 +1440,13 @@ fn agent_prompt_response(
     response.to_string()
 }
 
+fn agent_prompt_not_ready_error() -> (String, String) {
+    (
+        "agent_not_ready".to_string(),
+        "target agent has not exposed a prompt-ready composer; no prompt input was queued; inspect it with agent read and use agent keys only for an explicit interaction".to_string(),
+    )
+}
+
 /// Debounce dwell for committing a newly-desired agent state (hysteresis).
 /// Active states publish instantly (responsive sidebar); the fall back to a
 /// quiet state waits `QUIET_DWELL` so streaming pauses don't flap the status.
@@ -2045,6 +2052,10 @@ impl App {
                 running_for_detection,
                 &self.manifests,
             );
+            let inspect_codex_composer = known_agent.eq_ignore_ascii_case("codex")
+                || self
+                    .manifests
+                    .process_has_agent(running_for_detection, "codex");
             let (last_generation, force_detect) = self
                 .status
                 .get(&id)
@@ -2064,10 +2075,13 @@ impl App {
                             } else {
                                 engine.detection_text(detection_rows)
                             };
+                            let codex_composer_ready = inspect_codex_composer
+                                .then(|| engine.codex_composer_region().is_some());
                             Some((
                                 generation,
                                 engine.title().map(Arc::<str>::from),
                                 Arc::<str>::from(text),
+                                codex_composer_ready,
                             ))
                         } else {
                             None
@@ -2076,8 +2090,11 @@ impl App {
                     Err(_) => None,
                 }
             };
+            let inspected_composer_ready = inspected
+                .as_ref()
+                .and_then(|(_, _, _, composer_ready)| *composer_ready);
             if let Some(s) = self.status.get_mut(&id) {
-                if let Some((generation, title, bottom)) = inspected {
+                if let Some((generation, title, bottom, _)) = inspected {
                     if audit_only {
                         self.detection_audit_recoveries =
                             self.detection_audit_recoveries.saturating_add(1);
@@ -2124,6 +2141,13 @@ impl App {
                 Some(report) => detect::Detection {
                     state: report.state,
                     agent: report.agent.clone(),
+                    prompt_evidence: if report.state == State::Blocked {
+                        detect::PromptEvidence::Blocked
+                    } else if report.agent.eq_ignore_ascii_case("codex") {
+                        detect::PromptEvidence::Unknown
+                    } else {
+                        detect::PromptEvidence::Ready
+                    },
                     identity_source: "integration_report",
                     state_source: "integration_report",
                     rule_priority: None,
@@ -2146,6 +2170,17 @@ impl App {
                 s.state_source = det.state_source;
                 s.rule_priority = det.rule_priority;
                 s.rule_region = det.rule_region;
+                s.prompt_evidence = if det.prompt_evidence == detect::PromptEvidence::Blocked {
+                    detect::PromptEvidence::Blocked
+                } else if det.agent.eq_ignore_ascii_case("codex") {
+                    match inspected_composer_ready {
+                        Some(true) => detect::PromptEvidence::Ready,
+                        Some(false) => detect::PromptEvidence::Unknown,
+                        None => s.prompt_evidence,
+                    }
+                } else {
+                    det.prompt_evidence
+                };
                 let focused = id == focus;
                 if focused {
                     s.seen = true;
@@ -3754,6 +3789,9 @@ impl App {
                         "invalid_request".to_string(),
                         "agent send text must not be empty".to_string(),
                     ));
+                }
+                if !self.agent_prompt_is_ready(id) {
+                    return Err(agent_prompt_not_ready_error());
                 }
                 let pane = self.panes.get(&id).ok_or_else(|| {
                     (
@@ -6261,6 +6299,11 @@ impl App {
             fail("send_failed", message);
             return;
         }
+        if let Some(status) = self.status.get_mut(&pane) {
+            status.prompt_evidence = detect::PromptEvidence::Unknown;
+            status.prompt_evidence_required = detect::prompt_requires_positive_evidence(kind);
+            status.force_detect = true;
+        }
         self.set_agent_name(pane, Some(name));
         self.agent_starts.insert(
             pane,
@@ -6273,6 +6316,66 @@ impl App {
                 cancelled,
             },
         );
+    }
+
+    /// Return current raw readiness evidence for prompt admission. Normal
+    /// detection already caches this result. If terminal output arrived after
+    /// that pass, inspect only the same bounded live rows once, on this request,
+    /// so an agent-start/prompt race cannot submit Enter before a composer exists.
+    fn agent_prompt_is_ready(&self, id: PaneId) -> bool {
+        let Some(status) = self.status.get(&id) else {
+            return true;
+        };
+        let positive_evidence_required = status.prompt_evidence_required
+            || status
+                .agent_session
+                .as_ref()
+                .is_some_and(|session| detect::prompt_requires_positive_evidence(&session.agent));
+        let admits = |evidence| match evidence {
+            detect::PromptEvidence::Ready => true,
+            detect::PromptEvidence::Blocked => false,
+            detect::PromptEvidence::Unknown => !positive_evidence_required,
+        };
+        let Some(pane) = self.panes.get(&id) else {
+            return true;
+        };
+        let Ok(engine) = pane.engine.lock() else {
+            return false;
+        };
+        if !status.force_detect && status.last_detect_generation == Some(engine.output_generation())
+        {
+            return admits(status.prompt_evidence);
+        }
+        let running = self
+            .proc_commands
+            .get(&id)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let rows = detect::screen_rows(&status.agent, running, &self.manifests);
+        let bottom = if detect::screen_uses_non_empty_rows(&status.agent, running, &self.manifests)
+        {
+            engine.detection_text_non_empty(rows)
+        } else {
+            engine.detection_text(rows)
+        };
+        let raw = detect::prompt_evidence(
+            engine.title().as_deref(),
+            &bottom,
+            &status.agent,
+            &self.manifests,
+        );
+        let evidence = if raw == detect::PromptEvidence::Blocked {
+            raw
+        } else if status.agent.eq_ignore_ascii_case("codex") {
+            if engine.codex_composer_region().is_some() {
+                detect::PromptEvidence::Ready
+            } else {
+                detect::PromptEvidence::Unknown
+            }
+        } else {
+            raw
+        };
+        admits(evidence)
     }
 
     /// Atomically submit a prompt and, when requested, retain the response until
@@ -6368,6 +6471,11 @@ impl App {
                 );
                 return;
             }
+        }
+        if !self.agent_prompt_is_ready(pane) {
+            let (code, message) = agent_prompt_not_ready_error();
+            fail(&code, message);
+            return;
         }
         let Some(target) = self.panes.get(&pane) else {
             fail("not_found", "pane not found".to_string());
@@ -9345,6 +9453,106 @@ command = ["true"]
     }
 
     #[test]
+    fn prompt_apis_reject_a_fresh_interaction_screen_without_queueing_input() {
+        let _env = crate::persist::test_env("prompt-interaction-guard");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 32, tx).unwrap();
+        let pane = app.layout().focus;
+        app.status.get_mut(&pane).unwrap().agent = "codex".into();
+        app.panes[&pane].engine.lock().unwrap().advance(
+            b"\x1b[2J\x1b[HWelcome to Codex\r\n\r\n\
+              > 1. Sign in with ChatGPT\r\n\
+                2. Sign in with Device Code\r\n\
+                3. Provide your own API key\r\n\r\n\
+              Press enter to continue",
+        );
+        let (input, received) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input);
+
+        let error = app
+            .dispatch(
+                "agent.send",
+                &json!({"target":pane.0.to_string(),"text":"do not submit"}),
+            )
+            .expect_err("an interaction chooser must reject agent.send");
+        assert_eq!(error.0, "agent_not_ready");
+        assert!(error.1.contains("no prompt input was queued"));
+        assert!(received.try_recv().is_err());
+
+        let (reply, response) = std::sync::mpsc::channel();
+        app.start_agent_prompt(
+            "blocked-prompt".into(),
+            json!({"target":pane.0.to_string(),"text":"do not submit"}),
+            reply,
+            Arc::new(AtomicBool::new(false)),
+        );
+        let value: Value = serde_json::from_str(&response.try_recv().unwrap()).unwrap();
+        assert_eq!(value["error"]["code"], "agent_not_ready");
+        assert!(value["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("no prompt input was queued"));
+        assert!(received.try_recv().is_err());
+        assert!(app.agent_prompts.is_empty());
+    }
+
+    #[test]
+    fn native_codex_requires_live_composer_geometry() {
+        let _env = crate::persist::test_env("prompt-composer-geometry");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let status = app.status.get_mut(&pane).unwrap();
+        status.agent = "codex".into();
+        status.agent_session = Some(crate::app::AgentSession {
+            agent: "codex".into(),
+            session_id: "native-session".into(),
+        });
+
+        let (input, received) = std::sync::mpsc::channel();
+        app.panes
+            .get_mut(&pane)
+            .unwrap()
+            .replace_input_sender_for_test(input);
+
+        // A transcript can retain the same marker as the composer. Text alone
+        // is not enough to admit another turn.
+        app.panes[&pane]
+            .engine
+            .lock()
+            .unwrap()
+            .advance("\x1b[1;1Htranscript\r\n› old prompt\r\nanswer".as_bytes());
+        let error = app
+            .dispatch(
+                "agent.send",
+                &json!({"target":pane.0.to_string(),"text":"new prompt"}),
+            )
+            .expect_err("transcript marker must not establish readiness");
+        assert_eq!(error.0, "agent_not_ready");
+        assert!(received.try_recv().is_err());
+
+        // The existing VT boundary recognizes the live Codex composer from its
+        // cursor and padding geometry; no echo polling is needed.
+        app.panes[&pane]
+            .engine
+            .lock()
+            .unwrap()
+            .advance("\x1b[2J\x1b[2;1H› ".as_bytes());
+        app.dispatch(
+            "agent.send",
+            &json!({"target":pane.0.to_string(),"text":"new prompt"}),
+        )
+        .expect("live composer accepts prompt");
+        let crate::terminal::pty::InputAction::Submit { .. } = received.try_recv().unwrap() else {
+            panic!("prompt must remain one atomic submit action")
+        };
+        assert!(received.try_recv().is_err());
+    }
+
+    #[test]
     fn pane_input_methods_report_rejection_and_run_is_one_action() {
         let _env = crate::persist::test_env("pane-input-admission");
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -9924,6 +10132,11 @@ command = ["true"]
             Arc::new(AtomicBool::new(false)),
         );
         assert_eq!(app.agent_names.get("reviewer"), Some(&pane));
+        assert!(
+            app.status[&pane].prompt_evidence_required
+                && app.status[&pane].prompt_evidence == detect::PromptEvidence::Unknown,
+            "a server-launched Codex pane needs positive composer evidence"
+        );
         assert!(response.try_recv().is_err());
 
         let status = app.status.get_mut(&pane).unwrap();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1787,6 +1787,13 @@ pub struct PaneStatus {
     /// one-key answer. Captured **once** when the pane enters Blocked (not every
     /// tick), cleared when it leaves; `None` when the pane isn't blocked.
     pub blocked_hint: Option<String>,
+    /// Raw, non-debounced prompt-surface evidence. Prompt APIs consult this
+    /// separately from the presentation state's quiet-dwell hysteresis.
+    prompt_evidence: detect::PromptEvidence,
+    /// A server-owned launch whose CLI needs a proven composer before prompt
+    /// input. Existing panes retain the legacy permissive fallback when the
+    /// detector has neither ready nor blocked evidence.
+    prompt_evidence_required: bool,
     /// Explainable evidence from the last heuristic classification.
     pub identity_source: &'static str,
     pub state_source: &'static str,
@@ -1821,6 +1828,8 @@ impl PaneStatus {
             detected_bottom: Arc::from(""),
             force_detect: true,
             blocked_hint: None,
+            prompt_evidence: detect::PromptEvidence::Unknown,
+            prompt_evidence_required: false,
             identity_source: "command_fallback",
             state_source: "no_positive_state_evidence",
             rule_priority: None,

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -336,8 +336,10 @@ pub(crate) fn screen_rows(known_agent: &str, running: &[String], manifests: &Man
     }
 }
 
-/// Claude and Hermes can place a live approval panel above a tall blank footer.
-/// Keep their most recent non-empty live rows without pulling in scrollback.
+/// Claude, Codex, and Hermes can place a live interaction panel above a tall
+/// blank footer. Keep their most recent non-empty live rows without pulling in
+/// scrollback. For Codex this also keeps the first-run sign-in chooser visible
+/// to prompt admission instead of mistaking its blank footer for a composer.
 pub(crate) fn screen_uses_non_empty_rows(
     known_agent: &str,
     running: &[String],
@@ -345,6 +347,8 @@ pub(crate) fn screen_uses_non_empty_rows(
 ) -> bool {
     known_agent.eq_ignore_ascii_case("claude")
         || manifests.process_has_agent(running, "claude")
+        || known_agent.eq_ignore_ascii_case("codex")
+        || manifests.process_has_agent(running, "codex")
         || known_agent.eq_ignore_ascii_case("hermes")
         || manifests.process_has_agent(running, "hermes")
 }
@@ -956,9 +960,18 @@ impl RuleSpec {
 // ── public API ──────────────────────────────────────────────────────────────
 
 /// Result of classifying a pane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PromptEvidence {
+    Unknown,
+    Ready,
+    Blocked,
+}
+
 pub struct Detection {
     pub state: State,
     pub agent: String,
+    /// Raw, non-debounced prompt-surface evidence from this screen.
+    pub(crate) prompt_evidence: PromptEvidence,
     /// Where identity came from. Stable, machine-readable values are exposed by
     /// `agent.explain`; no consumer needs to reverse-engineer detection order.
     pub identity_source: &'static str,
@@ -1047,7 +1060,7 @@ pub fn classify(
         State::Idle
     };
     let matched = manifests.evaluate(&agent, &regions);
-    let (state, state_source, rule_priority, rule_region) = match matched {
+    let (state, state_source, rule_priority, rule_region, prompt_blocked) = match matched {
         Some(rule) => (
             rule.state,
             "manifest_rule",
@@ -1056,18 +1069,63 @@ pub fn classify(
                 Region::Title => "title",
                 Region::Screen => "screen",
             }),
+            rule.state == State::Blocked,
         ),
-        None if fallback == State::Working => (fallback, "shell_activity", None, None),
-        None => (fallback, "no_positive_state_evidence", None, None),
+        None if fallback == State::Working => (fallback, "shell_activity", None, None, false),
+        None => (fallback, "no_positive_state_evidence", None, None, false),
     };
 
+    let prompt_evidence = if prompt_blocked {
+        PromptEvidence::Blocked
+    } else if agent.eq_ignore_ascii_case("codex") {
+        // Text alone cannot distinguish Codex's live composer from a prompt
+        // marker retained in the transcript. The app combines this raw state
+        // evidence with the VT engine's bounded composer geometry.
+        PromptEvidence::Unknown
+    } else {
+        PromptEvidence::Ready
+    };
     Detection {
         state,
         agent,
+        prompt_evidence,
         identity_source,
         state_source,
         rule_priority,
         rule_region,
+    }
+}
+
+/// Codex can be identified from its process/title before its startup chooser or
+/// composer exists. Server-owned launches keep prompt admission closed until
+/// the screen proves which surface won that race.
+pub(crate) fn prompt_requires_positive_evidence(agent: &str) -> bool {
+    agent.eq_ignore_ascii_case("codex")
+}
+
+/// Re-evaluate raw prompt readiness from the current bounded screen. This
+/// deliberately reuses manifest state rules instead of teaching API dispatch
+/// about individual agents, and runs only when output changed after the normal
+/// detection pass.
+pub(crate) fn prompt_evidence(
+    title: Option<&str>,
+    bottom: &str,
+    agent: &str,
+    manifests: &Manifests,
+) -> PromptEvidence {
+    let regions = Regions {
+        screen: bottom.to_lowercase(),
+        title: title.map(str::to_lowercase).unwrap_or_default(),
+    };
+    let blocked = manifests
+        .evaluate(&agent.to_lowercase(), &regions)
+        .is_some_and(|rule| rule.state == State::Blocked);
+    if blocked {
+        PromptEvidence::Blocked
+    } else if agent.eq_ignore_ascii_case("codex") {
+        PromptEvidence::Unknown
+    } else {
+        PromptEvidence::Ready
     }
 }
 
@@ -2150,7 +2208,7 @@ Would you like to proceed?
     }
 
     #[test]
-    fn claude_approval_panels_use_non_empty_screen_rows() {
+    fn tall_interaction_panels_use_non_empty_screen_rows() {
         let manifests = Manifests::builtin();
         assert!(screen_uses_non_empty_rows("claude", &[], &manifests));
         assert!(screen_uses_non_empty_rows(
@@ -2158,7 +2216,7 @@ Would you like to proceed?
             &["/usr/local/bin/claude".to_string()],
             &manifests
         ));
-        assert!(!screen_uses_non_empty_rows(
+        assert!(screen_uses_non_empty_rows(
             "codex",
             &["/usr/local/bin/codex".to_string()],
             &manifests
@@ -2169,8 +2227,68 @@ Would you like to proceed?
     fn claude_command_approval_screen_is_blocked() {
         let detection = detection_from_claude_screen(CLAUDE_COMMAND_APPROVAL_SCREEN);
         assert_eq!(detection.state, State::Blocked);
+        assert_eq!(detection.prompt_evidence, PromptEvidence::Blocked);
         assert_eq!(detection.state_source, "manifest_rule");
         assert_eq!(detection.rule_priority, Some(300));
+    }
+
+    #[test]
+    fn codex_sign_in_above_blank_footer_blocks_prompt_submission() {
+        let manifests = Manifests::builtin();
+        let screen = "Welcome to Codex, OpenAI's command-line coding agent\n\n\
+            Sign in with ChatGPT to use Codex as part of your paid plan\n\
+            or connect an API key for usage-based billing\n\n\
+            > 1. Sign in with ChatGPT\n\
+            2. Sign in with Device Code\n\
+            3. Provide your own API key\n\n\
+            Press enter to continue";
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut engine = AlacrittyEngine::new(120, 32, tx, 1024 * 1024);
+        engine.advance(format!("\x1b[2J\x1b[H{}", screen.replace('\n', "\r\n")).as_bytes());
+
+        assert!(
+            engine.detection_text(14).trim().is_empty(),
+            "the normal bottom-row window misses the first-run chooser"
+        );
+        let bottom = engine.detection_text_non_empty(14);
+        let detection = classify(
+            Some("Codex"),
+            &bottom,
+            false,
+            false,
+            "codex",
+            "codex",
+            &["/usr/local/bin/codex".to_string()],
+            &manifests,
+        );
+        assert_eq!(detection.state, State::Blocked);
+        assert_eq!(detection.prompt_evidence, PromptEvidence::Blocked);
+        assert_eq!(
+            prompt_evidence(Some("Codex"), &bottom, "codex", &manifests),
+            PromptEvidence::Blocked
+        );
+    }
+
+    #[test]
+    fn codex_prompt_marker_text_alone_is_not_positive_prompt_evidence() {
+        let manifests = Manifests::builtin();
+        let bottom = "Ready to review.\n\n  › Write tests\n  100% context left";
+        let detection = classify(
+            Some("Codex"),
+            bottom,
+            false,
+            false,
+            "codex",
+            "codex",
+            &["/usr/local/bin/codex".to_string()],
+            &manifests,
+        );
+        assert_eq!(detection.state, State::Idle);
+        assert_eq!(detection.prompt_evidence, PromptEvidence::Unknown);
+        assert_eq!(
+            prompt_evidence(Some("Codex"), bottom, "codex", &manifests),
+            PromptEvidence::Unknown
+        );
     }
 
     #[test]

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -281,8 +281,13 @@ user named a specific project.
 `agent prompt` submits one complete prompt and can wait semantically. Prefer it
 to separate text and Enter operations. A timeout does not prove that an agent
 failed or stopped. Inspect it before deciding what to do next.
-Detected startup, sign-in, selection, and approval screens reject prompt
-submission with `agent_not_ready` before either text or Enter is queued.
+For `agent.send` and `agent.prompt`, detected blocked prompt evidence—including
+in non-Codex panes—rejects submission with `agent_not_ready` before either text
+or Enter is queued. Startup, sign-in, selection, and approval screens are
+examples, not an exhaustive list. A server-launched or restored Codex pane with
+an `agent_session` also returns `agent_not_ready` when prompt evidence is
+Unknown, unless live Codex composer geometry reports Ready. Existing Codex panes
+without that requirement retain the permissive Unknown-evidence fallback.
 
 `agent keys` refuses plain shells, validates every named key before sending any
 bytes, and queues a valid list as one ordered action. A closed target returns a

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -281,6 +281,8 @@ user named a specific project.
 `agent prompt` submits one complete prompt and can wait semantically. Prefer it
 to separate text and Enter operations. A timeout does not prove that an agent
 failed or stopped. Inspect it before deciding what to do next.
+Detected startup, sign-in, selection, and approval screens reject prompt
+submission with `agent_not_ready` before either text or Enter is queued.
 
 `agent keys` refuses plain shells, validates every named key before sending any
 bytes, and queues a valid list as one ordered action. A closed target returns a

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -314,3 +314,7 @@ Without `--wait`, the immediate `submitted:true`, `evidence:"queued"` response i
 unchanged and omits `observed_state`. Submission still means queue admission;
 state transitions do not confirm consumption of the prompt text. Do not resend
 automatically after a timeout or lost response because queued input may execute.
+When the current screen is a detected startup, sign-in, selection, or approval
+surface, prompt submission returns `agent_not_ready` without queuing text or
+Enter. Inspect it with `agent read`; use `agent keys` only for an intentional
+interaction.

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -439,6 +439,11 @@ response remains immediate: `submitted:true`, `matched:false`, `evidence:"queued
 with no `observed_state` field. Submission means queue admission, not confirmation
 that the agent consumed the prompt text.
 
+Before either prompt method queues input, Luvus rejects a currently detected
+startup, sign-in, selection, or approval screen with `agent_not_ready`. The
+rejection queues neither text nor Enter. Read the visible agent output and use
+`agent.keys` only when an explicit interaction is intended.
+
 With `wait:true`, a **new** `working` or `blocked` transition must be observed
 before a requested `until` state can complete the wait. An already active state,
 unchanged metadata, title flicker, and output settling alone do not qualify.


### PR DESCRIPTION
## Problem

A prompt sent while Codex is still starting or showing its sign-in chooser can be swallowed even though `agent.prompt` reports that input was queued. The following Enter may advance the chooser instead of submitting the requested prompt.

Related: #315.

## Solution

- Track raw prompt readiness separately from the debounced sidebar state.
- Keep Codex prompt admission closed after a server-owned launch until the existing VT boundary recognizes the live composer geometry.
- Apply the same positive-evidence rule to restored native Codex sessions.
- Reuse bounded non-empty screen detection so tall startup, sign-in, selection, and approval surfaces remain visible to classification.
- Reject both `agent.prompt` and legacy `agent.send` with `agent_not_ready` before queuing text or Enter.
- Preserve the existing atomic Submit action once the live composer is ready.
- Document the rejection and explicit `agent read` / `agent keys` recovery flow across CLI, UHP, public agent guidance, and both bundled skill copies.

A transcript line containing the `›` marker is not accepted as readiness. Admission uses the existing cursor-and-padding composer geometry, which distinguishes the live input surface from retained transcript text.

## Efficiency and scope

This addresses the confirmed startup/sign-in failure without adding prompt-echo polling, a request timer, a background thread, a dependency, or a new terminal-engine API. Normal detection caches a small readiness enum. If output changes between detection and a prompt request, Luvus performs one bounded live-grid inspection on that request.

No vendored terminal crate, PTY writer, response schema, or existing prompt wait semantics are changed.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked` — 1,644 passed, 0 failed, 3 ignored
- `cargo build --release --locked`
- Focused prompt-readiness, blocked-screen, composer-geometry, atomic submission, wait, timeout, cancellation, and pane-exit tests
- Isolated real debug lifecycle: immediate prompt on fresh Codex sign-in returned `agent_not_ready`; chooser remained unchanged and prompt marker was absent
- Isolated real optimized-release lifecycle: same result

All disposable test servers were stopped and their state was removed from the workspace. The production Luvus server was not touched.

## Remaining validation boundary

The failure and fix were exercised on macOS in debug and optimized release builds. The generic Rust paths compile and pass the repository suite, but real Windows hardware was not available for live validation. An authenticated Codex composer was not exercised with user credentials; its exact structural admission and atomic submit behavior are covered by focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt-readiness detection for agent interactions.
  * Prompts are now rejected with `agent_not_ready` when startup, sign-in, selection, or approval screens are detected, without queuing input.
  * Added support for identifying prompt-ready composer surfaces.

* **Documentation**
  * Updated CLI, agent, and control guidance to recommend reviewing visible screen content before taking authorized actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->