### PR TITLE
docs(changelog): credit v0.14.1 issue reporters

### DIFF
--- a/changelog/v0.14.1.md
+++ b/changelog/v0.14.1.md
@@ -72,9 +72,21 @@ Luvus v0.14.1 adds persistent SSH machines, native Devin, OpenCode 2, Kilo Code,
 
 ## Issue reporters
 
-- [K Behelit (@tobias-hui)](https://github.com/tobias-hui)
-- [zchcc](https://github.com/zchcc)
+- [Rudra Narayan Panda (@0xrnp)](https://github.com/0xrnp)
+- [Matt Robenolt (@mattrobenolt)](https://github.com/mattrobenolt)
+- [problaems](https://github.com/problaems)
+- [Rogerio Saulo (@rsaulo)](https://github.com/rsaulo)
 - [Juan S. Escobar (@escobar5)](https://github.com/escobar5)
+- [Aan (@aancw)](https://github.com/aancw)
+- [Misaka (@chuxubank)](https://github.com/chuxubank)
+- [Jake Birchall (@JABirchall)](https://github.com/JABirchall)
+- [jameswibe79](https://github.com/jameswibe79)
+- [TangXijn](https://github.com/TangXijn)
+- [Stephan Fitzpatrick (@knowsuchagency)](https://github.com/knowsuchagency)
+- [zchcc](https://github.com/zchcc)
+- [Pader (@xpader)](https://github.com/xpader)
+- [K Behelit (@tobias-hui)](https://github.com/tobias-hui)
+- [Yunus Korkmaz (@yunuskorkmaz)](https://github.com/yunuskorkmaz)
 
 ## Full changelog
 


### PR DESCRIPTION
Credits every person whose issue was resolved by work included in Luvus v0.14.1.

## What

- Expand the v0.14.1 issue-reporter section from 3 to 15 verified GitHub profiles.
- Include the FreeBSD reporter whose issue was manually closed after support landed.
- Keep the changelog source shared by the website, GitHub release renderer, and in-app changelog.

## Verification

- [x] All 14 directly linked closed issues were matched to merged PRs referenced by v0.14.1.
- [x] The manually completed FreeBSD issue was reviewed separately.
- [x] `cargo test changelog::tests --locked -- --nocapture`
- [x] `cd website && npm run build`
- [x] Built website contains all 15 reporter profile links.
- [x] Release-note renderer emits 15 avatars and 15 accessible fallback links.
- [x] `git diff --check`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

## T-Rex validation blocked

The website builds for both the base revision and this change completed successfully. The rendered reporter-card check stopped before evaluating the cards because its browser selector was invalid, and no final rendered evidence was available. No issue requiring a code change was established.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Base and head static builds completed successfully.
- The browser assertion did not reach the v0.14.1 Issue reporters cards because the browser-selection step encountered an invalid CSS selector '#issue-reporters-v0.14.1'.
- No uploaded evidence artifacts were supplied for these checks.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): credit v0.14.1 issue re..."](https://github.com/rizriyz/luvus/commit/520457b1d5743b1e932fa98eb88775080756ce1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63403719)</sub>

<!-- /greptile_comment -->