### PR TITLE
fix(themes): load symlinked theme files

### DIFF
--- a/src/theme/registry.rs
+++ b/src/theme/registry.rs
@@ -74,9 +74,22 @@ impl ThemeRegistry {
                 for entry in entries.flatten() {
                     let path = entry.path();
                     let is_toml = path.extension().and_then(|value| value.to_str()) == Some("toml");
-                    let is_file = entry.file_type().is_ok_and(|kind| kind.is_file());
-                    if is_toml && is_file {
-                        paths.push(path);
+                    if !is_toml {
+                        continue;
+                    }
+                    match entry.file_type() {
+                        Ok(kind) if kind.is_file() => paths.push(path),
+                        Ok(kind) if kind.is_symlink() => match fs::metadata(&path) {
+                            Ok(metadata) if metadata.is_file() => paths.push(path),
+                            Ok(_) => {}
+                            // Keep broken links in the bounded path set so
+                            // read_theme_file reports the concrete error.
+                            Err(_) => paths.push(path),
+                        },
+                        Ok(_) => {}
+                        // Recheck inaccessible candidates through the existing
+                        // bounded reader so failures are visible to the user.
+                        Err(_) => paths.push(path),
                     }
                 }
             }
@@ -448,6 +461,9 @@ fn display_name(id: &str) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
     fn write(dir: &Path, name: &str, body: &str) {
         fs::create_dir_all(dir).unwrap();
         fs::write(dir.join(name), body).unwrap();
@@ -510,6 +526,46 @@ coral = "#aa0000"
         assert!(registry.index_of("a-custom").unwrap() < registry.index_of("z-custom").unwrap());
         assert!(registry.problems().is_empty());
         fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loads_symlinked_theme_files() {
+        let root = temp("symlink-load");
+        let themes = root.join("themes");
+        let source = root.join("managed-theme");
+        fs::create_dir_all(&themes).unwrap();
+        fs::write(&source, complete("managed-link")).unwrap();
+        symlink(&source, themes.join("managed-link.toml")).unwrap();
+
+        let registry = ThemeRegistry::load_from(&themes);
+
+        let entry = registry
+            .get("managed-link")
+            .expect("symlinked theme is loaded");
+        assert!(matches!(entry.source, ThemeSource::Local { .. }));
+        assert!(registry.problems().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reports_broken_theme_symlinks_and_ignores_symlinked_directories() {
+        let root = temp("symlink-invalid");
+        let themes = root.join("themes");
+        let directory = root.join("directory-target");
+        fs::create_dir_all(&themes).unwrap();
+        fs::create_dir_all(&directory).unwrap();
+        symlink(root.join("missing-theme"), themes.join("broken.toml")).unwrap();
+        symlink(&directory, themes.join("directory.toml")).unwrap();
+
+        let registry = ThemeRegistry::load_from(&themes);
+
+        assert_eq!(registry.problems().len(), 1);
+        assert!(registry.problems()[0].path.ends_with("broken.toml"));
+        assert!(registry.problems()[0].message.contains("inspect"));
+        assert!(!registry.problems()[0].path.ends_with("directory.toml"));
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/website/src/content/docs/docs/guides/themes.mdx
+++ b/website/src/content/docs/docs/guides/themes.mdx
@@ -75,9 +75,10 @@ luvus theme uninstall my-theme
 
 `theme path` prints and creates the shared home-level directory, normally
 `~/.luvus/themes/` (`~/.luvus-dev/themes/` for debug builds). Manually copied
-`*.toml` files are loaded too. Invalid files are omitted from Settings and
-reported by `theme list` and `theme reload` without preventing valid themes from
-loading.
+`*.toml` files and symbolic links to theme files are loaded too, so managed
+configurations from tools such as Home Manager, Stow, and chezmoi work without
+copying. Broken links and invalid files are omitted from Settings and reported
+by `theme list` and `theme reload` without preventing valid themes from loading.
 
 The Settings remove action switches an active installed theme to the bundled
 default before removing it. The CLI remains explicit: select another theme


### PR DESCRIPTION
## Summary

- load `.toml` theme files reached through symbolic links
- report broken theme links through the existing bounded `ThemeProblem` path
- continue ignoring symlinked directories and special files
- document managed symlink workflows for Home Manager, Stow, and chezmoi

## Verification

- `cargo test theme::registry::tests:: -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release --locked`
- `npm run build` in `website/`
- `cargo test --locked`: 1,852 passed, 1 unrelated local failure because the user-owned untracked `changelog/v0.14.0.md` changes the embedded latest-release contributor fixture; that file is not part of this PR

Closes #195

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

## Summary
- Local theme discovery now accepts TOML symbolic links that resolve to regular files.
- Broken theme links are reported without preventing other themes from loading, while directory links remain ignored.
- The existing 256-candidate limit remains effective.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The pre-PR validation captured the old behavior, showing that the former implementation omitted valid and broken symlinks while still ignoring the directory symlink.
- The PR-head validation capture showed the system state with linked\_theme\_loaded=true, broken\_symlink\_reported=true, directory\_symlink\_ignored=true, and bounded\_candidate\_warning=true.
- The authored harness and the complete observed command output were uploaded for reviewer access.
- Artifacts including the harness script and three logs were uploaded to support reviewer inspection.

<a href="https://app.greptile.com/trex/runs/23977696/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(themes): load symlinked theme files"](https://github.com/rizriyz/luvus/commit/ad03d4571ca914fd19077da186914c9d1acb3c34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63394311)</sub>

<!-- /greptile_comment -->