### PR TITLE
fix(terminal): clear stale SSH identity from panes

### DIFF
--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -1163,6 +1163,14 @@ fn apply_pane_env(
     for (k, v) in extra_env {
         cmd.env(k, v);
     }
+    // A persistent Luvus server may have been started through an SSH bridge.
+    // Its panes own fresh local PTYs, so inheriting the bridge's connection
+    // identity makes terminal applications misclassify those PTYs as SSH
+    // terminals long after the originating connection is gone. Keep
+    // SSH_AUTH_SOCK: forwarded agent access is still useful inside panes.
+    for key in ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"] {
+        cmd.env_remove(key);
+    }
     cmd.env("TERM", "xterm-256color");
     cmd.env("LUVUS_ENV", "1");
     cmd.env("LUVUS_PANE_ID", id.0.to_string());
@@ -1661,8 +1669,10 @@ mod reap_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        child_poll_finished, path_with_server_binary, wrap_paste, write_input_action, InputAction,
+        apply_pane_env, child_poll_finished, path_with_server_binary, wrap_paste,
+        write_input_action, CommandBuilder, InputAction, PaneId,
     };
+    use std::ffi::OsStr;
     use std::path::PathBuf;
     use std::time::Duration;
 
@@ -1719,6 +1729,36 @@ mod tests {
         assert!(child_poll_finished(Ok(Some(
             portable_pty::ExitStatus::with_exit_code(0)
         ))));
+    }
+
+    #[test]
+    fn pane_env_drops_ssh_terminal_identity_but_keeps_agent_forwarding() {
+        let mut command = CommandBuilder::new("shell");
+        let extra_env = [
+            (
+                "SSH_CONNECTION".to_string(),
+                "client connection".to_string(),
+            ),
+            ("SSH_CLIENT".to_string(), "client identity".to_string()),
+            ("SSH_TTY".to_string(), "windows-pty".to_string()),
+            ("SSH_AUTH_SOCK".to_string(), "forwarded-agent".to_string()),
+        ];
+
+        apply_pane_env(
+            &mut command,
+            PaneId(1),
+            std::path::Path::new("."),
+            &extra_env,
+        );
+
+        for key in ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"] {
+            assert_eq!(command.get_env(key), None, "{key} must not reach panes");
+        }
+        assert_eq!(
+            command.get_env("SSH_AUTH_SOCK"),
+            Some(OsStr::new("forwarded-agent")),
+            "SSH agent forwarding remains available"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Prevent panes created by remote-started servers from being misclassified as SSH terminals.

## What

- Remove `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY` from every pane environment.
- Preserve `SSH_AUTH_SOCK` so SSH agent forwarding remains available.
- Cover the shared synchronous and deferred pane-spawn path.
- Add a cross-platform regression test for the environment contract.

## Why

A detached server started through the SSH bridge inherits connection identity from the spawning SSH process. Passing those values into pane PTYs makes terminal applications treat the pane as an SSH terminal, and the values become stale after the original connection closes.

Fixes #338.

## Verification

- [ ] `cargo test --locked`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test terminal::pty::tests -- --nocapture`
- [x] `cargo check --target x86_64-pc-windows-gnu --bin luvus`
- [x] Isolated macOS server and real PTY environment check
- [x] Linux SSH bridge → detached server → real PTY process-environment check

## Notes

The exact Windows 11 and Claude Code fullscreen scenario has not been tested live; Windows target compilation and the platform-independent environment regression are covered.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

## Summary
- Pane child environments now remove stale SSH connection identity values while preserving SSH agent forwarding.
- A real PTY run covered both the initial pane and a deferred split pane; each retained only `SSH_AUTH_SOCK` from the injected SSH variables.

This change is safe to merge.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a real Luvus server with synthetic SSH environment variables and verified that the initial pane PTY and the deferred pane split PTY snapshots contained only SSH\_AUTH\_SOCK and no SSH identity variables, and that the focused terminal test suite completed with 6 passing tests.
- Observed runtime evidence that the synchronous child snapshot and both deferred-path snapshots contained only SSH\_AUTH\_SOCK; the runtime harness reported PASS and exit code 0, and the focused terminal tests ended with 6 passed and 0 failed.

<a href="https://app.greptile.com/trex/runs/23977178/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(terminal): clear stale SSH identity ..."](https://github.com/rizriyz/luvus/commit/af9c27dc6043f62af668d0a53ee9af287906b4ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63391911)</sub>

<!-- /greptile_comment -->