### PR TITLE
feat(uhp): permit pane.rename through Control Access

### DIFF
--- a/examples/uhp/access_capabilities_conformance.py
+++ b/examples/uhp/access_capabilities_conformance.py
@@ -41,6 +41,7 @@ def main():
     parser.add_argument("--home", required=True)
     parser.add_argument("--session", default="luvus-pr-test")
     parser.add_argument("--expect", choices=["missing", "present"], required=True)
+    parser.add_argument("--expect-rename", choices=["denied", "allowed"], default="allowed")
     args = parser.parse_args()
     binary = str(pathlib.Path(args.binary).resolve(strict=True))
     home = pathlib.Path(args.home).resolve(strict=True)
@@ -122,10 +123,23 @@ def main():
                 allowed = access["allowed_methods"]
                 assert set(allowed) <= set(owner_caps["methods"])
                 assert ("agent.keys" in allowed) == control
+                assert ("pane.rename" in allowed) == (control and args.expect_rename == "allowed")
                 assert ("automation.create" in allowed) == control
                 assert "uhp.capabilities" in allowed
                 assert "terminal.backend.type_literal" not in allowed
                 assert not any(method.startswith("uhp.token.") for method in allowed)
+            rename_params = {"pane": pane, "name": "mobile-worker"}
+            rename = exchange(endpoint, {"id": "rename", "method": "pane.rename",
+                                        "params": rename_params, "auth": token})
+            if control and args.expect_rename == "allowed":
+                assert rename["result"] == {"type": "pane_rename", **rename_params}, rename
+                assert owner("agent.get", {"target": pane})["name"] == "mobile-worker"
+            else:
+                assert rename["error"]["code"] == "forbidden", rename
+                assert owner("agent.get", {"target": pane})["name"] is None
+            print(json.dumps({"mode": "control" if control else "read_only",
+                              "request": {"id": "rename", "method": "pane.rename", "params": rename_params},
+                              "response": rename}))
             denied = []
             for method, auth in [("agent.keys", "wrong"), ("terminal.backend.type_literal", token),
                                  ("uhp.capabilities.", token), ("uhp.token.list", token)]:

--- a/examples/uhp/access_capabilities_conformance.py
+++ b/examples/uhp/access_capabilities_conformance.py
@@ -131,6 +131,7 @@ def main():
                 assert not any(method.startswith("uhp.token.") for method in allowed)
             if args.expect_rename is not None:
                 rename_params = {"pane": pane, "name": "mobile-worker"}
+                name_before_rename = owner("agent.get", {"target": pane})["name"]
                 rename = exchange(endpoint, {"id": "rename", "method": "pane.rename",
                                             "params": rename_params, "auth": token})
                 if control and args.expect_rename == "allowed":
@@ -139,7 +140,7 @@ def main():
                     assert owner("agent.get", {"target": pane})["name"] == "mobile-worker"
                 else:
                     assert rename["error"]["code"] == "forbidden", rename
-                    assert owner("agent.get", {"target": pane})["name"] is None
+                    assert owner("agent.get", {"target": pane})["name"] == name_before_rename
                 print(json.dumps({"mode": "control" if control else "read_only",
                                   "request": {"id": "rename", "method": "pane.rename", "params": rename_params},
                                   "response": rename}))

--- a/examples/uhp/access_capabilities_conformance.py
+++ b/examples/uhp/access_capabilities_conformance.py
@@ -41,7 +41,7 @@ def main():
     parser.add_argument("--home", required=True)
     parser.add_argument("--session", default="luvus-pr-test")
     parser.add_argument("--expect", choices=["missing", "present"], required=True)
-    parser.add_argument("--expect-rename", choices=["denied", "allowed"], default="allowed")
+    parser.add_argument("--expect-rename", choices=["denied", "allowed"])
     args = parser.parse_args()
     binary = str(pathlib.Path(args.binary).resolve(strict=True))
     home = pathlib.Path(args.home).resolve(strict=True)
@@ -123,23 +123,26 @@ def main():
                 allowed = access["allowed_methods"]
                 assert set(allowed) <= set(owner_caps["methods"])
                 assert ("agent.keys" in allowed) == control
-                assert ("pane.rename" in allowed) == (control and args.expect_rename == "allowed")
+                if args.expect_rename is not None:
+                    assert ("pane.rename" in allowed) == (control and args.expect_rename == "allowed")
                 assert ("automation.create" in allowed) == control
                 assert "uhp.capabilities" in allowed
                 assert "terminal.backend.type_literal" not in allowed
                 assert not any(method.startswith("uhp.token.") for method in allowed)
-            rename_params = {"pane": pane, "name": "mobile-worker"}
-            rename = exchange(endpoint, {"id": "rename", "method": "pane.rename",
-                                        "params": rename_params, "auth": token})
-            if control and args.expect_rename == "allowed":
-                assert rename["result"] == {"type": "pane_rename", **rename_params}, rename
-                assert owner("agent.get", {"target": pane})["name"] == "mobile-worker"
-            else:
-                assert rename["error"]["code"] == "forbidden", rename
-                assert owner("agent.get", {"target": pane})["name"] is None
-            print(json.dumps({"mode": "control" if control else "read_only",
-                              "request": {"id": "rename", "method": "pane.rename", "params": rename_params},
-                              "response": rename}))
+            if args.expect_rename is not None:
+                rename_params = {"pane": pane, "name": "mobile-worker"}
+                rename = exchange(endpoint, {"id": "rename", "method": "pane.rename",
+                                            "params": rename_params, "auth": token})
+                if control and args.expect_rename == "allowed":
+                    for key, value in {"type": "pane_rename", **rename_params}.items():
+                        assert rename["result"][key] == value, rename
+                    assert owner("agent.get", {"target": pane})["name"] == "mobile-worker"
+                else:
+                    assert rename["error"]["code"] == "forbidden", rename
+                    assert owner("agent.get", {"target": pane})["name"] is None
+                print(json.dumps({"mode": "control" if control else "read_only",
+                                  "request": {"id": "rename", "method": "pane.rename", "params": rename_params},
+                                  "response": rename}))
             denied = []
             for method, auth in [("agent.keys", "wrong"), ("terminal.backend.type_literal", token),
                                  ("uhp.capabilities.", token), ("uhp.token.list", token)]:

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -46,12 +46,16 @@ control-stream `send_key`. Invalid batches queue no prefix. Success identifies
 the resolved `pane` and means queued, not consumed. Inspect before answering;
 do not infer permission for `agent.send`, raw pane input, launch, fork, or close.
 
+Control also permits `pane.rename` with the existing `pane` and `name` parameters;
+read-only Access denies it. Rename retains the owner name validation and
+`pane.renamed` event. An empty name clears the pane alias.
+
 After pairing through Access, `uhp.capabilities` retains owner `methods` and
 adds `access.mode`, `access.allowed_methods`, and gateway-specific
 `access.limits.connections` / `requests_per_minute`. Intersect the allowed set
 with server methods and your supported actions. Owner endpoints omit `access`;
 older gateways may omit it too, which never proves write permission. Control
-includes keys and existing automation writes, but excludes standalone terminal
+includes `pane.rename`, keys, and existing automation writes, but excludes standalone terminal
 input and token administration. Re-discover after reconnect; accept unknown
 additive fields. No owner socket/token or new event is exposed.
 

--- a/protocol/uhp/v1/access/README.md
+++ b/protocol/uhp/v1/access/README.md
@@ -63,3 +63,9 @@ and means queue admission, not child consumption. `agent.send`, pane raw input,
 agent launch/fork, close, token management, and standalone terminal input
 actions remain forbidden through Access. No request, response, or event shape
 changes are introduced by this permission.
+
+Control also permits `pane.rename` with the existing `pane` and `name` parameters;
+read-only Access denies it. Rename retains the owner name validation and
+`pane.renamed` event. An empty name clears the pane alias. Effective
+`access.allowed_methods` includes `pane.rename` only for Control endpoints
+whose owner advertises it; the request, response, and event schemas are unchanged.

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -46,12 +46,16 @@ control-stream `send_key`. Invalid batches queue no prefix. Success identifies
 the resolved `pane` and means queued, not consumed. Inspect before answering;
 do not infer permission for `agent.send`, raw pane input, launch, fork, or close.
 
+Control also permits `pane.rename` with the existing `pane` and `name` parameters;
+read-only Access denies it. Rename retains the owner name validation and
+`pane.renamed` event. An empty name clears the pane alias.
+
 After pairing through Access, `uhp.capabilities` retains owner `methods` and
 adds `access.mode`, `access.allowed_methods`, and gateway-specific
 `access.limits.connections` / `requests_per_minute`. Intersect the allowed set
 with server methods and your supported actions. Owner endpoints omit `access`;
 older gateways may omit it too, which never proves write permission. Control
-includes keys and existing automation writes, but excludes standalone terminal
+includes `pane.rename`, keys, and existing automation writes, but excludes standalone terminal
 input and token administration. Re-discover after reconnect; accept unknown
 additive fields. No owner socket/token or new event is exposed.
 

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -986,6 +986,8 @@ mod tests {
         assert!(allowed_method(AccessMode::Control, "workspace.focus"));
         assert!(allowed_method(AccessMode::Control, "tab.focus"));
         assert!(allowed_method(AccessMode::Control, "pane.focus"));
+        assert!(!allowed_method(AccessMode::ReadOnly, "pane.rename"));
+        assert!(allowed_method(AccessMode::Control, "pane.rename"));
         assert!(allowed_method(AccessMode::Control, "agent.prompt"));
         assert!(allowed_method(AccessMode::Control, "agent.keys"));
         assert!(!allowed_method(AccessMode::ReadOnly, "agent.keys"));
@@ -1018,6 +1020,9 @@ mod tests {
         assert!(!allowed_method(AccessMode::Control, "pane.send_input"));
         assert!(!allowed_method(AccessMode::Control, "pane.run"));
         assert!(!allowed_method(AccessMode::Control, "pane.close"));
+        for method in ["agent.name", "Pane.rename", "pane.rename.", "pane.rename "] {
+            assert!(!allowed_method(AccessMode::Control, method), "{method}");
+        }
         assert!(!allowed_method(AccessMode::Control, "agent.start"));
         assert!(!allowed_method(AccessMode::Control, "agent.fork"));
         assert!(!allowed_method(AccessMode::Control, "uhp.token.list"));
@@ -1123,6 +1128,13 @@ mod tests {
         assert_eq!(mutation["id"], "1");
         assert_eq!(mutation["error"]["code"], "forbidden");
 
+        let rename = exchange(
+            gateway.address(),
+            &json!({"id":"rename","method":"pane.rename","params":{"pane":"1","name":"worker"},"auth":token}),
+        );
+        assert_eq!(rename["id"], "rename");
+        assert_eq!(rename["error"]["code"], "forbidden");
+
         let omitted_auth = exchange(
             gateway.address(),
             &json!({"id":"2","method":"session.snapshot","params":{}}),
@@ -1159,6 +1171,12 @@ mod tests {
             &json!({"id":"focus","method":"workspace.focus","params":{"workspace":0},"auth":token}),
         );
         assert_eq!(focus["error"]["code"], "unavailable");
+        let rename = exchange(
+            gateway.address(),
+            &json!({"id":"rename","method":"pane.rename","params":{"pane":"1","name":"worker"},"auth":token}),
+        );
+        assert_eq!(rename["id"], "rename");
+        assert_eq!(rename["error"]["code"], "unavailable");
         let terminal_write = exchange(
             gateway.address(),
             &json!({"id":"write","method":"pane.send_input","params":{"pane":"1","text":"x"},"auth":token}),
@@ -1389,6 +1407,124 @@ mod tests {
     }
 
     #[test]
+    fn control_access_forwards_validated_pane_rename() {
+        // Fail before starting an upstream accept if the RPC is still denied.
+        assert!(allowed_method(AccessMode::Control, "pane.rename"));
+        let _env = crate::persist::test_env("access-pane-rename");
+        let path = crate::persist::ensure_config_dir().join("rename.sock");
+        let listener = crate::ipc::transport::bind(&path).unwrap();
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        let mut gateway = Gateway::start(
+            path,
+            "client".into(),
+            None,
+            "upstream-rename-test".into(),
+            Pairing::new(Duration::from_secs(60)).unwrap(),
+            AccessMode::Control,
+        )
+        .unwrap();
+        let relay = |app: &mut crate::app::App, params: Value| {
+            let request =
+                json!({"id":"rename","method":"pane.rename","params":params,"auth":"client"});
+            thread::scope(|scope| {
+                let address = gateway.address();
+                let client = scope.spawn(move || exchange(address, &request));
+                let mut local = BufReader::new(listener.accept().unwrap());
+                let forwarded: Value = serde_json::from_str(
+                    &crate::ipc::api::read_response_frame(&mut local).unwrap(),
+                )
+                .unwrap();
+                assert_eq!(forwarded["method"], "pane.rename");
+                assert_eq!(forwarded["auth"], "upstream-rename-test");
+                let response = match app.dispatch("pane.rename", &forwarded["params"]) {
+                    Ok(result) => json!({"id":"rename","result":result}),
+                    Err((code, message)) => {
+                        json!({"id":"rename","error":{"code":code,"message":message}})
+                    }
+                };
+                writeln!(local.get_mut(), "{response}").unwrap();
+                local.get_mut().flush().unwrap();
+                client.join().unwrap()
+            })
+        };
+        for (name, expected) in [
+            ("worker", Some("worker")),
+            ("  worker-2_a  ", Some("worker-2_a")),
+            (
+                "a1234567890123456789012345678901_2",
+                Some("a1234567890123456789012345678901_2"),
+            ),
+            ("", None),
+            ("  ", None),
+        ] {
+            let sequence = crate::ipc::api::current_sequence(&app.events);
+            let result = relay(&mut app, json!({"pane":pane.0.to_string(),"name":name}));
+            assert_eq!(
+                result["result"],
+                json!({
+                    "type":"pane_rename","pane":pane.0.to_string(),"name":expected
+                })
+            );
+            assert_eq!(
+                app.agent_names.get(expected.unwrap_or("")),
+                expected.map(|_| &pane)
+            );
+            assert_eq!(app.agent_names.len(), usize::from(expected.is_some()));
+            assert!(app.session_dirty);
+            let events = crate::ipc::api::replayed_events_after(&app.events, sequence);
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0]["event"], "pane.renamed");
+            assert_eq!(
+                events[0]["data"],
+                json!({"pane":pane.0.to_string(),"name":expected})
+            );
+            assert_eq!(app.layout().focus, pane);
+        }
+        app.set_agent_name(pane, Some("original"));
+        app.session_dirty = false;
+        for (params, code) in [
+            (json!({"pane":pane.0.to_string()}), "invalid_request"),
+            (
+                json!({"pane":pane.0.to_string(),"name":null}),
+                "invalid_request",
+            ),
+            (
+                json!({"pane":pane.0.to_string(),"name":7}),
+                "invalid_request",
+            ),
+            (
+                json!({"pane":pane.0.to_string(),"name":"Bad"}),
+                "invalid_request",
+            ),
+            (
+                json!({"pane":pane.0.to_string(),"name":"bad name"}),
+                "invalid_request",
+            ),
+            (
+                json!({"pane":pane.0.to_string(),"name":"a".repeat(33)}),
+                "invalid_request",
+            ),
+            (
+                json!({"pane":pane.0.to_string(),"name":"worker","extra":true}),
+                "invalid_request",
+            ),
+            (json!({"pane":"4294967295","name":"worker"}), "not_found"),
+        ] {
+            let before = app.agent_names.clone();
+            let sequence = crate::ipc::api::current_sequence(&app.events);
+            let result = relay(&mut app, params.clone());
+            assert_eq!(result["error"]["code"], code, "{params}: {result}");
+            assert_eq!(app.agent_names, before);
+            assert_eq!(crate::ipc::api::current_sequence(&app.events), sequence);
+            assert!(!app.session_dirty);
+            assert_eq!(app.layout().focus, pane);
+        }
+        gateway.stop();
+    }
+
+    #[test]
     fn access_keys_rejections_never_admit_input() {
         let _env = crate::persist::test_env("access-keys-denied");
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -1553,6 +1689,10 @@ mod tests {
             assert_eq!(access.as_object().unwrap().len(), 3);
             assert_eq!(
                 expected.contains(&"agent.keys"),
+                mode == AccessMode::Control
+            );
+            assert_eq!(
+                expected.contains(&"pane.rename"),
                 mode == AccessMode::Control
             );
             assert_eq!(

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -471,6 +471,7 @@ fn allowed_method(mode: AccessMode, method: &str) -> bool {
                 "workspace.focus"
                     | "tab.focus"
                     | "pane.focus"
+                    | "pane.rename"
                     | "agent.prompt"
                     | "agent.keys"
                     | "automation.create"
@@ -1453,8 +1454,8 @@ mod tests {
             ("worker", Some("worker")),
             ("  worker-2_a  ", Some("worker-2_a")),
             (
-                "a1234567890123456789012345678901_2",
-                Some("a1234567890123456789012345678901_2"),
+                "abcdefghijklmnopqrstuvwxyz0123_-",
+                Some("abcdefghijklmnopqrstuvwxyz0123_-"),
             ),
             ("", None),
             ("  ", None),

--- a/src/uhp/gateway.rs
+++ b/src/uhp/gateway.rs
@@ -1522,6 +1522,36 @@ mod tests {
             assert!(!app.session_dirty);
             assert_eq!(app.layout().focus, pane);
         }
+
+        // Reusing an alias transfers it, just as it does on the owner endpoint.
+        let split = app.dispatch("pane.split", &json!({})).unwrap();
+        let second = crate::ids::PaneId(split["pane"].as_str().unwrap().parse().unwrap());
+        assert_ne!(second, pane);
+        let first = relay(&mut app, json!({"pane":pane.0.to_string(),"name":"shared"}));
+        assert_eq!(first["result"]["name"], "shared");
+        assert_eq!(app.agent_name_for(pane), Some("shared"));
+        assert_eq!(app.agent_name_for(second), None);
+        let sequence = crate::ipc::api::current_sequence(&app.events);
+        app.session_dirty = false;
+        let transferred = relay(
+            &mut app,
+            json!({"pane":second.0.to_string(),"name":"shared"}),
+        );
+        assert_eq!(
+            transferred["result"],
+            json!({"type":"pane_rename","pane":second.0.to_string(),"name":"shared"})
+        );
+        assert_eq!(app.agent_name_for(pane), None);
+        assert_eq!(app.agent_name_for(second), Some("shared"));
+        assert_eq!(app.agent_names.len(), 1);
+        assert!(app.session_dirty);
+        let events = crate::ipc::api::replayed_events_after(&app.events, sequence);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0]["event"], "pane.renamed");
+        assert_eq!(
+            events[0]["data"],
+            json!({"pane":second.0.to_string(),"name":"shared"})
+        );
         gateway.stop();
     }
 

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -414,6 +414,10 @@ Read-only Access denies it. A rejected batch queues no prefix; success returns
 the resolved `pane` and means queued, not consumed. This does not authorize
 `agent.send`, raw pane input, launch, fork, or close through the gateway.
 
+Control also permits `pane.rename` with the existing `pane` and `name` parameters;
+read-only Access denies it. Rename retains the owner name validation and
+`pane.renamed` event. An empty name clears the pane alias.
+
 ## Remote use
 
 Observe/control `terminal.frame` messages replace the previous capture at the
@@ -436,7 +440,7 @@ adds `access.mode`, `access.allowed_methods`, and gateway-specific
 `access.limits.connections` / `requests_per_minute`. Intersect the allowed set
 with server methods and your supported actions. Owner endpoints omit `access`;
 older gateways may omit it too, which never proves write permission. Control
-includes keys and existing automation writes, but excludes standalone terminal
+includes `pane.rename`, keys, and existing automation writes, but excludes standalone terminal
 input and token administration. Re-discover after reconnect; accept unknown
 additive fields. No owner socket/token or new event is exposed.
 

--- a/website/src/content/docs/docs/uhp/conformance.mdx
+++ b/website/src/content/docs/docs/uhp/conformance.mdx
@@ -170,3 +170,9 @@ use the [method reference](/docs/uhp/methods/) and
 [terminal methods](/docs/uhp/terminal/).
 
 The `examples/uhp/access_capabilities_conformance.py` harness accepts an exact `--binary`, fresh `--home`, and `--session luvus-pr-test`. Run `--expect missing` against an older gateway and `--expect present` against the projection build. It compares paired read/control capability catalogs with owner capabilities, validates permission examples, proves rejected input stays empty, and stops its isolated processes.
+
+Add `--expect-rename denied` to verify a baseline that forbids `pane.rename`, or
+`--expect-rename allowed` to verify Control rename and effective permission
+parity. Both modes verify that read-only Access denies rename; the Control
+success case also checks the alias through owner readback. Omitting this flag
+keeps the original capabilities-only checks for older builds.

--- a/website/src/content/docs/docs/uhp/remote-access.mdx
+++ b/website/src/content/docs/docs/uhp/remote-access.mdx
@@ -65,8 +65,8 @@ its upstream server tokens bounded and rotates them internally, so
 `--no-expiry` does not create a permanent token in the server.
 
 Control mode does not expose every local mutation. The gateway allows the
-advertised read surface plus selected focus, prompt, agent-key, terminal-control, and
-automation methods. An automation created remotely is durable and can run
+advertised read surface plus selected focus, pane-rename, prompt, agent-key,
+terminal-control, and automation methods. An automation created remotely is durable and can run
 after the pairing token or access command expires; disable or delete it
 explicitly when that is not intended. Discover the exact live method set after
 pairing rather than treating a scope name as permission to call every method in
@@ -79,13 +79,17 @@ This vocabulary is wider than a terminal control stream's `send_key` action.
 A bad batch queues no prefix; success means queued, not consumed. `agent.send`,
 raw pane input, agent launch/fork, and pane close remain forbidden.
 
+Control also permits `pane.rename` with the existing `pane` and `name` parameters;
+read-only Access denies it. Rename retains the owner name validation and
+`pane.renamed` event. An empty name clears the pane alias.
+
 ## Effective permissions
 
 After pairing, `uhp.capabilities` retains the full owner `methods` catalog and
 adds an endpoint-specific projection (excerpt):
 
 ```json
-{"access":{"mode":"control","allowed_methods":["uhp.capabilities","agent.keys"],"limits":{"connections":16,"requests_per_minute":120}}}
+{"access":{"mode":"control","allowed_methods":["uhp.capabilities","pane.rename","agent.keys"],"limits":{"connections":16,"requests_per_minute":120}}}
 ```
 
 The abbreviated list above is illustrative. The live list includes every
@@ -97,7 +101,7 @@ not the owner server's capacity. The owner endpoint does not add `access`.
 
 Clients should intersect supported `methods` with `access.allowed_methods`
 and their own product action support. Keep unknown additive fields valid.
-Control includes `agent.keys` and existing `automation.*` writes. This does
+Control includes `pane.rename`, `agent.keys`, and existing `automation.*` writes. This does
 not mean every allowed method should become a UI action. Standalone terminal
 input methods and `uhp.token.*` remain absent, even when a terminal control
 stream can accept input actions.


### PR DESCRIPTION
Mobile clients can rename panes through UHP Control Access using the existing `pane.rename` method. Read-only Access continues to deny it.

## What and why

The mobile client shows Rename, but the gateway currently returns `forbidden` even for Control endpoints. #300 covers alias **display** in snapshots; this PR covers **write permission** through Access.

The production change is one exact method literal in the existing Control branch of `allowed_method`. Effective `access.allowed_methods` automatically follows the same predicate. The existing dispatcher, name validation, setter, response and `pane.renamed` event are reused.

**Alias transfer is unchanged upstream behavior:** assigning the same alias to a second pane moves the alias to that pane and removes it from the first. The gateway regression exercises both renames through Control Access and checks the second pane's event. This PR does not introduce duplicate-name rejection.

Access documentation, both bundled skill references and the existing live capability harness are updated. Existing schemas already describe `pane.rename` and `pane.renamed`; neither a wire shape nor a schema permission list changes.

## Verification

All Rust checks ran from the primary checkout, not a linked worktree:

```sh
cargo test uhp::gateway::tests -- --nocapture
cargo fmt
cargo clippy --all-targets -- -D warnings
cargo test
cargo test --locked
cargo build
cargo fmt --all --check
python3 examples/uhp/consumer.py --fixtures
git diff --check
```

- Test-first RED before the production change: `11 passed; 4 failed; 0 ignored; 1655 filtered out`. The failures pinned Control admission, effective permission projection and forwarding.
- GREEN, including alias transfer: `15 passed; 0 failed; 0 ignored; 1655 filtered out`.
- Full primary-checkout suite: `1667 passed; 0 failed; 3 ignored` (both ordinary and locked runs).
- Formatting, strict all-target Clippy, debug build and diff check passed.
- `validated 142 UHP fixtures and all JSON schema documents`.

Regression coverage:

- Read-only rename denied before local IPC; Control rename admitted; owner-unavailable response preserved.
- Effective capability catalog includes rename only in Control and preserves the owner catalog.
- Exact method matching: `agent.name`, case/suffix near misses, raw input, launch/fork/close and token administration remain denied.
- Existing trimmed names, 32-character boundary names, empty/whitespace clearing, and alias transfer remain accepted.
- Missing/null/non-string/invalid/overlong names, extra fields and nonexistent panes fail without changing aliases, dirty state, event sequence or focus.
- Successful rename/clear emits the existing event with the resolved pane; alias transfer removes the first pane's alias and emits `pane.renamed` for the second.

## Tests: before (base) vs after (branch)

Base: `ee169dadeefe8048a3e90482c66f0f0aa49a54a6`. The debug base binary was built in this checkout before the production edit and copied to `target/luvus-u01-base` (SHA-256 `f99c9c48d08ddfac9c470e8b3da4904eb12302c0845bb60c0b217b6e36c2b42a`).

The existing harness starts its own server plus paired read-only and Control endpoints, with an exact binary, fresh empty `LUVUS_HOME` and session `luvus-pr-test`. It strips inherited `LUVUS_SOCKET_PATH`, `LUVUS_SESSION`, `LUVUS_ENV` and `LUVUS_PANE_ID`, and cleans up only its own processes. Production sessions are untouched. Request records omit the secret `auth` field; JSON responses below are literal.

Before commands:

```sh
cargo build
cp target/debug/luvus target/luvus-u01-base
test_home=$(mktemp -d "$PWD/target/u01-before-final.XXXXXX")
python3 examples/uhp/access_capabilities_conformance.py --binary target/luvus-u01-base --home "$test_home" --session luvus-pr-test --expect present --expect-rename denied
```

```jsonl
{"binary": "/home/ubuntu/projects/Rust/luvus/target/luvus-u01-base", "home": "/home/ubuntu/projects/Rust/luvus/target/u01-before-final.8us19Z", "session": "luvus-pr-test", "pane": "2"}
{"mode": "read_only", "request": {"id": "rename", "method": "pane.rename", "params": {"pane": "2", "name": "mobile-worker"}}, "response": {"error": {"code": "forbidden", "message": "private gateway authorization failed"}, "id": "rename"}}
{"mode": "control", "request": {"id": "rename", "method": "pane.rename", "params": {"pane": "2", "name": "mobile-worker"}}, "response": {"error": {"code": "forbidden", "message": "private gateway authorization failed"}, "id": "rename"}}
```

After commands:

```sh
cargo build
test_home=$(mktemp -d "$PWD/target/u01-after-final.XXXXXX")
python3 examples/uhp/access_capabilities_conformance.py --binary target/debug/luvus --home "$test_home" --session luvus-pr-test --expect present --expect-rename allowed
```

```jsonl
{"binary": "/home/ubuntu/projects/Rust/luvus/target/debug/luvus", "home": "/home/ubuntu/projects/Rust/luvus/target/u01-after-final.3PzWeF", "session": "luvus-pr-test", "pane": "2"}
{"mode": "read_only", "request": {"id": "rename", "method": "pane.rename", "params": {"pane": "2", "name": "mobile-worker"}}, "response": {"error": {"code": "forbidden", "message": "private gateway authorization failed"}, "id": "rename"}}
{"mode": "control", "request": {"id": "rename", "method": "pane.rename", "params": {"pane": "2", "name": "mobile-worker"}}, "response": {"id": "rename", "result": {"name": "mobile-worker", "pane": "2", "revision": 7, "type": "pane_rename"}}}
```

Both runs exited 0. The harness also verifies owner alias readback, `pane.rename` in the effective Control list only after the fix, unchanged owner catalogs, pairing replay rejection and an empty captured input queue. The older invocation without `--expect-rename` also passed against the base binary. Rename assertions are opt-in so existing historical conformance invocations remain usable.

Linux was tested locally. macOS and Windows runtime behavior is not claimed verified.

## First-pass checklist

- R1: Exact `pane.rename` literal; unchanged owner grammar, clear forms and alias transfer pinned by regressions.
- R2: Existing validation failures preserve aliases, dirty state, sequence and focus; read-only rejects before IPC; no new mutation/cleanup branch.
- R3: [CodeRabbit completed its review](https://github.com/RizRiyz/luvus/pull/326#issuecomment-5595743890) of head `5fe52e804723c31798e4fd126a60542c1789216f` with no actionable comments; the inline comment list is empty and no findings required fixes or rebuttals.
- R4: Isolated base/branch commands and literal paired read/control responses above show denied/allowed behavior and read-only preservation.
- R5: Fresh `git fetch upstream && git rebase upstream/main` before opening; Access docs/skill copies synchronized; 142 fixtures and schemas validate without wire-shape changes.
- R6: Existing response meaning and resolved pane coordinates are unchanged.
- R7: One permission change based on `upstream/main`; no dispatcher changes or unrelated branch work.
- R8: Two layers: server policy/tests and documentation. No CLI, schema, terminal-VT or detection changes.
- R9: Existing predicate, dispatcher, setter and event reused; no new API, storage, event, thread, timer, polling or dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0157SP6ztLt1Lz91vWgXko8V




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change permits `pane.rename` for Control Access while keeping ReadOnly Access unable to rename panes. The prior harness failure was disproved by a live Control-then-ReadOnly run on one pane: the denied ReadOnly request returned `forbidden` and preserved the `mobile-worker` name set by Control Access.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reviewed the general-contract-validation-proof that documents how the test captures name\_before\_rename and requires preserving that value after a rename.
- T-Rex compared the pre-fix code to the live run and noted that the old expectation was not met, with the live path raising an AssertionError when ReadOnly followed a successful Control.
- T-Rex validated the exact after-state by checking that the pane\_rename response reports name "mobile-worker" and the subsequent ReadOnly error preserves that same value for name\_before\_rename and name\_after\_rename.
- T-Rex confirmed that no repository files were modified and that only executable evidence and two harness snapshots were captured as artifacts.
- T-Rex prepared the artifact summary linking the harness log to the general-contract-validation-proof for reviewers to inspect.

<a href="https://app.greptile.com/trex/runs/23516984/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(uhp): make denied rename check stat..."](https://github.com/rizriyz/luvus/commit/6d0e2927330b44fbe91ef5abfe04f911d4100af7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61947354)</sub>

<!-- /greptile_comment -->