### PR TITLE
feat(agent): add native Devin CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Keyboard → Keyboard Shortcuts → Input Sources** to free `Ctrl+Space`.
 | Fx | ✓ | ✓ | No |
 | Cursor | ✓ | resume command | No |
 | Kilo Code | ✓ | exact-ID resume | No |
+| Devin | ✓ | exact-ID resume | No |
 | Gemini · Aider · Amp · Droid · Qwen · Kiro | ✓ | No | No |
 
 Live status needs no agent integration. See the

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -458,9 +458,9 @@ surface:
 - OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
   OpenCode V1 integration for it or infer session IDs from its live database.
 - Devin has native detection and exact-ID resume only. Do not infer session
-  IDs from its private database; `agent.resume` cannot find Devin sessions,
-  so bind a pane with `pane report --agent devin --session <id>` when the
-  exact id is known.
+  IDs from its private database; `luvus agent resume <id>` cannot find Devin
+  sessions, so bind a pane with `luvus pane report --agent devin --session
+  <id>` when the exact id is known.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership for restart resume. Detection remains native, but Luvus does not
   scan Hermes's private history store.

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -457,6 +457,10 @@ surface:
   session ownership and structured usage. Without it, usage stays unavailable.
 - OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
   OpenCode V1 integration for it or infer session IDs from its live database.
+- Devin has native detection and exact-ID resume only. Do not infer session
+  IDs from its private database; `agent.resume` cannot find Devin sessions,
+  so bind a pane with `pane report --agent devin --session <id>` when the
+  exact id is known.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership for restart resume. Detection remains native, but Luvus does not
   scan Hermes's private history store.

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -458,9 +458,9 @@ surface:
 - OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
   OpenCode V1 integration for it or infer session IDs from its live database.
 - Devin has native detection and exact-ID resume only. Do not infer session
-  IDs from its private database; `agent.resume` cannot find Devin sessions,
-  so bind a pane with `pane report --agent devin --session <id>` when the
-  exact id is known.
+  IDs from its private database; `luvus agent resume <id>` cannot find Devin
+  sessions, so bind a pane with `luvus pane report --agent devin --session
+  <id>` when the exact id is known.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership for restart resume. Detection remains native, but Luvus does not
   scan Hermes's private history store.

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -457,6 +457,10 @@ surface:
   session ownership and structured usage. Without it, usage stays unavailable.
 - OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
   OpenCode V1 integration for it or infer session IDs from its live database.
+- Devin has native detection and exact-ID resume only. Do not infer session
+  IDs from its private database; `agent.resume` cannot find Devin sessions,
+  so bind a pane with `pane report --agent devin --session <id>` when the
+  exact id is known.
 - For Hermes, `luvus integration install hermes` adds exact per-pane session
   ownership for restart resume. Detection remains native, but Luvus does not
   scan Hermes's private history store.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -169,6 +169,12 @@ fn filter_launch_flags(agent: &str, launch: &[String]) -> Vec<String> {
             }
             continue;
         }
+        // Devin reads everything after `--` as the initial prompt. Replaying it
+        // on `devin --resume <id>` would run the captured task briefing again,
+        // so the separator ends the copy; the flags before it still apply.
+        if agent == "devin" && t == "--" {
+            break;
+        }
         if t.contains('=') && TAKES_VALUE.contains(&head) {
             i += 1; // glued form, e.g. --resume=<id>
             continue;
@@ -698,6 +704,25 @@ mod tests {
             f("copilot", &["--resume=old", "--banner"]),
             vec!["--banner"]
         );
+        // Devin: the flags before `--` are kept; the separator and the task
+        // briefing after it are not, and a stale selector before it still goes.
+        assert_eq!(
+            f(
+                "devin",
+                &[
+                    "--permission-mode",
+                    "auto",
+                    "--",
+                    "fix",
+                    "the",
+                    "login",
+                    "bug"
+                ]
+            ),
+            vec!["--permission-mode", "auto"]
+        );
+        assert!(f("devin", &["--", "fix", "the", "login", "bug"]).is_empty());
+        assert!(f("devin", &["--resume", "old", "--", "fix"]).is_empty());
         // Standalone selectors, a fork flag, and one-shot print mode all go.
         assert_eq!(
             f(
@@ -775,6 +800,24 @@ mod tests {
         assert_eq!(
             resume_command_with_flags("opencode2", "ses_2", &opencode2_launch).as_deref(),
             Some("opencode2 --session 'ses_2' '--standalone'\r")
+        );
+
+        // Devin keeps its option but never the `-- <briefing>` it was launched with.
+        let devin_launch = [
+            "--permission-mode",
+            "auto",
+            "--",
+            "fix",
+            "the",
+            "login",
+            "bug",
+        ]
+        .iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>();
+        assert_eq!(
+            resume_command_with_flags("devin", "quiet-meadow", &devin_launch).as_deref(),
+            Some("devin --resume 'quiet-meadow' '--permission-mode' 'auto'\r")
         );
 
         // All-filtered input and empty input both fall back to the plain command.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -22,6 +22,7 @@ pub(crate) mod claude;
 pub(crate) mod codex;
 pub(crate) mod copilot;
 pub(crate) mod cursor;
+pub(crate) mod devin;
 pub(crate) mod droid;
 pub(crate) mod fx;
 pub(crate) mod gemini;
@@ -430,6 +431,11 @@ mod tests {
             Some("hermes --resume '20260830_120000_a1b2c3'\r")
         );
         assert!(is_resumable("hermes"));
+        assert_eq!(
+            resume_command("devin", "quiet-meadow").as_deref(),
+            Some("devin --resume 'quiet-meadow'\r")
+        );
+        assert!(is_resumable("devin"));
         assert!(resume_command("unknown", "x").is_none());
         assert!(resume_command("claude", "").is_none()); // empty id
         assert!(resume_command("claude", "a b").is_none()); // unsafe char
@@ -863,6 +869,7 @@ mod tests {
         // Resume-capable, but no native fork (the copy-then-resume tier is future).
         assert!(!can_fork("copilot"));
         assert!(!can_fork("cursor"));
+        assert!(!can_fork("devin"));
         // Unknown agent / unsafe / empty id all refuse.
         assert!(fork_command("unknown", "x").is_none());
         assert!(fork_command("claude", "a b").is_none());

--- a/src/agent/devin/mod.rs
+++ b/src/agent/devin/mod.rs
@@ -1,0 +1,43 @@
+//! Native Devin CLI support.
+//!
+//! Devin keeps its session history in a private SQLite store under its config
+//! directory. Luvus does not open it: detection is native, and a session whose
+//! exact id is already known resumes with `devin --resume <id>`.
+//!
+//! Devin also reads hook definitions from the `hooks` key of its user config
+//! (`~/.config/devin/config.json`, `%APPDATA%\devin\config.json` on Windows) in
+//! the Claude Code format. An optional `luvus integration install devin` for
+//! exact live session ownership is left to a focused follow-up.
+
+use super::types::{AgentDescriptor, IdentityDescriptor, SessionOperations};
+
+pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
+    id: "devin",
+    aliases: &[],
+    launch_command: "devin",
+    // Devin reads every positional argument after `--` as the initial prompt.
+    task_prompt_args: &["--"],
+    // Devin does expose the pieces an unattended profile needs (`-p` print mode
+    // and `--permission-mode`), but its trust gate also has to be resolved:
+    // print mode fails in an untrusted directory because it cannot show the
+    // prompt. Declaring an access level that has not been run end to end could
+    // strand or over-permit a scheduled task, so automation waits for its own
+    // reviewed change.
+    automation: None,
+    identity: IdentityDescriptor {
+        // `devin` is an ordinary given name, so trust it only in deliberate
+        // command/title evidence — the same regime as `hermes` and `grok`.
+        distinct: &[],
+        ambiguous: &["devin"],
+        binary_matcher: None,
+        interpreter_packages: &[],
+        overlap_priority: 0,
+    },
+    sessions: Some(SessionOperations {
+        discovery: None,
+        resume: |session| format!("devin --resume {session}\r"),
+        // Devin documents no external command that forks a stored session.
+        fork: None,
+    }),
+    integration: None,
+};

--- a/src/agent/devin/mod.rs
+++ b/src/agent/devin/mod.rs
@@ -1,8 +1,11 @@
 //! Native Devin CLI support.
 //!
 //! Devin keeps its session history in a private SQLite store under its config
-//! directory. Luvus does not open it: detection is native, and a session whose
-//! exact id is already known resumes with `devin --resume <id>`.
+//! directory. Luvus does not open it, so there is no session discovery: a pane
+//! resumes on restore only from an exact binding that was reported to Luvus
+//! (`luvus pane report --agent devin --session <id>`) and persisted, and
+//! `luvus agent resume <id>` cannot find Devin sessions. A known id resumes
+//! with `devin --resume <id>`.
 //!
 //! Devin also reads hook definitions from the `hooks` key of its user config
 //! (`~/.config/devin/config.json`, `%APPDATA%\devin\config.json` on Windows) in

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -22,6 +22,7 @@ pub(crate) static BUILTINS: &[&AgentDescriptor] = &[
     &super::omp::DESCRIPTOR,
     &super::pi::DESCRIPTOR,
     &super::fx::DESCRIPTOR,
+    &super::devin::DESCRIPTOR,
 ];
 
 // Preserve the current Settings and CLI presentation order independently of
@@ -141,6 +142,7 @@ mod tests {
 
         assert!(find("antigravity").unwrap().automation.is_none());
         assert!(find("amp").unwrap().automation.is_none());
+        assert!(find("devin").unwrap().automation.is_none());
 
         let pi = find("pi").unwrap().automation.unwrap();
         assert!(pi.supports(AutomationAccess::ReadOnly));
@@ -244,6 +246,7 @@ mod tests {
             ("omp", &["oh-my-pi", "omp-coding-agent"][..], &["omp"][..]),
             ("pi", &["pi-coding-agent"][..], &["pi"][..]),
             ("fx", &[][..], &["fx"][..]),
+            ("devin", &[][..], &["devin"][..]),
         ];
         assert_eq!(actual, expected);
         assert!(BUILTINS.iter().all(|descriptor| {
@@ -280,6 +283,7 @@ mod tests {
                 "omp",
                 "pi",
                 "fx",
+                "devin",
             ]
         );
 

--- a/src/agent/usage.rs
+++ b/src/agent/usage.rs
@@ -187,7 +187,7 @@ pub fn session_usage(agent: &str, cwd: &Path, session_id: &str) -> Option<AgentU
         // These agents currently expose identity/state but no stable,
         // structured, per-session usage store Luvus can read safely.
         "aider" | "antigravity" | "kilo" | "kiro" | "cursor" | "amp" | "droid" | "opencode"
-        | "opencode2" => None,
+        | "opencode2" | "devin" => None,
         _ => None, // manifest-defined agents degrade honestly too.
     }
 }
@@ -887,6 +887,7 @@ mod tests {
             "amp",
             "droid",
             "opencode2",
+            "devin",
             "custom",
         ] {
             assert!(session_usage(agent, Path::new("/work"), "session").is_none());

--- a/src/app/board.rs
+++ b/src/app/board.rs
@@ -3317,6 +3317,7 @@ mod tests {
             ("codex", "codex"),
             ("copilot", "copilot --interactive"),
             ("cursor", "cursor-agent"),
+            ("devin", "devin --"),
             ("droid", "droid"),
             ("fx", "fx ask --prompt-permissions"),
             ("gemini", "gemini --prompt-interactive"),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10230,6 +10230,65 @@ mod tests {
         assert_eq!(old.agent_launch, None);
     }
 
+    /// A Devin pane restores from the exact binding Luvus persisted (it has no
+    /// session discovery), and the restore never replays the `-- <briefing>`
+    /// the pane was launched with: only the options before the separator come
+    /// back.
+    #[test]
+    fn devin_restores_its_exact_binding_without_replaying_the_briefing() {
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let focus = app.layout().focus;
+        let st = app.status.get_mut(&focus).unwrap();
+        st.agent = "devin".into();
+        st.agent_session = Some(AgentSession {
+            agent: "devin".into(),
+            session_id: "quiet-meadow".into(),
+        });
+        app.proc_commands.insert(
+            focus,
+            vec!["devin --permission-mode auto -- fix the login bug".into()],
+        );
+
+        let snap = persist::snapshot(&app);
+        let ps = snap
+            .workspaces
+            .iter()
+            .flat_map(|w| &w.tabs)
+            .flat_map(|t| &t.panes)
+            .find(|(id, _)| *id == focus.0)
+            .map(|(_, ps)| ps)
+            .unwrap();
+        assert_eq!(
+            ps.agent_session,
+            Some(("devin".to_string(), "quiet-meadow".to_string()))
+        );
+        assert_eq!(
+            ps.agent_launch.as_deref(),
+            Some(
+                &[
+                    "--permission-mode".to_string(),
+                    "auto".into(),
+                    "--".into(),
+                    "fix".into(),
+                    "the".into(),
+                    "login".into(),
+                    "bug".into(),
+                ][..]
+            )
+        );
+
+        let (agent, sid) = ps.agent_session.clone().unwrap();
+        assert_eq!(
+            crate::agent::resume_for(&agent, &sid, ps.agent_launch.as_deref(), true).as_deref(),
+            Some("devin --resume 'quiet-meadow' '--permission-mode' 'auto'\r")
+        );
+        assert_eq!(
+            crate::agent::resume_for(&agent, &sid, ps.agent_launch.as_deref(), false).as_deref(),
+            Some("devin --resume 'quiet-meadow'\r")
+        );
+    }
+
     /// The captured CLI options are **per pane**, not one global set (docs/62).
     ///
     /// `proc_commands` is keyed by `PaneId` and filled from each pane's own

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -336,10 +336,11 @@ pub(crate) fn screen_rows(known_agent: &str, running: &[String], manifests: &Man
     }
 }
 
-/// Claude, Codex, and Hermes can place a live interaction panel above a tall
-/// blank footer. Keep their most recent non-empty live rows without pulling in
-/// scrollback. For Codex this also keeps the first-run sign-in chooser visible
-/// to prompt admission instead of mistaking its blank footer for a composer.
+/// Claude, Codex, Hermes, and Devin can place a live interaction panel above a
+/// tall blank footer. Keep their most recent non-empty live rows without pulling
+/// in scrollback. For Codex this also keeps the first-run sign-in chooser
+/// visible to prompt admission instead of mistaking its blank footer for a
+/// composer; for Devin, the first-run workspace-trust menu.
 pub(crate) fn screen_uses_non_empty_rows(
     known_agent: &str,
     running: &[String],
@@ -351,6 +352,8 @@ pub(crate) fn screen_uses_non_empty_rows(
         || manifests.process_has_agent(running, "codex")
         || known_agent.eq_ignore_ascii_case("hermes")
         || manifests.process_has_agent(running, "hermes")
+        || known_agent.eq_ignore_ascii_case("devin")
+        || manifests.process_has_agent(running, "devin")
 }
 
 /// The compiled-in default rules (generic first, then per-agent).
@@ -758,6 +761,28 @@ fn builtin_rules() -> Vec<Rule> {
             325,
             Region::Screen,
             vec![all(&["yes, proceed", "yes, don't ask again this session"])],
+        ),
+        // Devin's first-run workspace-trust screen is a numbered menu without
+        // the generic paired enter/esc controls, worded both "…authors of this
+        // directory?" and "…authors of <dir>?". Match the shared stem together
+        // with its exit label, so transcript prose cannot fake it.
+        per(
+            "devin",
+            State::Blocked,
+            310,
+            Region::Screen,
+            vec![all(&["trust the authors of", "no, exit"])],
+        ),
+        // Devin says "esc again to interrupt" (or "esc twice…") while it
+        // generates. Neither phrase contains a generic WORKING_HINT, so without
+        // this rule the pane reads as working only while a spinner frame
+        // happens to lead a line.
+        per(
+            "devin",
+            State::Working,
+            105,
+            Region::Screen,
+            vec![any(&["esc again to interrupt", "esc twice to interrupt"])],
         ),
     ]
 }
@@ -2992,5 +3017,132 @@ Would you like to proceed?
             &manifests,
         );
         assert_eq!(prose.agent, "zsh");
+    }
+
+    #[test]
+    fn devin_identity_needs_deliberate_evidence() {
+        let manifests = Manifests::builtin();
+        for command in [
+            "/usr/local/bin/devin",
+            r"C:\Users\me\AppData\Local\devin\cli\bin\devin.exe --resume quiet-meadow",
+            // Windows delivers the PEB command line quoted, which is how
+            // an install path containing spaces stays one argv token.
+            "\"C:\\Users\\Ada Lovelace\\AppData\\Local\\devin\\cli\\bin\\devin.exe\"",
+        ] {
+            assert_eq!(
+                manifests.agent_in_processes(&[command.to_string()]),
+                Some("devin".to_string()),
+                "failed to recognize {command}"
+            );
+        }
+
+        // The bare launch command names the agent when no process scan is
+        // available (Windows, remote)...
+        let launched = classify(
+            Some("zsh"),
+            "",
+            false,
+            false,
+            "devin",
+            "devin",
+            &[],
+            &manifests,
+        );
+        assert_eq!(launched.agent, "devin");
+        assert_eq!(launched.identity_source, "launch_command");
+
+        // ...but `devin` is also a person's name, so prose must not claim it.
+        let prose = classify(
+            Some("zsh"),
+            "Devin reviewed our pull request yesterday\n",
+            true,
+            false,
+            "zsh",
+            "",
+            &[],
+            &manifests,
+        );
+        assert_eq!(prose.agent, "zsh");
+    }
+
+    #[test]
+    fn devin_state_reads_its_trust_and_interrupt_screens() {
+        let manifests = Manifests::builtin();
+        let detect = |screen: &str| {
+            classify(
+                Some("zsh"),
+                screen,
+                false,
+                false,
+                "zsh",
+                "devin",
+                &["/usr/local/bin/devin".to_string()],
+                &manifests,
+            )
+            .state
+        };
+
+        // Both wordings of the workspace-trust menu.
+        assert_eq!(
+            detect("Do you trust the authors of this directory?\n❭ 1 Yes, trust\n· 2 No, exit\n"),
+            State::Blocked
+        );
+        assert_eq!(
+            detect("Do you trust the authors of luvus?\n❭ 1 Yes, trust\n· 2 No, exit\n"),
+            State::Blocked
+        );
+        // Its interrupt hint is not a generic WORKING_HINT.
+        assert_eq!(detect("Thinking… esc again to interrupt\n"), State::Working);
+        assert_eq!(
+            detect("Running tests · esc twice to interrupt\n"),
+            State::Working
+        );
+        // Its permission menu already matches the generic prompt list.
+        assert_eq!(
+            detect("Run cargo test?\n❭ 1 Yes, allow once\n· 2 Yes, allow for this session\n"),
+            State::Blocked
+        );
+        assert_eq!(
+            detect("❭ Ask Devin to build features, fix bugs, or work on your code\n"),
+            State::Idle
+        );
+    }
+
+    // The live trust screen, transcribed from a captured pane: the CLI paints
+    // it on the first five rows of the grid and leaves everything below blank,
+    // so the ordinary bottom-row window sees only empty rows.
+    const DEVIN_WORKSPACE_TRUST_SCREEN: &str = r#"PS C:\luvus-devin-demo> devin
+Do you trust the authors of this directory?
+For security, devin.exe should not be run in directories with untrusted content.
+· 1 Yes, trust C:\luvus-devin-demo
+❭ 2 No, exit"#;
+
+    #[test]
+    fn devin_trust_screen_sits_above_the_bottom_rows() {
+        let manifests = Manifests::builtin();
+        let running = ["/usr/local/bin/devin".to_string()];
+        let rows = screen_rows("devin", &running, &manifests);
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut engine = AlacrittyEngine::new(80, 30, tx, 1024 * 1024);
+        let screen = DEVIN_WORKSPACE_TRUST_SCREEN.replace('\n', "\r\n");
+        engine.advance(format!("\x1b[2J\x1b[H{screen}").as_bytes());
+
+        assert!(
+            engine.detection_text(rows).trim().is_empty(),
+            "the trust menu is above the ordinary bottom-row window"
+        );
+        assert!(screen_uses_non_empty_rows("devin", &running, &manifests));
+        let detection = classify(
+            Some("devin"),
+            &engine.detection_text_non_empty(rows),
+            false,
+            false,
+            "devin",
+            "devin",
+            &running,
+            &manifests,
+        );
+        assert_eq!(detection.state, State::Blocked);
+        assert_eq!(detection.state_source, "manifest_rule");
     }
 }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -27,6 +27,9 @@ pub(crate) fn agent_hook_script(agent: &str) -> String {
 # on the hook's event name so modules and API clients get precise transitions.
 [ -n "$LUVUS_ENV" ] || exit 0
 [ -n "$LUVUS_SOCKET_PATH" ] || exit 0
+# Devin imports Claude-format hooks (global and project `.claude/settings.json`)
+# and marks every hook process it spawns. Never report its sessions as ours.
+[ -z "$DEVIN_PROJECT_DIR" ] || exit 0
 luvus_bin="${{LUVUS_BIN_PATH:-}}"
 [ -n "$luvus_bin" ] && [ -x "$luvus_bin" ] || luvus_bin="$(command -v luvus 2>/dev/null || true)"
 [ -n "$luvus_bin" ] || exit 0
@@ -452,6 +455,11 @@ mod tests {
 
         let script = tmp.join("luvus-agent-hook.sh");
         assert!(script.exists());
+        let body = fs::read_to_string(&script).unwrap();
+        // Devin imports Claude-format hooks and marks its hook processes; the
+        // script must bail on that marker and otherwise still report as claude.
+        assert!(body.contains("DEVIN_PROJECT_DIR"), "devin guard");
+        assert!(body.contains("--agent claude"), "reports as claude");
         let settings: Value =
             serde_json::from_str(&fs::read_to_string(tmp.join("settings.json")).unwrap()).unwrap();
         let groups = settings["hooks"]["SessionStart"].as_array().unwrap();
@@ -529,6 +537,7 @@ mod tests {
 
         let script = fs::read_to_string(tmp.join("luvus-agent-hook.sh")).unwrap();
         assert!(script.contains("--agent copilot"), "reports as copilot");
+        assert!(script.contains("DEVIN_PROJECT_DIR"), "shared devin guard");
         let settings: Value =
             serde_json::from_str(&fs::read_to_string(tmp.join("settings.json")).unwrap()).unwrap();
         // Copilot uses the camelCase event key (docs/23).
@@ -1175,5 +1184,78 @@ console.log(JSON.stringify(calls));
             "no named-pipe enumeration: reports must target the inherited \
              session socket via the luvus CLI"
         );
+    }
+
+    /// The hook script, run for real: a Claude `SessionStart` payload reaches
+    /// `luvus pane report --agent claude`, and the same payload under Devin's
+    /// hook environment reports nothing, so a Devin pane can never be persisted
+    /// as Claude. Needs bash and python3, exactly like the script itself.
+    #[cfg(unix)]
+    #[test]
+    fn hook_script_reports_claude_but_never_a_devin_host() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::{Command, Stdio};
+
+        let have = |bin: &str| {
+            Command::new("sh")
+                .args(["-c", &format!("command -v {bin} >/dev/null 2>&1")])
+                .status()
+                .is_ok_and(|status| status.success())
+        };
+        if !have("bash") || !have("python3") {
+            eprintln!("skipping: the hook script needs bash and python3");
+            return;
+        }
+
+        let tmp = std::env::temp_dir().join(format!("luvus-hook-run-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+        let script = tmp.join("luvus-agent-hook.sh");
+        fs::write(&script, agent_hook_script("claude")).unwrap();
+        // A stand-in `luvus` that records its argv instead of talking to a socket.
+        let log = tmp.join("calls.log");
+        let fake = tmp.join("luvus");
+        fs::write(
+            &fake,
+            format!(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> '{}'\n",
+                log.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&fake, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let run = |devin_host: bool| -> String {
+            let _ = fs::remove_file(&log);
+            let mut cmd = Command::new("bash");
+            cmd.arg(&script)
+                .env("LUVUS_ENV", "1")
+                .env("LUVUS_SOCKET_PATH", tmp.join("sock"))
+                .env("LUVUS_BIN_PATH", &fake)
+                .env_remove("DEVIN_PROJECT_DIR")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            if devin_host {
+                cmd.env("DEVIN_PROJECT_DIR", "/work/project");
+            }
+            let mut child = cmd.spawn().unwrap();
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(br#"{"hook_event_name":"SessionStart","session_id":"abc-123"}"#)
+                .unwrap();
+            assert!(child.wait().unwrap().success());
+            fs::read_to_string(&log).unwrap_or_default()
+        };
+
+        assert_eq!(
+            run(false).trim(),
+            "pane report --agent claude --session abc-123",
+            "a Claude payload is reported as claude"
+        );
+        assert_eq!(run(true), "", "a Devin host is never reported");
+        let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -54,7 +54,7 @@ static INSTALL_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 pub enum SkillHost {
     Claude,
     /// The open `~/.agents/skills` location shared by Codex, Copilot, Gemini,
-    /// Pi, Cursor, Amp, Droid, fx, and Kilo Code.
+    /// Pi, Cursor, Amp, Droid, fx, Kilo Code, and Devin.
     Shared,
     Opencode,
     Kimi,
@@ -543,6 +543,7 @@ fn host_commands(host: SkillHost) -> &'static [&'static str] {
             "fx",
             "kilo",
             "kilocode",
+            "devin",
         ],
         SkillHost::Opencode => &["opencode", "opencode2"],
         SkillHost::Kimi => &["kimi"],
@@ -583,6 +584,7 @@ fn host_config_dirs(
             home.join(".factory"),
             home.join(".fx"),
             home.join(".kilo"),
+            xdg.join("devin"),
         ],
         SkillHost::Opencode => vec![xdg.join("opencode")],
         SkillHost::Kimi => vec![kimi_home
@@ -1180,6 +1182,7 @@ mod tests {
             "fx",
             "kilo",
             "kilocode",
+            "devin",
         ] {
             assert!(
                 shared.contains(&agent),

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -84,11 +84,11 @@ for an agent to receive it:
 `luvus skill enable` makes no network request. It installs the same bundled
 skill into detected native skill locations without overwriting external or
 modified content. The shared `~/.agents/skills/luvus/` copy serves Codex,
-GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code.
-Dedicated adapters serve Claude Code, OpenCode, OpenCode 2 Preview, Kimi Code
-CLI, Grok Build, Hermes CLI, Qwen Code, and Kiro. Aider has no native Agent
-Skills installation surface, so use `luvus skill show` when an Aider
-conversation needs the instructions.
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, Kilo Code, and
+Devin. Dedicated adapters serve Claude Code, OpenCode, OpenCode 2 Preview,
+Kimi Code CLI, Grok Build, Hermes CLI, Qwen Code, and Kiro. Aider has no
+native Agent Skills installation surface, so use `luvus skill show` when an
+Aider conversation needs the instructions.
 
 Start a new agent conversation after installation, or use that agent's skill
 reload command when it provides one. To remove unchanged Luvus-managed copies:

--- a/website/public/manifests/devin.toml
+++ b/website/public/manifests/devin.toml
@@ -1,0 +1,11 @@
+# Official Luvus detection manifest for Devin CLI.
+# This provides detection-only compatibility to older identity-enabled Luvus
+# versions. Native launch, resume, and the screen rules for Devin's trust and
+# interrupt screens ship in the Luvus binary: those screens sit above the
+# bottom-row window a manifest rule reads, so they are not repeated here.
+agent = "devin"
+
+# `devin` is also an ordinary given name, so it is only ever ambiguous
+# evidence, exactly as the built-in descriptor declares it.
+[identity]
+ambiguous = ["devin"]

--- a/website/public/manifests/index.json
+++ b/website/public/manifests/index.json
@@ -2,6 +2,7 @@
   "files": [
     "antigravity.toml",
     "claude.toml",
+    "devin.toml",
     "gemini.toml",
     "kilo.toml",
     "opencode2.toml"

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -30,8 +30,8 @@ Run `luvus doctor`. Local views need `git`. PRs/issues need an authenticated
 luvus identifies an agent by the program running in the pane, matched against a
 list of names it knows (Claude Code, Copilot, Codex, opencode, OpenCode 2
 Preview, Kimi, Cursor, Gemini, Aider, Amp, Droid, Grok, Hermes, Muse, Qwen,
-Kilo Code, Kiro). If your agent runs under a name luvus does not know, teach it
-one in
+Kilo Code, Kiro, Devin). If your agent runs under a name luvus does not know,
+teach it one in
 `~/.luvus/manifests/<agent>.toml`:
 
 ```toml

--- a/website/src/content/docs/docs/guides/agent-messaging.mdx
+++ b/website/src/content/docs/docs/guides/agent-messaging.mdx
@@ -157,6 +157,7 @@ skill through their native adapters:
 - **Claude Code:** `~/.claude/skills/luvus/`
 - **Codex:** `~/.agents/skills/luvus/`
 - **Kilo Code:** `~/.agents/skills/luvus/`
+- **Devin:** `~/.agents/skills/luvus/`
 - **opencode:** `${XDG_CONFIG_HOME:-~/.config}/opencode/skills/luvus/`
 - **OpenCode 2 Preview:** `${XDG_CONFIG_HOME:-~/.config}/opencode/skills/luvus/`
 

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -11,8 +11,8 @@ back after a restart, all without wrapping or modifying the agents themselves.
 
 Every pane running a recognized agent (Claude Code, Copilot, Codex, opencode,
 OpenCode 2 Preview, Kimi, Grok, Hermes CLI, Muse Code, Pi, Oh My Pi (OMP),
-Cursor, Gemini, Qwen, Kilo Code, Kiro, Aider, Amp, Droid, or fx) appears in the
-sidebar with a live state:
+Cursor, Gemini, Qwen, Kilo Code, Kiro, Aider, Amp, Droid, Devin, or fx) appears
+in the sidebar with a live state:
 
 | State | Meaning | How it's detected |
 |---|---|---|
@@ -79,10 +79,10 @@ Click a session row to select it and update the Selected Agent panel. Use
 | Gemini and Qwen | project chat records |
 | fx | session usage snapshot |
 
-Aider, OpenCode 2 Preview, Kilo Code, Kiro, Cursor, Amp, Droid, Muse, and
-manifest-defined agents still receive live identity and state detection, but
-show `—` for usage until they expose a stable per-session counter or report one
-through an integration. Luvus never estimates tokens from transcript text.
+Aider, OpenCode 2 Preview, Kilo Code, Kiro, Cursor, Amp, Droid, Muse, Devin,
+and manifest-defined agents still receive live identity and state detection,
+but show `—` for usage until they expose a stable per-session counter or report
+one through an integration. Luvus never estimates tokens from transcript text.
 
 Usage parsing runs off the render path only when Mission Control becomes active,
 its scope changes, or you choose **Refresh**. A hidden dashboard schedules no
@@ -147,6 +147,7 @@ not sufficient, and Luvus runs the agent's own resume command:
 | fx | its session store (`~/.fx/sessions`) |
 | Cursor | resume command (when the session id is known) |
 | Kilo Code | `kilo --session <id>` (when the exact session id is known) |
+| Devin | `devin --resume <id>` (when the exact session id is known) |
 
 OpenCode 2 Preview runs beside OpenCode V1 under the distinct `opencode2`
 executable. Luvus does not scan the V2 service's live SQLite database or reuse

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -206,6 +206,12 @@ Kilo Code also requires an exact session ID for resume or fork. Luvus detects
 the `kilo` and `kilocode` executables natively, but it does not scan Kilo's
 current database or guess which session belongs to a pane.
 
+Devin has the same boundary, without fork. Luvus does not open Devin's private
+session database, so its sessions are never listed as resumable and
+`luvus agent resume <id>` cannot find them. A pane resumes on restore only from
+an exact binding reported to Luvus (`luvus pane report --agent devin --session
+<id>`) and persisted, which restores as `devin --resume <id>`.
+
 Muse Code supports native detection and resume, but not **Fork to New Pane**.
 Its `/fork` command exists only inside the active TUI, and its CLI refuses to
 resume the same live session in a sibling pane.

--- a/website/src/content/docs/docs/guides/automation.mdx
+++ b/website/src/content/docs/docs/guides/automation.mdx
@@ -232,10 +232,11 @@ behalf.
 | Pi | yes | no | no |
 | fx | no | yes | yes |
 
-Luvus also detects Antigravity and Amp, but their current CLIs do not expose a
-reviewed unattended permission profile, so they are not available as new
-automation workers. They can still appear when an automation targets a live
-agent that is already running in a pane.
+Luvus also detects Antigravity, Amp, and Devin, but they are not available as
+new automation workers: Antigravity and Amp do not expose a reviewed unattended
+permission profile, and Devin's workspace-trust gate has not been validated for
+unattended runs. They can still appear when an automation targets a live agent
+that is already running in a pane.
 
 Kilo Code currently exposes one reviewed unattended profile: **Full access**,
 launched as `kilo run --auto`. Kilo documents that `--auto` may approve actions

--- a/website/src/content/docs/docs/guides/codex-plugin.mdx
+++ b/website/src/content/docs/docs/guides/codex-plugin.mdx
@@ -41,7 +41,8 @@ luvus skill enable
 The command makes no network request. It detects supported coding-agent
 environments and installs the one bundled Luvus skill through their native
 skill directories. The shared `~/.agents/skills/luvus/` destination serves
-Codex, GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code.
+Codex, GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, Kilo Code,
+and Devin.
 Claude Code, OpenCode, Kimi Code CLI, Grok Build, Hermes CLI, Qwen Code, and
 Kiro use their native dedicated destinations. It does not add an always-on
 pointer to `~/.codex/AGENTS.md`, and it never overwrites an installation it

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -20,6 +20,7 @@ description: What luvus supports per agent, covering live status, session resume
 | fx | ✓ | ✓ | no | no |
 | Cursor | ✓ | resume command | no | no |
 | Kilo Code | ✓ | with exact session ID | with exact session ID | no |
+| Devin | ✓ | with exact session ID | no | no |
 | Gemini | ✓ | no | no | no |
 | Aider | ✓ | no | no | no |
 | Amp | ✓ | no | no | no |
@@ -115,11 +116,12 @@ Print the release-matched instructions for one conversation with
 `luvus skill show`, or install them persistently with `luvus skill enable`.
 
 The shared `~/.agents/skills/luvus/` destination is understood by Codex,
-GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, and Kilo Code. Luvus
-uses dedicated native destinations for Claude Code, OpenCode, OpenCode 2
-Preview, Kimi Code CLI, Grok Build, Hermes CLI, Qwen Code, Oh My Pi (omp), and
-Kiro. Aider does not expose a native Agent Skills installation directory, so
-use `luvus skill show` when an Aider conversation needs the instructions.
+GitHub Copilot CLI, Gemini CLI, Pi, Cursor, Amp, Droid, fx, Kilo Code, and
+Devin. Luvus uses dedicated native destinations for Claude Code, OpenCode,
+OpenCode 2 Preview, Kimi Code CLI, Grok Build, Hermes CLI, Qwen Code, Oh My Pi
+(omp), and Kiro. Aider does not expose a native Agent Skills installation
+directory, so use `luvus skill show` when an Aider conversation needs the
+instructions.
 
 `luvus skill status` reports the bundled release separately from its managed
 filesystem installations. Codex marketplace plugins are managed by Codex and

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -90,6 +90,14 @@ description: What luvus supports per agent, covering live status, session resume
   available only with explicit **Full access**, which maps to Kilo's documented
   `kilo run --auto` contract; read-only and workspace automation are rejected.
 
+  Devin is detected through its `devin` executable, which is also an ordinary
+  given name, so only process, launch-command, or title evidence names it.
+  Luvus can resume `devin --resume <id>` when an exact session ID was reported
+  and persisted, but does not open Devin's private session database, so
+  `luvus agent resume <id>` cannot find Devin sessions and there is no native
+  fork. Automation profiles and the optional hook integration are not
+  declared yet.
+
   Hermes installs `~/.hermes/plugins/luvus-agent-state`, or the equivalent
   directory under `HERMES_HOME`, and enables only that plugin in
   `config.yaml`. Its callbacks report each exact CLI session once. Native

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -99,6 +99,7 @@ const AGENTS = [
   { name: 'Droid', mask: droidMask.src },
   { name: 'Grok', Icon: IconGrok, mono: true, hook: true },
   { name: 'Pi', Icon: IconPi, mono: true, hook: true },
+  { name: 'Devin', letter: 'D' },
 ];
 
 const cap = (s) => s.charAt(0).toUpperCase() + s.slice(1);


### PR DESCRIPTION
Devin CLI panes appear in the AGENTS sidebar with live state, and a pane whose exact session id Luvus recorded reopens with `devin --resume <id>`.

## What

- Registers `devin` as a built-in agent with the Cursor-shaped session contract: `discovery: None`, restore from an exact binding that was reported to Luvus and persisted (`luvus pane report --agent devin --session <id>`), and no fork. Nothing is discovered, so `luvus agent resume <id>` cannot find Devin sessions; the descriptor doc, the guides, the reference, and the Luvus skill doc say so, in the same terms Kilo Code and OpenCode 2 use.
- Treats `devin` as an ambiguous identity, since it is also a given name. Only deliberate process, launch-command, or title evidence names the agent; prose on screen does not.
- Adds two Devin-specific screen rules:
  - **blocked** on the first-run workspace-trust menu, matching the shared stem `trust the authors of` together with its `No, exit` label. Devin words that screen both as "…authors of this directory?" and "…authors of `<dir>`?", so the stem covers both without matching either label alone.
  - **working** on `esc again to interrupt` and `esc twice to interrupt`. Neither phrase contains a generic `WORKING_HINT`, so without this rule a generating Devin pane only read as working while a spinner frame happened to lead a line.
- Adds Devin to `screen_uses_non_empty_rows`, beside Claude, Codex, and Hermes. Devin paints the trust menu on the first rows of the grid and leaves the rest blank, so the ordinary 14-row bottom window sees only empty rows and the pane read as idle while waiting on the prompt. A VT-backed test renders the captured screen, asserts it sits above the bottom window, and checks the non-empty path reports blocked — the same shape as the existing Claude approval-panel test.
- Stops `filter_launch_flags` at `--` for Devin. ORCH launches Devin as `devin -- <briefing>`, and with **Settings → General → resume launch flags** on, a restored pane would otherwise replay that briefing after `devin --resume <id>`. The options before the separator still return.
- Guards the shared Claude/Copilot hook script against Devin. Devin imports Claude-format hooks from the global and project `.claude/settings.json` and marks every hook process it spawns with `DEVIN_PROJECT_DIR`; the script now exits before reporting when it is set, so a Devin pane can never be reported, displayed, or persisted as Claude (or Copilot).
- Devin's permission menu (`Yes, allow once` / `Yes, allow for this session`) already matches the generic `yes, allow` prompt. A test pins that so it is not duplicated.
- Uses Devin's documented `devin -- <prompt>` syntax for ORCH workers.
- Adds `devin` to the shared `~/.agents/skills` host, which Devin reads, keyed on the `devin` command and `$XDG_CONFIG_HOME/devin`.
- Publishes the detection-only manifest `website/public/manifests/devin.toml` (identity only, like Kilo Code's) for older Luvus versions that fetch `luvus.dev/manifests`.
- Updates the README support table, the homepage agent grid, the FAQ agent list, the agent guide and reference, the automation guide, the agent-messaging skill destinations, the shared-skill destination lists, the ORCH task-command table, `usage.rs`, and the Luvus skill doc.

## Why

Devin CLI had no native adapter. A detection manifest could name the process, but not the `--` prompt contract, the resume command, the trust screen, or the interrupt hint, so a pane running Devin stayed idle in the sidebar both while generating and while waiting on the trust prompt.

Session discovery is deliberately absent. Devin keeps history in a private SQLite store under its config root whose schema is on migration 16 and still moving, and #248 established that Luvus does not open agent databases. A workspace-to-session mapping needs a documented file or a Devin-side hook, not a database read.

## Verification

- [ ] `cargo test --locked` — see details
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Manual testing, if applicable

Details:

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean for this change. Pre-existing findings are reported in `src/agent/opencode/config.rs` and `src/terminal/host_input/console.rs`, which this PR does not touch; both files are byte-identical to `main`, and they appear to be newer lints than the CI toolchain that last passed there.
- `cargo test agent::` / `detect::` / `skill::` / `usage::` / `agent_task_commands_follow_each_cli_prompt_contract` / `automation_capabilities` / `devin_restores_its_exact_binding_without_replaying_the_briefing` — 148 passed. `cargo test integration::` — 34 passed, 1 failed: `installing_replaces_only_the_legacy_managed_hook`, which fails identically on unmodified `main` in this Windows checkout (CRLF in a fixture). The hook-script execution test is `cfg(unix)` and runs on the Linux and macOS jobs.
- `cargo test --locked` (full suite) does not complete on the Windows checkout used here: sixteen tests stall under parallel execution, and the list is byte-for-byte identical on unmodified `main` in the same checkout, so it is not introduced by this change. The Linux job ran the full suite green on the first round.
- `npm run build` in `website/` — 49 pages.
- Command, path, and screen contracts were checked against the installed `devin 3000.6.7`: `--help` for `--resume` and the `--` prompt separator, `devin skills paths` for the shared skills directory, and the trust-screen and interrupt strings taken from the shipped binary. The four screenshots below are the manual test, taken with a build of `main` and a build of this branch from the same base commit.
- Devin's hook behavior was measured, not assumed: a dump hook in a project-scope `.claude/settings.json` recorded the environment and payload of every event Devin emits (details under Notes).

## Screenshots

Same directory (`C:\luvus-devin-demo`, outside any directory Devin already trusts), same pane, same command, on both builds.

**Before — `main`, Devin waiting on the trust prompt: `no active agents`**

<img width="1482" height="873" alt="Before: Luvus on main, Devin waiting on its trust prompt, sidebar shows no active agents" src="https://github.com/user-attachments/assets/3422a4f2-7a71-4888-8b47-2ee83a909731" />

**After — this branch, the same screen: `blocked devin`**

<img width="1484" height="868" alt="After: same trust screen on this branch, sidebar shows blocked devin" src="https://github.com/user-attachments/assets/297bbd72-90f7-4386-ae8e-affd4ce42a69" />

**After — trust accepted, Devin at its prompt: `idle devin`**

<img width="1486" height="873" alt="After: Devin at its prompt after trust was accepted, sidebar shows idle devin" src="https://github.com/user-attachments/assets/13cf6e97-c186-42a0-8a56-52a805a1f19d" />

**After — generating, "esc twice to interrupt" on screen: `working devin`**

<img width="1488" height="870" alt="After: Devin generating with esc twice to interrupt on screen, sidebar shows working devin" src="https://github.com/user-attachments/assets/6c9d022b-c385-465b-b83e-49995f6e4a8f" />

## Notes

- **Automation is declared `None` on purpose.** Devin does expose the pieces an unattended profile needs (`-p` print mode and `--permission-mode`), but its trust gate has to be resolved as well: print mode fails in an untrusted directory because it cannot show the prompt. Declaring an access level that has not been run end to end could strand a scheduled task or over-permit it, so automation is left to its own reviewed change rather than guessed here.
- **The integration hook is a separate follow-up.** Devin reads hook definitions in the Claude Code format from the `hooks` key of its own config (`~/.config/devin/config.json`, `%APPDATA%\devin\config.json` on Windows) and, as measured for this PR, from the global and project `.claude/settings.json` as well, covering `SessionStart`, `SessionEnd`, `PermissionRequest`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, and `PostCompaction`. A `luvus integration install devin` would add exact live session ownership and put Devin in **Settings → Integrations**, but it is its own reviewable surface (config editing, uninstall preservation, Windows shell behavior) and is intentionally out of scope here.
- **What Devin hands a hook, measured on 3000.6.7.** Beyond the parent environment it sets exactly `DEVIN_PROJECT_DIR`, `CHISEL_SESSION_DB` (its session database), and `CLAUDE_PROJECT_DIR` — the last one mimics Claude Code, so it cannot tell the two apart; the guard keys on `DEVIN_PROJECT_DIR`, the mirror of that Claude variable. The payload carries `hook_event_name` and `session_id` (a `word-word` slug) and no `transcript_path`. Devin's hook parser is strict: an event name it does not know (`Notification`, which the Luvus Claude hook registers) rejects the whole settings file, so on this version the Luvus Claude hook is not imported at all today. The guard is there for the day that parser loosens, or for an older install that registered `SessionStart` alone.
- Windows process command lines arrive quoted from the PEB, which is how an install path with spaces (`C:\Users\Ada Lovelace\...\devin.exe`) stays one token. The identity test covers that form; no other agent test in the tree did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds native Devin CLI support for exact-session restoration, terminal state detection, hook isolation, shared skills, and documentation. Executed checks confirmed that session restoration excludes the original task briefing, top-positioned trust prompts are classified correctly, and Devin-hosted hooks do not report Claude session ownership.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused session-contract harness with exact-ID resume, capability, and persisted-launch tests; both harness modes exited cleanly and all four tests passed; a permission-mode auto pane was opened to fix the login bug and Devin resumed as specified, remaining unavailable for discovery or forking.
- Executed the focused Devin terminal classification suite in Chromium with an 80×30 terminal fixture; all five tests passed, and the ordinary extraction showed a blank top portion while non-empty rows included the trust prompt and labeled it Blocked; interrupt hints were Working, the composer Idle, and prose about Devin identity did not claim Devin.
- Ran the shared hook validation with a luvus recording and a Claude SessionStart payload; in normal Claude mode a Claude session was reported, while the Devin-marked path produced no report, and the focused Rust hook runtime test also passed, confirming the guard against Devin-hosted Claude hooks.
- Validated harness stability by confirming both harness modes exited with status 0 and all four tests passed; the authored harness source and two before/after captures were saved for review.
- Observed exact terminal classification behaviors: trust content in rows 1–5 with rows 6–30 blank is absent from detection\_text(14) but retained by detection\_text\_non\_empty(14) to yield Blocked; certain prompts produced Working and Idle classifications, and prose indicating Devin did not create Devin identity avoided a false positive.

<a href="https://app.greptile.com/trex/runs/23466505/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(skill): use full luvus commands in ..."](https://github.com/rizriyz/luvus/commit/15c00bdd56802ebc7b755e1089e955c449f60e8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61796070)</sub>

<!-- /greptile_comment -->