### PR TITLE
feat(uhp): optional content-revision fence for agent.keys

### DIFF
--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -75,7 +75,7 @@ FIELDS = {
     "agent.start": {"name", "kind", "pane", "anchor", "direction", "args", "timeout_s"},
     "agent.prompt": {"target", "text", "wait", "until", "timeout_s"},
     "agent.wait": {"pane", "status", "statuses", "timeout_s"},
-    "agent.keys": {"target", "keys"},
+    "agent.keys": {"target", "keys", "if_content_revision", "terminal_id"},
     "events.subscribe": set(),
 }
 
@@ -291,9 +291,19 @@ def agent_key(value):
 
 
 def valid_agent_keys_params(params):
+    fields = set(params)
+    if fields == {"target", "keys", "if_content_revision", "terminal_id"}:
+        if not (
+            type(params["if_content_revision"]) is int
+            and params["if_content_revision"] >= 0
+            and isinstance(params["terminal_id"], str)
+            and re.fullmatch(r"[0-9a-f]{32}", params["terminal_id"]) is not None
+        ):
+            return False
+    elif fields != {"target", "keys"}:
+        return False
     return (
-        set(params) == {"target", "keys"}
-        and bounded_string(params["target"], 128, allow_empty=False)
+        bounded_string(params["target"], 128, allow_empty=False)
         and isinstance(params["keys"], list)
         and bool(params["keys"])
         and all(agent_key(key) for key in params["keys"])

--- a/examples/uhp/consumer.py
+++ b/examples/uhp/consumer.py
@@ -291,6 +291,7 @@ def agent_key(value):
 
 
 def valid_agent_keys_params(params):
+    """Validate an atomic key batch and its optional paired snapshot coordinates."""
     fields = set(params)
     if fields == {"target", "keys", "if_content_revision", "terminal_id"}:
         if not (

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -289,6 +289,26 @@ For a blocked agent:
 key names. It validates the entire list before queuing one ordered action; any
 invalid entry sends nothing, and a closed target returns `send_failed`.
 
+For UHP interactions that must match the inspected screen, use `agent.read`
+with `source:"visible"` and pass its `content_revision` as `if_content_revision`
+together with its `terminal_id` in `agent.keys` params. The revision is a
+non-negative integer; the terminal ID is exactly 32 lowercase hex characters.
+Both fields are optional as a pair; a one-sided or malformed pair is
+`invalid_request`. A deferred pane has `terminal_id:null` and cannot be fenced.
+An unavailable read snapshot has empty text and null coordinates.
+
+The server checks the pair and queues keys under the same engine lock used to
+capture the text. `content_revision_conflict` means no keys were queued: re-read
+and reassess the authorized action, never retry the same pair. Generic response
+`revision` / request `if_revision` are global event coordinates, not the pane's
+content counter. Without the pair, behavior is unchanged. Older servers omit the
+coordinates or reject the new fields; omit the pair only when legacy unfenced
+admission is acceptable. These are UHP params, not CLI flags.
+
+The fence covers queue admission only. Already queued input and child-side
+changes not yet observed remain outside it. Cursor/SGR output can make a pair
+stale even if the dialog text looks unchanged.
+
 ## Control panes, tabs, and workspaces
 
 Use these read routes before a write whose target is not already known:

--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -190,3 +190,33 @@ also returns `agent_not_ready` when prompt evidence is Unknown, unless live Code
 composer geometry reports Ready. Existing Codex panes without that requirement
 retain the permissive Unknown-evidence fallback. Inspect the visible screen and
 use `agent.keys` only for an explicitly authorized interaction.
+
+For UHP interactions that must match the inspected screen, use `agent.read`
+with `source:"visible"` and pass its `content_revision` as `if_content_revision`
+together with its `terminal_id` in `agent.keys` params. The revision is a
+non-negative integer; the terminal ID is exactly 32 lowercase hex characters.
+Both fields are optional as a pair; a one-sided or malformed pair is
+`invalid_request`. A deferred pane has `terminal_id:null` and cannot be fenced.
+An unavailable read snapshot has empty text and null coordinates.
+
+The server checks the pair and queues keys under the same engine lock used to
+capture the text. `content_revision_conflict` means no keys were queued: re-read
+and reassess the authorized action, never retry the same pair. Generic response
+`revision` / request `if_revision` are global event coordinates, not the pane's
+content counter. Without the pair, behavior is unchanged. Older servers omit the
+coordinates or reject the new fields; omit the pair only when legacy unfenced
+admission is acceptable. These are UHP params, not CLI flags.
+
+The fence covers queue admission only. Already queued input and child-side
+changes not yet observed remain outside it. Cursor/SGR output can make a pair
+stale even if the dialog text looks unchanged.
+
+```json
+{"id":"answer","method":"agent.keys","params":{"target":"reviewer","keys":["enter"],"if_content_revision":12,"terminal_id":"0123456789abcdef0123456789abcdef"}}
+```
+
+Replace the example coordinates with the actual `agent.read` result. The whole
+key list validates before comparing the fence. A mismatched revision or terminal
+identity, missing runtime, or unavailable engine sends nothing and reports
+`content_revision_conflict` with expected/actual context; a closed writer still
+returns `send_failed` for an otherwise matching pair.

--- a/protocol/uhp/v1/fixtures/invalid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/invalid/requests.jsonl
@@ -32,3 +32,5 @@
 {"id":"bad-agent-keys-mixed","method":"agent.keys","params":{"target":"reviewer","keys":["enter",7]}}
 {"id":"bad-agent-keys-name","method":"agent.keys","params":{"target":"reviewer","keys":["f13"]}}
 {"id":"bad-agent-keys-extra","method":"agent.keys","params":{"target":"reviewer","keys":["enter"],"extra":true}}
+{"id":"bad-keys-fence-revision-only","method":"agent.keys","params":{"target":"7","keys":["enter"],"if_content_revision":12}}
+{"id":"bad-keys-fence-terminal-only","method":"agent.keys","params":{"target":"7","keys":["enter"],"terminal_id":"0123456789abcdef0123456789abcdef"}}

--- a/protocol/uhp/v1/fixtures/manifest.json
+++ b/protocol/uhp/v1/fixtures/manifest.json
@@ -1,10 +1,10 @@
 {
   "protocol": { "name": "luvus-uhp", "major": 1, "minor": 0 },
   "files": [
-    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 48 },
+    { "path": "valid/requests.jsonl", "kind": "request", "expect": "valid", "count": 49 },
     { "path": "valid/responses.jsonl", "kind": "response", "expect": "valid", "count": 24 },
     { "path": "valid/events.jsonl", "kind": "event", "expect": "valid", "count": 3 },
-    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 34 },
+    { "path": "invalid/requests.jsonl", "kind": "request", "expect": "invalid", "count": 36 },
     { "path": "invalid/responses.jsonl", "kind": "response", "expect": "invalid", "count": 33 }
   ]
 }

--- a/protocol/uhp/v1/fixtures/valid/requests.jsonl
+++ b/protocol/uhp/v1/fixtures/valid/requests.jsonl
@@ -46,3 +46,4 @@
 {"id":"prompt-0","method":"agent.prompt","params":{"target":"7","text":"review"}}
 {"id":"prompt-1","method":"agent.prompt","params":{"target":"reviewer","text":"review","wait":true,"until":["idle","idle"],"timeout_s":0}}
 {"id":"prompt-2","method":"agent.prompt","params":{"target":"codex","text":"first\n\u7b2c\u4e8c\u884c","wait":true,"until":["idle","working","blocked","done"],"timeout_s":3600}}
+{"id":"keys-content-fence","method":"agent.keys","params":{"target":"7","keys":["enter"],"if_content_revision":12,"terminal_id":"0123456789abcdef0123456789abcdef"}}

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -88,8 +88,14 @@
     },
     "agentKeysParams": {
       "type": "object", "additionalProperties": false, "required": ["target", "keys"],
+      "dependentRequired": {
+        "if_content_revision": ["terminal_id"],
+        "terminal_id": ["if_content_revision"]
+      },
       "properties": {
         "target": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "if_content_revision": { "type": "integer", "minimum": 0 },
+        "terminal_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
         "keys": {
           "type": "array", "minItems": 1,
           "items": { "$ref": "#/$defs/agentKey" }

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -289,6 +289,26 @@ For a blocked agent:
 key names. It validates the entire list before queuing one ordered action; any
 invalid entry sends nothing, and a closed target returns `send_failed`.
 
+For UHP interactions that must match the inspected screen, use `agent.read`
+with `source:"visible"` and pass its `content_revision` as `if_content_revision`
+together with its `terminal_id` in `agent.keys` params. The revision is a
+non-negative integer; the terminal ID is exactly 32 lowercase hex characters.
+Both fields are optional as a pair; a one-sided or malformed pair is
+`invalid_request`. A deferred pane has `terminal_id:null` and cannot be fenced.
+An unavailable read snapshot has empty text and null coordinates.
+
+The server checks the pair and queues keys under the same engine lock used to
+capture the text. `content_revision_conflict` means no keys were queued: re-read
+and reassess the authorized action, never retry the same pair. Generic response
+`revision` / request `if_revision` are global event coordinates, not the pane's
+content counter. Without the pair, behavior is unchanged. Older servers omit the
+coordinates or reject the new fields; omit the pair only when legacy unfenced
+admission is acceptable. These are UHP params, not CLI flags.
+
+The fence covers queue admission only. Already queued input and child-side
+changes not yet observed remain outside it. Cursor/SGR output can make a pair
+stale even if the dialog text looks unchanged.
+
 ## Control panes, tabs, and workspaces
 
 Use these read routes before a write whose target is not already known:

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -190,3 +190,33 @@ also returns `agent_not_ready` when prompt evidence is Unknown, unless live Code
 composer geometry reports Ready. Existing Codex panes without that requirement
 retain the permissive Unknown-evidence fallback. Inspect the visible screen and
 use `agent.keys` only for an explicitly authorized interaction.
+
+For UHP interactions that must match the inspected screen, use `agent.read`
+with `source:"visible"` and pass its `content_revision` as `if_content_revision`
+together with its `terminal_id` in `agent.keys` params. The revision is a
+non-negative integer; the terminal ID is exactly 32 lowercase hex characters.
+Both fields are optional as a pair; a one-sided or malformed pair is
+`invalid_request`. A deferred pane has `terminal_id:null` and cannot be fenced.
+An unavailable read snapshot has empty text and null coordinates.
+
+The server checks the pair and queues keys under the same engine lock used to
+capture the text. `content_revision_conflict` means no keys were queued: re-read
+and reassess the authorized action, never retry the same pair. Generic response
+`revision` / request `if_revision` are global event coordinates, not the pane's
+content counter. Without the pair, behavior is unchanged. Older servers omit the
+coordinates or reject the new fields; omit the pair only when legacy unfenced
+admission is acceptable. These are UHP params, not CLI flags.
+
+The fence covers queue admission only. Already queued input and child-side
+changes not yet observed remain outside it. Cursor/SGR output can make a pair
+stale even if the dialog text looks unchanged.
+
+```json
+{"id":"answer","method":"agent.keys","params":{"target":"reviewer","keys":["enter"],"if_content_revision":12,"terminal_id":"0123456789abcdef0123456789abcdef"}}
+```
+
+Replace the example coordinates with the actual `agent.read` result. The whole
+key list validates before comparing the fence. A mismatched revision or terminal
+identity, missing runtime, or unavailable engine sends nothing and reports
+`content_revision_conflict` with expected/actual context; a closed writer still
+returns `send_failed` for an otherwise matching pair.

--- a/src/app/dispatch/agents.rs
+++ b/src/app/dispatch/agents.rs
@@ -186,8 +186,8 @@ impl App {
         }
     }
 
-    // Send named control keys (enter, esc, ctrl+c, up, …) to a target agent,
-    // e.g. to answer a blocked approval prompt. All keys validate first.
+    /// Send an atomic key batch to an agent, optionally fenced to read coordinates.
+    /// Validate every key before comparing the fence or admitting input.
     pub(super) fn api_agent_keys(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = (method, p);
         {
@@ -287,7 +287,7 @@ impl App {
         }
     }
 
-    // Read a target agent's output, addressed by name or pane id.
+    /// Read an agent's text and terminal coordinates under one engine lock.
     pub(super) fn api_agent_read(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = (method, p);
         {

--- a/src/app/dispatch/agents.rs
+++ b/src/app/dispatch/agents.rs
@@ -191,7 +191,7 @@ impl App {
     pub(super) fn api_agent_keys(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = (method, p);
         {
-            reject_api_fields(p, &["target", "keys"])?;
+            reject_api_fields(p, &["target", "keys", "if_content_revision", "terminal_id"])?;
             let id = self.resolve_agent_target(p)?;
             if !self.is_agent_pane(id) {
                 return Err((
@@ -223,11 +223,66 @@ impl App {
                     ("invalid_request".to_string(), format!("unknown key: {key}"))
                 })?);
             }
-            self.panes
-                .get(&id)
-                .ok_or_else(not_found)?
-                .try_send(&bytes)
-                .map_err(|message| ("send_failed".to_string(), message))?;
+            let fence = match (p.get("if_content_revision"), p.get("terminal_id")) {
+                (None, None) => None,
+                (Some(revision), Some(terminal_id)) => {
+                    let revision = revision.as_u64().ok_or_else(|| {
+                        (
+                            "invalid_request".to_string(),
+                            "if_content_revision must be a non-negative integer".to_string(),
+                        )
+                    })?;
+                    let terminal_id = terminal_id
+                        .as_str()
+                        .filter(|id| crate::terminal::backend::valid_id(id))
+                        .ok_or_else(|| {
+                            (
+                                "invalid_request".to_string(),
+                                "terminal_id must be 32 lowercase hexadecimal characters"
+                                    .to_string(),
+                            )
+                        })?;
+                    Some((revision, terminal_id))
+                }
+                _ => {
+                    return Err((
+                        "invalid_request".to_string(),
+                        "if_content_revision and terminal_id must be supplied together".to_string(),
+                    ));
+                }
+            };
+            let pane = self.panes.get(&id).ok_or_else(not_found)?;
+            if let Some((expected_revision, expected_terminal)) = fence {
+                // The PTY reader advances content_revision under this same lock.
+                // Keep it through queue admission, but never through child I/O.
+                let engine = pane.engine.lock().map_err(|_| {
+                    (
+                        "content_revision_conflict".to_string(),
+                        format!(
+                            "expected terminal_id={expected_terminal} content_revision={expected_revision}; actual unavailable (terminal engine lock failed)"
+                        ),
+                    )
+                })?;
+                let actual_revision = pane.content_revision();
+                let actual_terminal = pane.terminal_runtime().map(|runtime| runtime.terminal_id);
+                if actual_revision != expected_revision
+                    || actual_terminal.as_deref() != Some(expected_terminal)
+                {
+                    return Err((
+                        "content_revision_conflict".to_string(),
+                        format!(
+                            "expected terminal_id={expected_terminal} content_revision={expected_revision}; actual terminal_id={} content_revision={actual_revision}",
+                            actual_terminal.as_deref().unwrap_or("null")
+                        ),
+                    ));
+                }
+                let sent = pane.try_send(&bytes);
+                drop(engine);
+                sent.map_err(|message| ("send_failed".to_string(), message))?;
+            } else {
+                pane.try_send(&bytes)
+                    .map_err(|message| ("send_failed".to_string(), message))?;
+            }
             Ok(json!({"type":"ok","pane": id.0.to_string()}))
         }
     }
@@ -241,20 +296,29 @@ impl App {
             // `visible` = the current screen; anything else = recent output
             // (soft wraps joined), the default and best for transcripts.
             let source = p.get("source").and_then(|v| v.as_str()).unwrap_or("recent");
-            let text = self
+            let (text, content_revision, terminal_id) = self
                 .panes
                 .get(&id)
                 .and_then(|pane| {
                     pane.engine.lock().ok().map(|e| {
-                        if source == "visible" {
+                        let text = if source == "visible" {
                             e.visible_rows().join("\n")
                         } else {
                             e.detection_text(lines)
-                        }
+                        };
+                        // Capture coordinates with the text, as terminal capture does.
+                        (
+                            text,
+                            Some(pane.content_revision()),
+                            pane.terminal_runtime().map(|runtime| runtime.terminal_id),
+                        )
                     })
                 })
                 .unwrap_or_default();
-            Ok(json!({"type":"agent_read","pane": id.0.to_string(), "text": text}))
+            Ok(
+                json!({"type":"agent_read","pane": id.0.to_string(), "text": text,
+                "content_revision": content_revision, "terminal_id": terminal_id}),
+            )
         }
     }
 

--- a/src/app/dispatch/tests/agents.rs
+++ b/src/app/dispatch/tests/agents.rs
@@ -1711,3 +1711,261 @@ fn closing_a_workspace_cancels_parked_waiters() {
     );
     assert!(app.output_waits.is_empty(), "no waiters leak");
 }
+
+// Keep the real terminal lifetime, but observe admission through a private queue.
+fn content_fence_app() -> (
+    App,
+    PaneId,
+    std::sync::mpsc::Receiver<crate::terminal::pty::InputAction>,
+) {
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let mut app = App::new(80, 24, tx).unwrap();
+    let pane = app.layout().focus;
+    app.status.get_mut(&pane).unwrap().agent = "claude".into();
+    let (input_tx, input_rx) = std::sync::mpsc::channel();
+    app.panes
+        .get_mut(&pane)
+        .unwrap()
+        .replace_input_sender_for_test(input_tx);
+    (app, pane, input_rx)
+}
+
+fn content_fence_pair(app: &App, pane_id: PaneId) -> Value {
+    let pane = &app.panes[&pane_id];
+    let _engine = pane.engine.lock().unwrap();
+    json!({
+        "target": pane_id.0.to_string(), "keys": ["enter"],
+        "if_content_revision": pane.content_revision(),
+        "terminal_id": pane.terminal_runtime().unwrap().terminal_id,
+    })
+}
+
+fn content_fence_advance(app: &App, pane: PaneId) {
+    let pane = &app.panes[&pane];
+    let mut engine = pane.engine.lock().unwrap();
+    engine.advance(b"\x1b[2J\x1b[HCHOOSER_B");
+    pane.content_revision_handle()
+        .fetch_add(1, Ordering::Release);
+}
+
+#[test]
+fn content_fence_legacy_keys_still_queue_after_output_changes() {
+    let _env = crate::persist::test_env("content-fence-legacy");
+    let (mut app, pane, input) = content_fence_app();
+    content_fence_advance(&app, pane);
+    app.dispatch(
+        "agent.keys",
+        &json!({"target":pane.0.to_string(),"keys":["enter"]}),
+    )
+    .unwrap();
+    let crate::terminal::pty::InputAction::Bytes(bytes) = input.try_recv().unwrap() else {
+        panic!("expected bytes")
+    };
+    assert_eq!(bytes, b"\r");
+    assert!(input.try_recv().is_err());
+}
+
+#[test]
+fn content_fence_matching_pair_queues_one_ordered_batch() {
+    let _env = crate::persist::test_env("content-fence-match");
+    let (mut app, pane, input) = content_fence_app();
+    let mut params = content_fence_pair(&app, pane);
+    params["keys"] = json!(["up", "enter", "CTRL+C", "é"]);
+    app.dispatch("agent.keys", &params).unwrap();
+    let crate::terminal::pty::InputAction::Bytes(bytes) = input.try_recv().unwrap() else {
+        panic!("expected bytes")
+    };
+    assert_eq!(bytes, "\x1b[A\r\x03é".as_bytes());
+    assert!(input.try_recv().is_err());
+}
+
+#[test]
+fn content_fence_stale_revision_queues_nothing() {
+    let _env = crate::persist::test_env("content-fence-stale");
+    let (mut app, pane, input) = content_fence_app();
+    let params = content_fence_pair(&app, pane);
+    content_fence_advance(&app, pane);
+    let error = app.dispatch("agent.keys", &params).unwrap_err();
+    assert_eq!(error.0, "content_revision_conflict");
+    assert!(error.1.contains("expected"));
+    assert!(error.1.contains("actual"));
+    assert!(error.1.contains(&params["if_content_revision"].to_string()));
+    assert!(input.try_recv().is_err());
+}
+
+#[test]
+fn content_fence_wrong_terminal_identity_queues_nothing() {
+    let _env = crate::persist::test_env("content-fence-identity");
+    let (mut app, pane, input) = content_fence_app();
+    let mut params = content_fence_pair(&app, pane);
+    let actual = params["terminal_id"].as_str().unwrap().to_owned();
+    let first = if actual.starts_with('0') { "1" } else { "0" };
+    params["terminal_id"] = json!(format!("{first}{}", &actual[1..]));
+    let error = app.dispatch("agent.keys", &params).unwrap_err();
+    assert_eq!(error.0, "content_revision_conflict");
+    assert!(error.1.contains(params["terminal_id"].as_str().unwrap()));
+    assert!(error.1.contains(&actual));
+    assert!(input.try_recv().is_err());
+}
+
+#[test]
+fn content_fence_requires_both_fields() {
+    let _env = crate::persist::test_env("content-fence-pair");
+    let (mut app, pane, input) = content_fence_app();
+    for missing in ["if_content_revision", "terminal_id"] {
+        let mut params = content_fence_pair(&app, pane);
+        params.as_object_mut().unwrap().remove(missing);
+        assert_eq!(
+            app.dispatch("agent.keys", &params).unwrap_err().0,
+            "invalid_request"
+        );
+        assert!(input.try_recv().is_err());
+    }
+}
+
+#[test]
+fn content_fence_read_returns_text_and_runtime_coordinates() {
+    let _env = crate::persist::test_env("content-fence-read");
+    let (mut app, pane, _input) = content_fence_app();
+    content_fence_advance(&app, pane);
+    for source in ["visible", "recent"] {
+        let result = app
+            .dispatch(
+                "agent.read",
+                &json!({"target":pane.0.to_string(), "source":source}),
+            )
+            .unwrap();
+        assert_eq!(
+            result["content_revision"],
+            app.panes[&pane].content_revision()
+        );
+        assert_eq!(
+            result["terminal_id"],
+            app.panes[&pane].terminal_runtime().unwrap().terminal_id
+        );
+        assert!(result["text"].as_str().unwrap().contains("CHOOSER_B"));
+    }
+}
+
+#[test]
+fn content_fence_invalid_keys_validate_before_comparison() {
+    let _env = crate::persist::test_env("content-fence-invalid-keys");
+    let (mut app, pane, input) = content_fence_app();
+    for stale in [false, true] {
+        let mut params = content_fence_pair(&app, pane);
+        if stale {
+            content_fence_advance(&app, pane);
+        }
+        for keys in [
+            json!([]),
+            Value::Null,
+            json!("enter"),
+            json!(["enter", 7]),
+            json!(["enter", "not-a-key"]),
+        ] {
+            params["keys"] = keys;
+            assert_eq!(
+                app.dispatch("agent.keys", &params).unwrap_err().0,
+                "invalid_request"
+            );
+            assert!(input.try_recv().is_err());
+        }
+    }
+}
+
+#[test]
+fn content_fence_rejects_malformed_coordinates() {
+    let _env = crate::persist::test_env("content-fence-malformed");
+    let (mut app, pane, input) = content_fence_app();
+    for (field, values) in [
+        (
+            "if_content_revision",
+            vec![Value::Null, json!(-1), json!(1.5), json!(true), json!("1")],
+        ),
+        (
+            "terminal_id",
+            vec![
+                Value::Null,
+                json!(7),
+                json!(""),
+                json!("0123456789ABCDEF0123456789ABCDEF"),
+                json!("0123456789abcdef0123456789abcdeg"),
+                json!("0123456789abcdef0123456789abcdef\n"),
+            ],
+        ),
+    ] {
+        for value in values {
+            let mut params = content_fence_pair(&app, pane);
+            params[field] = value;
+            assert_eq!(
+                app.dispatch("agent.keys", &params).unwrap_err().0,
+                "invalid_request"
+            );
+            assert!(input.try_recv().is_err());
+        }
+    }
+}
+
+#[test]
+fn content_fence_closed_writer_is_send_failed() {
+    let _env = crate::persist::test_env("content-fence-closed");
+    let (mut app, pane, input) = content_fence_app();
+    drop(input);
+    let params = content_fence_pair(&app, pane);
+    assert_eq!(
+        app.dispatch("agent.keys", &params).unwrap_err().0,
+        "send_failed"
+    );
+}
+
+#[test]
+fn content_fence_missing_runtime_is_conflict_and_read_identity_is_null() {
+    let _env = crate::persist::test_env("content-fence-no-runtime");
+    let (mut app, _, _) = content_fence_app();
+    app.config.shell = "luvus-content-fence-nonexistent-shell".into();
+    let pane = app.spawn_into_deferred(app.ws().cwd.clone(), &[]).unwrap();
+    assert!(app.panes[&pane].terminal_runtime().is_none());
+    app.status.get_mut(&pane).unwrap().agent = "claude".into();
+    let (sender, input) = std::sync::mpsc::channel();
+    app.panes
+        .get_mut(&pane)
+        .unwrap()
+        .replace_input_sender_for_test(sender);
+    let params = json!({"target":pane.0.to_string(),"keys":["enter"],"if_content_revision":0,"terminal_id":"0123456789abcdef0123456789abcdef"});
+    let error = app.dispatch("agent.keys", &params).unwrap_err();
+    assert_eq!(error.0, "content_revision_conflict");
+    assert!(error.1.contains("expected"));
+    assert!(error.1.contains("actual"));
+    assert!(input.try_recv().is_err());
+    let result = app
+        .dispatch("agent.read", &json!({"target":pane.0.to_string()}))
+        .unwrap();
+    assert!(result.as_object().unwrap().contains_key("terminal_id"));
+    assert!(result["terminal_id"].is_null());
+    assert_eq!(
+        result["content_revision"],
+        app.panes[&pane].content_revision()
+    );
+}
+
+#[test]
+fn content_fence_unavailable_engine_queues_nothing() {
+    let _env = crate::persist::test_env("content-fence-poison");
+    let (mut app, pane, input) = content_fence_app();
+    let params = content_fence_pair(&app, pane);
+    let engine = app.panes[&pane].engine.clone();
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _guard = engine.lock().unwrap();
+        panic!("fixture poisons the engine lock");
+    }));
+    let error = app.dispatch("agent.keys", &params).unwrap_err();
+    assert_eq!(error.0, "content_revision_conflict");
+    assert!(input.try_recv().is_err());
+    let result = app
+        .dispatch("agent.read", &json!({"target":pane.0.to_string()}))
+        .unwrap();
+    assert_eq!(result["text"], "");
+    assert!(result["content_revision"].is_null());
+    // Clear poison so unrelated teardown does not inherit the fixture failure.
+    engine.clear_poison();
+}

--- a/src/app/dispatch/tests/agents.rs
+++ b/src/app/dispatch/tests/agents.rs
@@ -1712,7 +1712,7 @@ fn closing_a_workspace_cancels_parked_waiters() {
     assert!(app.output_waits.is_empty(), "no waiters leak");
 }
 
-// Launched only by the fixture below: after READY there is no unsolicited output.
+/// Launched only by the fixture below: after READY there is no unsolicited output.
 #[test]
 #[ignore = "PTY child for content fence tests"]
 fn content_fence_quiet_child() {
@@ -1726,8 +1726,8 @@ fn content_fence_quiet_child() {
     while std::io::stdin().read(&mut byte).unwrap_or(0) != 0 {}
 }
 
-// Keep a real terminal lifetime with controlled output, and observe admission
-// through a private queue. A normal interactive shell can redraw after a read.
+/// Keep a real terminal lifetime with controlled output and a private input queue.
+/// A normal interactive shell can redraw after a read and invalidate test pairs.
 fn content_fence_app() -> (
     App,
     PaneId,
@@ -1786,6 +1786,7 @@ fn content_fence_app() -> (
     (app, pane, input_rx)
 }
 
+/// Capture valid fence parameters from the fixture terminal under its engine lock.
 fn content_fence_pair(app: &App, pane_id: PaneId) -> Value {
     let pane = &app.panes[&pane_id];
     let _engine = pane.engine.lock().unwrap();
@@ -1796,6 +1797,7 @@ fn content_fence_pair(app: &App, pane_id: PaneId) -> Value {
     })
 }
 
+/// Replace fixture output and increment its revision while holding the reader lock.
 fn content_fence_advance(app: &App, pane: PaneId) {
     let pane = &app.panes[&pane];
     let mut engine = pane.engine.lock().unwrap();
@@ -1804,6 +1806,7 @@ fn content_fence_advance(app: &App, pane: PaneId) {
         .fetch_add(1, Ordering::Release);
 }
 
+/// Unfenced callers retain their existing admission behavior after output changes.
 #[test]
 fn content_fence_legacy_keys_still_queue_after_output_changes() {
     let _env = crate::persist::test_env("content-fence-legacy");
@@ -1821,6 +1824,7 @@ fn content_fence_legacy_keys_still_queue_after_output_changes() {
     assert!(input.try_recv().is_err());
 }
 
+/// Matching coordinates admit exactly one ordered batch, including aliases and Unicode.
 #[test]
 fn content_fence_matching_pair_queues_one_ordered_batch() {
     let _env = crate::persist::test_env("content-fence-match");
@@ -1835,6 +1839,7 @@ fn content_fence_matching_pair_queues_one_ordered_batch() {
     assert!(input.try_recv().is_err());
 }
 
+/// A changed output revision rejects the complete batch without admitting a prefix.
 #[test]
 fn content_fence_stale_revision_queues_nothing() {
     let _env = crate::persist::test_env("content-fence-stale");
@@ -1849,6 +1854,7 @@ fn content_fence_stale_revision_queues_nothing() {
     assert!(input.try_recv().is_err());
 }
 
+/// A different terminal lifetime rejects keys even when the revision matches.
 #[test]
 fn content_fence_wrong_terminal_identity_queues_nothing() {
     let _env = crate::persist::test_env("content-fence-identity");
@@ -1864,6 +1870,7 @@ fn content_fence_wrong_terminal_identity_queues_nothing() {
     assert!(input.try_recv().is_err());
 }
 
+/// Either one-sided fence is a validation error and leaves the queue empty.
 #[test]
 fn content_fence_requires_both_fields() {
     let _env = crate::persist::test_env("content-fence-pair");
@@ -1879,6 +1886,7 @@ fn content_fence_requires_both_fields() {
     }
 }
 
+/// Visible and recent reads report the coordinates belonging to their captured text.
 #[test]
 fn content_fence_read_returns_text_and_runtime_coordinates() {
     let _env = crate::persist::test_env("content-fence-read");
@@ -1903,6 +1911,7 @@ fn content_fence_read_returns_text_and_runtime_coordinates() {
     }
 }
 
+/// Invalid key arrays fail before both matching and stale fence comparisons.
 #[test]
 fn content_fence_invalid_keys_validate_before_comparison() {
     let _env = crate::persist::test_env("content-fence-invalid-keys");
@@ -1929,6 +1938,7 @@ fn content_fence_invalid_keys_validate_before_comparison() {
     }
 }
 
+/// Malformed revision and identity values cannot admit keys.
 #[test]
 fn content_fence_rejects_malformed_coordinates() {
     let _env = crate::persist::test_env("content-fence-malformed");
@@ -1962,6 +1972,7 @@ fn content_fence_rejects_malformed_coordinates() {
     }
 }
 
+/// A matching fence preserves the existing closed-writer delivery error.
 #[test]
 fn content_fence_closed_writer_is_send_failed() {
     let _env = crate::persist::test_env("content-fence-closed");
@@ -1974,6 +1985,7 @@ fn content_fence_closed_writer_is_send_failed() {
     );
 }
 
+/// Deferred panes expose no terminal identity and cannot accept a fenced batch.
 #[test]
 fn content_fence_missing_runtime_is_conflict_and_read_identity_is_null() {
     let _env = crate::persist::test_env("content-fence-no-runtime");
@@ -2004,6 +2016,7 @@ fn content_fence_missing_runtime_is_conflict_and_read_identity_is_null() {
     );
 }
 
+/// An unavailable engine cannot admit fenced input or fabricate a read revision.
 #[test]
 fn content_fence_unavailable_engine_queues_nothing() {
     let _env = crate::persist::test_env("content-fence-poison");

--- a/src/app/dispatch/tests/agents.rs
+++ b/src/app/dispatch/tests/agents.rs
@@ -1712,7 +1712,22 @@ fn closing_a_workspace_cancels_parked_waiters() {
     assert!(app.output_waits.is_empty(), "no waiters leak");
 }
 
-// Keep the real terminal lifetime, but observe admission through a private queue.
+// Launched only by the fixture below: after READY there is no unsolicited output.
+#[test]
+#[ignore = "PTY child for content fence tests"]
+fn content_fence_quiet_child() {
+    if std::env::var("LUVUS_CONTENT_FENCE_CHILD").as_deref() != Ok("1") {
+        return;
+    }
+    use std::io::{Read, Write};
+    println!("\nU02_QUIET_CHILD_READY");
+    std::io::stdout().flush().unwrap();
+    let mut byte = [0];
+    while std::io::stdin().read(&mut byte).unwrap_or(0) != 0 {}
+}
+
+// Keep a real terminal lifetime with controlled output, and observe admission
+// through a private queue. A normal interactive shell can redraw after a read.
 fn content_fence_app() -> (
     App,
     PaneId,
@@ -1721,6 +1736,47 @@ fn content_fence_app() -> (
     let (tx, _rx) = std::sync::mpsc::channel();
     let mut app = App::new(80, 24, tx).unwrap();
     let pane = app.layout().focus;
+    let child = Pane::spawn_command(
+        pane,
+        80,
+        24,
+        app.ws().cwd.clone(),
+        app.app_tx.clone(),
+        &[
+            std::env::current_exe()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned(),
+            "--exact".into(),
+            "app::dispatch::tests::agents::content_fence_quiet_child".into(),
+            "--ignored".into(),
+            "--nocapture".into(),
+            "--quiet".into(),
+        ],
+        &[("LUVUS_CONTENT_FENCE_CHILD".into(), "1".into())],
+        app.config.scrollback_bytes(),
+        app.pane_appearance,
+    )
+    .unwrap();
+    app.panes.insert(pane, child);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let ready = app.panes[&pane]
+            .engine
+            .lock()
+            .unwrap()
+            .visible_rows()
+            .iter()
+            .any(|line| line.trim() == "U02_QUIET_CHILD_READY");
+        if ready {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "quiet child did not become ready"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
     app.status.get_mut(&pane).unwrap().agent = "claude".into();
     let (input_tx, input_rx) = std::sync::mpsc::channel();
     app.panes

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -293,6 +293,26 @@ without that requirement retain the permissive Unknown-evidence fallback.
 bytes, and queues a valid list as one ordered action. A closed target returns a
 structured `send_failed` error.
 
+For UHP interactions that must match the inspected screen, use `agent.read`
+with `source:"visible"` and pass its `content_revision` as `if_content_revision`
+together with its `terminal_id` in `agent.keys` params. The revision is a
+non-negative integer; the terminal ID is exactly 32 lowercase hex characters.
+Both fields are optional as a pair; a one-sided or malformed pair is
+`invalid_request`. A deferred pane has `terminal_id:null` and cannot be fenced.
+An unavailable read snapshot has empty text and null coordinates.
+
+The server checks the pair and queues keys under the same engine lock used to
+capture the text. `content_revision_conflict` means no keys were queued: re-read
+and reassess the authorized action, never retry the same pair. Generic response
+`revision` / request `if_revision` are global event coordinates, not the pane's
+content counter. Without the pair, behavior is unchanged. Older servers omit the
+coordinates or reject the new fields; omit the pair only when legacy unfenced
+admission is acceptable. These are UHP params, not CLI flags.
+
+The fence covers queue admission only. Already queued input and child-side
+changes not yet observed remain outside it. Cursor/SGR output can make a pair
+stale even if the dialog text looks unchanged.
+
 Identity, live state, lifecycle hooks, usage, native resume, and fork support
 are separate capabilities. An agent can be detected without supporting every
 other capability. Use `agent explain`, the supported-agent reference, and UHP

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -444,6 +444,51 @@ startup, sign-in, selection, or approval screen with `agent_not_ready`. The
 rejection queues neither text nor Enter. Read the visible agent output and use
 `agent.keys` only when an explicit interaction is intended.
 
+For explicit key interactions, `agent.read` adds `content_revision` (the pane's
+PTY output counter) and `terminal_id` (32 lowercase hexadecimal characters for
+that PTY lifetime) alongside `text`. Text and coordinates are captured under the
+same engine lock for both `source:"visible"` and recent output. A deferred pane
+without a runtime has `terminal_id:null`; an unavailable engine snapshot returns
+empty text and null coordinates. These fields are additive: legacy results stay
+valid. The response's generic `revision` is a global event sequence and is not
+this pane counter.
+
+`agent.keys` still requires only `target` and a non-empty `keys` array. UHP callers
+may optionally supply **both** `if_content_revision` (a non-negative integer)
+and `terminal_id` from the read they inspected:
+
+```json
+{"id":"inspect","method":"agent.read","params":{"target":"reviewer","source":"visible"}}
+{"id":"answer","method":"agent.keys","params":{"target":"reviewer","keys":["enter"],"if_content_revision":12,"terminal_id":"0123456789abcdef0123456789abcdef"}}
+```
+
+The example coordinates must be replaced with the actual read result. Supplying
+only one field, malformed coordinates, an unknown parameter, or any invalid key
+returns `invalid_request` without queuing input. The complete key list validates
+before the fence comparison. Plain shells still return `agent_not_ready`.
+
+For a fenced request, the server holds the existing engine lock while comparing
+identity and content revision and admitting the entire key batch. A stale
+revision, different terminal lifetime, missing runtime, or unavailable engine
+returns `content_revision_conflict` with expected/actual values (or an explicit
+unavailable actual value), and queues no bytes. A matching fence still reports
+`send_failed` if the writer rejects admission.
+
+On conflict, re-read the visible screen and reassess the intended action; never
+retry the same pair. Without the pair, admission is unchanged. Older servers omit
+the read coordinates or reject the unknown parameters; use the legacy unfenced
+request only when that compatibility behavior is acceptable for the authorized
+action. The pair is a UHP parameter option, not a new CLI flag.
+
+This is an **admission-only** fence: it does not cancel already queued input or
+cover child-side changes the server has not observed. Cursor, SGR, and other PTY
+output can increment the counter without changing visible dialog text; a conflict
+still requires a fresh read. Generic `if_revision` cannot replace this fence:
+it tracks unrelated global events and is checked before dispatch without the
+engine lock. The prompt guard introduced in #320 routes explicit interactions
+to `agent.keys`; this opt-in fence binds those interactions to the inspected
+terminal snapshot.
+
 With `wait:true`, a **new** `working` or `blocked` transition must be observed
 before a requested `until` state can complete the wait. An already active state,
 unchanged metadata, title flicker, and output settling alone do not qualify.


### PR DESCRIPTION
Fence an explicitly authorized `agent.keys` interaction to the terminal snapshot returned by `agent.read`, without changing unfenced admission.

## Why

1. At the base, `agent.read` copies visible text under the engine lock but returns no pane revision ([agents.rs:235–258](https://github.com/RizRiyz/luvus/blob/ee169dadeefe8048a3e90482c66f0f0aa49a54a6/src/app/dispatch/agents.rs#L235)).
2. The client inspects that text before its next request; the child can replace the dialog during this interval.
3. `agent.keys` then queues the validated key batch without locking the engine or comparing content ([agents.rs:191–231](https://github.com/RizRiyz/luvus/blob/ee169dadeefe8048a3e90482c66f0f0aa49a54a6/src/app/dispatch/agents.rs#L191), [try_send:787–791](https://github.com/RizRiyz/luvus/blob/ee169dadeefe8048a3e90482c66f0f0aa49a54a6/src/terminal/pty.rs#L787)).
4. Meanwhile the Unix actor advances the engine and bumps `content_revision` under that engine lock ([unix_actor.rs:417–458](https://github.com/RizRiyz/luvus/blob/ee169dadeefe8048a3e90482c66f0f0aa49a54a6/src/terminal/pty/io/unix_actor.rs#L417)); the old decision can therefore reach the replacement dialog.

Generic `if_revision` compares the global event sequence before dispatch, outside the engine lock ([dispatch.rs:103–125](https://github.com/RizRiyz/luvus/blob/ee169dadeefe8048a3e90482c66f0f0aa49a54a6/src/app/dispatch.rs#L103)). It includes unrelated events and cannot fence this admission window. #320 routes explicit blocked-screen interactions to `agent.keys`; this optional fence binds those callers to the content they actually inspected.

## What

- Add `content_revision` and `terminal_id` to `agent.read`, captured with text under the same engine lock. The terminal ID is null before a deferred runtime exists. An unavailable engine snapshot retains the empty-text fallback and supplies null coordinates. Legacy result schemas remain valid.
- Add optional paired `if_content_revision` (non-negative integer) and `terminal_id` (32 lowercase hex characters) to UHP `agent.keys`. `required` stays `[target, keys]`, `additionalProperties:false` stays, and `dependentRequired` runs both ways.
- Validate the whole key array before the fence. Under the existing engine lock, Acquire-load the pane revision, compare terminal identity and revision, call existing `try_send`, then unlock. A mismatch, missing runtime, or unavailable lock returns `content_revision_conflict` with expected/actual context and sends nothing. Matching requests preserve `send_failed` when admission fails.
- **Default behavior is unchanged and the fields are opt-in.** No CLI flags, global revision changes, gateway changes, PTY/VT changes, dependencies, threads, or timers were added. This only fences admission: previously queued keys and child-side changes not yet observed remain outside the guarantee. Cursor/SGR output may cause conservative conflicts. Re-read and reassess on conflict; never retry the same pair.
- Update the schema, append fixtures, adjust only request fixture counts in the manifest (49 valid / 36 invalid), update the Python validator, public methods reference, both bundled skill trees, and public agent readme. The manifest count update was explicitly authorized as part of layer 2. All previous fixture bytes are preserved.

## Tests: test-first RED → GREEN

RED commit: `6551c37` (before implementation).

```text
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID LUVUS_HOME="$(mktemp -d)" cargo test content_fence -- --nocapture
test result: FAILED. 4 passed; 7 failed; 0 ignored; 0 measured; 1669 filtered out; finished in 0.24s
$ python3 examples/uhp/consumer.py
AssertionError: {"id":"keys-content-fence","method":"agent.keys","params":{"target":"7","keys":["enter"],"if_content_revision":12,"terminal_id":"0123456789abcdef0123456789abcdef"}}
```

GREEN implementation: `f8ff8cb`. Follow-up `f5cd930` documents the touched handlers/test helpers and Python validator to address CodeRabbit docstring coverage; it changes no executable behavior. Formatting and all 145 fixtures also pass after that follow-up.

```text
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID LUVUS_HOME="$(mktemp -d)" cargo test content_fence -- --nocapture
test result: ok. 11 passed; 0 failed; 1 ignored; 0 measured; 1669 filtered out; finished in 0.21s
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID LUVUS_HOME="$(mktemp -d)" cargo test --locked
test result: ok. 1677 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 25.49s
$ python3 examples/uhp/consumer.py
validated 145 UHP fixtures and all JSON schema documents
```

The one new ignored test is a subprocess-only quiet PTY child, explicitly invoked by the 11 focused tests. Its ready marker prevents asynchronous shell output from making revision assertions flaky. A separate Draft 2020-12 JSON Schema validator accepted/rejected all 10 `agent.keys` request fixtures as intended (3 valid, 7 invalid).

Regression list / required eight cases:

1. Unfenced keys still queue after engine output advances.
2. A matching pair queues one ordered batch (navigation, Enter, uppercase Ctrl alias, Unicode).
3. A stale revision after locked advance conflicts and leaves the receiver empty.
4. A different terminal identity with a matching revision conflicts and leaves the receiver empty.
5. Either one-sided pair is `invalid_request`, with no queued bytes.
6. Visible and recent reads return text plus the matching runtime identity and pane counter.
7. Invalid arrays with matching **or stale** coordinates validate first and queue no prefix.
8. Existing unfenced/extra-property fixtures stay; a paired valid fixture and both one-sided invalid fixtures are appended and checked by consumer and schema validation.

Additional failure regressions cover malformed/null/negative/fractional/bool revision values, malformed terminal IDs, closed writer (`send_failed`), absent runtime (`content_revision_conflict`, null read identity), and poisoned engine lock (conflict, no bytes, no fabricated read revision). Existing tests retain recognized-agent checks, all key aliases and printable Unicode, empty/wrong-type/mixed/unknown key arrays, unknown params, one-batch ordering, closed writer, and read-text behavior. Target resolution and non-agent failures use unchanged existing paths.

Verification: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, locked full tests, fixture validation, and locked debug build passed. `cargo build --release --locked` also passed. Local platform: Linux; macOS/Windows runtime behavior was not exercised locally.

## Tests: before (base) vs after (branch)

Both exact debug binaries were built in the primary checkout. Base SHA: `ee169dadeefe8048a3e90482c66f0f0aa49a54a6`; branch SHA: `f8ff8cbd3ebf9749fad6953dff54ed3f293a54f0`. Each run used a fresh `LUVUS_HOME`, fresh `CODEX_HOME`, cleared inherited selectors, and session `luvus-pr-test`. Only fixture-owned server processes were terminated; both exited 0. No production session/socket was used.

The deterministic raw child runs behind a fixture-only reported agent pane, following the existing Access conformance harness pattern. It starts with chooser A, switches to chooser B on a filesystem trigger, logs every stdin byte, and prints `ACCEPTED_B` on input. A separate plain bash pane verifies `agent_not_ready`. A separate real installed Codex pane verifies sign-in chooser navigation using native process detection; no authentication was submitted.

- **Before:** read chooser A; output B; unfenced Enter succeeds, input log is `0d`, and B accepts it.
- **After:** read revision 4; output B at revision 5; stale pair returns `content_revision_conflict`, the input log remains empty after 300 ms, and B is unchanged; a fresh pair queues `0d` and B accepts it.
- **Real Codex:** after changing the highlighted sign-in option, the branch rejects stale navigation and accepts a fresh pair. The raw-child byte log supplies the stronger no-input evidence; screen stability alone is not treated as queue proof. Unit receiver assertions directly prove no queue item for each rejection path.

<details>
<summary>Literal base commands and JSON responses</summary>

```text
{"phase": "before", "binary": "/home/ubuntu/projects/Rust/luvus/target/u02-base/luvus", "sha256": "23b9db341097a8825194e9c120237a08df7c387244a508461829702a9065fa5c", "home": "/tmp/tmp.rF3Ajo2Tn3", "session": "luvus-pr-test"}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test server
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.split","params":{}}
JSON
{"id": "u02", "result": {"pane": "2", "revision": 2, "tab": "1", "type": "pane", "workspace": "0"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"2","keys":["enter"]}}
JSON
{"error": {"code": "agent_not_ready", "message": "target pane is not a running agent"}, "id": "u02"}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.split","params":{}}
JSON
{"id": "u02", "result": {"pane": "3", "revision": 4, "tab": "1", "type": "pane", "workspace": "0"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.run","params":{"pane":"3","command":"exec /usr/bin/python3 /home/ubuntu/projects/zengbo-agent/.agents/state/reviews/luvus-u02-live.py --child /tmp/tmp.rF3Ajo2Tn3"}}
JSON
{"id": "u02", "result": {"revision": 5, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.report_session","params":{"pane":"3","agent":"codex","session_id":"u02-raw-byte-fixture"}}
JSON
{"id": "u02", "result": {"revision": 12, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"3","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"pane": "3", "revision": 12, "text": "CHOOSER_A: Enter accepts A                                                      \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ touch /tmp/tmp.rF3Ajo2Tn3/change
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"3","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"pane": "3", "revision": 13, "text": "CHOOSER_B: Enter accepts B                                                      \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"3","keys":["enter"]}}
JSON
{"id": "u02", "result": {"pane": "3", "revision": 13, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"3","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"pane": "3", "revision": 14, "text": "CHOOSER_B: Enter accepts B                                                      \nACCEPTED_B                                                                      \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
{"accepted_input_hex": "0d", "new_dialog_accepted": true}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.start","params":{"name":"real-codex","kind":"codex","timeout_s":30}}
JSON
{"id": "u02", "result": {"kind": "codex", "name": "real-codex", "pane": "4", "ready": true, "status": "blocked", "type": "agent_start"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"real-codex","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"pane": "4", "revision": 31, "text": "  Welcome to Codex, OpenAI's command-line coding agent                          \n                                                                                \n  Sign in with ChatGPT to use Codex as part of your paid plan                   \n  or connect an API key for usage-based billing                                 \n                                                                                \n> 1. Sign in with ChatGPT                                                       \n     Usage included with Plus, Pro, Business, and Enterprise plans              \n                                                                                \n  2. Sign in with Device Code                                                   \n     Sign in from another device with a one-time code                           \n                                                                                \n  3. Provide your own API key                                                   \n     Pay for what you use                                                       \n                                                                                \n  Press enter to continue                                                       \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"real-codex","keys":["down"]}}
JSON
{"id": "u02", "result": {"pane": "4", "revision": 31, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"real-codex","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"pane": "4", "revision": 32, "text": "  Welcome to Codex, OpenAI's command-line coding agent                          \n                                                                                \n  Sign in with ChatGPT to use Codex as part of your paid plan                   \n  or connect an API key for usage-based billing                                 \n                                                                                \n  1. Sign in with ChatGPT                                                       \n     Usage included with Plus, Pro, Business, and Enterprise plans              \n                                                                                \n> 2. Sign in with Device Code                                                   \n     Sign in from another device with a one-time code                           \n                                                                                \n  3. Provide your own API key                                                   \n     Pay for what you use                                                       \n                                                                                \n  Press enter to continue                                                       \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"real-codex","keys":["up"]}}
JSON
{"id": "u02", "result": {"pane": "4", "revision": 32, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.rF3Ajo2Tn3 CODEX_HOME=/tmp/tmp.rF3Ajo2Tn3/codex-home /home/ubuntu/projects/Rust/luvus/target/u02-base/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"real-codex","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"pane": "4", "revision": 33, "text": "  Welcome to Codex, OpenAI's command-line coding agent                          \n                                                                                \n  Sign in with ChatGPT to use Codex as part of your paid plan                   \n  or connect an API key for usage-based billing                                 \n                                                                                \n> 1. Sign in with ChatGPT                                                       \n     Usage included with Plus, Pro, Business, and Enterprise plans              \n                                                                                \n  2. Sign in with Device Code                                                   \n     Sign in from another device with a one-time code                           \n                                                                                \n  3. Provide your own API key                                                   \n     Pay for what you use                                                       \n                                                                                \n  Press enter to continue                                                       \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
{"real_agent": "codex", "selection_restored": true, "auth_submitted": false}
{"isolated_server_exit": 0}
```
</details>

<details>
<summary>Literal branch commands and JSON responses</summary>

```text
{"phase": "after", "binary": "/home/ubuntu/projects/Rust/luvus/target/debug/luvus", "sha256": "f984f9c389ea7a688bffae0ecb1c485240147ab3f8703a491df9f261421f8629", "home": "/tmp/tmp.2PUXKFJyNF", "session": "luvus-pr-test"}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test server
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.split","params":{}}
JSON
{"id": "u02", "result": {"pane": "2", "revision": 2, "tab": "1", "type": "pane", "workspace": "0"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"2","keys":["enter"]}}
JSON
{"error": {"code": "agent_not_ready", "message": "target pane is not a running agent"}, "id": "u02"}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.split","params":{}}
JSON
{"id": "u02", "result": {"pane": "3", "revision": 4, "tab": "1", "type": "pane", "workspace": "0"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.run","params":{"pane":"3","command":"exec /usr/bin/python3 /home/ubuntu/projects/zengbo-agent/.agents/state/reviews/luvus-u02-live.py --child /tmp/tmp.2PUXKFJyNF"}}
JSON
{"id": "u02", "result": {"revision": 6, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"pane.report_session","params":{"pane":"3","agent":"codex","session_id":"u02-raw-byte-fixture"}}
JSON
{"id": "u02", "result": {"revision": 11, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"3","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 4, "pane": "3", "revision": 11, "terminal_id": "93ae1cbf9e760c1f12a867e8b1468007", "text": "CHOOSER_A: Enter accepts A                                                      \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ touch /tmp/tmp.2PUXKFJyNF/change
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"3","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 5, "pane": "3", "revision": 11, "terminal_id": "93ae1cbf9e760c1f12a867e8b1468007", "text": "CHOOSER_B: Enter accepts B                                                      \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"3","keys":["enter"],"if_content_revision":4,"terminal_id":"93ae1cbf9e760c1f12a867e8b1468007"}}
JSON
{"error": {"code": "content_revision_conflict", "message": "expected terminal_id=93ae1cbf9e760c1f12a867e8b1468007 content_revision=4; actual terminal_id=93ae1cbf9e760c1f12a867e8b1468007 content_revision=5"}, "id": "u02"}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"3","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 5, "pane": "3", "revision": 11, "terminal_id": "93ae1cbf9e760c1f12a867e8b1468007", "text": "CHOOSER_B: Enter accepts B                                                      \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
{"stale_input_hex": "", "stale_admitted_bytes": 0, "new_dialog_unchanged": true}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"3","keys":["enter"],"if_content_revision":5,"terminal_id":"93ae1cbf9e760c1f12a867e8b1468007"}}
JSON
{"id": "u02", "result": {"pane": "3", "revision": 11, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"3","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 6, "pane": "3", "revision": 12, "terminal_id": "93ae1cbf9e760c1f12a867e8b1468007", "text": "CHOOSER_B: Enter accepts B                                                      \nACCEPTED_B                                                                      \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
{"accepted_input_hex": "0d", "new_dialog_accepted": true}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.start","params":{"name":"real-codex","kind":"codex","timeout_s":30}}
JSON
{"id": "u02", "result": {"kind": "codex", "name": "real-codex", "pane": "4", "ready": true, "status": "blocked", "type": "agent_start"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"real-codex","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 23, "pane": "4", "revision": 31, "terminal_id": "33a2f4dd6839cebebee01569e50ab79b", "text": "  Welcome to Codex, OpenAI's command-line coding agent                          \n                                                                                \n  Sign in with ChatGPT to use Codex as part of your paid plan                   \n  or connect an API key for usage-based billing                                 \n                                                                                \n> 1. Sign in with ChatGPT                                                       \n     Usage included with Plus, Pro, Business, and Enterprise plans              \n                                                                                \n  2. Sign in with Device Code                                                   \n     Sign in from another device with a one-time code                           \n                                                                                \n  3. Provide your own API key                                                   \n     Pay for what you use                                                       \n                                                                                \n  Press enter to continue                                                       \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"real-codex","keys":["down"]}}
JSON
{"id": "u02", "result": {"pane": "4", "revision": 31, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"real-codex","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 24, "pane": "4", "revision": 32, "terminal_id": "33a2f4dd6839cebebee01569e50ab79b", "text": "  Welcome to Codex, OpenAI's command-line coding agent                          \n                                                                                \n  Sign in with ChatGPT to use Codex as part of your paid plan                   \n  or connect an API key for usage-based billing                                 \n                                                                                \n  1. Sign in with ChatGPT                                                       \n     Usage included with Plus, Pro, Business, and Enterprise plans              \n                                                                                \n> 2. Sign in with Device Code                                                   \n     Sign in from another device with a one-time code                           \n                                                                                \n  3. Provide your own API key                                                   \n     Pay for what you use                                                       \n                                                                                \n  Press enter to continue                                                       \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"real-codex","keys":["up"],"if_content_revision":23,"terminal_id":"33a2f4dd6839cebebee01569e50ab79b"}}
JSON
{"error": {"code": "content_revision_conflict", "message": "expected terminal_id=33a2f4dd6839cebebee01569e50ab79b content_revision=23; actual terminal_id=33a2f4dd6839cebebee01569e50ab79b content_revision=24"}, "id": "u02"}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"real-codex","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 27, "pane": "4", "revision": 33, "terminal_id": "33a2f4dd6839cebebee01569e50ab79b", "text": "  Welcome to Codex, OpenAI's command-line coding agent                          \n                                                                                \n  Sign in with ChatGPT to use Codex as part of your paid plan                   \n  or connect an API key for usage-based billing                                 \n                                                                                \n  1. Sign in with ChatGPT                                                       \n     Usage included with Plus, Pro, Business, and Enterprise plans              \n                                                                                \n> 2. Sign in with Device Code                                                   \n     Sign in from another device with a one-time code                           \n                                                                                \n  3. Provide your own API key                                                   \n     Pay for what you use                                                       \n                                                                                \n  Press enter to continue                                                       \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.keys","params":{"target":"real-codex","keys":["up"],"if_content_revision":27,"terminal_id":"33a2f4dd6839cebebee01569e50ab79b"}}
JSON
{"id": "u02", "result": {"pane": "4", "revision": 33, "type": "ok"}}
$ env -u LUVUS_SOCKET_PATH -u LUVUS_SESSION -u LUVUS_ENV -u LUVUS_PANE_ID -u LUVUS_BIN_PATH LUVUS_HOME=/tmp/tmp.2PUXKFJyNF CODEX_HOME=/tmp/tmp.2PUXKFJyNF/codex-home /home/ubuntu/projects/Rust/luvus/target/debug/luvus --session luvus-pr-test uhp proxy <<'JSON'
{"id":"u02","method":"agent.read","params":{"target":"real-codex","source":"visible","lines":80}}
JSON
{"id": "u02", "result": {"content_revision": 28, "pane": "4", "revision": 34, "terminal_id": "33a2f4dd6839cebebee01569e50ab79b", "text": "  Welcome to Codex, OpenAI's command-line coding agent                          \n                                                                                \n  Sign in with ChatGPT to use Codex as part of your paid plan                   \n  or connect an API key for usage-based billing                                 \n                                                                                \n> 1. Sign in with ChatGPT                                                       \n     Usage included with Plus, Pro, Business, and Enterprise plans              \n                                                                                \n  2. Sign in with Device Code                                                   \n     Sign in from another device with a one-time code                           \n                                                                                \n  3. Provide your own API key                                                   \n     Pay for what you use                                                       \n                                                                                \n  Press enter to continue                                                       \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                \n                                                                                ", "type": "agent_read"}}
{"real_agent": "codex", "selection_restored": true, "auth_submitted": false}
{"isolated_server_exit": 0}
```
</details>

## First-pass checklist

- R1 — Exact existing `valid_id` and key parser; existing key/target forms preserved; aliases, Unicode, malformed arrays, and paired coordinates covered above.
- R2 — No partial sends: all validation and conflict branches precede `try_send`; missing runtime, poisoned lock, stale revision, wrong identity, malformed pair, and closed writer have focused tests; existing target/non-agent paths remain covered.
- R3 — CodeRabbit completed both reviews with no actionable code comments. The one pre-merge docstring warning was fixed in `f5cd930`; the follow-up reports 95.00% coverage (threshold 80.00%) and passes all pre-merge checks.
- R4 — Isolated base/branch byte-log evidence plus plain bash and real Codex chooser above; stale input is empty, fresh Enter is `0d`.
- R5 — Immediately before opening, `git fetch upstream && git rebase upstream/main` reported up to date at `ee169dadeefe8048a3e90482c66f0f0aa49a54a6`; schema/fixtures/consumer/docs/skill copies updated together. No new event or CLI syntax requires catalog/CLI-file changes.
- R6 — `agent.read` returns the exact pane content counter and terminal lifetime needed by the caller; generic event `revision` remains separate.
- R7 — One concern, base `upstream/main`, primary checkout, 13 explicitly authorized files, no unrelated changes.
- R8 — **2 layers:** dispatch plus its tests; UHP schema/fixtures/consumer/documentation/skills. Manifest request-count changes stay in layer 2.
- R9 — Reuse the existing engine lock, Acquire counter, terminal identity validator, and `try_send`; no production thread/timer/poll/dependency or new VT interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0157SP6ztLt1Lz91vWgXko8V


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change lets automation bind `agent.keys` input to the terminal content returned by `agent.read`. Matching coordinates deliver the requested key, while changed terminal content or a replaced terminal rejects the request before any input is queued.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran cargo test content\_fence\_read\_coordinates\_control\_queue\_admission and cargo test content\_fence; both suites completed with expected outcomes, confirming the fence admits only the observed terminal state and that the coordination between agent.read and agent.keys reproduces content\_revision and content\_revision\_conflict behavior.
- Executed the focused Rust dispatch and PTY queue test under isolated LUVUS environment variables; the test completed with exit code 0: 1 passed and 0 failed, showing that stale observations cannot queue agent input.
- Validated the same pattern with a different terminal ID and noted a panic from the lock-poison fixture, while both content\_fence tests still completed; a temporary test addition in the dispatch tests was later reverted.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(uhp): document content fence handle..."](https://github.com/rizriyz/luvus/commit/f5cd9304148b162424cb9b1e80178aff744ad579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61964085)</sub>

<!-- /greptile_comment -->