### PR TITLE
fix(clipboard): wake idle clients and retry worker startup

### DIFF
--- a/src/app/config_persistence.rs
+++ b/src/app/config_persistence.rs
@@ -380,7 +380,8 @@ impl App {
                 }
                 app.schedule_config_save(Instant::now());
                 app.flush_config_reloads(saved);
-                !saved
+                let theme_changed = app.flush_theme_uninstalls(saved);
+                !saved || theme_changed
             })
         });
         let state = &mut self.config_persistence;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2806,6 +2806,8 @@ pub struct App {
     /// `(previous theme, selection revision)` restores an automatically replaced
     /// active theme only when the user has not selected another theme meanwhile.
     pub(crate) pending_theme_uninstalls: HashMap<String, Option<(String, u64)>>,
+    /// Pending removals waiting for configuration persistence, not worker completion.
+    pub(crate) deferred_theme_uninstalls: Vec<String>,
     pub(crate) theme_selection_revision: u64,
     /// Slider arrows in the modal: (control index, ±1 direction, rect).
     pub settings_arrow_rects: Vec<(usize, i32, Rect)>,
@@ -3188,6 +3190,7 @@ impl App {
             settings_ctl_rects: Vec::new(),
             settings_theme_remove_rects: Vec::new(),
             pending_theme_uninstalls: HashMap::new(),
+            deferred_theme_uninstalls: Vec::new(),
             theme_selection_revision: 0,
             settings_arrow_rects: Vec::new(),
             modules,
@@ -3844,6 +3847,7 @@ impl App {
             settings_ctl_rects: Vec::new(),
             settings_theme_remove_rects: Vec::new(),
             pending_theme_uninstalls: HashMap::new(),
+            deferred_theme_uninstalls: Vec::new(),
             theme_selection_revision: 0,
             settings_arrow_rects: Vec::new(),
             modules,

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -856,9 +856,38 @@ impl App {
             .retain(|(theme_id, _)| theme_id != id);
         self.pending_theme_uninstalls
             .insert(id.to_string(), restore);
+        self.show_toast(self.catalog.settings.theme_removing.replace("{id}", id));
+        self.deferred_theme_uninstalls.push(id.to_string());
+        self.flush_theme_uninstalls(true);
+    }
+
+    /// Saving and removing use separate workers. Do not let removal observe the
+    /// previous active theme on disk while the fallback save is still in flight.
+    pub(super) fn flush_theme_uninstalls(&mut self, saved: bool) -> bool {
+        if saved && self.config_save_pending() {
+            return false;
+        }
+        let changed = !self.deferred_theme_uninstalls.is_empty();
+        for id in std::mem::take(&mut self.deferred_theme_uninstalls) {
+            if !saved {
+                self.finish_theme_uninstall(
+                    id,
+                    Err("settings save failed; theme was not removed".into()),
+                );
+            } else if theme::canonical(&self.config.theme) == id {
+                self.finish_theme_uninstall(
+                    id,
+                    Err("theme is active again; removal cancelled".into()),
+                );
+            } else {
+                self.start_theme_uninstall(id);
+            }
+        }
+        changed
+    }
+
+    fn start_theme_uninstall(&self, id: String) {
         let tx = self.app_tx.clone();
-        let id = id.to_string();
-        self.show_toast(self.catalog.settings.theme_removing.replace("{id}", &id));
         std::thread::spawn(move || {
             let result = crate::theme::install::uninstall(&id)
                 .map(|_| crate::theme::ThemeRegistry::load())
@@ -2366,6 +2395,8 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::channel();
         let mut app = crate::app::App::new(80, 24, tx).unwrap();
         app.apply_theme("custom-enter");
+        app.flush_config_for_test(&rx);
+        assert_eq!(crate::config::load().theme, "custom-enter");
         app.open_settings();
         app.settings_set_tab(SettingsTab::Theme);
         let index = app.theme_registry.index_of("custom-enter").unwrap();
@@ -2375,6 +2406,7 @@ mod tests {
 
         assert_eq!(app.config.theme, theme::THEMES[0]);
         assert!(app.theme_uninstall_pending("custom-enter"));
+        assert_eq!(app.deferred_theme_uninstalls, vec!["custom-enter"]);
         let event = loop {
             match rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap() {
                 event @ crate::event::AppEvent::ThemeUninstalled { .. } => break event,
@@ -2385,6 +2417,43 @@ mod tests {
         };
         app.handle_event(event);
         assert!(app.theme_registry.get("custom-enter").is_none());
+    }
+
+    #[test]
+    fn theme_removal_save_failure_keeps_the_file_and_restores_selection() {
+        let _env = crate::persist::test_env("theme-remove-save-failure");
+        let source = crate::persist::ensure_config_dir().join("custom-save-failure.toml");
+        crate::theme::install::init(&source, "custom-save-failure", None).unwrap();
+        let installed = crate::theme::install::install(source.to_str().unwrap(), true).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        app.apply_theme("custom-save-failure");
+        app.flush_config_for_test(&rx);
+        app.request_theme_uninstall("custom-save-failure");
+        app.flush_theme_uninstalls(false);
+        assert!(installed.path.exists());
+        assert!(!app.theme_uninstall_pending("custom-save-failure"));
+        assert!(app.deferred_theme_uninstalls.is_empty());
+        assert_eq!(app.config.theme, "custom-save-failure");
+        app.flush_config_for_test(&rx);
+    }
+
+    #[test]
+    fn theme_removal_cancels_when_reselected_before_save_completes() {
+        let _env = crate::persist::test_env("theme-remove-reselected");
+        let source = crate::persist::ensure_config_dir().join("custom-reselected.toml");
+        crate::theme::install::init(&source, "custom-reselected", None).unwrap();
+        let installed = crate::theme::install::install(source.to_str().unwrap(), true).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        app.apply_theme("custom-reselected");
+        app.flush_config_for_test(&rx);
+        app.request_theme_uninstall("custom-reselected");
+        app.apply_theme("custom-reselected");
+        app.flush_config_for_test(&rx);
+        assert!(installed.path.exists());
+        assert!(!app.theme_uninstall_pending("custom-reselected"));
+        assert_eq!(app.config.theme, "custom-reselected");
     }
 
     #[test]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,21 +1,83 @@
 //! Client-side clipboard helpers. Never borrow a remote server's display environment.
 
-// A coalesced completion event, consumed only by the UI owner. In the thin
-// client it is drained with the next server message, without idle polling or
-// another transport-reader thread. The worker never writes terminal output.
-static NOTIFICATION: std::sync::Mutex<Option<&'static str>> = std::sync::Mutex::new(None);
+use std::sync::{Arc, Mutex, OnceLock};
 
-fn report_failure() {
-    let language = crate::config::load().language;
-    *NOTIFICATION.lock().unwrap_or_else(|e| e.into_inner()) =
-        Some(crate::i18n::by_code(&language).clipboard_failed);
+/// One bounded completion slot per attachment. Retired attachments reject late
+/// completions, so a previous session cannot notify a newly attached client.
+pub(crate) struct Completion {
+    state: Mutex<(bool, Option<&'static str>)>,
+    #[cfg(unix)]
+    wake: Option<std::os::unix::net::UnixStream>,
+}
+
+impl Completion {
+    pub(crate) fn local() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new((true, None)),
+            #[cfg(unix)]
+            wake: None,
+        })
+    }
+
+    pub(crate) fn take(&self) -> Option<&'static str> {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .1
+            .take()
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn close(&self) {
+        *self.state.lock().unwrap_or_else(|e| e.into_inner()) = (false, None);
+    }
+
+    pub(crate) fn publish(&self, message: &'static str) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if !state.0 {
+            return;
+        }
+        state.1 = Some(message);
+        #[cfg(unix)]
+        if let Some(mut wake) = self.wake.as_ref() {
+            use std::io::Write;
+            // Nonblocking, coalesced wakeup. A full socket already signals work.
+            loop {
+                match wake.write(&[1]) {
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                    _ => break,
+                }
+            }
+        }
+    }
+
+    fn failure(&self) {
+        let language = crate::config::load().language;
+        self.publish(crate::i18n::by_code(&language).clipboard_failed);
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn channel() -> std::io::Result<(Arc<Self>, std::os::unix::net::UnixStream)> {
+        let (read, write) = std::os::unix::net::UnixStream::pair()?;
+        read.set_nonblocking(true)?;
+        write.set_nonblocking(true)?;
+        Ok((
+            Arc::new(Self {
+                state: Mutex::new((true, None)),
+                wake: Some(write),
+            }),
+            read,
+        ))
+    }
+}
+
+fn local_completion() -> Arc<Completion> {
+    static LOCAL: OnceLock<Arc<Completion>> = OnceLock::new();
+    LOCAL.get_or_init(Completion::local).clone()
 }
 
 pub(crate) fn take_notification() -> Option<&'static str> {
-    NOTIFICATION
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .take()
+    local_completion().take()
 }
 
 #[cfg(unix)]
@@ -23,22 +85,39 @@ mod native {
     use std::io::{self, Write};
     use std::os::fd::AsRawFd;
     use std::process::{Command, Stdio};
-    use std::sync::{Arc, Condvar, Mutex, OnceLock};
+    use std::sync::{Arc, Condvar, Mutex};
     use std::time::{Duration, Instant};
 
-    type Pending = Arc<(Mutex<Option<String>>, Condvar)>;
+    struct Request {
+        text: String,
+        completion: Arc<super::Completion>,
+    }
+    type Pending = Arc<(Mutex<Option<Request>>, Condvar)>;
+
+    fn worker(
+        queue: &Mutex<Option<Pending>>,
+        spawn: impl FnOnce() -> io::Result<Pending>,
+    ) -> io::Result<Pending> {
+        let mut slot = queue.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(pending) = slot.as_ref() {
+            return Ok(pending.clone());
+        }
+        let pending = spawn()?;
+        *slot = Some(pending.clone());
+        Ok(pending)
+    }
 
     /// One lazy worker, one pending selection. Rapid copies replace pending work
     /// instead of spawning a thread/process for every mouse gesture.
-    pub(super) fn copy(text: &str) {
-        static WORKER: OnceLock<Option<Pending>> = OnceLock::new();
-        let worker = WORKER.get_or_init(|| {
+    pub(super) fn copy(text: &str, completion: Arc<super::Completion>) {
+        static WORKER: Mutex<Option<Pending>> = Mutex::new(None);
+        let worker = worker(&WORKER, || {
             let pending: Pending = Arc::new((Mutex::new(None), Condvar::new()));
             let queue = pending.clone();
             std::thread::Builder::new()
                 .name("clipboard".into())
                 .spawn(move || loop {
-                    let text = {
+                    let request = {
                         let (lock, ready) = &*queue;
                         let mut slot = lock.lock().unwrap_or_else(|e| e.into_inner());
                         while slot.is_none() {
@@ -48,19 +127,23 @@ mod native {
                     };
                     let helpers = tools();
                     if !helpers.is_empty()
-                        && copy_with_tools(&text, &helpers, Duration::from_secs(2)).is_err()
+                        && copy_with_tools(&request.text, &helpers, Duration::from_secs(2)).is_err()
                     {
                         // Do not log clipboard contents or helper stderr (either
                         // can contain private data). OSC 52 was already requested.
-                        super::report_failure();
+                        request.completion.failure();
                     }
                 })
-                .ok()
                 .map(|_| pending)
         });
-        if let Some(queue) = worker {
-            *queue.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(text.to_owned());
+        if let Ok(queue) = worker {
+            *queue.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(Request {
+                text: text.to_owned(),
+                completion,
+            });
             queue.1.notify_one();
+        } else {
+            completion.failure();
         }
     }
 
@@ -165,6 +248,18 @@ mod native {
 
     #[cfg(test)]
     mod tests {
+        #[test]
+        fn clipboard_worker_retries_failed_start_and_reuses_success() {
+            let slot = Mutex::new(None);
+            assert!(worker(&slot, || Err(io::Error::other("spawn failed"))).is_err());
+            assert!(slot.lock().unwrap().is_none());
+            let pending: Pending = Arc::new((Mutex::new(None), Condvar::new()));
+            let started = worker(&slot, || Ok(pending.clone())).unwrap();
+            let reused = worker(&slot, || panic!("must reuse the running worker")).unwrap();
+            assert!(Arc::ptr_eq(&started, &pending));
+            assert!(Arc::ptr_eq(&started, &reused));
+        }
+
         use super::*;
 
         /// Run explicitly against a disposable compositor, never a user's desktop.
@@ -189,7 +284,7 @@ mod native {
             assert_eq!(result.stdout, text.as_bytes());
             // Also exercise the production worker and latest-pending policy.
             for n in 0..20 {
-                copy(&format!("selection {n}"));
+                copy(&format!("selection {n}"), super::super::local_completion());
             }
             let deadline = Instant::now() + Duration::from_secs(5);
             loop {
@@ -282,21 +377,36 @@ mod native {
 }
 
 pub(crate) fn copy_native(text: &str) {
+    copy_native_to(text, local_completion());
+}
+
+pub(crate) fn copy_native_to(text: &str, completion: Arc<Completion>) {
     #[cfg(unix)]
-    native::copy(text);
+    native::copy(text, completion);
     #[cfg(not(unix))]
     if crate::system_clipboard_copy(text).is_err() {
-        report_failure();
+        completion.failure();
     }
 }
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn clipboard_retired_completion_rejects_late_results() {
+        let (completion, _wake) = super::Completion::channel().unwrap();
+        completion.publish("before detach");
+        completion.close();
+        completion.publish("after detach");
+        assert_eq!(completion.take(), None);
+    }
+
     #[test]
     fn clipboard_completion_is_coalesced_and_consumed_once() {
-        *super::NOTIFICATION.lock().unwrap() = Some("first");
-        *super::NOTIFICATION.lock().unwrap() = Some("latest");
-        assert_eq!(super::take_notification(), Some("latest"));
-        assert_eq!(super::take_notification(), None);
+        let completion = super::Completion::local();
+        completion.publish("first");
+        completion.publish("latest");
+        assert_eq!(completion.take(), Some("latest"));
+        assert_eq!(completion.take(), None);
     }
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -23,6 +23,73 @@ use ratatui::{DefaultTerminal, Terminal};
 use crate::ipc::protocol::{self, ClientMessage, FrameData, FrameDiff, ServerMessage};
 use crate::ipc::transport;
 
+#[cfg(unix)]
+pub trait ClientRead: Read + std::os::fd::AsRawFd {}
+#[cfg(unix)]
+impl<T: Read + std::os::fd::AsRawFd> ClientRead for T {}
+#[cfg(not(unix))]
+pub trait ClientRead: Read {}
+#[cfg(not(unix))]
+impl<T: Read> ClientRead for T {}
+
+/// Wake the UI thread without a polling timer or interrupting frame decoding.
+#[cfg(unix)]
+struct CompletionReader<F: FnMut(&str)> {
+    source: Box<dyn ClientRead>,
+    wake: std::os::unix::net::UnixStream,
+    completion: Arc<crate::clipboard::Completion>,
+    notify: F,
+}
+
+#[cfg(unix)]
+impl<F: FnMut(&str)> Read for CompletionReader<F> {
+    fn read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
+        use std::os::fd::AsRawFd;
+        if bytes.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            let mut fds = [
+                libc::pollfd {
+                    fd: self.source.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                },
+                libc::pollfd {
+                    fd: self.wake.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                },
+            ];
+            // Both descriptors remain owned by this reader throughout poll.
+            if unsafe { libc::poll(fds.as_mut_ptr(), 2, -1) } < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error);
+            }
+            if fds[1].revents != 0 {
+                let mut drain = [0; 128];
+                while self.wake.read(&mut drain).is_ok_and(|n| n > 0) {}
+                if let Some(message) = self.completion.take() {
+                    (self.notify)(message);
+                }
+            }
+            if fds[0].revents != 0 {
+                return self.source.read(bytes);
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl<F: FnMut(&str)> Drop for CompletionReader<F> {
+    fn drop(&mut self) {
+        self.completion.close();
+    }
+}
+
 #[derive(Debug)]
 struct HandshakeIoError(std::io::Error);
 
@@ -78,12 +145,13 @@ pub fn run(sock: &Path) -> Result<()> {
     attach_inner(stream.clone(), stream, true)
 }
 
-/// Attach a thin client over **any** reader/writer carrying the binary frame
+/// Attach a thin client over a reader/writer carrying the binary frame
 /// protocol. The local path passes the two halves of a `Conn`; remote attach
 /// (docs/18 RA) passes an `ssh` child's stdout/stdin — the protocol is the same.
+/// Unix readers expose their descriptor so clipboard completion can wake reads.
 pub fn attach<R, W>(reader: R, writer: W) -> Result<()>
 where
-    R: Read + 'static,
+    R: ClientRead + 'static,
     W: Write + Send + 'static,
 {
     let _logging = crate::logging::init(crate::logging::Role::Client);
@@ -97,7 +165,7 @@ where
 
 fn attach_inner<R, W>(reader: R, writer: W, local: bool) -> Result<()>
 where
-    R: Read + 'static,
+    R: ClientRead + 'static,
     W: Write + Send + 'static,
 {
     let mut terminal = ratatui::init();
@@ -105,7 +173,7 @@ where
     let mut input = ClientInput::default();
     let mut selected = crate::session::display_name();
     let result = (|| {
-        let mut reader: Box<dyn Read> = Box::new(reader);
+        let mut reader: Box<dyn ClientRead> = Box::new(reader);
         let mut writer: Box<dyn Write + Send> = Box::new(writer);
         loop {
             let exit = run_inner(reader, writer, &mut terminal, &mut input, &selected)?;
@@ -174,15 +242,14 @@ struct ClientInput {
     windows_input_mode: Option<crate::terminal::host_input::WindowsInputModeGuard>,
 }
 
-fn run_inner<R, W>(
-    reader: R,
+fn run_inner<W>(
+    reader: Box<dyn ClientRead>,
     mut writer: W,
     terminal: &mut DefaultTerminal,
     input: &mut ClientInput,
     selected: &str,
 ) -> Result<ClientExit>
 where
-    R: Read,
     W: Write + Send + 'static,
 {
     let truecolor = protocol::truecolor_supported();
@@ -196,6 +263,17 @@ where
         },
     )?;
 
+    #[cfg(unix)]
+    let (completion, wake) = crate::clipboard::Completion::channel()?;
+    #[cfg(unix)]
+    let reader = CompletionReader {
+        source: reader,
+        wake,
+        completion: completion.clone(),
+        notify: crate::emit_notification,
+    };
+    #[cfg(not(unix))]
+    let completion = crate::clipboard::Completion::local();
     let mut reader = BufReader::new(reader);
     match read_handshake_message(&mut reader)? {
         // The one user-facing handshake failure is an old server after an
@@ -298,9 +376,6 @@ where
     let mut last_cursor = None;
     let exit = loop {
         let message = protocol::read_message::<_, ServerMessage>(&mut reader);
-        if let Some(notification) = crate::clipboard::take_notification() {
-            crate::emit_notification(notification);
-        }
         match message {
             // A full frame repaints the whole screen; a diff writes *only its changed
             // cells* straight to the terminal (O(changed), not a whole re-blit). Each
@@ -349,7 +424,12 @@ where
             }
             Ok(ServerMessage::Notify(msg)) => crate::emit_notification(&msg),
             Ok(ServerMessage::Sound(signal)) => crate::emit_sound(signal),
-            Ok(ServerMessage::Clipboard(text)) => crate::emit_clipboard(&text),
+            Ok(ServerMessage::Clipboard(text)) => {
+                crate::emit_clipboard_to(&text, completion.clone());
+                if let Some(message) = completion.take() {
+                    crate::emit_notification(message);
+                }
+            }
             Ok(ServerMessage::OpenUrl(url)) => crate::platform::open_url(&url),
             Ok(ServerMessage::SwitchSession { name }) => break ClientExit::SwitchSession(name),
             Ok(ServerMessage::Detach) => break ClientExit::Detached,
@@ -727,6 +807,53 @@ where
 
 #[cfg(all(test, unix))]
 mod tests {
+    #[test]
+    fn clipboard_completion_wakes_idle_and_partial_frame_reads() {
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixStream;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        for prefix in [0, 2, 5] {
+            let (source, mut server) = UnixStream::pair().unwrap();
+            let (completion, wake) = crate::clipboard::Completion::channel().unwrap();
+            let mut frame = Vec::new();
+            crate::ipc::protocol::write_message(
+                &mut frame,
+                &super::ServerMessage::Notify("server message".into()),
+            )
+            .unwrap();
+            server.write_all(&frame[..prefix]).unwrap();
+            let (notified, received) = mpsc::channel();
+            let retained = completion.clone();
+            let reader_thread = std::thread::spawn(move || {
+                let mut reader = super::CompletionReader {
+                    source: Box::new(source),
+                    wake,
+                    completion,
+                    notify: move |message: &str| {
+                        notified.send(message.to_owned()).unwrap();
+                    },
+                };
+                let message =
+                    crate::ipc::protocol::read_message::<_, super::ServerMessage>(&mut reader)
+                        .unwrap();
+                assert!(
+                    matches!(message, super::ServerMessage::Notify(text) if text == "server message")
+                );
+                assert_eq!(reader.read(&mut []).unwrap(), 0);
+            });
+            retained.publish("clipboard failed");
+            let notification = received.recv_timeout(Duration::from_secs(3));
+            // Always unblock the reader even when the wakeup assertion fails.
+            server.write_all(&frame[prefix..]).unwrap();
+            reader_thread.join().unwrap();
+            assert_eq!(notification.unwrap(), "clipboard failed");
+            retained.publish("stale attachment");
+            assert_eq!(retained.take(), None);
+        }
+    }
+
     use super::{
         copy_and_flush, is_handshake_io_error, read_handshake_message, relay,
         write_handshake_message,

--- a/src/ipc/transport.rs
+++ b/src/ipc/transport.rs
@@ -99,6 +99,14 @@ fn connect_for_liveness(path: &Path) -> io::Result<Conn> {
 #[derive(Clone)]
 pub struct Conn(Arc<Stream>);
 
+#[cfg(unix)]
+impl std::os::fd::AsRawFd for Conn {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        let Stream::UdSocket(socket) = &*self.0;
+        socket.inner().as_raw_fd()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TimeoutMode {
     Kernel,

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,15 @@ pub(crate) fn emit_notification(msg: &str) {
 ///    where no clipboard tool is installed. Harmless if unsupported.
 pub(crate) fn emit_clipboard(text: &str) {
     clipboard::copy_native(text);
+    emit_clipboard_escape(text);
+}
 
+pub(crate) fn emit_clipboard_to(text: &str, completion: std::sync::Arc<clipboard::Completion>) {
+    clipboard::copy_native_to(text, completion);
+    emit_clipboard_escape(text);
+}
+
+fn emit_clipboard_escape(text: &str) {
     use std::io::Write;
     let b64 = base64_encode(text.as_bytes());
     let mut out = std::io::stdout().lock();


### PR DESCRIPTION
Fix the two post-merge clipboard completion findings from #335.

## What changed

- Wake an idle Unix thin client when its native clipboard helper fails, using a nonblocking socket pair alongside the existing transport descriptor.
- Deliver notifications on the UI thread without waiting for a server frame, adding an idle polling timer, or creating another reader thread.
- Preserve partially received protocol headers and payloads while processing clipboard completions. This works with local sockets and SSH child stdout.
- Scope completion state to its original attachment and reject late results after detach or session switching.
- Retry clipboard worker creation after a failed thread spawn instead of permanently caching the failure. Successful initialization still reuses one worker with one replaceable pending selection.
- Drain synchronous clipboard failures immediately on Windows.

## Scope and resource impact

The clipboard fix does not change helper selection, clipboard text semantics, protocol format, or dependencies. Unix clients own two additional descriptors per attachment for the wakeup channel. No background polling or extra transport threads were introduced.

## Verification

- Focused clipboard tests: 22 passed, 1 existing Wayland compositor test ignored.
- Thin-client tests: 8 passed, including a real server handshake test.
- Regression coverage for idle reads, partial headers and payloads, retired attachments, and failed worker startup followed by successful reuse.
- Native strict Clippy and Windows GNU target strict Clippy passed for all targets.
- Formatting and diff whitespace checks passed.
- Rebuilt debug binary tested through an isolated client/server PTY with a fixture clipboard helper: successful delivery, OSC 52, and native failure feedback passed. The first fixture attempt selected the wrong row, which was corrected before rerunning both cases.

Production sessions and the host clipboard were not touched. Windows was cross-checked, not run on Windows hardware. The compositor-dependent Wayland test was not rerun for this follow-up.

## macOS CI follow-up

The macOS job exposed an existing race between saving the fallback theme and uninstalling the previously active theme. The uninstall worker could read the old configuration and refuse removal.

- Defer uninstall until the existing asynchronous configuration-save completion reports that no saves remain pending.
- Keep the theme file and restore the prior selection when saving fails, without overwriting a newer user selection.
- Cancel queued removal if the user reselects the theme before persistence completes.
- Keep all filesystem work off the UI thread and use existing completion events without polling.
- Strengthen the original regression to begin with the selected theme persisted on disk, and add save-failure and reselection coverage.

Verification for this follow-up: 29 Settings tests and 9 configuration-persistence tests passed, as did strict all-target Clippy and formatting. A full local test run passed 1,691 tests, failed 5, and ignored 5. Three failures came from non-repository fixtures placed under this repository via TMPDIR, and two copy tests observed shell-prompt text instead of their fixture text. These unrelated cases were not changed. The original macOS theme-removal failure passed locally with the fix. Fresh GitHub CI remains the release gate.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This update delivers clipboard completion notifications to idle Unix clients without interrupting frame decoding, retries clipboard worker initialization after a startup failure, and delays active-theme removal until the fallback preference is safely saved. The exercised clipboard and theme-removal flows completed successfully with no remaining blocking failure.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Five focused Rust tests ran from the repository and all five passed.
- The Unix thin-client reader test exercised idle completion wakeups with zero-, two-, and five-byte partial protocol-frame prefixes, then completed frame decoding; the teardown test rejected a late completion.
- The native clipboard worker test exercised a failed worker creation followed by a successful retry and reuse.
- The theme tests exercised a fallback-save failure and reselection before save completion, confirming the installed file and selected theme were preserved.

<a href="https://app.greptile.com/trex/runs/23533895/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(theme): save fallback before removin..."](https://github.com/rizriyz/luvus/commit/97d351327d4e530ce52b2faf5f416a2dd5fea9b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62472995)</sub>

<!-- /greptile_comment -->