### PR TITLE
feat(ui): let modules publish agent session titles

### DIFF
--- a/plugins/luvus/skills/luvus/references/uhp-control.md
+++ b/plugins/luvus/skills/luvus/references/uhp-control.md
@@ -110,7 +110,7 @@ read current state and reconcile instead of blindly retrying.
     selected pane proves the same native conversation.
 - Extensions: `module.*`
 - Themes and configuration: `theme.*`, `config.*`, and `manifest.reload`
-- UI surfaces: `ui.sidebar`, `ui.dock.*`, `ui.bar.*`,
+- UI surfaces: `ui.sidebar`, `ui.agent_title.*`, `ui.dock.*`, `ui.bar.*`,
   `ui.notification.*`, and `ui.toast`
 - Terminal backends: `terminal.backend.*`
 

--- a/protocol/uhp/v1/schema/request.schema.json
+++ b/protocol/uhp/v1/schema/request.schema.json
@@ -32,7 +32,7 @@
         "lease.acquire", "lease.list", "lease.release",
         "module.list", "module.info", "module.link", "module.unlink", "module.uninstall", "module.enable", "module.disable", "module.action.list", "module.action.invoke", "module.pane.open", "module.pane.focus", "module.pane.close", "module.config_dir", "module.settings.list", "module.settings.get", "module.settings.set", "module.log.list",
         "theme.list", "theme.path", "theme.use", "theme.reload", "manifest.reload",
-        "ui.sidebar", "ui.dock.push", "ui.dock.list", "ui.dock.move", "ui.bar.push", "ui.bar.list", "ui.bar.move", "ui.bar.remove", "ui.notification.push", "ui.notification.clear", "ui.toast",
+        "ui.sidebar", "ui.agent_title.push", "ui.agent_title.clear", "ui.dock.push", "ui.dock.list", "ui.dock.move", "ui.bar.push", "ui.bar.list", "ui.bar.move", "ui.bar.remove", "ui.notification.push", "ui.notification.clear", "ui.toast",
         "terminal.backend.inventory", "terminal.backend.snapshot", "terminal.backend.validate", "terminal.backend.processes", "terminal.backend.capture", "terminal.backend.observe", "terminal.backend.control", "terminal.backend.type_literal", "terminal.backend.submit_text", "terminal.backend.send_key", "terminal.backend.set_title", "terminal.backend.notify", "terminal.backend.create", "terminal.backend.close", "terminal.backend.wait_change", "terminal.backend.wait_output", "terminal.backend.events.subscribe"
       ]
     },

--- a/skills/luvus-module/SKILL.md
+++ b/skills/luvus-module/SKILL.md
@@ -58,6 +58,7 @@ Run the `luvus` CLI from inside the command; it talks to the running server over
 - `luvus bar push --id <widget> --content <json>` — atomically publish structured `text`, `symbol`, `state`, `badge`, `progress`, `spacer`, and `separator` segments. Add `--compact-content`; an `action` must name one of your `[[actions]]`.
 - `luvus ui notification push --text <text> --level info|success|warning|error` — publish bounded transient status; use `--dedupe-key` for replacement.
 - `luvus ui toast "<text>"` — flash a one-line confirmation.
+- `luvus ui agent-title push --titles <json>` — publish AGENTS sidebar titles for live panes (`pane`) and resumable sessions (`agent` + `session_id`). OSC still wins; never send a Luvus `=alias` as the title. `luvus ui agent-title clear` drops one key or all titles.
 - `luvus ui sidebar` / `ui dock list` / `ui dock move` — sidebar/dock control.
 - `luvus tab rename <name>` / `tab list` — tabs.
 - `luvus module settings <id>` / `module settings <id> <key>` — read your settings exactly (values are masked in `settings list` when `secret`, but exact in `settings get`).

--- a/skills/luvus-module/SKILL.md
+++ b/skills/luvus-module/SKILL.md
@@ -41,7 +41,7 @@ Then any of these tables, each declaring an argv `command` (a list, run as-is, c
 luvus puts context in the environment, flat, so a bash module never parses JSON:
 
 - `LUVUS_MODULE_ID`, `LUVUS_MODULE_ROOT` (the module dir), `LUVUS_MODULE_VERSION`
-- `LUVUS_MODULE_TOKEN` — process-scoped UI-publisher credential; the Luvus CLI forwards it automatically, so do not persist or override it
+- `LUVUS_MODULE_TOKEN` — UI-publisher credential for this server; the Luvus CLI forwards it automatically, so do not persist or override it
 - `LUVUS_MODULE_CONFIG_DIR`, `LUVUS_MODULE_STATE_DIR` — writable per-module dirs
 - `LUVUS_WORKSPACE_ID`, `LUVUS_WORKSPACE_CWD`, `LUVUS_TAB_INDEX`
 - `LUVUS_PANE_ID`, `LUVUS_PANE_CWD`, `LUVUS_PANE_AGENT`, `LUVUS_PANE_STATUS` (the clicked/target pane)

--- a/skills/luvus-module/SKILL.md
+++ b/skills/luvus-module/SKILL.md
@@ -58,7 +58,7 @@ Run the `luvus` CLI from inside the command; it talks to the running server over
 - `luvus bar push --id <widget> --content <json>` — atomically publish structured `text`, `symbol`, `state`, `badge`, `progress`, `spacer`, and `separator` segments. Add `--compact-content`; an `action` must name one of your `[[actions]]`.
 - `luvus ui notification push --text <text> --level info|success|warning|error` — publish bounded transient status; use `--dedupe-key` for replacement.
 - `luvus ui toast "<text>"` — flash a one-line confirmation.
-- `luvus ui agent-title push --titles <json>` — publish AGENTS sidebar titles for live panes (`pane`) and resumable sessions (`agent` + `session_id`). OSC still wins; never send a Luvus `=alias` as the title. `luvus ui agent-title clear` drops one key or all titles.
+- `luvus ui agent-title push --titles <json>` — publish AGENTS sidebar titles for live panes (`pane`) and resumable sessions (`agent` + `session_id`). OSC still wins; never send a Luvus `=alias` as the title. `luvus ui agent-title clear` drops one key or every title owned by your module.
 - `luvus ui sidebar` / `ui dock list` / `ui dock move` — sidebar/dock control.
 - `luvus tab rename <name>` / `tab list` — tabs.
 - `luvus module settings <id>` / `module settings <id> <key>` — read your settings exactly (values are masked in `settings list` when `secret`, but exact in `settings get`).

--- a/skills/luvus-module/SKILL.md
+++ b/skills/luvus-module/SKILL.md
@@ -41,6 +41,7 @@ Then any of these tables, each declaring an argv `command` (a list, run as-is, c
 luvus puts context in the environment, flat, so a bash module never parses JSON:
 
 - `LUVUS_MODULE_ID`, `LUVUS_MODULE_ROOT` (the module dir), `LUVUS_MODULE_VERSION`
+- `LUVUS_MODULE_TOKEN` — process-scoped UI-publisher credential; the Luvus CLI forwards it automatically, so do not persist or override it
 - `LUVUS_MODULE_CONFIG_DIR`, `LUVUS_MODULE_STATE_DIR` — writable per-module dirs
 - `LUVUS_WORKSPACE_ID`, `LUVUS_WORKSPACE_CWD`, `LUVUS_TAB_INDEX`
 - `LUVUS_PANE_ID`, `LUVUS_PANE_CWD`, `LUVUS_PANE_AGENT`, `LUVUS_PANE_STATUS` (the clicked/target pane)
@@ -58,7 +59,7 @@ Run the `luvus` CLI from inside the command; it talks to the running server over
 - `luvus bar push --id <widget> --content <json>` — atomically publish structured `text`, `symbol`, `state`, `badge`, `progress`, `spacer`, and `separator` segments. Add `--compact-content`; an `action` must name one of your `[[actions]]`.
 - `luvus ui notification push --text <text> --level info|success|warning|error` — publish bounded transient status; use `--dedupe-key` for replacement.
 - `luvus ui toast "<text>"` — flash a one-line confirmation.
-- `luvus ui agent-title push --titles <json>` — publish AGENTS sidebar titles for live panes (`pane`) and resumable sessions (`agent` + `session_id`). OSC still wins; never send a Luvus `=alias` as the title. `luvus ui agent-title clear` drops one key or every title owned by your module.
+- `luvus ui agent-title push --titles <json>` — publish AGENTS sidebar titles for live panes (`pane`) and resumable sessions (built-in `agent` + `session_id`). OSC still wins; never send a Luvus `=alias` as the title. `luvus ui agent-title clear` drops one key or every title owned by your module. The CLI authenticates ownership automatically.
 - `luvus ui sidebar` / `ui dock list` / `ui dock move` — sidebar/dock control.
 - `luvus tab rename <name>` / `tab list` — tabs.
 - `luvus module settings <id>` / `module settings <id> <key>` — read your settings exactly (values are masked in `settings list` when `secret`, but exact in `settings get`).
@@ -91,6 +92,6 @@ Iterate: edit the script, re-run the action or trigger the event, watch `module 
 ## Conventions
 
 - One module, one job. Keep commands fast and quiet — luvus caps a command's output (64 KiB) and runs at most 32 at a time.
-- Identity env (`LUVUS_MODULE_ID`, socket path) is injected and cannot be overridden.
+- Identity env (`LUVUS_MODULE_ID`, `LUVUS_MODULE_TOKEN`, socket path) is injected and cannot be overridden. Never log or persist the token.
 - Use `platforms` on the manifest or any item to skip a build step / hook / pane / action where it does not apply.
 - To share it: `luvus module install <owner>/<repo>` clones + builds + registers from GitHub; tag the repo with the `luvus-module` topic so `luvus module search` finds it.

--- a/skills/luvus/references/uhp-control.md
+++ b/skills/luvus/references/uhp-control.md
@@ -110,7 +110,7 @@ read current state and reconcile instead of blindly retrying.
     selected pane proves the same native conversation.
 - Extensions: `module.*`
 - Themes and configuration: `theme.*`, `config.*`, and `manifest.reload`
-- UI surfaces: `ui.sidebar`, `ui.dock.*`, `ui.bar.*`,
+- UI surfaces: `ui.sidebar`, `ui.agent_title.*`, `ui.dock.*`, `ui.bar.*`,
   `ui.notification.*`, and `ui.toast`
 - Terminal backends: `terminal.backend.*`
 

--- a/src/api/capabilities.rs
+++ b/src/api/capabilities.rs
@@ -168,6 +168,8 @@ pub const METHODS: &[&str] = &[
     "theme.reload",
     "manifest.reload",
     "ui.sidebar",
+    "ui.agent_title.push",
+    "ui.agent_title.clear",
     "ui.dock.push",
     "ui.dock.list",
     "ui.dock.move",

--- a/src/api/capabilities.rs
+++ b/src/api/capabilities.rs
@@ -403,6 +403,9 @@ pub fn capabilities(event_sequence: u64) -> Value {
             "workspace_move_block":super::topology::MAX_WORKSPACE_MOVE_BLOCK,
             "task_title_bytes":crate::orch::MAX_TASK_TITLE_BYTES,
             "task_prompt_bytes":crate::orch::MAX_TASK_PROMPT_BYTES,
+            "agent_row_titles":crate::app::MAX_AGENT_ROW_TITLES,
+            "agent_row_title_bytes":crate::app::MAX_AGENT_ROW_TITLE_BYTES,
+            "agent_row_title_agent_bytes":crate::app::MAX_AGENT_ROW_TITLE_AGENT_BYTES,
             "automations":crate::automation::MAX_AUTOMATIONS,
             "automation_runs":crate::automation::MAX_RUNS,
             "automation_prompt_bytes":crate::automation::MAX_PROMPT_BYTES,
@@ -471,6 +474,9 @@ mod tests {
             capabilities["limits"]["task_prompt_bytes"],
             crate::orch::MAX_TASK_PROMPT_BYTES
         );
+        assert_eq!(capabilities["limits"]["agent_row_titles"], 256);
+        assert_eq!(capabilities["limits"]["agent_row_title_bytes"], 256);
+        assert_eq!(capabilities["limits"]["agent_row_title_agent_bytes"], 64);
         assert!(is_idempotent("pane.list"));
         assert!(!is_read_only("mission.open"));
         assert_eq!(required_scope("mission.open"), "workspace");

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -80,6 +80,8 @@ impl App {
             "ui.bar.push",
             "ui.bar.move",
             "ui.bar.remove",
+            "ui.agent_title.push",
+            "ui.agent_title.clear",
             "ui.notification.push",
             "ui.notification.clear",
             "theme.list",

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -260,6 +260,8 @@ impl App {
             // A module pushes rows into its sidebar dock (docs/29, DOCK-4).
             // A one-line confirmation, the same transient toast a copy shows.
             "ui.toast" => self.api_ui_toast(method, p),
+            "ui.agent_title.push" => self.api_ui_agent_title_push(method, p),
+            "ui.agent_title.clear" => self.api_ui_agent_title_clear(method, p),
             "ui.dock.push" => self.api_ui_dock_push(method, p),
             "ui.dock.list" => self.api_ui_dock_list(method, p),
             "ui.dock.move" => self.api_ui_dock_move(method, p),

--- a/src/app/dispatch/agents.rs
+++ b/src/app/dispatch/agents.rs
@@ -695,15 +695,33 @@ impl App {
             })
     }
 
-    /// The pane's live session title (the OSC title the agent set), trimmed, if
-    /// non-empty. The AGENTS sidebar shows it in place of the meta line when the
-    /// "show agent session title" setting is on (`config.layout.agent_title`).
+    /// The pane's live session title, trimmed, if non-empty. OSC title wins;
+    /// otherwise a module-provided title (`ui.agent_title.push`). Luvus pane
+    /// aliases (`=name`) are never used as a title. The AGENTS sidebar shows
+    /// this in place of the meta line when the "show agent session title"
+    /// setting is on (`config.layout.agent_title`).
     pub(crate) fn pane_title(&self, pane: PaneId) -> Option<String> {
-        self.panes
+        if let Some(title) = self
+            .panes
             .get(&pane)
             .and_then(|p| p.engine.lock().ok().and_then(|e| e.title()))
             .map(|s| strip_title_icon(&s))
             .filter(|s| !s.is_empty())
+        {
+            return Some(title);
+        }
+        if let Some(title) = self
+            .agent_title_panes
+            .get(&pane)
+            .map(|title| strip_title_icon(title))
+            .filter(|title| !title.is_empty())
+        {
+            return Some(title);
+        }
+        let session = self.status.get(&pane)?.agent_session.as_ref()?;
+        self.agent_row_title_for_session(&session.agent, &session.session_id)
+            .map(strip_title_icon)
+            .filter(|title| !title.is_empty())
     }
 
     /// Whether `pane` currently hosts a recognised agent (detection) or a bound

--- a/src/app/dispatch/agents.rs
+++ b/src/app/dispatch/agents.rs
@@ -713,7 +713,7 @@ impl App {
         if let Some(title) = self
             .agent_title_panes
             .get(&pane)
-            .map(|title| strip_title_icon(title))
+            .map(|title| strip_title_icon(&title.text))
             .filter(|title| !title.is_empty())
         {
             return Some(title);

--- a/src/app/dispatch/extensions.rs
+++ b/src/app/dispatch/extensions.rs
@@ -3,6 +3,13 @@
 use super::*;
 use super::{params::*, projection::*};
 
+#[derive(Clone)]
+struct AgentRowTitleUpdate {
+    pane: Option<PaneId>,
+    session: Option<(String, String)>,
+    title: Option<String>,
+}
+
 impl App {
     pub(super) fn api_theme_list(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = (method, p);
@@ -74,31 +81,48 @@ impl App {
 
     pub(super) fn api_ui_agent_title_push(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = method;
+        reject_api_fields(p, &["owner", "titles"])?;
+        let owner = self.agent_row_title_owner(p)?;
         let titles = p.get("titles").and_then(Value::as_array).ok_or_else(|| {
             (
                 "invalid_request".to_string(),
                 "titles must be a JSON array".to_string(),
             )
         })?;
-        if titles.len() > MAX_AGENT_ROW_TITLES {
+        if titles.len() > crate::app::MAX_AGENT_ROW_TITLES {
             return Err(("invalid_request".to_string(), "too many titles".to_string()));
         }
-        let mut changed = false;
-        for item in titles {
-            changed |= self.apply_agent_row_title_item(item)?;
-        }
+        let updates = titles
+            .iter()
+            .map(|item| self.parse_agent_row_title_item(item))
+            .collect::<Result<Vec<_>, _>>()?;
+        let changed = self.apply_agent_row_title_items_atomically(&updates, owner.as_deref())?;
         Ok(json!({"type":"ok", "changed": changed}))
     }
 
     pub(super) fn api_ui_agent_title_clear(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = method;
+        reject_api_fields(p, &["owner", "pane", "agent", "session_id"])?;
+        let owner = self.agent_row_title_owner(p)?;
         let pane = match p.get("pane") {
             Some(value) => Some(self.parse_agent_row_title_pane(value)?),
             None => None,
         };
         let session = agent_row_title_session(p.get("agent"), p.get("session_id"))?;
-        let changed = self.clear_agent_row_titles(pane, session);
+        let changed = self.clear_agent_row_titles_owned(pane, session, owner.as_deref())?;
         Ok(json!({"type":"ok", "changed": changed}))
+    }
+
+    fn agent_row_title_owner(&self, p: &Value) -> Result<Option<String>, (String, String)> {
+        let Some(owner) = p.get("owner") else {
+            return Ok(None);
+        };
+        let owner = owner
+            .as_str()
+            .filter(|owner| !owner.is_empty() && owner.len() <= 120)
+            .ok_or_else(|| ("invalid_request".into(), "invalid module owner".into()))?;
+        validate_bar_action(self, owner, None)?;
+        Ok(Some(owner.to_string()))
     }
 
     fn parse_agent_row_title_pane(&self, value: &Value) -> Result<PaneId, (String, String)> {
@@ -114,15 +138,16 @@ impl App {
         Ok(id)
     }
 
-    fn apply_agent_row_title_item(&mut self, item: &Value) -> Result<bool, (String, String)> {
-        if !item.is_object() {
-            return Err((
-                "invalid_request".into(),
-                "each title must be an object".into(),
-            ));
-        }
-        let title =
-            sanitize_agent_row_title(item.get("title").and_then(Value::as_str).unwrap_or(""))?;
+    fn parse_agent_row_title_item(
+        &self,
+        item: &Value,
+    ) -> Result<AgentRowTitleUpdate, (String, String)> {
+        reject_api_fields(item, &["pane", "agent", "session_id", "title"])?;
+        let raw_title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ("invalid_request".into(), "title must be a string".into()))?;
+        let title = sanitize_agent_row_title(raw_title)?;
         let pane = match item.get("pane") {
             Some(value) => Some(self.parse_agent_row_title_pane(value)?),
             None => None,
@@ -134,14 +159,74 @@ impl App {
                 "each title needs pane or agent+session_id".into(),
             ));
         }
-        let mut changed = false;
-        if let Some(pane) = pane {
-            changed |= self.set_agent_row_title_for_pane(pane, title.clone());
+        Ok(AgentRowTitleUpdate {
+            pane,
+            session,
+            title,
+        })
+    }
+
+    fn apply_agent_row_title_items_atomically(
+        &mut self,
+        updates: &[AgentRowTitleUpdate],
+        owner: Option<&str>,
+    ) -> Result<bool, (String, String)> {
+        let mut panes = self.agent_title_panes.clone();
+        let mut sessions = self.agent_title_sessions.clone();
+        for update in updates {
+            if let Some(pane) = update.pane {
+                set_owned_agent_row_title(&mut panes, pane, update.title.clone(), owner)
+                    .map_err(module_err)?;
+            }
+            if let Some((agent, session_id)) = &update.session {
+                set_owned_agent_session_title(
+                    &mut sessions,
+                    agent.clone(),
+                    session_id.clone(),
+                    update.title.clone(),
+                    owner,
+                )
+                .map_err(module_err)?;
+            }
         }
-        if let Some((agent, session_id)) = session {
-            changed |= self.set_agent_row_title_for_session(agent, session_id, title);
+        if panes.len() + agent_session_title_count(&sessions) > crate::app::MAX_AGENT_ROW_TITLES {
+            return Err((
+                "resource_exhausted".into(),
+                "too many agent row titles".into(),
+            ));
+        }
+        let changed = panes != self.agent_title_panes || sessions != self.agent_title_sessions;
+        if changed {
+            self.agent_title_panes = panes;
+            self.agent_title_sessions = sessions;
         }
         Ok(changed)
+    }
+
+    fn clear_agent_row_titles_owned(
+        &mut self,
+        pane: Option<PaneId>,
+        session: Option<(String, String)>,
+        owner: Option<&str>,
+    ) -> Result<bool, (String, String)> {
+        if pane.is_none() && session.is_none() {
+            return Ok(match owner {
+                Some(owner) => self.clear_agent_row_titles_for_owner(owner),
+                None => {
+                    let changed =
+                        !self.agent_title_panes.is_empty() || !self.agent_title_sessions.is_empty();
+                    self.agent_title_panes.clear();
+                    self.agent_title_sessions.clear();
+                    changed
+                }
+            });
+        }
+        let update = AgentRowTitleUpdate {
+            pane,
+            session,
+            title: None,
+        };
+        self.apply_agent_row_title_items_atomically(&[update], owner)
     }
 
     pub(super) fn api_ui_dock_push(&mut self, method: &str, p: &Value) -> DispatchResult {

--- a/src/app/dispatch/extensions.rs
+++ b/src/app/dispatch/extensions.rs
@@ -72,6 +72,78 @@ impl App {
         }
     }
 
+    pub(super) fn api_ui_agent_title_push(&mut self, method: &str, p: &Value) -> DispatchResult {
+        let _ = method;
+        let titles = p.get("titles").and_then(Value::as_array).ok_or_else(|| {
+            (
+                "invalid_request".to_string(),
+                "titles must be a JSON array".to_string(),
+            )
+        })?;
+        if titles.len() > MAX_AGENT_ROW_TITLES {
+            return Err(("invalid_request".to_string(), "too many titles".to_string()));
+        }
+        let mut changed = false;
+        for item in titles {
+            changed |= self.apply_agent_row_title_item(item)?;
+        }
+        Ok(json!({"type":"ok", "changed": changed}))
+    }
+
+    pub(super) fn api_ui_agent_title_clear(&mut self, method: &str, p: &Value) -> DispatchResult {
+        let _ = method;
+        let pane = match p.get("pane") {
+            Some(value) => Some(self.parse_agent_row_title_pane(value)?),
+            None => None,
+        };
+        let session = agent_row_title_session(p.get("agent"), p.get("session_id"))?;
+        let changed = self.clear_agent_row_titles(pane, session);
+        Ok(json!({"type":"ok", "changed": changed}))
+    }
+
+    fn parse_agent_row_title_pane(&self, value: &Value) -> Result<PaneId, (String, String)> {
+        let id = value
+            .as_u64()
+            .or_else(|| value.as_str().and_then(|s| s.trim().parse::<u64>().ok()))
+            .and_then(|id| u32::try_from(id).ok())
+            .map(PaneId)
+            .ok_or_else(|| ("invalid_request".into(), "invalid pane".into()))?;
+        if !self.panes.contains_key(&id) {
+            return Err(("not_found".into(), "pane not found".into()));
+        }
+        Ok(id)
+    }
+
+    fn apply_agent_row_title_item(&mut self, item: &Value) -> Result<bool, (String, String)> {
+        if !item.is_object() {
+            return Err((
+                "invalid_request".into(),
+                "each title must be an object".into(),
+            ));
+        }
+        let title =
+            sanitize_agent_row_title(item.get("title").and_then(Value::as_str).unwrap_or(""))?;
+        let pane = match item.get("pane") {
+            Some(value) => Some(self.parse_agent_row_title_pane(value)?),
+            None => None,
+        };
+        let session = agent_row_title_session(item.get("agent"), item.get("session_id"))?;
+        if pane.is_none() && session.is_none() {
+            return Err((
+                "invalid_request".into(),
+                "each title needs pane or agent+session_id".into(),
+            ));
+        }
+        let mut changed = false;
+        if let Some(pane) = pane {
+            changed |= self.set_agent_row_title_for_pane(pane, title.clone());
+        }
+        if let Some((agent, session_id)) = session {
+            changed |= self.set_agent_row_title_for_session(agent, session_id, title);
+        }
+        Ok(changed)
+    }
+
     pub(super) fn api_ui_dock_push(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = (method, p);
         {

--- a/src/app/dispatch/extensions.rs
+++ b/src/app/dispatch/extensions.rs
@@ -81,7 +81,7 @@ impl App {
 
     pub(super) fn api_ui_agent_title_push(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = method;
-        reject_api_fields(p, &["owner", "titles"])?;
+        reject_api_fields(p, &["owner", "module_token", "titles"])?;
         let owner = self.agent_row_title_owner(p)?;
         let titles = p.get("titles").and_then(Value::as_array).ok_or_else(|| {
             (
@@ -102,7 +102,7 @@ impl App {
 
     pub(super) fn api_ui_agent_title_clear(&mut self, method: &str, p: &Value) -> DispatchResult {
         let _ = method;
-        reject_api_fields(p, &["owner", "pane", "agent", "session_id"])?;
+        reject_api_fields(p, &["owner", "module_token", "pane", "agent", "session_id"])?;
         let owner = self.agent_row_title_owner(p)?;
         let pane = match p.get("pane") {
             Some(value) => Some(self.parse_agent_row_title_pane(value)?),
@@ -115,6 +115,12 @@ impl App {
 
     fn agent_row_title_owner(&self, p: &Value) -> Result<Option<String>, (String, String)> {
         let Some(owner) = p.get("owner") else {
+            if p.get("module_token").is_some() {
+                return Err((
+                    "invalid_request".into(),
+                    "module_token requires owner".into(),
+                ));
+            }
             return Ok(None);
         };
         let owner = owner
@@ -122,6 +128,14 @@ impl App {
             .filter(|owner| !owner.is_empty() && owner.len() <= 120)
             .ok_or_else(|| ("invalid_request".into(), "invalid module owner".into()))?;
         validate_bar_action(self, owner, None)?;
+        let token = p
+            .get("module_token")
+            .and_then(Value::as_str)
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| ("forbidden".into(), "module token required".into()))?;
+        if self.module_tokens.get(owner).map(String::as_str) != Some(token) {
+            return Err(("forbidden".into(), "invalid module token".into()));
+        }
         Ok(Some(owner.to_string()))
     }
 
@@ -210,16 +224,10 @@ impl App {
         owner: Option<&str>,
     ) -> Result<bool, (String, String)> {
         if pane.is_none() && session.is_none() {
-            return Ok(match owner {
-                Some(owner) => self.clear_agent_row_titles_for_owner(owner),
-                None => {
-                    let changed =
-                        !self.agent_title_panes.is_empty() || !self.agent_title_sessions.is_empty();
-                    self.agent_title_panes.clear();
-                    self.agent_title_sessions.clear();
-                    changed
-                }
-            });
+            let Some(owner) = owner else {
+                return Ok(false);
+            };
+            return Ok(self.clear_agent_row_titles_for_owner(owner));
         }
         let update = AgentRowTitleUpdate {
             pane,

--- a/src/app/dispatch/params.rs
+++ b/src/app/dispatch/params.rs
@@ -88,6 +88,57 @@ pub(in crate::app::dispatch) fn agent_fork_error(err: AgentForkError) -> (String
     (code.to_string(), message.to_string())
 }
 
+pub(in crate::app::dispatch) const MAX_AGENT_ROW_TITLE_BYTES: usize = 256;
+pub(in crate::app::dispatch) const MAX_AGENT_ROW_TITLES: usize = 256;
+
+pub(in crate::app::dispatch) fn sanitize_agent_row_title(
+    raw: &str,
+) -> Result<Option<String>, (String, String)> {
+    let cleaned: String = raw
+        .chars()
+        .map(|character| {
+            if matches!(character, '\n' | '\r') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.len() > MAX_AGENT_ROW_TITLE_BYTES {
+        return Err(("invalid_request".into(), "title is too long".into()));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+pub(in crate::app::dispatch) fn agent_row_title_session(
+    agent: Option<&Value>,
+    session_id: Option<&Value>,
+) -> Result<Option<(String, String)>, (String, String)> {
+    match (agent, session_id) {
+        (None, None) => Ok(None),
+        (Some(agent), Some(session_id)) => {
+            let agent = agent
+                .as_str()
+                .map(str::trim)
+                .filter(|agent| !agent.is_empty())
+                .ok_or_else(|| ("invalid_request".into(), "agent is required".into()))?;
+            let session_id = session_id.as_str().unwrap_or("");
+            if !crate::agent::safe_session_id(session_id) {
+                return Err(("invalid_request".into(), "invalid session_id".into()));
+            }
+            Ok(Some((agent.to_string(), session_id.to_string())))
+        }
+        _ => Err((
+            "invalid_request".into(),
+            "agent and session_id must be supplied together".into(),
+        )),
+    }
+}
+
 /// Strip a leading decorative icon/glyph that some agents prepend to their OSC
 /// title (a spinner or status emoji), plus the surrounding whitespace, so the
 /// sidebar shows just the text. A non-ASCII symbol/emoji leads is dropped;

--- a/src/app/dispatch/params.rs
+++ b/src/app/dispatch/params.rs
@@ -88,16 +88,25 @@ pub(in crate::app::dispatch) fn agent_fork_error(err: AgentForkError) -> (String
     (code.to_string(), message.to_string())
 }
 
-pub(in crate::app::dispatch) const MAX_AGENT_ROW_TITLE_BYTES: usize = 256;
-pub(in crate::app::dispatch) const MAX_AGENT_ROW_TITLES: usize = 256;
-
 pub(in crate::app::dispatch) fn sanitize_agent_row_title(
     raw: &str,
 ) -> Result<Option<String>, (String, String)> {
+    if raw.len() > crate::app::MAX_AGENT_ROW_TITLE_BYTES {
+        return Err(("invalid_request".into(), "title is too long".into()));
+    }
+    if raw
+        .chars()
+        .any(|character| character.is_control() && !matches!(character, '\n' | '\r' | '\t'))
+    {
+        return Err((
+            "invalid_request".into(),
+            "title contains unsupported control characters".into(),
+        ));
+    }
     let cleaned: String = raw
         .chars()
         .map(|character| {
-            if matches!(character, '\n' | '\r') {
+            if matches!(character, '\n' | '\r' | '\t') {
                 ' '
             } else {
                 character
@@ -107,9 +116,6 @@ pub(in crate::app::dispatch) fn sanitize_agent_row_title(
     let trimmed = cleaned.trim();
     if trimmed.is_empty() {
         return Ok(None);
-    }
-    if trimmed.len() > MAX_AGENT_ROW_TITLE_BYTES {
-        return Err(("invalid_request".into(), "title is too long".into()));
     }
     Ok(Some(trimmed.to_string()))
 }
@@ -121,11 +127,20 @@ pub(in crate::app::dispatch) fn agent_row_title_session(
     match (agent, session_id) {
         (None, None) => Ok(None),
         (Some(agent), Some(session_id)) => {
-            let agent = agent
+            let raw_agent = agent
                 .as_str()
                 .map(str::trim)
                 .filter(|agent| !agent.is_empty())
                 .ok_or_else(|| ("invalid_request".into(), "agent is required".into()))?;
+            if raw_agent.len() > crate::app::MAX_AGENT_ROW_TITLE_AGENT_BYTES {
+                return Err(("invalid_request".into(), "agent is too long".into()));
+            }
+            let agent = crate::agent::canonical_builtin(raw_agent).ok_or_else(|| {
+                (
+                    "invalid_request".into(),
+                    "agent must name a built-in Luvus adapter".into(),
+                )
+            })?;
             let session_id = session_id.as_str().unwrap_or("");
             if !crate::agent::safe_session_id(session_id) {
                 return Err(("invalid_request".into(), "invalid session_id".into()));

--- a/src/app/dispatch/tests/extensions.rs
+++ b/src/app/dispatch/tests/extensions.rs
@@ -166,9 +166,10 @@ command = ["true"]
     assert_eq!(result["changed"], true);
     let before = app.bar.widgets["you.ci:status"].clone();
 
+    let title_token = app.module_tokens["you.ci"].clone();
     app.dispatch(
         "ui.agent_title.push",
-        &json!({"owner":"you.ci","titles":[{
+        &json!({"owner":"you.ci","module_token":title_token,"titles":[{
             "agent":"pi","session_id":"owned-session","title":"Owned title"
         }]}),
     )
@@ -269,6 +270,24 @@ fn agent_row_titles_are_module_provided_and_never_use_alias() {
     )
     .unwrap();
     assert!(app.agent_row_title_for_session("pi", "old-1").is_none());
+
+    app.dispatch(
+        "ui.agent_title.push",
+        &json!({"titles": [{
+            "agent":"cursor-agent", "session_id":"alias-session", "title":"Alias title"
+        }]}),
+    )
+    .unwrap();
+    app.status.get_mut(&pane).unwrap().agent_session = Some(crate::app::AgentSession {
+        agent: "cursor-agent".into(),
+        session_id: "alias-session".into(),
+    });
+    assert_eq!(
+        app.pane_title(pane).as_deref(),
+        Some("Alias title"),
+        "live session aliases must use the canonical title key"
+    );
+
     for invalid in [
         json!({"titles": [{"title": "no target"}]}),
         json!({"titles": [{"agent":"pi","session_id":"old-1"}]}),
@@ -281,6 +300,56 @@ fn agent_row_titles_are_module_provided_and_never_use_alias() {
             "invalid_request"
         );
     }
+}
+
+#[test]
+fn ownerless_clear_does_not_remove_module_owned_agent_titles() {
+    let _env = crate::persist::test_env("agent-row-title-ownerless-clear");
+    let module =
+        std::path::PathBuf::from(std::env::var_os("LUVUS_HOME").unwrap()).join("title-module");
+    std::fs::create_dir_all(&module).unwrap();
+    std::fs::write(
+        module.join("luvus-module.toml"),
+        r#"
+id = "module.alpha"
+name = "Alpha"
+version = "0.1.0"
+min_luvus_version = "0.1.0"
+"#,
+    )
+    .unwrap();
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let mut app = App::new(80, 24, tx).unwrap();
+    app.module_link_with(&module, true, None).unwrap();
+    let token = app.module_tokens["module.alpha"].clone();
+    app.dispatch(
+        "ui.agent_title.push",
+        &json!({"owner":"module.alpha","module_token":token,"titles":[{
+            "agent":"pi","session_id":"owned","title":"Owned"
+        }]}),
+    )
+    .unwrap();
+
+    let spoof = app
+        .dispatch(
+            "ui.agent_title.push",
+            &json!({"owner":"module.alpha","module_token":"forged","titles":[{
+                "agent":"pi","session_id":"owned","title":"Spoofed"
+            }]}),
+        )
+        .unwrap_err();
+    assert_eq!(spoof.0, "forbidden");
+    assert_eq!(
+        app.agent_row_title_for_session("pi", "owned"),
+        Some("Owned")
+    );
+
+    let cleared = app.dispatch("ui.agent_title.clear", &json!({})).unwrap();
+    assert_eq!(cleared["changed"], false);
+    assert_eq!(
+        app.agent_row_title_for_session("pi", "owned"),
+        Some("Owned")
+    );
 }
 
 #[test]

--- a/src/app/dispatch/tests/extensions.rs
+++ b/src/app/dispatch/tests/extensions.rs
@@ -353,6 +353,53 @@ min_luvus_version = "0.1.0"
 }
 
 #[test]
+fn re_enabling_a_module_keeps_live_publisher_credentials_valid() {
+    let _env = crate::persist::test_env("agent-row-title-reenable-token");
+    let module =
+        std::path::PathBuf::from(std::env::var_os("LUVUS_HOME").unwrap()).join("reenable-module");
+    std::fs::create_dir_all(&module).unwrap();
+    std::fs::write(
+        module.join("luvus-module.toml"),
+        r#"
+id = "module.reenable"
+name = "Reenable"
+version = "0.1.0"
+min_luvus_version = "0.1.0"
+"#,
+    )
+    .unwrap();
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let mut app = App::new(80, 24, tx).unwrap();
+    app.module_link_with(&module, true, None).unwrap();
+    // The credential a live module process received when it was spawned.
+    let spawned_token = app.module_tokens["module.reenable"].clone();
+
+    app.module_set_enabled("module.reenable", false).unwrap();
+    let disabled = app
+        .dispatch(
+            "ui.agent_title.push",
+            &json!({"owner":"module.reenable","module_token":spawned_token,"titles":[{
+                "agent":"pi","session_id":"live","title":"Disabled"
+            }]}),
+        )
+        .expect_err("a disabled module cannot publish");
+    assert_eq!(disabled.0, "module_error");
+
+    app.module_set_enabled("module.reenable", true).unwrap();
+    app.dispatch(
+        "ui.agent_title.push",
+        &json!({"owner":"module.reenable","module_token":spawned_token,"titles":[{
+            "agent":"pi","session_id":"live","title":"Still mine"
+        }]}),
+    )
+    .expect("a surviving module process keeps publishing after re-enable");
+    assert_eq!(
+        app.agent_row_title_for_session("pi", "live"),
+        Some("Still mine")
+    );
+}
+
+#[test]
 fn agent_row_title_push_is_atomic_and_globally_bounded() {
     let _env = crate::persist::test_env("agent-row-title-bounds");
     let (tx, _rx) = std::sync::mpsc::channel();

--- a/src/app/dispatch/tests/extensions.rs
+++ b/src/app/dispatch/tests/extensions.rs
@@ -166,6 +166,27 @@ command = ["true"]
     assert_eq!(result["changed"], true);
     let before = app.bar.widgets["you.ci:status"].clone();
 
+    app.dispatch(
+        "ui.agent_title.push",
+        &json!({"owner":"you.ci","titles":[{
+            "agent":"pi","session_id":"owned-session","title":"Owned title"
+        }]}),
+    )
+    .unwrap();
+    assert_eq!(
+        app.agent_row_title_for_session("pi", "owned-session"),
+        Some("Owned title")
+    );
+    assert_eq!(
+        app.dispatch(
+            "ui.agent_title.push",
+            &json!({"owner":"missing.module","titles":[]}),
+        )
+        .unwrap_err()
+        .0,
+        "module_error"
+    );
+
     let mut invalid = valid;
     invalid["content"] = json!([{"type":"text","text":"\u{1b}[31mraw"}]);
     assert!(app.dispatch("ui.bar.push", &invalid).is_err());
@@ -200,6 +221,126 @@ command = ["true"]
     );
     app.module_set_enabled("you.ci", false).unwrap();
     assert!(!app.bar.widgets.contains_key("you.ci:status"));
+    assert!(app
+        .agent_row_title_for_session("pi", "owned-session")
+        .is_none());
+}
+
+#[test]
+fn agent_row_titles_are_module_provided_and_never_use_alias() {
+    let _env = crate::persist::test_env("agent-row-titles");
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let mut app = App::new(80, 24, tx).unwrap();
+    let pane = app.layout().focus;
+    app.status.get_mut(&pane).unwrap().agent_session = Some(crate::app::AgentSession {
+        agent: "pi".into(),
+        session_id: "sess-1".into(),
+    });
+    app.agent_names.insert("chezmoi".into(), pane);
+    let pushed = app
+        .dispatch(
+            "ui.agent_title.push",
+            &json!({"titles": [
+                {"pane": pane.0.to_string(), "title": "Ship desktop"},
+                {"agent": "pi", "session_id": "old-1", "title": "History title"}
+            ]}),
+        )
+        .unwrap();
+    assert_eq!(pushed["changed"], true);
+    assert_eq!(app.pane_title(pane).as_deref(), Some("Ship desktop"));
+    assert_eq!(app.agent_name_for(pane), Some("chezmoi"));
+    assert_eq!(
+        app.agent_row_title_for_session("pi", "old-1"),
+        Some("History title")
+    );
+    app.dispatch(
+        "ui.agent_title.push",
+        &json!({"titles": [
+            {"pane": pane.0.to_string(), "title": ""}
+        ]}),
+    )
+    .unwrap();
+    assert_eq!(app.pane_title(pane), None, "must not fall back to =alias");
+    app.dispatch(
+        "ui.agent_title.clear",
+        &json!({
+            "agent":"pi", "session_id":"old-1"
+        }),
+    )
+    .unwrap();
+    assert!(app.agent_row_title_for_session("pi", "old-1").is_none());
+    for invalid in [
+        json!({"titles": [{"title": "no target"}]}),
+        json!({"titles": [{"agent":"pi","session_id":"old-1"}]}),
+        json!({"titles": [{"agent":"pi","session_id":"old-1","title":42}]}),
+        json!({"titles": [{"agent":"pi","session_id":"old-1","title":"bad\u{7}title"}]}),
+        json!({"titles": [{"agent":"not-built-in","session_id":"old-1","title":"bad"}]}),
+    ] {
+        assert_eq!(
+            app.dispatch("ui.agent_title.push", &invalid).unwrap_err().0,
+            "invalid_request"
+        );
+    }
+}
+
+#[test]
+fn agent_row_title_push_is_atomic_and_globally_bounded() {
+    let _env = crate::persist::test_env("agent-row-title-bounds");
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let mut app = App::new(80, 24, tx).unwrap();
+    let invalid = json!({"titles":[
+        {"agent":"pi","session_id":"first","title":"must not stick"},
+        {"title":"missing target"}
+    ]});
+    assert!(app.dispatch("ui.agent_title.push", &invalid).is_err());
+    assert!(app.agent_row_title_for_session("pi", "first").is_none());
+
+    let titles = (0..crate::app::MAX_AGENT_ROW_TITLES)
+        .map(|index| {
+            json!({
+                "agent":"pi", "session_id":format!("session-{index}"),
+                "title":format!("Title {index}")
+            })
+        })
+        .collect::<Vec<_>>();
+    app.dispatch("ui.agent_title.push", &json!({"titles":titles}))
+        .unwrap();
+    let before = agent_session_title_count(&app.agent_title_sessions);
+    let error = app
+        .dispatch(
+            "ui.agent_title.push",
+            &json!({"titles":[{
+                "agent":"pi", "session_id":"overflow", "title":"No"
+            }]}),
+        )
+        .unwrap_err();
+    assert_eq!(error.0, "resource_exhausted");
+    assert_eq!(agent_session_title_count(&app.agent_title_sessions), before);
+    assert!(app.agent_row_title_for_session("pi", "overflow").is_none());
+}
+
+#[test]
+fn agent_row_session_titles_work_without_a_workspace() {
+    let _env = crate::persist::test_env("agent-row-title-no-workspace");
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let mut app = App::new(80, 24, tx).unwrap();
+    for pane in app.panes.keys().copied().collect::<Vec<_>>() {
+        app.drop_leaf_runtime(pane);
+    }
+    app.workspaces.clear();
+    let (reply, _response) = std::sync::mpsc::channel();
+    let request = ApiRequest {
+        id: "title".into(),
+        method: "ui.agent_title.push".into(),
+        params: json!({"titles":[{"agent":"pi","session_id":"offline","title":"Offline"}]}),
+        reply,
+    };
+    let response: Value = serde_json::from_str(&app.handle_api(&request)).unwrap();
+    assert_eq!(response["result"]["changed"], true);
+    assert_eq!(
+        app.agent_row_title_for_session("pi", "offline"),
+        Some("Offline")
+    );
 }
 
 #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -258,8 +258,8 @@ pub struct ModuleDock {
     pub rows: Vec<DockRow>,
 }
 
-/// One volatile AGENTS-row title and the module that owns it. `None` is reserved
-/// for direct local-owner API calls; module commands always include their id.
+/// One volatile AGENTS-row title and its authenticated publishing module.
+/// `None` is reserved for direct local control-API calls.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub(crate) struct AgentRowTitle {
     pub(crate) owner: Option<String>,
@@ -283,8 +283,8 @@ pub(crate) fn set_owned_agent_row_title(
     owner: Option<&str>,
 ) -> Result<bool, String> {
     if let Some(existing) = titles.get(&pane) {
-        if owner.is_some() && existing.owner.as_deref() != owner {
-            return Err("agent row title belongs to another module".into());
+        if existing.owner.as_deref() != owner {
+            return Err("agent row title belongs to another publisher".into());
         }
     }
     match text {
@@ -315,8 +315,8 @@ pub(crate) fn set_owned_agent_session_title(
         .get(&agent)
         .and_then(|sessions| sessions.get(&session_id));
     if let Some(existing) = existing {
-        if owner.is_some() && existing.owner.as_deref() != owner {
-            return Err("agent row title belongs to another module".into());
+        if existing.owner.as_deref() != owner {
+            return Err("agent row title belongs to another publisher".into());
         }
     }
     match text {
@@ -2902,6 +2902,9 @@ pub struct App {
     pub settings_arrow_rects: Vec<(usize, i32, Rect)>,
     /// Installed modules (docs/13) and the ring buffer of their command logs.
     pub modules: crate::module::ModuleRegistry,
+    /// Per-server credentials injected only into processes Luvus starts for each
+    /// module. Public API owner fields are accepted only with the matching token.
+    pub(crate) module_tokens: HashMap<String, String>,
     pub module_logs: Vec<crate::module::ModuleCommandLog>,
     /// Live module panes by pane id, untracked automatically on close (MOD-2).
     pub module_panes: HashMap<PaneId, crate::module::ModulePaneRecord>,
@@ -2920,6 +2923,17 @@ pub struct ModuleSettingEdit {
     pub title: String,
     pub buffer: String,
     pub secret: bool,
+}
+
+fn module_tokens_for(
+    modules: &crate::module::ModuleRegistry,
+) -> Result<HashMap<String, String>, String> {
+    modules
+        .modules
+        .iter()
+        .filter(|module| module.is_runnable())
+        .map(|module| crate::terminal::backend::random_id().map(|token| (module.id.clone(), token)))
+        .collect()
 }
 
 fn child_appearance(
@@ -2956,6 +2970,7 @@ impl App {
         let direct_keymap = keys::build_direct_keymap(&config.direct_keybindings);
         let prefix = keys::PrefixSpec::parse(&config.prefix).unwrap_or_default();
         let modules = crate::module::registry::load();
+        let module_tokens = module_tokens_for(&modules).map_err(anyhow::Error::msg)?;
         let mut bar = crate::bar::BarState::default();
         bar.sync_modules(&modules);
 
@@ -3284,6 +3299,7 @@ impl App {
             theme_selection_revision: 0,
             settings_arrow_rects: Vec::new(),
             modules,
+            module_tokens,
             module_logs: Vec::new(),
             module_panes: HashMap::new(),
             module_startup_done: std::collections::HashSet::new(),
@@ -3325,6 +3341,7 @@ impl App {
         let shell = crate::platform::resolve_shell(&config.shell);
         let history_budget_bytes = config.scrollback_bytes();
         let modules = crate::module::registry::load();
+        let module_tokens = module_tokens_for(&modules).ok()?;
         let mut panes = HashMap::new();
         let mut status = HashMap::new();
         let mut module_panes: HashMap<PaneId, crate::module::ModulePaneRecord> = HashMap::new();
@@ -3506,7 +3523,7 @@ impl App {
                     // installed + runnable; otherwise it falls back to a shell.
                     let restored = ps.module.as_ref().and_then(|(mid, ep)| {
                         restore_module_pane(
-                            &modules,
+                            (&modules, &module_tokens),
                             mid,
                             ep,
                             id,
@@ -3942,6 +3959,7 @@ impl App {
             theme_selection_revision: 0,
             settings_arrow_rects: Vec::new(),
             modules,
+            module_tokens,
             module_logs: Vec::new(),
             module_panes,
             module_startup_done: std::collections::HashSet::new(),
@@ -7131,7 +7149,7 @@ impl App {
             title,
             None,
         )
-        .expect("the direct local owner may replace any title")
+        .expect("the test helper writes only unowned title keys")
     }
 
     pub(crate) fn clear_agent_row_titles_for_owner(&mut self, owner: &str) -> bool {
@@ -7152,6 +7170,7 @@ impl App {
         agent: &str,
         session_id: &str,
     ) -> Option<&str> {
+        let agent = crate::agent::canonical_builtin(agent)?;
         self.agent_title_sessions
             .get(agent)?
             .get(session_id)
@@ -8056,7 +8075,7 @@ pub(crate) fn worktree_membership(cwd: &std::path::Path) -> Option<crate::git::W
 /// Re-spawn a saved module pane if its module is still installed + runnable;
 /// returns the pane + its tracking record, or `None` to fall back to a shell.
 fn restore_module_pane(
-    modules: &crate::module::ModuleRegistry,
+    module_runtime: (&crate::module::ModuleRegistry, &HashMap<String, String>),
     mid: &str,
     ep: &str,
     id: PaneId,
@@ -8064,6 +8083,7 @@ fn restore_module_pane(
     history_budget_bytes: usize,
     appearance: crate::terminal::appearance::PaneAppearance,
 ) -> Option<(Pane, crate::module::ModulePaneRecord)> {
+    let (modules, module_tokens) = module_runtime;
     let m = modules.find(mid).filter(|m| m.is_runnable())?;
     let argv = m
         .manifest
@@ -8074,6 +8094,7 @@ fn restore_module_pane(
     let ctx = serde_json::json!({ "invocation_source": "restore" });
     let env = crate::module::runtime::env(
         m,
+        module_tokens.get(mid)?,
         &ctx,
         vec![("LUVUS_MODULE_ENTRYPOINT_ID".to_string(), ep.to_string())],
     );

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8097,7 +8097,9 @@ fn restore_module_pane(
     let ctx = serde_json::json!({ "invocation_source": "restore" });
     let env = crate::module::runtime::env(
         m,
-        module_tokens.get(mid)?,
+        // A snapshot may name the module by its install shorthand, which
+        // `find` accepts but the token map (keyed by manifest id) does not.
+        module_tokens.get(m.id.as_str())?,
         &ctx,
         vec![("LUVUS_MODULE_ENTRYPOINT_ID".to_string(), ep.to_string())],
     );
@@ -8116,7 +8118,7 @@ fn restore_module_pane(
     Some((
         pane,
         crate::module::ModulePaneRecord {
-            module_id: mid.to_string(),
+            module_id: m.id.clone(),
             entrypoint: ep.to_string(),
         },
     ))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2496,6 +2496,10 @@ pub struct App {
     cwd_git_hits: HashMap<PaneId, (PathBuf, u8)>,
     /// Resumable agent sessions discovered on disk (for the AGENTS sidebar).
     pub resumable: Vec<crate::agent::SessionInfo>,
+    /// Module-provided AGENTS sidebar titles for live panes. OSC still wins.
+    pub(crate) agent_title_panes: HashMap<PaneId, String>,
+    /// Module-provided titles for native sessions (live idle fallback and All/history).
+    pub(crate) agent_title_sessions: HashMap<(String, String), String>,
     /// A resumable-session disk scan is running on a worker thread; don't start
     /// another until its `SessionsScanned` result arrives.
     sessions_scan_inflight: bool,
@@ -3042,6 +3046,8 @@ impl App {
             cwd_scan_inflight: false,
             cwd_git_hits: HashMap::new(),
             resumable: Vec::new(),
+            agent_title_panes: HashMap::new(),
+            agent_title_sessions: HashMap::new(),
             sessions_scan_inflight: false,
             proc_commands: HashMap::new(),
             proc_scan_inflight: false,
@@ -3698,6 +3704,8 @@ impl App {
             cwd_scan_inflight: false,
             cwd_git_hits: HashMap::new(),
             resumable: Vec::new(),
+            agent_title_panes: HashMap::new(),
+            agent_title_sessions: HashMap::new(),
             sessions_scan_inflight: false,
             proc_commands: HashMap::new(),
             proc_scan_inflight: false,
@@ -7022,6 +7030,72 @@ impl App {
         changed
     }
 
+    pub(crate) fn set_agent_row_title_for_pane(
+        &mut self,
+        pane: PaneId,
+        title: Option<String>,
+    ) -> bool {
+        match title {
+            Some(title) if self.agent_title_panes.get(&pane) == Some(&title) => false,
+            Some(title) => {
+                self.agent_title_panes.insert(pane, title);
+                true
+            }
+            None => self.agent_title_panes.remove(&pane).is_some(),
+        }
+    }
+
+    pub(crate) fn set_agent_row_title_for_session(
+        &mut self,
+        agent: String,
+        session_id: String,
+        title: Option<String>,
+    ) -> bool {
+        let key = (agent, session_id);
+        match title {
+            Some(title) if self.agent_title_sessions.get(&key) == Some(&title) => false,
+            Some(title) => {
+                self.agent_title_sessions.insert(key, title);
+                true
+            }
+            None => self.agent_title_sessions.remove(&key).is_some(),
+        }
+    }
+
+    pub(crate) fn clear_agent_row_titles(
+        &mut self,
+        pane: Option<PaneId>,
+        session: Option<(String, String)>,
+    ) -> bool {
+        match (pane, session) {
+            (None, None) => {
+                let changed =
+                    !self.agent_title_panes.is_empty() || !self.agent_title_sessions.is_empty();
+                self.agent_title_panes.clear();
+                self.agent_title_sessions.clear();
+                changed
+            }
+            (Some(pane), None) => self.agent_title_panes.remove(&pane).is_some(),
+            (None, Some(session)) => self.agent_title_sessions.remove(&session).is_some(),
+            (Some(pane), Some(session)) => {
+                let pane_changed = self.agent_title_panes.remove(&pane).is_some();
+                let session_changed = self.agent_title_sessions.remove(&session).is_some();
+                pane_changed || session_changed
+            }
+        }
+    }
+
+    pub(crate) fn agent_row_title_for_session(
+        &self,
+        agent: &str,
+        session_id: &str,
+    ) -> Option<&str> {
+        self.agent_title_sessions
+            .get(&(agent.to_string(), session_id.to_string()))
+            .map(String::as_str)
+            .filter(|title| !title.is_empty())
+    }
+
     /// Remove a resumable session from the sidebar list. Hides it for the rest of
     /// the run (so the periodic rescan doesn't bring it back) — it does NOT touch
     /// the agent's stored session on disk.
@@ -7496,6 +7570,7 @@ impl App {
         self.emit_backend_terminal_event(id, "terminal.closed", serde_json::json!({}));
         self.backend_terminal_index.retain(|_, pane| *pane != id);
         self.backend_labels.remove(&id);
+        self.agent_title_panes.remove(&id);
         self.cancel_backend_revision_waits(id);
         let reported = self
             .reported_usage
@@ -13161,6 +13236,41 @@ mod tests {
 
         drop(restored);
         let _ = std::fs::remove_dir_all(other);
+    }
+
+    #[test]
+    fn module_agent_titles_apply_to_live_and_resumable_without_using_alias() {
+        let _env = crate::persist::test_env("module-agent-titles");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        let pane = app.layout().focus;
+        {
+            let status = app.status.get_mut(&pane).unwrap();
+            status.agent = "pi".into();
+            status.agent_session = Some(AgentSession {
+                agent: "pi".into(),
+                session_id: "live-1".into(),
+            });
+        }
+        app.agent_names.insert("chezmoi".into(), pane);
+        assert!(app.set_agent_row_title_for_session(
+            "pi".into(),
+            "live-1".into(),
+            Some("Live module title".into()),
+        ));
+        assert!(app.set_agent_row_title_for_session(
+            "pi".into(),
+            "old-1".into(),
+            Some("History title".into()),
+        ));
+        assert_eq!(app.pane_title(pane).as_deref(), Some("Live module title"));
+        assert_eq!(app.agent_name_for(pane), Some("chezmoi"));
+        assert_eq!(
+            app.agent_row_title_for_session("pi", "old-1"),
+            Some("History title")
+        );
+        assert!(app.clear_agent_row_titles(None, Some(("pi".into(), "live-1".into()))));
+        assert!(app.pane_title(pane).is_none());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -258,6 +258,92 @@ pub struct ModuleDock {
     pub rows: Vec<DockRow>,
 }
 
+/// One volatile AGENTS-row title and the module that owns it. `None` is reserved
+/// for direct local-owner API calls; module commands always include their id.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) struct AgentRowTitle {
+    pub(crate) owner: Option<String>,
+    pub(crate) text: String,
+}
+
+pub(crate) const MAX_AGENT_ROW_TITLE_BYTES: usize = 256;
+pub(crate) const MAX_AGENT_ROW_TITLES: usize = 256;
+pub(crate) const MAX_AGENT_ROW_TITLE_AGENT_BYTES: usize = 64;
+
+pub(crate) fn agent_session_title_count(
+    titles: &HashMap<String, HashMap<String, AgentRowTitle>>,
+) -> usize {
+    titles.values().map(HashMap::len).sum()
+}
+
+pub(crate) fn set_owned_agent_row_title(
+    titles: &mut HashMap<PaneId, AgentRowTitle>,
+    pane: PaneId,
+    text: Option<String>,
+    owner: Option<&str>,
+) -> Result<bool, String> {
+    if let Some(existing) = titles.get(&pane) {
+        if owner.is_some() && existing.owner.as_deref() != owner {
+            return Err("agent row title belongs to another module".into());
+        }
+    }
+    match text {
+        Some(text) => {
+            let title = AgentRowTitle {
+                owner: owner.map(String::from),
+                text,
+            };
+            if titles.get(&pane) == Some(&title) {
+                Ok(false)
+            } else {
+                titles.insert(pane, title);
+                Ok(true)
+            }
+        }
+        None => Ok(titles.remove(&pane).is_some()),
+    }
+}
+
+pub(crate) fn set_owned_agent_session_title(
+    titles: &mut HashMap<String, HashMap<String, AgentRowTitle>>,
+    agent: String,
+    session_id: String,
+    text: Option<String>,
+    owner: Option<&str>,
+) -> Result<bool, String> {
+    let existing = titles
+        .get(&agent)
+        .and_then(|sessions| sessions.get(&session_id));
+    if let Some(existing) = existing {
+        if owner.is_some() && existing.owner.as_deref() != owner {
+            return Err("agent row title belongs to another module".into());
+        }
+    }
+    match text {
+        Some(text) => {
+            let title = AgentRowTitle {
+                owner: owner.map(String::from),
+                text,
+            };
+            if existing == Some(&title) {
+                return Ok(false);
+            }
+            titles.entry(agent).or_default().insert(session_id, title);
+            Ok(true)
+        }
+        None => {
+            let Some(sessions) = titles.get_mut(&agent) else {
+                return Ok(false);
+            };
+            let changed = sessions.remove(&session_id).is_some();
+            if sessions.is_empty() {
+                titles.remove(&agent);
+            }
+            Ok(changed)
+        }
+    }
+}
+
 /// One sidebar's live state: shown/hidden, width, and its ordered docks.
 #[derive(Clone)]
 pub struct SideState {
@@ -2497,9 +2583,10 @@ pub struct App {
     /// Resumable agent sessions discovered on disk (for the AGENTS sidebar).
     pub resumable: Vec<crate::agent::SessionInfo>,
     /// Module-provided AGENTS sidebar titles for live panes. OSC still wins.
-    pub(crate) agent_title_panes: HashMap<PaneId, String>,
+    pub(crate) agent_title_panes: HashMap<PaneId, AgentRowTitle>,
     /// Module-provided titles for native sessions (live idle fallback and All/history).
-    pub(crate) agent_title_sessions: HashMap<(String, String), String>,
+    /// The nested shape permits borrowed, allocation-free lookups while rendering.
+    pub(crate) agent_title_sessions: HashMap<String, HashMap<String, AgentRowTitle>>,
     /// A resumable-session disk scan is running on a worker thread; don't start
     /// another until its `SessionsScanned` result arrives.
     sessions_scan_inflight: bool,
@@ -7030,59 +7117,34 @@ impl App {
         changed
     }
 
-    pub(crate) fn set_agent_row_title_for_pane(
-        &mut self,
-        pane: PaneId,
-        title: Option<String>,
-    ) -> bool {
-        match title {
-            Some(title) if self.agent_title_panes.get(&pane) == Some(&title) => false,
-            Some(title) => {
-                self.agent_title_panes.insert(pane, title);
-                true
-            }
-            None => self.agent_title_panes.remove(&pane).is_some(),
-        }
-    }
-
+    #[cfg(test)]
     pub(crate) fn set_agent_row_title_for_session(
         &mut self,
         agent: String,
         session_id: String,
         title: Option<String>,
     ) -> bool {
-        let key = (agent, session_id);
-        match title {
-            Some(title) if self.agent_title_sessions.get(&key) == Some(&title) => false,
-            Some(title) => {
-                self.agent_title_sessions.insert(key, title);
-                true
-            }
-            None => self.agent_title_sessions.remove(&key).is_some(),
-        }
+        set_owned_agent_session_title(
+            &mut self.agent_title_sessions,
+            agent,
+            session_id,
+            title,
+            None,
+        )
+        .expect("the direct local owner may replace any title")
     }
 
-    pub(crate) fn clear_agent_row_titles(
-        &mut self,
-        pane: Option<PaneId>,
-        session: Option<(String, String)>,
-    ) -> bool {
-        match (pane, session) {
-            (None, None) => {
-                let changed =
-                    !self.agent_title_panes.is_empty() || !self.agent_title_sessions.is_empty();
-                self.agent_title_panes.clear();
-                self.agent_title_sessions.clear();
-                changed
-            }
-            (Some(pane), None) => self.agent_title_panes.remove(&pane).is_some(),
-            (None, Some(session)) => self.agent_title_sessions.remove(&session).is_some(),
-            (Some(pane), Some(session)) => {
-                let pane_changed = self.agent_title_panes.remove(&pane).is_some();
-                let session_changed = self.agent_title_sessions.remove(&session).is_some();
-                pane_changed || session_changed
-            }
-        }
+    pub(crate) fn clear_agent_row_titles_for_owner(&mut self, owner: &str) -> bool {
+        let pane_count = self.agent_title_panes.len();
+        self.agent_title_panes
+            .retain(|_, title| title.owner.as_deref() != Some(owner));
+        let session_count = agent_session_title_count(&self.agent_title_sessions);
+        self.agent_title_sessions.retain(|_, sessions| {
+            sessions.retain(|_, title| title.owner.as_deref() != Some(owner));
+            !sessions.is_empty()
+        });
+        pane_count != self.agent_title_panes.len()
+            || session_count != agent_session_title_count(&self.agent_title_sessions)
     }
 
     pub(crate) fn agent_row_title_for_session(
@@ -7091,8 +7153,9 @@ impl App {
         session_id: &str,
     ) -> Option<&str> {
         self.agent_title_sessions
-            .get(&(agent.to_string(), session_id.to_string()))
-            .map(String::as_str)
+            .get(agent)?
+            .get(session_id)
+            .map(|title| title.text.as_str())
             .filter(|title| !title.is_empty())
     }
 
@@ -13239,6 +13302,43 @@ mod tests {
     }
 
     #[test]
+    fn module_agent_title_owners_cannot_overwrite_or_clear_each_other() {
+        let _env = crate::persist::test_env("module-agent-title-owners");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        set_owned_agent_session_title(
+            &mut app.agent_title_sessions,
+            "pi".into(),
+            "shared".into(),
+            Some("Alpha".into()),
+            Some("module.alpha"),
+        )
+        .unwrap();
+        assert!(set_owned_agent_session_title(
+            &mut app.agent_title_sessions,
+            "pi".into(),
+            "shared".into(),
+            Some("Beta".into()),
+            Some("module.beta"),
+        )
+        .is_err());
+        set_owned_agent_session_title(
+            &mut app.agent_title_sessions,
+            "pi".into(),
+            "beta-only".into(),
+            Some("Beta".into()),
+            Some("module.beta"),
+        )
+        .unwrap();
+        assert!(app.clear_agent_row_titles_for_owner("module.alpha"));
+        assert!(app.agent_row_title_for_session("pi", "shared").is_none());
+        assert_eq!(
+            app.agent_row_title_for_session("pi", "beta-only"),
+            Some("Beta")
+        );
+    }
+
+    #[test]
     fn module_agent_titles_apply_to_live_and_resumable_without_using_alias() {
         let _env = crate::persist::test_env("module-agent-titles");
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -13269,7 +13369,7 @@ mod tests {
             app.agent_row_title_for_session("pi", "old-1"),
             Some("History title")
         );
-        assert!(app.clear_agent_row_titles(None, Some(("pi".into(), "live-1".into()))));
+        assert!(app.set_agent_row_title_for_session("pi".into(), "live-1".into(), None));
         assert!(app.pane_title(pane).is_none());
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2925,13 +2925,16 @@ pub struct ModuleSettingEdit {
     pub secret: bool,
 }
 
+/// One publisher credential per registered module, valid for this server's
+/// lifetime. Every registered module gets one regardless of its enabled state,
+/// so toggling a module cannot strand a still-running module process with a
+/// stale token. Authorization is enforced per request against `is_runnable()`.
 fn module_tokens_for(
     modules: &crate::module::ModuleRegistry,
 ) -> Result<HashMap<String, String>, String> {
     modules
         .modules
         .iter()
-        .filter(|module| module.is_runnable())
         .map(|module| crate::terminal::backend::random_id().map(|token| (module.id.clone(), token)))
         .collect()
 }

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -53,9 +53,7 @@ impl App {
         if self.modules.find(&id).is_some() {
             return Err(format!("module {id} is already registered"));
         }
-        let token = enabled
-            .then(crate::terminal::backend::random_id)
-            .transpose()?;
+        let token = crate::terminal::backend::random_id()?;
         self.modules.modules.push(InstalledModule {
             id: id.clone(),
             root,
@@ -64,9 +62,7 @@ impl App {
             manifest,
             warning: None,
         });
-        if let Some(token) = token {
-            self.module_tokens.insert(id.clone(), token);
-        }
+        self.module_tokens.insert(id.clone(), token);
         registry::save(&self.modules);
         self.bar.sync_modules(&self.modules);
         // A freshly linked module gets its startup hooks now rather than at the
@@ -129,7 +125,6 @@ impl App {
         if was_enabled == on {
             return Ok(());
         }
-        let replacement_token = on.then(crate::terminal::backend::random_id).transpose()?;
         self.modules
             .find_mut(id)
             .ok_or_else(|| format!("no module {id}"))?
@@ -137,19 +132,21 @@ impl App {
         registry::save(&self.modules);
         // Disabling a module retires its docks; re-enabling re-runs its startup
         // hooks so it can repaint them (docs/29, DOCK-4).
+        //
+        // The publisher credential deliberately survives this transition. A
+        // module pane or command started before the toggle keeps running with
+        // the token it was given, and rotating here would fail-closed on that
+        // still-legitimate process. Authorization is enforced per request
+        // against `is_runnable()`, so a disabled module cannot publish even
+        // while holding a valid token.
         if !on {
             let dock_ids = self.module_dock_ids(id);
             self.remove_module_docks(&dock_ids);
             self.bar.clear_owner(id);
             self.clear_agent_row_titles_for_owner(id);
-            self.module_tokens.remove(id);
             self.module_startup_done.remove(id);
             self.bar.sync_modules(&self.modules);
         } else {
-            self.module_tokens.insert(
-                id.clone(),
-                replacement_token.expect("enabled modules receive a token"),
-            );
             // Make declarations visible before the asynchronous startup command
             // can call `luvus bar push` (`ui.bar.push` on the UHP).
             self.bar.sync_modules(&self.modules);
@@ -1000,10 +997,12 @@ command = ["sh", "-c", "echo hello-from-module; echo oops 1>&2"]
             Some("Owned title")
         );
 
-        // Disabling makes it non-runnable; unlink removes it.
+        // Disabling makes it non-runnable; unlink removes it. The publisher
+        // credential is stable for the module's registry lifetime, so a module
+        // process that outlives a disable/enable toggle stays authorized.
         app.module_set_enabled(&id, false).unwrap();
         assert!(!app.modules.find(&id).unwrap().is_runnable());
-        assert!(!app.module_tokens.contains_key(&id));
+        assert_eq!(app.module_tokens[&id], original_token);
         assert!(app
             .agent_row_title_for_session("pi", "owned-session")
             .is_none());
@@ -1014,10 +1013,7 @@ command = ["sh", "-c", "echo hello-from-module; echo oops 1>&2"]
             .unwrap_err();
         assert!(err.contains("disabled"), "got: {err}");
         app.module_set_enabled(&id, true).unwrap();
-        let replacement_token = app.module_tokens[&id].clone();
-        assert_ne!(replacement_token, original_token);
-        app.module_set_enabled(&id, true).unwrap();
-        assert_eq!(app.module_tokens[&id], replacement_token);
+        assert_eq!(app.module_tokens[&id], original_token);
         app.module_unlink(&id).unwrap();
         assert!(!app.module_tokens.contains_key(&id));
         assert!(app.modules.find(&id).is_none());

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -89,6 +89,7 @@ impl App {
         let _ = std::fs::remove_dir_all(&root);
         self.remove_module_docks(&dock_ids);
         self.bar.clear_owner(id);
+        self.clear_agent_row_titles_for_owner(id);
         self.bar.sync_modules(&self.modules);
         Ok(())
     }
@@ -105,6 +106,7 @@ impl App {
         registry::save(&self.modules);
         self.remove_module_docks(&dock_ids);
         self.bar.clear_owner(id);
+        self.clear_agent_row_titles_for_owner(id);
         self.bar.sync_modules(&self.modules);
         Ok(())
     }
@@ -123,6 +125,7 @@ impl App {
             let dock_ids = self.module_dock_ids(id);
             self.remove_module_docks(&dock_ids);
             self.bar.clear_owner(id);
+            self.clear_agent_row_titles_for_owner(id);
             self.module_startup_done.remove(id);
             self.bar.sync_modules(&self.modules);
         } else {
@@ -945,9 +948,26 @@ command = ["sh", "-c", "echo hello-from-module; echo oops 1>&2"]
         );
         assert!(log.err.contains("oops"), "captured stderr: {:?}", log.err);
 
+        // Volatile UI contributions are owned and retire with the module.
+        set_owned_agent_session_title(
+            &mut app.agent_title_sessions,
+            "pi".into(),
+            "owned-session".into(),
+            Some("Owned title".into()),
+            Some(&id),
+        )
+        .unwrap();
+        assert_eq!(
+            app.agent_row_title_for_session("pi", "owned-session"),
+            Some("Owned title")
+        );
+
         // Disabling makes it non-runnable; unlink removes it.
         app.module_set_enabled(&id, false).unwrap();
         assert!(!app.modules.find(&id).unwrap().is_runnable());
+        assert!(app
+            .agent_row_title_for_session("pi", "owned-session")
+            .is_none());
         assert!(app.module_invoke_action("refresh", None, "test").is_err());
         // Naming the module explicitly gives a clear "disabled" error.
         let err = app

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -53,6 +53,9 @@ impl App {
         if self.modules.find(&id).is_some() {
             return Err(format!("module {id} is already registered"));
         }
+        let token = enabled
+            .then(crate::terminal::backend::random_id)
+            .transpose()?;
         self.modules.modules.push(InstalledModule {
             id: id.clone(),
             root,
@@ -61,6 +64,9 @@ impl App {
             manifest,
             warning: None,
         });
+        if let Some(token) = token {
+            self.module_tokens.insert(id.clone(), token);
+        }
         registry::save(&self.modules);
         self.bar.sync_modules(&self.modules);
         // A freshly linked module gets its startup hooks now rather than at the
@@ -90,6 +96,7 @@ impl App {
         self.remove_module_docks(&dock_ids);
         self.bar.clear_owner(id);
         self.clear_agent_row_titles_for_owner(id);
+        self.module_tokens.remove(id);
         self.bar.sync_modules(&self.modules);
         Ok(())
     }
@@ -107,17 +114,26 @@ impl App {
         self.remove_module_docks(&dock_ids);
         self.bar.clear_owner(id);
         self.clear_agent_row_titles_for_owner(id);
+        self.module_tokens.remove(id);
         self.bar.sync_modules(&self.modules);
         Ok(())
     }
 
     pub fn module_set_enabled(&mut self, spec: &str, on: bool) -> Result<(), String> {
         let id = &self.module_id_for(spec)?;
-        let m = self
+        let was_enabled = self
             .modules
+            .find(id)
+            .ok_or_else(|| format!("no module {id}"))?
+            .enabled;
+        if was_enabled == on {
+            return Ok(());
+        }
+        let replacement_token = on.then(crate::terminal::backend::random_id).transpose()?;
+        self.modules
             .find_mut(id)
-            .ok_or_else(|| format!("no module {id}"))?;
-        m.enabled = on;
+            .ok_or_else(|| format!("no module {id}"))?
+            .enabled = on;
         registry::save(&self.modules);
         // Disabling a module retires its docks; re-enabling re-runs its startup
         // hooks so it can repaint them (docs/29, DOCK-4).
@@ -126,9 +142,14 @@ impl App {
             self.remove_module_docks(&dock_ids);
             self.bar.clear_owner(id);
             self.clear_agent_row_titles_for_owner(id);
+            self.module_tokens.remove(id);
             self.module_startup_done.remove(id);
             self.bar.sync_modules(&self.modules);
         } else {
+            self.module_tokens.insert(
+                id.clone(),
+                replacement_token.expect("enabled modules receive a token"),
+            );
             // Make declarations visible before the asynchronous startup command
             // can call `luvus bar push` (`ui.bar.push` on the UHP).
             self.bar.sync_modules(&self.modules);
@@ -512,6 +533,9 @@ impl App {
                 m.root.clone(),
                 runtime::env(
                     m,
+                    self.module_tokens
+                        .get(module_id)
+                        .ok_or_else(|| format!("module {module_id} has no runtime token"))?,
                     &ctx,
                     vec![(
                         "LUVUS_MODULE_ENTRYPOINT_ID".to_string(),
@@ -622,7 +646,14 @@ impl App {
         let ctx = context::build_for(self, source, &target);
         let (root, env) = {
             let module = self.modules.find(module_id).unwrap();
-            (module.root.clone(), runtime::env(module, &ctx, extra_env))
+            let token = self
+                .module_tokens
+                .get(module_id)
+                .ok_or_else(|| format!("module {module_id} has no runtime token"))?;
+            (
+                module.root.clone(),
+                runtime::env(module, token, &ctx, extra_env),
+            )
         };
         let log_id = runtime::next_log_id();
         self.push_module_log(ModuleCommandLog {
@@ -921,6 +952,8 @@ command = ["sh", "-c", "echo hello-from-module; echo oops 1>&2"]
         assert_eq!(id, "you.echo");
         assert!(app.modules.find(&id).unwrap().is_runnable());
 
+        let original_token = app.module_tokens[&id].clone();
+
         // Invoke the action; pump the loop until its log resolves.
         let log_id = app.module_invoke_action("refresh", None, "test").unwrap();
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -965,6 +998,7 @@ command = ["sh", "-c", "echo hello-from-module; echo oops 1>&2"]
         // Disabling makes it non-runnable; unlink removes it.
         app.module_set_enabled(&id, false).unwrap();
         assert!(!app.modules.find(&id).unwrap().is_runnable());
+        assert!(!app.module_tokens.contains_key(&id));
         assert!(app
             .agent_row_title_for_session("pi", "owned-session")
             .is_none());
@@ -974,7 +1008,13 @@ command = ["sh", "-c", "echo hello-from-module; echo oops 1>&2"]
             .module_invoke_action("refresh", Some(&id), "test")
             .unwrap_err();
         assert!(err.contains("disabled"), "got: {err}");
+        app.module_set_enabled(&id, true).unwrap();
+        let replacement_token = app.module_tokens[&id].clone();
+        assert_ne!(replacement_token, original_token);
+        app.module_set_enabled(&id, true).unwrap();
+        assert_eq!(app.module_tokens[&id], replacement_token);
         app.module_unlink(&id).unwrap();
+        assert!(!app.module_tokens.contains_key(&id));
         assert!(app.modules.find(&id).is_none());
 
         std::env::remove_var("LUVUS_HOME");

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -409,9 +409,12 @@ impl App {
         source: &str,
         extra_env: Vec<(String, String)>,
     ) -> Result<u64, String> {
+        let module_filter = module_filter
+            .map(|spec| self.module_id_for(spec))
+            .transpose()?;
         // When a specific module is named, validate it up front for a clear
         // error (e.g. "disabled") instead of a generic "no runnable module …".
-        if let Some(mid) = module_filter {
+        if let Some(mid) = module_filter.as_deref() {
             match self.modules.find(mid) {
                 None => return Err(format!("no module {mid}")),
                 Some(m) if !m.is_runnable() => {
@@ -431,7 +434,7 @@ impl App {
             .modules
             .iter()
             .filter(|m| m.is_runnable())
-            .filter(|m| module_filter.is_none_or(|f| m.id == f))
+            .filter(|m| module_filter.as_deref().is_none_or(|f| m.id == f))
             .filter_map(|m| {
                 m.manifest
                     .action(action_id)
@@ -504,10 +507,11 @@ impl App {
         placement: Option<&str>,
         source: &str,
     ) -> Result<PaneId, String> {
+        let module_id = self.module_id_for(module_id)?;
         let argv = {
             let m = self
                 .modules
-                .find(module_id)
+                .find(&module_id)
                 .ok_or_else(|| format!("no module {module_id}"))?;
             if !m.is_runnable() {
                 return Err(m
@@ -528,13 +532,13 @@ impl App {
 
         let ctx = context::build(self, source);
         let (root, env) = {
-            let m = self.modules.find(module_id).unwrap();
+            let m = self.modules.find(&module_id).unwrap();
             (
                 m.root.clone(),
                 runtime::env(
                     m,
                     self.module_tokens
-                        .get(module_id)
+                        .get(m.id.as_str())
                         .ok_or_else(|| format!("module {module_id} has no runtime token"))?,
                     &ctx,
                     vec![(
@@ -585,7 +589,7 @@ impl App {
         self.module_panes.insert(
             id,
             ModulePaneRecord {
-                module_id: module_id.to_string(),
+                module_id: module_id.clone(),
                 entrypoint: entrypoint.to_string(),
             },
         );
@@ -620,10 +624,11 @@ impl App {
         source: &str,
         target: Target,
     ) -> Result<u64, String> {
+        let module_id = self.module_id_for(module_id)?;
         {
             let module = self
                 .modules
-                .find(module_id)
+                .find(&module_id)
                 .ok_or_else(|| format!("no module {module_id}"))?;
             if !module.is_runnable() {
                 return Err(module
@@ -645,10 +650,10 @@ impl App {
         }
         let ctx = context::build_for(self, source, &target);
         let (root, env) = {
-            let module = self.modules.find(module_id).unwrap();
+            let module = self.modules.find(&module_id).unwrap();
             let token = self
                 .module_tokens
-                .get(module_id)
+                .get(module.id.as_str())
                 .ok_or_else(|| format!("module {module_id} has no runtime token"))?;
             (
                 module.root.clone(),
@@ -658,7 +663,7 @@ impl App {
         let log_id = runtime::next_log_id();
         self.push_module_log(ModuleCommandLog {
             id: log_id,
-            module_id: module_id.to_string(),
+            module_id: module_id.clone(),
             label,
             argv: argv.clone(),
             status: ModuleStatus::Running,
@@ -1848,7 +1853,7 @@ secret = true
         let _ = std::fs::remove_dir_all(&home);
         std::env::set_var("LUVUS_HOME", &home);
 
-        let (tx, _rx) = std::sync::mpsc::channel();
+        let (tx, rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
 
         let dir = home.join("spec-mod");
@@ -1865,6 +1870,16 @@ min_luvus_version = "0.1.0"
 key = "token"
 title = "Token"
 type = "string"
+
+[[actions]]
+id = "ping"
+title = "Ping"
+command = ["sh", "-c", "echo shorthand-action"]
+
+[[panes]]
+id = "status"
+title = "Status"
+command = ["sh", "-c", "sleep 5"]
 "#,
         )
         .unwrap();
@@ -1914,6 +1929,27 @@ type = "string"
         assert!(!app.modules.find("example.agent-ping").unwrap().enabled);
         app.module_set_enabled("Riz/luvus-agent-ping", true)
             .unwrap();
+
+        // Executable entrypoints also resolve before looking up their runtime
+        // token, and every retained identity uses the canonical manifest id.
+        let log_id = app
+            .module_invoke_action("ping", Some("Riz/luvus-agent-ping"), "test")
+            .unwrap();
+        settle(&mut app, &rx, log_id);
+        let log = app.module_logs.iter().find(|log| log.id == log_id).unwrap();
+        assert_eq!(log.module_id, "example.agent-ping");
+        assert_eq!(log.status, ModuleStatus::Succeeded);
+
+        let pane = app
+            .module_open_pane("Riz/luvus-agent-ping", "status", Some("split"), "test")
+            .unwrap();
+        assert_eq!(
+            app.module_panes
+                .get(&pane)
+                .map(|record| record.module_id.as_str()),
+            Some("example.agent-ping")
+        );
+        app.close_pane(pane);
 
         // And unlink by owner/repo actually removes it, rather than reporting
         // success while the module stays registered.

--- a/src/app/modules.rs
+++ b/src/app/modules.rs
@@ -1208,6 +1208,66 @@ command = ["sh", "-c", "sleep 5"]
     }
 
     #[test]
+    fn module_pane_restores_from_a_snapshot_that_names_the_install_shorthand() {
+        let _env = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("luvus-restoreshort-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("LUVUS_HOME", &home);
+
+        let dir = home.join("short-mod");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("luvus-module.toml"),
+            r#"
+id = "you.short"
+name = "Short"
+version = "0.1.0"
+min_luvus_version = "0.1.0"
+
+[[panes]]
+id = "board"
+title = "Board"
+command = ["sh", "-c", "sleep 5"]
+"#,
+        )
+        .unwrap();
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(80, 24, tx).unwrap();
+        app.module_link_with(&dir, true, Some("Riz/luvus-short@abc123".into()))
+            .unwrap();
+        let pid = app
+            .module_open_pane("you.short", "board", Some("split"), "test")
+            .unwrap();
+
+        // A snapshot written by an older build stored whatever spec the caller
+        // used, so the persisted id can be the `owner/repo` install shorthand
+        // rather than the manifest id. Restore must still re-run the module.
+        app.module_panes.get_mut(&pid).unwrap().module_id = "Riz/luvus-short".into();
+        let snap = crate::persist::snapshot(&app);
+        let (tx2, _rx2) = std::sync::mpsc::channel();
+        let restored = App::from_snapshot(snap, tx2).expect("restore");
+
+        let rec = restored
+            .module_panes
+            .iter()
+            .find(|(_, r)| r.entrypoint == "board");
+        assert!(
+            rec.is_some(),
+            "a shorthand-named module pane still restores as a module pane"
+        );
+        let (rid, _) = rec.unwrap();
+        assert_eq!(
+            restored.panes.get(rid).map(|p| p.command.as_str()),
+            Some("sh"),
+            "it re-ran the module command, not the login shell"
+        );
+
+        std::env::remove_var("LUVUS_HOME");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
     fn settings_modules_tab_lists_and_toggles() {
         use ratatui::backend::TestBackend;
         use ratatui::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -213,6 +213,10 @@ appearance:
   ui dock push --id <id> [--title <t>] [--side left|right] [--rows <json>]
                              feed a module's sidebar dock its rows (JSON array,
                              or piped on stdin). See docs/29 + the website
+  ui agent-title push [--titles <json>]
+                             set AGENTS sidebar titles for live and resumable rows
+  ui agent-title clear [--pane <id>|--agent <id> --session-id <id>]
+                             clear module-provided AGENTS sidebar titles
   ui notification push --text <text> [--level info|success|warning|error]
   ui notification clear [--dedupe-key <key>]
   ui toast <text>            flash a one-line message in the UI
@@ -749,7 +753,7 @@ fn write_topic_help_english(
             detailed_section("bars:\n", "\nappearance:\n"),
         ),
         "ui" => (
-            "luvus ui <sidebar|dock|notification|toast> [args]",
+            "luvus ui <sidebar|dock|agent-title|notification|toast> [args]",
             detailed_section("appearance:\n", "\nmodules (extensions):\n"),
         ),
         "module" => (
@@ -2843,6 +2847,46 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
                     ("ui.dock.move".into(), Value::Object(obj))
                 }
                 _ => ("ui.dock.list".into(), json!({})),
+            }
+        }
+        ("ui", "agent-title") => {
+            let sub = rest.first().map(String::as_str).unwrap_or("");
+            match sub {
+                "push" => {
+                    let titles_str = match flag(args, "--titles") {
+                        Some(s) => s,
+                        None => {
+                            use std::io::Read;
+                            let mut s = String::new();
+                            let _ = std::io::stdin().read_to_string(&mut s);
+                            s
+                        }
+                    };
+                    let titles: Value = if titles_str.trim().is_empty() {
+                        json!([])
+                    } else {
+                        serde_json::from_str(&titles_str)
+                            .map_err(|e| anyhow!("--titles must be a JSON array: {e}"))?
+                    };
+                    if !titles.is_array() {
+                        return Err(anyhow!("--titles must be a JSON array"));
+                    }
+                    ("ui.agent_title.push".into(), json!({ "titles": titles }))
+                }
+                "clear" => {
+                    let mut obj = serde_json::Map::new();
+                    if let Some(pane) = flag(args, "--pane") {
+                        obj.insert("pane".into(), json!(pane));
+                    }
+                    if let Some(agent) = flag(args, "--agent") {
+                        obj.insert("agent".into(), json!(agent));
+                    }
+                    if let Some(session_id) = flag(args, "--session-id") {
+                        obj.insert("session_id".into(), json!(session_id));
+                    }
+                    ("ui.agent_title.clear".into(), Value::Object(obj))
+                }
+                _ => return Err(anyhow!("usage: luvus ui agent-title push|clear")),
             }
         }
         ("bar", sub) => {
@@ -5003,6 +5047,25 @@ mod tests {
 
         let (m, _) = parse(&argv("luvus ui dock list")).unwrap();
         assert_eq!(m, "ui.dock.list");
+
+        let titles_argv: Vec<String> = vec![
+            "luvus".into(),
+            "ui".into(),
+            "agent-title".into(),
+            "push".into(),
+            "--titles".into(),
+            r#"[{"pane":"3","title":"Ship desktop"}]"#.into(),
+        ];
+        let (m, p) = parse(&titles_argv).unwrap();
+        assert_eq!(m, "ui.agent_title.push");
+        assert_eq!(p["titles"][0]["title"].as_str(), Some("Ship desktop"));
+        let (m, p) = parse(&argv(
+            "luvus ui agent-title clear --agent pi --session-id sess-1",
+        ))
+        .unwrap();
+        assert_eq!(m, "ui.agent_title.clear");
+        assert_eq!(p.get("agent").and_then(|v| v.as_str()), Some("pi"));
+        assert!(parse(&argv("luvus ui agent-title")).is_err());
 
         // `ui sidebar` now takes an optional side.
         let (m, p) = parse(&argv("luvus ui sidebar --side right --width 30")).unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2855,6 +2855,9 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
             if let Ok(owner) = std::env::var("LUVUS_MODULE_ID") {
                 obj.insert("owner".into(), json!(owner));
             }
+            if let Ok(token) = std::env::var(crate::module::runtime::MODULE_TOKEN_ENV) {
+                obj.insert("module_token".into(), json!(token));
+            }
             match sub {
                 "push" => {
                     let titles_str = match flag(args, "--titles") {
@@ -5081,6 +5084,7 @@ mod tests {
     fn maps_luvus_bar_and_notification_commands() {
         let _env = crate::persist::test_env("cli-bar");
         std::env::set_var("LUVUS_MODULE_ID", "you.ci");
+        std::env::set_var(crate::module::runtime::MODULE_TOKEN_ENV, "module-token");
         let args = vec![
             "luvus".into(),
             "bar".into(),
@@ -5103,9 +5107,11 @@ mod tests {
         .unwrap();
         assert_eq!(method, "ui.agent_title.push");
         assert_eq!(params["owner"], "you.ci");
+        assert_eq!(params["module_token"], "module-token");
         let (method, params) = parse(&argv("luvus ui agent-title clear")).unwrap();
         assert_eq!(method, "ui.agent_title.clear");
         assert_eq!(params["owner"], "you.ci");
+        assert_eq!(params["module_token"], "module-token");
 
         let (method, params) =
             parse(&argv("luvus bar move --id status --region bottom-right")).unwrap();
@@ -5120,6 +5126,7 @@ mod tests {
         assert_eq!(params["ttl_ms"], 6000);
         assert_eq!(params["owner"], "you.ci");
         std::env::remove_var("LUVUS_MODULE_ID");
+        std::env::remove_var(crate::module::runtime::MODULE_TOKEN_ENV);
 
         for bad in [
             "luvus bar push --id status",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2851,6 +2851,10 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
         }
         ("ui", "agent-title") => {
             let sub = rest.first().map(String::as_str).unwrap_or("");
+            let mut obj = serde_json::Map::new();
+            if let Ok(owner) = std::env::var("LUVUS_MODULE_ID") {
+                obj.insert("owner".into(), json!(owner));
+            }
             match sub {
                 "push" => {
                     let titles_str = match flag(args, "--titles") {
@@ -2871,10 +2875,10 @@ fn parse(args: &[String]) -> Result<(String, Value)> {
                     if !titles.is_array() {
                         return Err(anyhow!("--titles must be a JSON array"));
                     }
-                    ("ui.agent_title.push".into(), json!({ "titles": titles }))
+                    obj.insert("titles".into(), titles);
+                    ("ui.agent_title.push".into(), Value::Object(obj))
                 }
                 "clear" => {
-                    let mut obj = serde_json::Map::new();
                     if let Some(pane) = flag(args, "--pane") {
                         obj.insert("pane".into(), json!(pane));
                     }
@@ -5092,6 +5096,16 @@ mod tests {
         assert_eq!(method, "ui.bar.push");
         assert_eq!(params["owner"], "you.ci");
         assert_eq!(params["content"].as_array().unwrap().len(), 2);
+
+        let (method, params) = parse(&argv(
+            r#"luvus ui agent-title push --titles [{"agent":"pi","session_id":"s1","title":"Title"}]"#,
+        ))
+        .unwrap();
+        assert_eq!(method, "ui.agent_title.push");
+        assert_eq!(params["owner"], "you.ci");
+        let (method, params) = parse(&argv("luvus ui agent-title clear")).unwrap();
+        assert_eq!(method, "ui.agent_title.clear");
+        assert_eq!(params["owner"], "you.ci");
 
         let (method, params) =
             parse(&argv("luvus bar move --id status --region bottom-right")).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -212,10 +212,11 @@ pub struct LayoutConfig {
     /// its name, an unnamed pane its path (the original behavior).
     #[serde(default)]
     pub pane_title_path: bool,
-    /// In the AGENTS sidebar, show each agent's live session title (the OSC title
-    /// it sets, e.g. "Ship the desktop release…") in place of the `wsname · =<id>`
-    /// meta line. Off by default; falls back to the meta line when an agent set no
-    /// useful title.
+    /// In the AGENTS sidebar, show each agent's session title in place of the
+    /// `wsname · =<id>` meta line (live) or the project folder (resumable).
+    /// OSC title wins when the agent set one; otherwise a module-provided title
+    /// from `ui.agent_title.push`. Off by default. Luvus pane aliases are never
+    /// used as a title.
     #[serde(default)]
     pub agent_title: bool,
     /// Show the cwd line beneath each WORKSPACES entry. On by default to retain

--- a/src/i18n/cli.rs
+++ b/src/i18n/cli.rs
@@ -1795,6 +1795,28 @@ static HELP: &[Translation] = &[
         "모듈의 사이드바 도킹에 행 전달 (JSON 배열,"
     ),
     tr!(
+        "set AGENTS sidebar titles for live and resumable rows",
+        "definir títulos de la barra AGENTS para filas vivas y reanudables",
+        "definir títulos da barra AGENTS para linhas ativas e retomáveis",
+        "définir les titres de la barre AGENTS pour les lignes actives et reprises",
+        "AGENTS-Seitenleistentitel für Live- und fortsetzbare Zeilen setzen",
+        "atur judul bilah sisi AGENTS untuk baris live dan yang dapat dilanjutkan",
+        "设置 AGENTS 侧栏标题（活动与可恢复行）",
+        "AGENTS サイドバーのライブ行と履歴行のタイトルを設定",
+        "AGENTS 사이드바 타이틀을 실행 및 재개 행에 설정"
+    ),
+    tr!(
+        "clear module-provided AGENTS sidebar titles",
+        "borrar títulos de AGENTS aportados por un módulo",
+        "limpar títulos de AGENTS fornecidos por um módulo",
+        "effacer les titres AGENTS fournis par un module",
+        "von einem Modul gesetzte AGENTS-Titel löschen",
+        "hapus judul bilah sisi AGENTS dari modul",
+        "清除模块提供的 AGENTS 侧栏标题",
+        "モジュールが提供した AGENTS サイドバータイトルを消去",
+        "모듈이 제공한 AGENTS 사이드바 타이틀 지우기"
+    ),
+    tr!(
         "or piped on stdin). See docs/29 + the website",
         "o por stdin). Consulta docs/29 y el sitio web",
         "ou via stdin). Veja docs/29 e o site",

--- a/src/module/runtime.rs
+++ b/src/module/runtime.rs
@@ -21,6 +21,7 @@ use crate::event::AppEvent;
 pub const MAX_IN_FLIGHT: usize = 32;
 pub const LOG_LIMIT: usize = 200;
 pub const OUTPUT_CAP: usize = 64 * 1024;
+pub const MODULE_TOKEN_ENV: &str = "LUVUS_MODULE_TOKEN";
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -55,7 +56,7 @@ pub fn next_log_id() -> u64 {
 /// Alongside `LUVUS_MODULE_CONTEXT_JSON` this flattens the ids into plain
 /// `LUVUS_WORKSPACE_ID` / `LUVUS_PANE_ID` / … vars and each declared setting
 /// into `LUVUS_SETTING_<KEY>`, so a bash module never has to parse JSON.
-fn base_env(module: &InstalledModule, ctx: &Value) -> Vec<(String, String)> {
+fn base_env(module: &InstalledModule, module_token: &str, ctx: &Value) -> Vec<(String, String)> {
     let config = paths::config_dir(&module.id);
     let state = paths::state_dir(&module.id);
     let _ = std::fs::create_dir_all(&config);
@@ -64,6 +65,7 @@ fn base_env(module: &InstalledModule, ctx: &Value) -> Vec<(String, String)> {
     let mut env = vec![
         ("LUVUS_ENV".to_string(), "1".to_string()),
         ("LUVUS_MODULE_ID".to_string(), module.id.clone()),
+        (MODULE_TOKEN_ENV.to_string(), module_token.to_string()),
         (
             "LUVUS_MODULE_ROOT".to_string(),
             module.root.display().to_string(),
@@ -100,10 +102,11 @@ fn base_env(module: &InstalledModule, ctx: &Value) -> Vec<(String, String)> {
 /// selected entrypoint, dock, row, action, or event.
 pub fn env(
     module: &InstalledModule,
+    module_token: &str,
     ctx: &Value,
     extra: Vec<(String, String)>,
 ) -> Vec<(String, String)> {
-    complete_env(base_env(module, ctx), extra)
+    complete_env(base_env(module, module_token, ctx), extra)
 }
 
 fn complete_env(
@@ -196,12 +199,15 @@ fn read_capped<R: Read>(r: &mut R) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::complete_env;
+    use super::{complete_env, MODULE_TOKEN_ENV};
 
     #[test]
     fn complete_environment_keeps_canonical_module_variables() {
         let env = complete_env(
-            vec![("LUVUS_MODULE_ID".into(), "example.test".into())],
+            vec![
+                ("LUVUS_MODULE_ID".into(), "example.test".into()),
+                (MODULE_TOKEN_ENV.into(), "runtime-token".into()),
+            ],
             vec![
                 ("LUVUS_MODULE_ENTRYPOINT_ID".into(), "monitor".into()),
                 ("LUVUS_MODULE_DOCK_ID".into(), "boards".into()),
@@ -210,6 +216,7 @@ mod tests {
         );
         for (key, value) in [
             ("LUVUS_MODULE_ID", "example.test"),
+            (MODULE_TOKEN_ENV, "runtime-token"),
             ("LUVUS_MODULE_ENTRYPOINT_ID", "monitor"),
             ("LUVUS_MODULE_DOCK_ID", "boards"),
             ("LUVUS_MODULE_ACTION_ID", "flash"),

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -824,8 +824,8 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                         .agent_name_for(id)
                         .map(|n| format!("={n}"))
                         .unwrap_or_else(|| format!("={}", id.0));
-                    // When enabled, show the live OSC title in place of the meta
-                    // line; fall back when the agent set no useful title.
+                    // When enabled, show OSC first, then a module-provided
+                    // title; fall back to workspace · =pane when neither is set.
                     let meta = app
                         .config
                         .layout
@@ -924,11 +924,21 @@ fn draw_agents_dock(f: &mut RenderTarget, area: Rect, app: &mut App, t: &Theme) 
                         .file_name()
                         .and_then(|n| n.to_str())
                         .unwrap_or("project");
+                    let meta = app
+                        .config
+                        .layout
+                        .agent_title
+                        .then(|| {
+                            app.agent_row_title_for_session(&s.agent, &s.session_id)
+                                .map(|title| format!("  {title}"))
+                        })
+                        .flatten()
+                        .unwrap_or_else(|| format!("  {proj}"));
                     line_at(
                         f,
                         y + 1,
                         Line::from(Span::styled(
-                            crate::ui::truncate(&format!("  {proj}"), cw as usize),
+                            crate::ui::truncate(&meta, cw as usize),
                             Style::new().fg(t.overlay0),
                         )),
                     );
@@ -1678,6 +1688,66 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["a1"],
             "closed-workspace schedules do not leak into the remaining scope"
+        );
+    }
+
+    #[test]
+    fn agent_title_shows_module_title_not_alias() {
+        let _env = crate::persist::test_env("agent-module-title");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.config.layout.agent_title = true;
+        let id = app.layout().focus;
+        {
+            let status = app.status.get_mut(&id).unwrap();
+            status.agent = "pi".into();
+            status.agent_session = Some(crate::app::AgentSession {
+                agent: "pi".into(),
+                session_id: "sess-1".into(),
+            });
+        }
+        app.agent_names.insert("chezmoi".into(), id);
+        assert!(app.set_agent_row_title_for_session(
+            "pi".into(),
+            "sess-1".into(),
+            Some("Ship desktop".into()),
+        ));
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert!(
+            buffer_contains(&term, "Ship desktop"),
+            "idle live rows show the module-provided session title"
+        );
+        assert!(
+            !buffer_contains(&term, "=chezmoi"),
+            "a Luvus pane alias must not stand in for the session title"
+        );
+    }
+
+    #[test]
+    fn resumable_rows_show_module_session_title() {
+        let _env = crate::persist::test_env("resumable-module-title");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut app = App::new(120, 40, tx).unwrap();
+        app.config.layout.agent_title = true;
+        app.agents_active_only = false;
+        app.resumable = vec![crate::agent::SessionInfo {
+            agent: "pi".into(),
+            session_id: "sess-closed".into(),
+            cwd: std::path::PathBuf::from("/tmp/proj"),
+            updated: std::time::SystemTime::UNIX_EPOCH,
+        }];
+        assert!(app.set_agent_row_title_for_session(
+            "pi".into(),
+            "sess-closed".into(),
+            Some("Closed session name".into()),
+        ));
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| crate::ui::render(f, &mut app)).unwrap();
+        assert!(buffer_contains(&term, "resume"));
+        assert!(
+            buffer_contains(&term, "Closed session name"),
+            "All history rows show the module-provided title"
         );
     }
 }

--- a/website/src/content/docs/docs/extend/writing-modules.mdx
+++ b/website/src/content/docs/docs/extend/writing-modules.mdx
@@ -25,6 +25,7 @@ A module can reach every surface the app has:
 | **Settings** | `[[settings]]` | Typed controls in Settings → Modules, no UI code |
 | **Events** | `[[events]]` | Run when agents, panes, tabs, or tasks change |
 | **Startup** | `[[startup]]` | Restore your state when the session comes up |
+| **AGENTS titles** | any command | Publish session titles onto live and resumable AGENTS rows |
 
 ## Author with your AI agent
 
@@ -646,7 +647,31 @@ selected=$(printf '%s' "$LUVUS_MODULE_CONTEXT_JSON" | jq -r .selection)
 "$LUVUS_BIN_PATH" tab rename review        # name the current tab
 "$LUVUS_BIN_PATH" ui toast "build passing" # flash a one-line message
 "$LUVUS_BIN_PATH" ui dock push --id you:ci --rows '[...]'   # feed your sidebar dock
+"$LUVUS_BIN_PATH" ui agent-title push --titles '[{"agent":"pi","session_id":"01a0…","title":"Ship desktop"}]'
 ```
+
+### AGENTS sidebar titles
+
+Luvus does not parse an agent's native session store for the AGENTS sidebar.
+A module can publish titles onto live rows (including idle) and All/history
+resumable rows:
+
+```sh
+"$LUVUS_BIN_PATH" ui agent-title push --titles '[
+  {"pane":"3","title":"Ship desktop"},
+  {"agent":"pi","session_id":"01a07061-9cc8-779d-b50d-f09889439f94","title":"Ship desktop"}
+]'
+```
+
+OSC titles still win. If there is no OSC title, the pane title is used, then
+the `agent`+`session_id` title. If neither exists, live rows keep
+`workspace · =pane` and resumable rows keep the project folder. Never send a
+Luvus pane alias (`=name`) as `title`. Empty `title` clears that key. Clear
+everything with `ui agent-title clear`, or one row with `--pane` /
+`--agent` + `--session-id`.
+
+Repaint from `[[startup]]` and `[[events]]` such as `pane.agent_status_changed`.
+Pi's `session_info.name` belongs in that module, not in Luvus core.
 
 Anything in `luvus help all` is available: panes, tabs, workspaces, worktrees, the
 git tab, the orchestration board, agents, and the UI chrome. Your command reads

--- a/website/src/content/docs/docs/extend/writing-modules.mdx
+++ b/website/src/content/docs/docs/extend/writing-modules.mdx
@@ -666,9 +666,10 @@ resumable rows:
 OSC titles still win. If there is no OSC title, the pane title is used, then
 the `agent`+`session_id` title. If neither exists, live rows keep
 `workspace · =pane` and resumable rows keep the project folder. Never send a
-Luvus pane alias (`=name`) as `title`. Empty `title` clears that key. Clear
-everything with `ui agent-title clear`, or one row with `--pane` /
-`--agent` + `--session-id`.
+Luvus pane alias (`=name`) as `title`. Empty `title` clears that key. Clear all
+titles owned by your module with `ui agent-title clear`, or one row with
+`--pane` / `--agent` + `--session-id`. Luvus removes a module's titles when the
+module is disabled, unlinked, or uninstalled.
 
 Repaint from `[[startup]]` and `[[events]]` such as `pane.agent_status_changed`.
 Pi's `session_info.name` belongs in that module, not in Luvus core.

--- a/website/src/content/docs/docs/extend/writing-modules.mdx
+++ b/website/src/content/docs/docs/extend/writing-modules.mdx
@@ -670,9 +670,11 @@ the `agent`+`session_id` title. If neither exists, live rows keep
 Luvus pane alias (`=name`) as `title`. Empty `title` clears that key. Clear all
 titles owned by your module with `ui agent-title clear`, or one row with
 `--pane` / `--agent` + `--session-id`. The CLI authenticates these updates with
-the process-scoped module token automatically; do not pass or persist it
-manually. Luvus removes a module's titles and revokes the token when the module
-is disabled, unlinked, or uninstalled.
+the module token automatically; do not pass or persist it manually. Luvus removes
+a module's titles when the module is disabled, unlinked, or uninstalled, and a
+disabled module cannot publish. Your token stays valid while the module remains
+registered on that server, so a pane or command that outlives a disable/enable
+toggle keeps working.
 
 Repaint from `[[startup]]` and `[[events]]` such as `pane.agent_status_changed`.
 Pi's `session_info.name` belongs in that module, not in Luvus core.

--- a/website/src/content/docs/docs/extend/writing-modules.mdx
+++ b/website/src/content/docs/docs/extend/writing-modules.mdx
@@ -575,6 +575,7 @@ takes down luvus.
 |---|---|
 | `LUVUS_ENV` | Always `1`, meaning you're running under luvus. |
 | `LUVUS_MODULE_ID` | Your module's id. |
+| `LUVUS_MODULE_TOKEN` | Per-server credential forwarded automatically by the CLI for module-owned UI data. Do not persist or override it. |
 | `LUVUS_MODULE_VERSION` | Your module's declared version. |
 | `LUVUS_MODULE_ROOT` | The module directory (also the cwd). Read-only by convention. |
 | `LUVUS_MODULE_CONFIG_DIR` | Durable, user-owned config/secrets dir (created for you). |
@@ -654,7 +655,7 @@ selected=$(printf '%s' "$LUVUS_MODULE_CONTEXT_JSON" | jq -r .selection)
 
 Luvus does not parse an agent's native session store for the AGENTS sidebar.
 A module can publish titles onto live rows (including idle) and All/history
-resumable rows:
+resumable rows. `agent` must name a built-in Luvus adapter:
 
 ```sh
 "$LUVUS_BIN_PATH" ui agent-title push --titles '[
@@ -668,8 +669,10 @@ the `agent`+`session_id` title. If neither exists, live rows keep
 `workspace · =pane` and resumable rows keep the project folder. Never send a
 Luvus pane alias (`=name`) as `title`. Empty `title` clears that key. Clear all
 titles owned by your module with `ui agent-title clear`, or one row with
-`--pane` / `--agent` + `--session-id`. Luvus removes a module's titles when the
-module is disabled, unlinked, or uninstalled.
+`--pane` / `--agent` + `--session-id`. The CLI authenticates these updates with
+the process-scoped module token automatically; do not pass or persist it
+manually. Luvus removes a module's titles and revokes the token when the module
+is disabled, unlinked, or uninstalled.
 
 Repaint from `[[startup]]` and `[[events]]` such as `pane.agent_status_changed`.
 Pi's `session_info.name` belongs in that module, not in Luvus core.

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -49,6 +49,13 @@ The **All / Active** toggle in the header switches between the full resumable
 history and live agents only. A new configuration starts with **All**, then
 luvus remembers whichever view you select across restarts.
 
+When **Show agent session title** is on, the second line of each agent row
+prefers the live OSC title, then a title a module published with
+`ui.agent_title.push`. If neither is set, live rows keep `workspace · =pane`
+and resumable rows keep the project folder. Luvus pane aliases (`=name`) are
+not used as titles. Core Luvus does not parse an agent's native session store
+for this line; a module supplies names such as Pi's `session_info.name`.
+
 ## Usage in Mission Control
 
 Open Mission Control with `Ctrl+Space m`, from the desktop switcher, or with

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -153,6 +153,10 @@ appearance:
   ui dock push --id <id> [--title <t>] [--side left|right] [--rows <json>]
                              feed a module's sidebar dock its rows (JSON array,
                              or piped on stdin). See docs/29 + the website
+  ui agent-title push [--titles <json>]
+                             set AGENTS sidebar titles for live and resumable rows
+  ui agent-title clear [--pane <id>|--agent <id> --session-id <id>]
+                             clear module-provided AGENTS sidebar titles
   ui notification push --text <text> [--level info|success|warning|error]
   ui notification clear [--dedupe-key <key>]
   ui toast <text>            flash a one-line message in the UI

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -927,8 +927,8 @@ rendering.
 | Method | Params | Result |
 |---|---|---|
 | `ui.sidebar` | `{side?: "left"\|"right", width?: int, visible?: bool}` | `{width, visible}` for that side |
-| `ui.agent_title.push` | `{titles: Title[]}` | `{type:"ok", changed}` |
-| `ui.agent_title.clear` | `{pane?, agent?, session_id?}` | `{type:"ok", changed}` |
+| `ui.agent_title.push` | `{owner?, titles: Title[]}` | `{type:"ok", changed}` |
+| `ui.agent_title.clear` | `{owner?, pane?, agent?, session_id?}` | `{type:"ok", changed}` |
 | `ui.dock.push` | `{id, title?, placement?: "left"\|"right", rows: Row[]}` | `{type:"ok"}` |
 | `ui.dock.list` | `{}` | `{docks: [{id, side}]}` |
 | `ui.dock.move` | `{id, side: "left"\|"right"}` | `{type:"ok"}` |
@@ -943,9 +943,12 @@ Luvus parsing any agent's native store. Each `Title` is:
 A row needs `pane` and/or `agent`+`session_id`. Empty `title` clears that key.
 Live rows still prefer an OSC title; otherwise they use a pane title, then a
 session title. Resumable All/history rows use the session title. Luvus pane
-aliases (`=name`) are never used as titles. `clear` with no filters drops every
-module-provided title. The CLI wrappers are `luvus ui agent-title push|clear`
-(`push` also reads `--titles` from stdin).
+aliases (`=name`) are never used as titles. Module commands include their owner
+automatically, cannot replace another module's title, and `clear` with no filters
+drops every title owned by that module. A direct local-owner API call with no
+owner may clear all titles. Luvus also clears an owner's titles when that module
+is disabled, unlinked, or uninstalled. The CLI wrappers are
+`luvus ui agent-title push|clear` (`push` also reads `--titles` from stdin).
 
 A `Row` is:
 

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -100,7 +100,7 @@ Luvus release number.
 | agent automation | `automation.create` · `automation.list` · `automation.get` · `automation.update` · `automation.enable` · `automation.disable` · `automation.rebind` · `automation.delete` · `automation.run` · `automation.history` · `automation.preview` · `automation.health` |
 | modules | `module.list` · `module.info` · `module.link` · `module.unlink` · `module.enable` · `module.disable` · `module.action.list` · `module.action.invoke` · `module.pane.open` · `module.pane.focus` · `module.pane.close` · `module.config_dir` · `module.settings.list` · `module.settings.get` · `module.settings.set` · `module.log.list` |
 | themes | `theme.list` · `theme.path` · `theme.use` · `theme.reload` |
-| ui / server | `ui.sidebar` · `ui.dock.push` · `ui.dock.list` · `ui.dock.move` · `ui.bar.push` · `ui.bar.list` · `ui.bar.move` · `ui.bar.remove` · `ui.notification.push` · `ui.notification.clear` · `ui.toast` · `ping` · `server.stop` · `events.subscribe` · `events.wait` |
+| ui / server | `ui.sidebar` · `ui.agent_title.push` · `ui.agent_title.clear` · `ui.dock.push` · `ui.dock.list` · `ui.dock.move` · `ui.bar.push` · `ui.bar.list` · `ui.bar.move` · `ui.bar.remove` · `ui.notification.push` · `ui.notification.clear` · `ui.toast` · `ping` · `server.stop` · `events.subscribe` · `events.wait` |
 
 Parameter shapes mirror the CLI flags (`luvus task add --paths x` →
 `{"paths": ["x"]}`). For CLI commands, an omitted pane uses
@@ -927,9 +927,25 @@ rendering.
 | Method | Params | Result |
 |---|---|---|
 | `ui.sidebar` | `{side?: "left"\|"right", width?: int, visible?: bool}` | `{width, visible}` for that side |
+| `ui.agent_title.push` | `{titles: Title[]}` | `{type:"ok", changed}` |
+| `ui.agent_title.clear` | `{pane?, agent?, session_id?}` | `{type:"ok", changed}` |
 | `ui.dock.push` | `{id, title?, placement?: "left"\|"right", rows: Row[]}` | `{type:"ok"}` |
 | `ui.dock.list` | `{}` | `{docks: [{id, side}]}` |
 | `ui.dock.move` | `{id, side: "left"\|"right"}` | `{type:"ok"}` |
+
+`ui.agent_title.push` lets a module supply AGENTS sidebar session titles without
+Luvus parsing any agent's native store. Each `Title` is:
+
+```json
+{ "pane": "3", "agent": "pi", "session_id": "01a0…", "title": "Ship desktop" }
+```
+
+A row needs `pane` and/or `agent`+`session_id`. Empty `title` clears that key.
+Live rows still prefer an OSC title; otherwise they use a pane title, then a
+session title. Resumable All/history rows use the session title. Luvus pane
+aliases (`=name`) are never used as titles. `clear` with no filters drops every
+module-provided title. The CLI wrappers are `luvus ui agent-title push|clear`
+(`push` also reads `--titles` from stdin).
 
 A `Row` is:
 

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -927,8 +927,8 @@ rendering.
 | Method | Params | Result |
 |---|---|---|
 | `ui.sidebar` | `{side?: "left"\|"right", width?: int, visible?: bool}` | `{width, visible}` for that side |
-| `ui.agent_title.push` | `{owner?, titles: Title[]}` | `{type:"ok", changed}` |
-| `ui.agent_title.clear` | `{owner?, pane?, agent?, session_id?}` | `{type:"ok", changed}` |
+| `ui.agent_title.push` | `{owner?, module_token?, titles: Title[]}` | `{type:"ok", changed}` |
+| `ui.agent_title.clear` | `{owner?, module_token?, pane?, agent?, session_id?}` | `{type:"ok", changed}` |
 | `ui.dock.push` | `{id, title?, placement?: "left"\|"right", rows: Row[]}` | `{type:"ok"}` |
 | `ui.dock.list` | `{}` | `{docks: [{id, side}]}` |
 | `ui.dock.move` | `{id, side: "left"\|"right"}` | `{type:"ok"}` |
@@ -940,15 +940,20 @@ Luvus parsing any agent's native store. Each `Title` is:
 { "pane": "3", "agent": "pi", "session_id": "01a0…", "title": "Ship desktop" }
 ```
 
-A row needs `pane` and/or `agent`+`session_id`. Empty `title` clears that key.
-Live rows still prefer an OSC title; otherwise they use a pane title, then a
+A row needs `pane` and/or `agent`+`session_id`. `agent` must name a built-in
+Luvus adapter. Empty `title` clears that key. Live rows still prefer an OSC title; otherwise they use a pane title, then a
 session title. Resumable All/history rows use the session title. Luvus pane
 aliases (`=name`) are never used as titles. Module commands include their owner
-automatically, cannot replace another module's title, and `clear` with no filters
-drops every title owned by that module. A direct local-owner API call with no
-owner may clear all titles. Luvus also clears an owner's titles when that module
-is disabled, unlinked, or uninstalled. The CLI wrappers are
-`luvus ui agent-title push|clear` (`push` also reads `--titles` from stdin).
+and per-server `module_token` automatically. Luvus accepts a module owner only
+with that token, so one module cannot publish or clear another module's titles.
+`clear` with no filters drops every title owned by the authenticated module.
+Direct local control-API calls may omit both fields; those calls can mutate only
+unowned titles, and an unfiltered clear is a no-op. Luvus clears an owner's
+titles and revokes its token when that module is disabled, unlinked, or
+uninstalled. The CLI wrappers are `luvus ui agent-title push|clear` (`push` also
+reads `--titles` from stdin). Raw local API clients acting for a module must pass
+the injected `LUVUS_MODULE_TOKEN` as `module_token`; module scripts calling the
+CLI do not handle it themselves.
 
 A `Row` is:
 

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -949,8 +949,11 @@ with that token, so one module cannot publish or clear another module's titles.
 `clear` with no filters drops every title owned by the authenticated module.
 Direct local control-API calls may omit both fields; those calls can mutate only
 unowned titles, and an unfiltered clear is a no-op. Luvus clears an owner's
-titles and revokes its token when that module is disabled, unlinked, or
-uninstalled. The CLI wrappers are `luvus ui agent-title push|clear` (`push` also
+titles when that module is disabled, unlinked, or uninstalled, and a disabled
+module cannot publish. A module's token stays valid for as long as it remains
+registered on that server, so toggling a module does not strand a module process
+that is still running; the token is dropped on unlink or uninstall. The CLI
+wrappers are `luvus ui agent-title push|clear` (`push` also
 reads `--titles` from stdin). Raw local API clients acting for a module must pass
 the injected `LUVUS_MODULE_TOKEN` as `module_token`; module scripts calling the
 CLI do not handle it themselves.


### PR DESCRIPTION
Discussion: #331

Let modules supply bounded titles for live and resumable AGENTS sidebar sessions.

## What

- Add `ui.agent_title.push` and `ui.agent_title.clear` UHP methods plus `luvus ui agent-title push|clear` CLI wrappers.
- Prefer OSC titles for live panes, then module pane titles, then native `agent` + `session_id` titles; resumable rows use the native-session title.
- Keep pane aliases out of title rendering and preserve the existing project/workspace fallback.
- Validate batches atomically, canonicalize built-in agents, reject unsafe or oversized values, and cap the global title cache.
- Namespace module-published titles by owner so modules cannot overwrite each other and disabling, unlinking, or uninstalling clears their titles.
- Update capabilities, schemas, localized CLI help, bundled skills, and public documentation.

## Why

Agent-specific modules can already read native session metadata, but Luvus previously had no bounded UI seam for them to label closed resumable sessions in the built-in AGENTS sidebar. This keeps private store parsing outside core while retaining server-owned validation, lifecycle, and rendering.

## Verification

- [x] `cargo test --locked`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --locked`
- [ ] Manual testing, if applicable

## Notes

- Rebased onto `upstream/main` at `78a5772` and adapted to the split dispatch modules.
- No manual cross-platform UI test was performed; automated API, rendering, CLI, module-lifecycle, and capability tests cover the changed behavior.









<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change lets modules publish bounded titles for agent rows, protects those titles with per-module credentials, and cleans them up as modules are disabled or removed. The previously reported problem where a running module lost permission after being disabled and re-enabled does not occur: focused execution showed its original credential is rejected while disabled and accepted again after re-enabling.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran focused Rust tests against the luvus binary to validate forged ownership, ownerless clear preservation, cross-owner isolation, disabled-state rejection, and original-token acceptance after re-enable.
- Observed that forged token attempts were rejected and left the module-owned title unchanged; ownerless clear returned changed: false and preserved the module-owned title; the original token was accepted again after re-enabling.
- Captured executable test source for the canonical-agent-title-00 test, but the validation runner reported Not connected, so no before/after runtime output was captured.
- Authored the agent-title-validation-test.rs validation source, but no executable behavior proof could be captured due to the validation runner being Not connected.

<a href="https://app.greptile.com/trex/runs/23538092/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(modules): restore module panes named..."](https://github.com/rizriyz/luvus/commit/c3c1d11e9ac957138bca6c140c81beaa108ae7b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62060146)</sub>

<!-- /greptile_comment -->