### PR TITLE
fix(session): preserve input across local session switches

### DIFF
--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -376,13 +376,24 @@ where
 /// during a handoff is discarded rather than sent to an old pane.
 #[derive(Clone, Default)]
 struct InputRoute {
-    writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
+    writer: Arc<Mutex<RouteWriter>>,
     closed: Arc<AtomicBool>,
+}
+
+#[derive(Default)]
+struct RouteWriter {
+    generation: u64,
+    active: Option<Box<dyn Write + Send>>,
 }
 
 impl InputRoute {
     fn replace(&self, writer: Option<Box<dyn Write + Send>>) {
-        *self.writer.lock().unwrap_or_else(|e| e.into_inner()) = writer;
+        let retired = {
+            let mut route = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+            route.generation = route.generation.wrapping_add(1);
+            std::mem::replace(&mut route.active, writer)
+        };
+        drop(retired);
     }
 
     fn close(&self) {
@@ -397,10 +408,17 @@ impl InputRoute {
         let Some(message) = event_message(event) else {
             return true;
         };
-        let mut route = self.writer.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(writer) = route.as_mut() {
-            if protocol::write_message(writer, &message).is_err() {
-                *route = None;
+        // The sole input reader owns the writer during I/O. Replacement and
+        // shutdown must remain possible even if the peer stops reading.
+        let (generation, writer) = {
+            let mut route = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+            (route.generation, route.active.take())
+        };
+        if let Some(mut writer) = writer {
+            let sent = protocol::write_message(&mut writer, &message).is_ok();
+            let mut route = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+            if sent && route.generation == generation && !self.closed.load(Ordering::Acquire) {
+                route.active = Some(writer);
             }
         }
         true
@@ -1067,6 +1085,90 @@ mod tests {
 mod render_tests {
     use super::*;
     use ratatui::backend::TestBackend;
+
+    #[test]
+    fn blocked_input_write_does_not_block_switch_or_close_or_restore_retired_writer() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        struct BlockedWriter {
+            entered: Option<mpsc::Sender<()>>,
+            release: mpsc::Receiver<()>,
+            fail: bool,
+        }
+        impl Write for BlockedWriter {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if let Some(entered) = self.entered.take() {
+                    entered.send(()).unwrap();
+                    self.release.recv_timeout(Duration::from_secs(5)).unwrap();
+                }
+                if self.fail {
+                    Err(std::io::ErrorKind::BrokenPipe.into())
+                } else {
+                    Ok(bytes.len())
+                }
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<u8>>>);
+        impl Write for Capture {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        for close in [false, true] {
+            for fail in [false, true] {
+                let route = InputRoute::default();
+                let (entered_tx, entered_rx) = mpsc::channel();
+                let (release_tx, release_rx) = mpsc::channel();
+                route.replace(Some(Box::new(BlockedWriter {
+                    entered: Some(entered_tx),
+                    release: release_rx,
+                    fail,
+                })));
+                let sender = route.clone();
+                let sending = thread::spawn(move || sender.send(Event::Paste("old".into())));
+                entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+                let capture = Capture::default();
+                let replacement = capture.clone();
+                let changing = route.clone();
+                let (done_tx, done_rx) = mpsc::channel();
+                let replacing = thread::spawn(move || {
+                    if close {
+                        changing.close();
+                    } else {
+                        changing.replace(Some(Box::new(replacement)));
+                    }
+                    done_tx.send(()).unwrap();
+                });
+                let completed = done_rx.recv_timeout(Duration::from_secs(2)).is_ok();
+                // Always release and join the workers, including on regression.
+                release_tx.send(()).unwrap();
+                sending.join().unwrap();
+                replacing.join().unwrap();
+                assert!(completed, "route change waited for the blocked write");
+                assert_eq!(route.send(Event::Paste("new".into())), !close);
+                let bytes = capture.0.lock().unwrap().clone();
+                if close {
+                    assert!(bytes.is_empty());
+                    assert!(route.writer.lock().unwrap().active.is_none());
+                } else {
+                    let mut bytes = std::io::Cursor::new(bytes);
+                    assert!(matches!(protocol::read_message(&mut bytes).unwrap(),
+                        ClientMessage::Paste(text) if text == "new"));
+                    assert_eq!(bytes.position(), bytes.get_ref().len() as u64);
+                }
+            }
+        }
+    }
 
     #[test]
     fn session_input_route_moves_complete_events_and_survives_old_disconnect() {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -3,6 +3,8 @@
 
 use std::io::{BufReader, Read, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use anyhow::{anyhow, Result};
@@ -73,7 +75,7 @@ pub fn run(sock: &Path) -> Result<()> {
     };
     crate::logging::event(crate::logging::EventKind::ClientConnect, &[]);
     // `Conn` is a cloneable duplex handle: one clone reads, the other writes.
-    attach_inner(stream.clone(), stream)
+    attach_inner(stream.clone(), stream, true)
 }
 
 /// Attach a thin client over **any** reader/writer carrying the binary frame
@@ -81,7 +83,7 @@ pub fn run(sock: &Path) -> Result<()> {
 /// (docs/18 RA) passes an `ssh` child's stdout/stdin — the protocol is the same.
 pub fn attach<R, W>(reader: R, writer: W) -> Result<()>
 where
-    R: Read,
+    R: Read + 'static,
     W: Write + Send + 'static,
 {
     let _logging = crate::logging::init(crate::logging::Role::Client);
@@ -90,17 +92,44 @@ where
         &[crate::logging::Field::Role(crate::logging::Role::Client)],
     );
     crate::logging::event(crate::logging::EventKind::ClientConnect, &[]);
-    attach_inner(reader, writer)
+    attach_inner(reader, writer, false)
 }
 
-fn attach_inner<R, W>(reader: R, writer: W) -> Result<()>
+fn attach_inner<R, W>(reader: R, writer: W, local: bool) -> Result<()>
 where
-    R: Read,
+    R: Read + 'static,
     W: Write + Send + 'static,
 {
     let mut terminal = ratatui::init();
     crate::install_tui_panic_hook();
-    let result = run_inner(reader, writer, &mut terminal);
+    let mut input = ClientInput::default();
+    let mut selected = crate::session::display_name();
+    let result = (|| {
+        let mut reader: Box<dyn Read> = Box::new(reader);
+        let mut writer: Box<dyn Write + Send> = Box::new(writer);
+        loop {
+            let exit = run_inner(reader, writer, &mut terminal, &mut input, &selected)?;
+            input.route.replace(None);
+            match exit {
+                ClientExit::SwitchSession(name) if local => {
+                    let name =
+                        crate::session::parse_target_name(&name).map_err(anyhow::Error::msg)?;
+                    let sock = crate::session::client_socket_path_for(name.as_deref());
+                    // The selector prepares the target server before emitting
+                    // SwitchSession. Never resolve through an inherited pane socket.
+                    let stream =
+                        transport::connect_timeout(&sock, std::time::Duration::from_secs(5))?;
+                    selected = name.unwrap_or_else(|| crate::session::DEFAULT_SESSION_NAME.into());
+                    reader = Box::new(stream.clone());
+                    writer = Box::new(stream);
+                }
+                exit => break Ok::<_, anyhow::Error>(exit),
+            }
+        }
+    })();
+    input.route.close();
+    #[cfg(windows)]
+    drop(input.windows_input_mode.take());
     let _ = execute!(
         std::io::stdout(),
         crossterm::event::PopKeyboardEnhancementFlags,
@@ -112,12 +141,12 @@ where
     match result? {
         ClientExit::Done => Ok(()),
         ClientExit::Detached => {
-            crate::print_detached_status(crate::i18n::cli::Context::configured());
+            crate::print_detached_status_for(crate::i18n::cli::Context::configured(), &selected);
             Ok(())
         }
         ClientExit::ServerStopped => {
             let context = crate::i18n::cli::Context::configured();
-            let session = crate::session::display_name();
+            let session = selected;
             let rows = [
                 (context.text("status"), context.text("stopped")),
                 (context.text("session"), session.as_str()),
@@ -136,7 +165,22 @@ enum ClientExit {
     SwitchSession(String),
 }
 
-fn run_inner<R, W>(reader: R, mut writer: W, terminal: &mut DefaultTerminal) -> Result<ClientExit>
+#[derive(Default)]
+struct ClientInput {
+    route: InputRoute,
+    started: bool,
+    colors: Option<crate::terminal::theme_probe::TerminalColors>,
+    #[cfg(windows)]
+    windows_input_mode: Option<crate::terminal::host_input::WindowsInputModeGuard>,
+}
+
+fn run_inner<R, W>(
+    reader: R,
+    mut writer: W,
+    terminal: &mut DefaultTerminal,
+    input: &mut ClientInput,
+    selected: &str,
+) -> Result<ClientExit>
 where
     R: Read,
     W: Write + Send + 'static,
@@ -185,11 +229,22 @@ where
         ServerMessage::Ready { probe_terminal } => probe_terminal,
         _ => return Err(anyhow!("unexpected handshake negotiation")),
     };
-    let pending = if probe_terminal {
+    let pending = if probe_terminal && !input.started {
         let probe = crate::terminal::theme_probe::probe();
-        protocol::write_message(&mut writer, &ClientMessage::TerminalColors(probe.colors))?;
+        input.colors = probe.colors;
+        protocol::write_message(
+            &mut writer,
+            &ClientMessage::TerminalColors(input.colors.clone()),
+        )?;
         probe.pending
     } else {
+        if probe_terminal {
+            // The sole input reader already owns stdin after initial attach.
+            protocol::write_message(
+                &mut writer,
+                &ClientMessage::TerminalColors(input.colors.clone()),
+            )?;
+        }
         Vec::new()
     };
     crate::logging::event(
@@ -212,16 +267,28 @@ where
         // back) is our cue that the terminal may have been repainted underneath us,
         // so we ask the server for a full frame (see the input loop).
         EnableFocusChange,
-        crossterm::terminal::SetTitle(crate::window_title())
+        crossterm::terminal::SetTitle(if selected == crate::session::DEFAULT_SESSION_NAME {
+            match std::env::var("TERM_PROGRAM") {
+                Ok(program) if program == "Apple_Terminal" => String::new(),
+                _ => "luvus".to_string(),
+            }
+        } else {
+            format!("luvus · {selected}")
+        })
     );
     #[cfg(windows)]
-    let _windows_input_mode = crate::terminal::host_input::enable_input_mode();
+    if !input.started {
+        input.windows_input_mode = Some(crate::terminal::host_input::enable_input_mode());
+    }
     // Let the terminal report Shift+Enter et al. as distinct keys, so agents get
     // a real "new line" key instead of a bare CR (see `push_key_protocol`).
-    crate::push_key_protocol();
-
-    // Input thread: terminal events → the server.
-    thread::spawn(move || input_loop(writer, pending));
+    input.route.replace(Some(Box::new(writer)));
+    if !input.started {
+        crate::push_key_protocol();
+        let route = input.route.clone();
+        thread::spawn(move || input_loop(route, pending));
+        input.started = true;
+    }
 
     // Main thread: paint frames as they arrive. A full frame repaints the screen; a
     // diff writes only its changed cells straight to the terminal (no full re-blit,
@@ -304,6 +371,42 @@ where
     Ok(exit)
 }
 
+/// One terminal reader for the entire local client lifetime. Replacing the
+/// destination drops the previous connection before the next handshake; input
+/// during a handoff is discarded rather than sent to an old pane.
+#[derive(Clone, Default)]
+struct InputRoute {
+    writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
+    closed: Arc<AtomicBool>,
+}
+
+impl InputRoute {
+    fn replace(&self, writer: Option<Box<dyn Write + Send>>) {
+        *self.writer.lock().unwrap_or_else(|e| e.into_inner()) = writer;
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.replace(None);
+    }
+
+    fn send(&self, event: Event) -> bool {
+        if self.closed.load(Ordering::Acquire) {
+            return false;
+        }
+        let Some(message) = event_message(event) else {
+            return true;
+        };
+        let mut route = self.writer.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(writer) = route.as_mut() {
+            if protocol::write_message(writer, &message).is_err() {
+                *route = None;
+            }
+        }
+        true
+    }
+}
+
 /// Hand this thin client process to the same launch mode targeting another
 /// logical session. Unix replaces the process. Windows starts the successor
 /// and immediately lets this process exit, so the old terminal-input thread is
@@ -348,31 +451,25 @@ fn switched_args(raw: &[String], name: &str) -> Vec<String> {
     out
 }
 
-fn input_loop<W: Write>(mut writer: W, pending: Vec<Event>) {
+fn input_loop(route: InputRoute, pending: Vec<Event>) {
     #[cfg(windows)]
     {
-        crate::terminal::host_input::run_input_loop(pending, |event| {
-            write_input_event(&mut writer, event)
-        });
+        crate::terminal::host_input::run_input_loop(pending, |event| route.send(event));
     }
 
     #[cfg(not(windows))]
     {
         for event in pending {
-            if !write_input_event(&mut writer, event) {
+            if !route.send(event) {
                 return;
             }
         }
         while let Ok(event) = read_event() {
-            if !write_input_event(&mut writer, event) {
+            if !route.send(event) {
                 break;
             }
         }
     }
-}
-
-fn write_input_event(writer: &mut impl Write, event: Event) -> bool {
-    event_message(event).is_none_or(|message| protocol::write_message(writer, &message).is_ok())
 }
 
 fn event_message(event: Event) -> Option<ClientMessage> {
@@ -970,6 +1067,58 @@ mod tests {
 mod render_tests {
     use super::*;
     use ratatui::backend::TestBackend;
+
+    #[test]
+    fn session_input_route_moves_complete_events_and_survives_old_disconnect() {
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<u8>>>);
+        impl Write for Capture {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        struct Disconnected;
+        impl Write for Disconnected {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::ErrorKind::BrokenPipe.into())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        use ratatui::crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+        let route = InputRoute::default();
+        route.replace(Some(Box::new(Disconnected)));
+        assert!(route.send(Event::Paste("old".into())));
+        assert!(route.send(Event::Paste("during handoff".into())));
+        for _ in 0..10 {
+            let capture = Capture::default();
+            route.replace(Some(Box::new(capture.clone())));
+            let mouse = MouseEvent {
+                kind: MouseEventKind::Moved,
+                column: 7,
+                row: 2,
+                modifiers: KeyModifiers::NONE,
+            };
+            assert!(route.send(Event::Mouse(mouse)));
+            assert!(route.send(Event::Paste("new\n雪".into())));
+            route.replace(None);
+            assert!(route.send(Event::Paste("gap".into())));
+            let bytes = capture.0.lock().unwrap().clone();
+            let mut bytes = std::io::Cursor::new(bytes);
+            assert!(matches!(protocol::read_message(&mut bytes).unwrap(),
+                ClientMessage::Mouse(received) if received == mouse));
+            assert!(matches!(protocol::read_message(&mut bytes).unwrap(),
+                ClientMessage::Paste(text) if text == "new\n雪"));
+            assert_eq!(bytes.position(), bytes.get_ref().len() as u64);
+        }
+        route.close();
+        assert!(!route.send(Event::Paste("after detach".into())));
+    }
 
     #[test]
     fn paste_event_preserves_windows_paths_quotes_and_unicode() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1074,10 +1074,14 @@ fn print_server_card(
 
 fn print_detached_status(context: i18n::cli::Context) {
     let session = session::display_name();
+    print_detached_status_for(context, &session);
+}
+
+fn print_detached_status_for(context: i18n::cli::Context, session: &str) {
     let runtime = format!("{} + {}", context.text("server"), context.text("panes"));
     let rows = [
         (context.text("status"), context.text("detached")),
-        (context.text("session"), session.as_str()),
+        (context.text("session"), session),
         (runtime.as_str(), context.text("running")),
     ];
     cli::print_status_card("Luvus session", &rows);

--- a/src/terminal/host_input.rs
+++ b/src/terminal/host_input.rs
@@ -17,7 +17,7 @@ mod console;
 mod windows;
 
 #[cfg(windows)]
-pub use windows::{enable_input_mode, run_input_loop};
+pub use windows::{enable_input_mode, run_input_loop, WindowsInputModeGuard};
 
 const START_MARKER: &[char] = &['\u{1b}', '[', '2', '0', '0', '~'];
 const END_MARKER: &[char] = &['\u{1b}', '[', '2', '0', '1', '~'];

--- a/website/src/content/docs/docs/getting-started/first-session.mdx
+++ b/website/src/content/docs/docs/getting-started/first-session.mdx
@@ -54,6 +54,12 @@ Scroll an agent's history with two-finger scroll, or press `Shift+↑` for
 [scroll mode](/docs/guides/scrollback/), where `1`–`9` jump through history and
 `q` snaps back to live.
 
+Press `Ctrl+Space` then `t` to choose another named session. Switching local
+sessions keeps the client open and reconnects its display and input to the
+selected server. Both sessions keep their agents, shells, and pane processes
+running, so you can switch back and continue working. Switching does not
+restart a server or resume agents into replacement processes.
+
 ## 4. Detach: this is the magic
 
 Press `Ctrl+Space` then `q`. The client exits, **but nothing stops**: your


### PR DESCRIPTION
Switching between local Luvus sessions now retains the client and its terminal input reader, so mouse and keyboard input remain connected to the selected session without tearing down the terminal.

## What

- Reconnect the existing client to the selected local session instead of replacing or spawning the client process.
- Keep mouse, focus, paste, keyboard, and Windows input-mode ownership across switches. Restore the terminal when the client finally exits.
- Replace the input destination as one operation and tolerate the previous connection closing. Discard input while the destination is unavailable.
- Reuse the initial terminal palette without competing with the input reader for stdin, and reset display cursor state for each connection.
- Show the selected session in the window title and detach message.
- Document that both sessions retain their live servers, agents, and pane processes.

## Why

Fixes #322.

The previous local switch restored terminal modes and then handed execution to another client process. On Windows it spawned a successor; on Unix it replaced the process. Keeping terminal ownership in one client removes that handoff from local switching on every supported platform.

Only the display client reconnects. This change does not stop servers, kill panes, or replace running agents. Direct SSH attachment retains its existing process handoff.

## Verification

- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `cargo build --locked`
- `cargo test --locked ipc::client::render_tests` — 6 passed
- `cargo test --locked --test named_sessions` — 4 passed
- Local macOS PTY regression using the real debug client and bounded protocol fixtures: 8 switches, each forwarding keyboard, hover, click, scroll, multiline paste, and resize events. Terminal modes were restored only at final detach.
- The same PTY regression fails against unchanged main because switching re-enters the alternate screen.
- Local macOS test with two real isolated debug servers and the actual session selector: 4 switches retained both servers and each pane's terminal ID, process ID, and process start identity. Final detach also left both servers alive.

The PTY script remains local in the ignored tests directory. No tests-directory files or CI changes are included. The input-routing regression is embedded in the Rust source.

## Notes

Native Windows Terminal and Linux interactive verification remain outstanding. The macOS regression establishes the ownership change and input continuity; it does not reproduce every platform-specific manifestation of the reported mouse failure. The recurring DIFF scan warnings in the issue are outside this fix.




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The client now removes the active input writer from the route before a synchronous write, allowing a session switch or close to install a replacement route even when the previous connection is blocked. The reported blocked-input failure was disproved by forcing an old write to stall: route replacement completed and the new route received input before the old write was released.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed an isolated Rust harness that blocks an old input write to compare the former lock-held route behavior against the current take/write/restore flow.
- Observed that the former behavior left the route replacement incomplete while the old write was blocked, whereas the current implementation completes the replacement with the old write blocked and the replacement receiving new before release.
- Ran the focused IPC blocked-write and session-handoff tests; they passed across replacement, close, successful writes, and failed writes.
- Inspected the current InputRoute implementation region (lines 389 through 425) to verify the changes aligned with the observed behavior.

<a href="https://app.greptile.com/trex/runs/23309617/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(session): keep blocked input writes ..."](https://github.com/rizriyz/luvus/commit/cc93d1a31321f5a9e99e926dc11ef3e5a1e72224) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62041487)</sub>

<!-- /greptile_comment -->