### PR TITLE
ci(size): validate Intel macOS release size

### DIFF
--- a/.github/binary-size-baseline.json
+++ b/.github/binary-size-baseline.json
@@ -10,8 +10,8 @@
       "archive_bytes": 4666841
     },
     "x86_64-apple-darwin": {
-      "executable_bytes": 9550124,
-      "archive_bytes": 4031584
+      "executable_bytes": 12150348,
+      "archive_bytes": 5084425
     },
     "aarch64-unknown-linux-musl": {
       "executable_bytes": 10345896,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,32 @@ jobs:
             --binary target/release/luvus \
             --archive target/luvus-size.tar.gz
 
+  binary-size-intel-macos:
+    name: macos Intel binary size
+    runs-on: macos-14
+    permissions:
+      contents: read
+    env:
+      SQLITE3_LIB_DIR: /usr/lib
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+      - run: cargo build --release --locked --target x86_64-apple-darwin
+      - name: Package measured binary
+        run: |
+          COPYFILE_DISABLE=1 tar \
+            -C target/x86_64-apple-darwin/release \
+            -czf target/luvus-x86_64-size.tar.gz \
+            luvus
+      - name: Check reviewed baseline
+        run: |
+          python3 scripts/check-binary-size.py \
+            --target x86_64-apple-darwin \
+            --binary target/x86_64-apple-darwin/release/luvus \
+            --archive target/luvus-x86_64-size.tar.gz
+
   windows:
     name: windows protocol · ConPTY
     runs-on: windows-latest


### PR DESCRIPTION
Prevents Intel macOS binary growth from being discovered only after a release tag is pushed.

## What

- Refresh the reviewed `x86_64-apple-darwin` executable and archive baselines from the current release build.
- Add an Intel macOS cross-build and binary-size check to normal PR CI.
- Keep the existing 5% warning and 10% blocking thresholds unchanged for every target.

## Why

The machine feature updated the ARM64 macOS baseline, but the Intel macOS baseline remained at the v0.13.4 size. A current Intel release build is 12,150,348 bytes, which appears as +27.23% against that stale baseline and would fail only after tagging a release.

## Verification

- [x] `SQLITE3_LIB_DIR=/usr/lib cargo build --release --locked --target x86_64-apple-darwin`
- [x] Packaged the binary with the same `COPYFILE_DISABLE=1 tar` flow used by CI.
- [x] `python3 scripts/check-binary-size.py --target x86_64-apple-darwin --binary target/x86_64-apple-darwin/release/luvus --archive /private/tmp/luvus-x86_64-apple-size-2.tar.gz`
- [x] JSON validation for `.github/binary-size-baseline.json`
- [x] `git diff --check`

## Measured baseline

| Artifact | Current | Previous baseline | Previous change |
| --- | ---: | ---: | ---: |
| Executable | 12,150,348 B | 9,550,124 B | +27.23% |
| Archive | 5,084,425 B | 4,031,584 B | +26.11% |

## Notes

This deliberately does not raise the global threshold to 50%, which would hide substantial regressions on Linux and Windows as well as macOS.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Intel macOS release-size coverage and refreshes its reviewed artifact baseline. The target-specific build, packaging paths, and baseline check are wired consistently.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the Intel macOS target flow builds and packages the target-specific release binary for the size checker.
- Compared baselines and observed the pre-capture rejection and post-capture acceptance of the Intel artifact sizes by the size checker (0% change).
- Noted that a full Intel-target release build cannot complete on the Linux runner due to missing macOS SDK and linker; the workflow is configured to run on macOS-14 where Xcode provides the required tools.
- Collected and referenced artifacts showing the size-check helper and the pre/post baseline logs to support reviewer inspection.

<a href="https://app.greptile.com/trex/runs/23979666/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(size): validate Intel macOS release s..."](https://github.com/rizriyz/luvus/commit/2ba96b5d4258cf06fb9ff7df00fc44d4dbb8cbe1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63398798)</sub>

<!-- /greptile_comment -->