### PR TITLE
fix(session): recover named sessions after upgrades

### DIFF
--- a/src/app/dispatch/core.rs
+++ b/src/app/dispatch/core.rs
@@ -10,6 +10,7 @@ impl App {
             "type":"pong",
             "version": env!("CARGO_PKG_VERSION"),
             "protocol":1,
+            "client_protocol":crate::ipc::protocol::PROTOCOL_VERSION,
             "session": crate::session::display_name()
         }))
     }

--- a/src/app/dispatch/tests/core.rs
+++ b/src/app/dispatch/tests/core.rs
@@ -1,5 +1,17 @@
 use super::super::*;
 use super::support::*;
+
+#[test]
+fn ping_exposes_the_binary_transport_protocol_for_upgrade_preflight() {
+    let (_env, mut app) = app("ping-client-protocol");
+    let result = app.dispatch("ping", &json!({})).unwrap();
+    assert_eq!(result["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        result["client_protocol"],
+        crate::ipc::protocol::PROTOCOL_VERSION
+    );
+}
+
 #[test]
 fn config_patch_rejects_unknown_fields_without_mutation() {
     let (_env, mut app) = app("socket-config");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -360,7 +360,7 @@ server:
   server status              is the server running, and what version
   server start               start the background server if it isn't up
   server stop                stop the server (and all panes)
-  server restart             stop + start (load a newly-installed binary)
+  server restart [--all]     stop + start (load a newly-installed binary)
   server update-manifest     fetch the latest agent-detection rules from luvus.dev
                              (applies live if the server is up; else on next start)
   integration install|uninstall <claude|copilot|codex|antigravity|opencode|kimi|grok|hermes|omp>

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -117,23 +117,8 @@ fn read_handshake_message<R: Read>(reader: &mut R) -> Result<ServerMessage> {
     protocol::read_message(reader).map_err(|error| HandshakeIoError(error).into())
 }
 
-/// The v0.14.1 wire accidentally placed `ShellSidebars` before `Welcome`, so
-/// its pre-version reply used enum variant one. Accept that one released shape
-/// as well as the frozen variant-zero shape; all post-handshake traffic remains
-/// guarded by the negotiated protocol version.
-#[derive(serde::Deserialize)]
-enum WelcomeHandshakeMessage {
-    Welcome { version: u32, error: Option<String> },
-    V0141Welcome { version: u32, error: Option<String> },
-}
-
 fn read_welcome_message<R: Read>(reader: &mut R) -> Result<(u32, Option<String>)> {
-    let message: WelcomeHandshakeMessage =
-        protocol::read_message(reader).map_err(HandshakeIoError)?;
-    Ok(match message {
-        WelcomeHandshakeMessage::Welcome { version, error }
-        | WelcomeHandshakeMessage::V0141Welcome { version, error } => (version, error),
-    })
+    protocol::read_welcome_message(reader).map_err(|error| HandshakeIoError(error).into())
 }
 
 fn write_handshake_message<W: Write>(writer: &mut W, message: &ClientMessage) -> Result<()> {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -117,6 +117,25 @@ fn read_handshake_message<R: Read>(reader: &mut R) -> Result<ServerMessage> {
     protocol::read_message(reader).map_err(|error| HandshakeIoError(error).into())
 }
 
+/// The v0.14.1 wire accidentally placed `ShellSidebars` before `Welcome`, so
+/// its pre-version reply used enum variant one. Accept that one released shape
+/// as well as the frozen variant-zero shape; all post-handshake traffic remains
+/// guarded by the negotiated protocol version.
+#[derive(serde::Deserialize)]
+enum WelcomeHandshakeMessage {
+    Welcome { version: u32, error: Option<String> },
+    V0141Welcome { version: u32, error: Option<String> },
+}
+
+fn read_welcome_message<R: Read>(reader: &mut R) -> Result<(u32, Option<String>)> {
+    let message: WelcomeHandshakeMessage =
+        protocol::read_message(reader).map_err(HandshakeIoError)?;
+    Ok(match message {
+        WelcomeHandshakeMessage::Welcome { version, error }
+        | WelcomeHandshakeMessage::V0141Welcome { version, error } => (version, error),
+    })
+}
+
 fn write_handshake_message<W: Write>(writer: &mut W, message: &ClientMessage) -> Result<()> {
     protocol::write_message(writer, message).map_err(|error| HandshakeIoError(error).into())
 }
@@ -273,10 +292,11 @@ where
     #[cfg(not(unix))]
     let completion = crate::clipboard::Completion::local();
     let mut reader = BufReader::new(reader);
-    match read_handshake_message(&mut reader)? {
+    let (server_protocol, handshake_error) = read_welcome_message(&mut reader)?;
+    match handshake_error {
         // The one user-facing handshake failure is an old server after an
         // upgrade — tell them the fix, not just the symptom.
-        ServerMessage::Welcome { error: Some(e), .. } => {
+        Some(error) => {
             crate::logging::event(
                 crate::logging::EventKind::ClientHandshakeRejected,
                 &[
@@ -285,19 +305,24 @@ where
                 ],
             );
             return Err(anyhow!(
-                "server: {e}\nAn older luvus server is likely still running — \
+                "server: {error}\nAn older luvus server is likely still running — \
                  run `luvus server restart` to load this version (your session is saved)."
             ));
         }
-        ServerMessage::Welcome { .. } => {}
-        _ => {
+        None if server_protocol == protocol::PROTOCOL_VERSION => {}
+        None => {
             crate::logging::event(
                 crate::logging::EventKind::ClientHandshakeRejected,
-                &[crate::logging::Field::Reason(
-                    crate::logging::Reason::Handshake,
-                )],
+                &[
+                    crate::logging::Field::Reason(crate::logging::Reason::VersionMismatch),
+                    crate::logging::Field::ProtocolVersion(u64::from(server_protocol)),
+                ],
             );
-            return Err(anyhow!("unexpected handshake"));
+            return Err(anyhow!(
+                "server protocol {server_protocol} does not match client protocol {}\n\
+                 Run `luvus server restart` to load this version (your session is saved).",
+                protocol::PROTOCOL_VERSION
+            ));
         }
     }
 
@@ -901,7 +926,8 @@ mod tests {
     }
 
     use super::{
-        copy_and_flush, is_handshake_io_error, read_handshake_message, write_handshake_message,
+        copy_and_flush, is_handshake_io_error, read_handshake_message, read_welcome_message,
+        write_handshake_message,
     };
     use crate::ipc::protocol::{ClientMessage, PROTOCOL_VERSION};
     use std::cell::RefCell;
@@ -921,6 +947,49 @@ mod tests {
             error.to_string(),
             "connection failed before the Luvus handshake: failed to fill whole buffer"
         );
+    }
+
+    #[test]
+    fn welcome_reader_accepts_frozen_and_v0141_wire_positions() {
+        #[derive(serde::Serialize)]
+        enum FrozenServerMessage {
+            Welcome { version: u32, error: Option<String> },
+        }
+        #[derive(serde::Serialize)]
+        enum V0141ServerMessage {
+            ShellSidebars,
+            Welcome { version: u32, error: Option<String> },
+        }
+
+        let mut frozen = Vec::new();
+        crate::ipc::protocol::write_message(
+            &mut frozen,
+            &FrozenServerMessage::Welcome {
+                version: 5,
+                error: Some("protocol version mismatch".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            read_welcome_message(&mut &frozen[..]).unwrap(),
+            (5, Some("protocol version mismatch".into()))
+        );
+
+        let mut v0141 = Vec::new();
+        crate::ipc::protocol::write_message(
+            &mut v0141,
+            &V0141ServerMessage::Welcome {
+                version: 17,
+                error: Some("protocol version mismatch".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            read_welcome_message(&mut &v0141[..]).unwrap(),
+            (17, Some("protocol version mismatch".into()))
+        );
+
+        let _ = V0141ServerMessage::ShellSidebars;
     }
 
     #[test]

--- a/src/ipc/federated.rs
+++ b/src/ipc/federated.rs
@@ -455,6 +455,22 @@ pub(super) fn run(
     }
 }
 
+fn validate_local_welcome(reader: &mut impl std::io::Read) -> Result<()> {
+    let (server_protocol, error) = protocol::read_welcome_message(reader)?;
+    if let Some(error) = error {
+        return Err(anyhow!(
+            "server: {error}\nAn older luvus server is likely still running — \
+             run `luvus server restart` to load this version (your session is saved)."
+        ));
+    }
+    if server_protocol != PROTOCOL_VERSION {
+        return Err(anyhow!(
+            "server protocol {server_protocol} does not match client {PROTOCOL_VERSION}"
+        ));
+    }
+    Ok(())
+}
+
 fn run_inner(
     reader: crate::ipc::transport::Conn,
     mut writer: crate::ipc::transport::Conn,
@@ -472,18 +488,7 @@ fn run_inner(
         },
     )?;
     let mut reader = BufReader::new(reader);
-    match protocol::read_message::<_, ServerMessage>(&mut reader)? {
-        ServerMessage::Welcome { error: None, .. } => {}
-        ServerMessage::Welcome {
-            error: Some(error), ..
-        } => {
-            return Err(anyhow!(
-                "server: {error}\nAn older luvus server is likely still running — \
-                 run `luvus server restart` to load this version (your session is saved)."
-            ))
-        }
-        _ => return Err(anyhow!("unexpected local server handshake")),
-    }
+    validate_local_welcome(&mut reader)?;
     let probe_terminal = match protocol::read_message::<_, ServerMessage>(&mut reader)? {
         ServerMessage::Ready { probe_terminal } => probe_terminal,
         _ => return Err(anyhow!("unexpected local server negotiation")),
@@ -5538,6 +5543,31 @@ fn write_row(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn local_handshake_decodes_v0141_mismatch_as_actionable_error() {
+        #[allow(dead_code)]
+        #[derive(serde::Serialize)]
+        enum V0141ServerMessage {
+            ShellSidebars,
+            Welcome { version: u32, error: Option<String> },
+        }
+
+        let mut bytes = Vec::new();
+        protocol::write_message(
+            &mut bytes,
+            &V0141ServerMessage::Welcome {
+                version: 17,
+                error: Some("protocol version mismatch".into()),
+            },
+        )
+        .unwrap();
+
+        let error = validate_local_welcome(&mut &bytes[..]).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("protocol version mismatch"));
+        assert!(message.contains("luvus server restart"));
+    }
 
     #[test]
     fn frame_diff_repaints_only_when_it_touches_the_client_dock() {

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -14,6 +14,9 @@ use crate::sound::SoundSignal;
 use crate::terminal::theme_probe::TerminalColors;
 
 pub const PROTOCOL_VERSION: u32 = 18;
+/// v0.14.1 shipped protocol 17 with `Welcome` accidentally moved to enum
+/// variant one. Its mismatch reply must use that released position.
+const V0141_PROTOCOL_VERSION: u32 = 17;
 const MAX_FRAME: usize = 64 * 1024 * 1024;
 
 /// Local display cell size in pixels, or `(0, 0)` when the host does not report it.
@@ -244,6 +247,59 @@ pub enum ServerMessage {
     MachineCatalogChanged {
         revision: u64,
     },
+}
+
+/// The only historical pre-negotiation server shape that shipped with
+/// `Welcome` outside variant zero. This decoder is shared by local, federated,
+/// and SSH-backed clients so every attach path reports an actionable mismatch.
+#[derive(Deserialize)]
+enum WelcomeHandshakeMessage {
+    Welcome { version: u32, error: Option<String> },
+    V0141Welcome { version: u32, error: Option<String> },
+}
+
+#[allow(dead_code)]
+#[derive(Serialize)]
+enum V0141HandshakeMessage {
+    ShellSidebars,
+    Welcome { version: u32, error: Option<String> },
+}
+
+/// Decode the frozen variant-zero `Welcome` and the released v0.14.1
+/// variant-one shape before the peers have agreed on a protocol version.
+pub(crate) fn read_welcome_message<R: Read>(
+    reader: &mut R,
+) -> std::io::Result<(u32, Option<String>)> {
+    let message: WelcomeHandshakeMessage = read_message(reader)?;
+    Ok(match message {
+        WelcomeHandshakeMessage::Welcome { version, error }
+        | WelcomeHandshakeMessage::V0141Welcome { version, error } => (version, error),
+    })
+}
+
+/// Write a protocol-mismatch response in the shape the peer can decode.
+pub(crate) fn write_version_mismatch<W: Write>(
+    writer: &mut W,
+    peer_version: Option<u32>,
+) -> std::io::Result<()> {
+    let error = Some("protocol version mismatch".to_string());
+    if peer_version == Some(V0141_PROTOCOL_VERSION) {
+        write_message(
+            writer,
+            &V0141HandshakeMessage::Welcome {
+                version: PROTOCOL_VERSION,
+                error,
+            },
+        )
+    } else {
+        write_message(
+            writer,
+            &ServerMessage::Welcome {
+                version: PROTOCOL_VERSION,
+                error,
+            },
+        )
+    }
 }
 
 /// Theme projection for the owner-local Remote Machine form. Keeping this
@@ -762,6 +818,35 @@ mod tests {
         assert!(matches!(
             read_message::<_, LegacyServerMessage>(&mut &current_reply[..]).unwrap(),
             LegacyServerMessage::Welcome { version, error: Some(error) }
+                if version == PROTOCOL_VERSION && error == "protocol version mismatch"
+        ));
+    }
+
+    /// v0.14.1 moved `Welcome` to variant one. A current server must answer
+    /// that released client in the shape it can decode, while retaining the
+    /// frozen variant-zero shape for every other protocol generation.
+    #[test]
+    fn version_mismatch_reply_matches_the_requesting_client_wire_shape() {
+        #[allow(dead_code)]
+        #[derive(Deserialize)]
+        enum V0141ServerMessage {
+            ShellSidebars,
+            Welcome { version: u32, error: Option<String> },
+        }
+
+        let mut v0141_reply = Vec::new();
+        write_version_mismatch(&mut v0141_reply, Some(V0141_PROTOCOL_VERSION)).unwrap();
+        assert!(matches!(
+            read_message::<_, V0141ServerMessage>(&mut &v0141_reply[..]).unwrap(),
+            V0141ServerMessage::Welcome { version, error: Some(error) }
+                if version == PROTOCOL_VERSION && error == "protocol version mismatch"
+        ));
+
+        let mut frozen_reply = Vec::new();
+        write_version_mismatch(&mut frozen_reply, Some(6)).unwrap();
+        assert!(matches!(
+            read_message::<_, ServerMessage>(&mut &frozen_reply[..]).unwrap(),
+            ServerMessage::Welcome { version, error: Some(error) }
                 if version == PROTOCOL_VERSION && error == "protocol version mismatch"
         ));
     }

--- a/src/ipc/protocol.rs
+++ b/src/ipc/protocol.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::sound::SoundSignal;
 use crate::terminal::theme_probe::TerminalColors;
 
-pub const PROTOCOL_VERSION: u32 = 17;
+pub const PROTOCOL_VERSION: u32 = 18;
 const MAX_FRAME: usize = 64 * 1024 * 1024;
 
 /// Local display cell size in pixels, or `(0, 0)` when the host does not report it.
@@ -167,11 +167,14 @@ where
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum ServerMessage {
-    ShellSidebars(ShellSidebars),
+    /// **Frozen wire position and shape.** `Welcome` is decoded before peers
+    /// agree on a protocol version. Keep it as variant zero and carry new
+    /// negotiation data in messages sent after a successful handshake.
     Welcome {
         version: u32,
         error: Option<String>,
     },
+    ShellSidebars(ShellSidebars),
     /// A full frame — sent first, on resize, and to a freshly-attached client.
     Frame(FrameData),
     /// Only the cells that changed since the last frame (docs/18 — the wire-level
@@ -720,6 +723,47 @@ mod tests {
             rows,
         } = read_message::<_, LegacyClientMessage>(&mut &buf[..]).unwrap();
         assert_eq!((version, cols, rows), (PROTOCOL_VERSION, 100, 40));
+    }
+
+    /// `Welcome` is the server half of the pre-version handshake. Both an old
+    /// server reply and a current mismatch reply must remain decodable before
+    /// either peer knows whether later messages are compatible.
+    #[test]
+    fn welcome_wire_shape_is_backward_decodable() {
+        #[derive(Serialize, Deserialize)]
+        enum LegacyServerMessage {
+            Welcome { version: u32, error: Option<String> },
+        }
+
+        let mut old_reply = Vec::new();
+        write_message(
+            &mut old_reply,
+            &LegacyServerMessage::Welcome {
+                version: 5,
+                error: Some("protocol version mismatch".into()),
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            read_message::<_, ServerMessage>(&mut &old_reply[..]).unwrap(),
+            ServerMessage::Welcome { version: 5, error: Some(error) }
+                if error == "protocol version mismatch"
+        ));
+
+        let mut current_reply = Vec::new();
+        write_message(
+            &mut current_reply,
+            &ServerMessage::Welcome {
+                version: PROTOCOL_VERSION,
+                error: Some("protocol version mismatch".into()),
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            read_message::<_, LegacyServerMessage>(&mut &current_reply[..]).unwrap(),
+            LegacyServerMessage::Welcome { version, error: Some(error) }
+                if version == PROTOCOL_VERSION && error == "protocol version mismatch"
+        ));
     }
 
     #[test]

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1924,13 +1924,7 @@ fn handle_client(id: u64, stream: Conn, app_tx: Sender<AppEvent>, terminal_theme
                 crate::logging::Field::ProtocolVersion(u64::from(version.unwrap_or(0))),
             ],
         );
-        let _ = protocol::write_message(
-            writer,
-            &ServerMessage::Welcome {
-                version: protocol::PROTOCOL_VERSION,
-                error: Some("protocol version mismatch".into()),
-            },
-        );
+        let _ = protocol::write_version_mismatch(writer, version);
     };
 
     let (cols, rows) = match protocol::read_message::<_, ClientMessage>(&mut reader) {

--- a/src/machine/link.rs
+++ b/src/machine/link.rs
@@ -194,6 +194,47 @@ fn start_child(
         .stack_size(256 * 1024)
         .spawn(move || {
             let mut reader = BufReader::new(stdout);
+            let welcome = protocol::read_welcome_message(&mut reader)
+                .map(|(version, error)| ServerMessage::Welcome { version, error });
+            match welcome {
+                Ok(message) => {
+                    if !notify(LinkEvent::Message {
+                        machine_id: machine_id.clone(),
+                        session: reader_session.clone(),
+                        generation,
+                        message,
+                    }) {
+                        cleanup.close();
+                        let _ = input_writer.join();
+                        let _ = cleanup
+                            .child
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .wait();
+                        return;
+                    }
+                }
+                Err(error) => {
+                    let _ = notify(LinkEvent::Disconnected {
+                        machine_id,
+                        session: reader_session,
+                        generation,
+                        reason: if error.kind() == std::io::ErrorKind::UnexpectedEof {
+                            "SSH connection closed".to_string()
+                        } else {
+                            "remote session protocol failed".to_string()
+                        },
+                    });
+                    cleanup.close();
+                    let _ = input_writer.join();
+                    let _ = cleanup
+                        .child
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .wait();
+                    return;
+                }
+            }
             loop {
                 match protocol::read_message::<_, ServerMessage>(&mut reader) {
                     Ok(message) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,17 @@ fn main() -> Result<()> {
     if args.get(1).map(String::as_str) == Some("__automation-worker") {
         std::process::exit(automation::run_worker(&args)?);
     }
+    // A server restart initiated inside one of its panes cannot synchronously
+    // survive that server closing the pane's PTY. `restart_session_via_helper`
+    // launches this private route in a detached process group first.
+    if args.get(1).map(String::as_str) == Some("__restart-session-helper") {
+        if args.len() != 2 {
+            return Err(anyhow!("invalid internal session restart invocation"));
+        }
+        let selected = session::active_name();
+        session::restart_session(selected.as_deref()).map_err(anyhow::Error::msg)?;
+        return Ok(());
+    }
 
     // One-time local cleanup of the old default-on skill installation. This
     // never downloads or installs a skill; it only removes legacy managed
@@ -1169,7 +1180,12 @@ fn server_restart_all(context: i18n::cli::Context) -> Result<()> {
     let mut errors = Vec::new();
     for info in sessions {
         let selected = (!info.default).then_some(info.name.as_str());
-        match session::restart_session(selected) {
+        let restarted = if info.name == current {
+            session::restart_session_via_helper(selected)
+        } else {
+            session::restart_session(selected)
+        };
+        match restarted {
             Ok(restarted) => print_server_card_for(
                 context,
                 context.text("restarted"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,11 +603,10 @@ fn retry_control_probe<T>(
 fn report_server_version(running: String) -> Result<()> {
     let binary = env!("CARGO_PKG_VERSION");
     if running != binary {
-        eprintln!(
+        return Err(anyhow!(
             "luvus v{binary} installed, but the running server is v{running} — \
              run `luvus server restart` to load it (your session is saved and restored)."
-        );
-        thread::sleep(Duration::from_millis(2000));
+        ));
     }
     Ok(())
 }
@@ -976,18 +975,20 @@ fn server_cmd(args: &[String]) -> Result<()> {
         return ipc::server::run(); // internal role: run the server in the foreground
     };
     let context = i18n::cli::Context::configured();
-    match command {
-        "start" => server_start(context),
-        "stop" => server_stop(context),
-        "restart" => server_restart(context),
-        "status" => server_status(context),
-        "update-manifest" => update_manifest(context),
+    let options = &args[3..];
+    match (command, options) {
+        ("start", []) => server_start(context),
+        ("stop", []) => server_stop(context),
+        ("restart", []) => server_restart(context),
+        ("restart", [flag]) if flag == "--all" => server_restart_all(context),
+        ("status", []) => server_status(context),
+        ("update-manifest", []) => update_manifest(context),
         other => {
-            eprintln!("{}: {other}", context.text("unknown server command"));
+            eprintln!("{}: {}", context.text("unknown server command"), other.0);
             eprintln!(
                 "{}",
                 i18n::cli::help(
-                    "usage: luvus server <start|stop|restart|status|update-manifest>",
+                    "usage: luvus server <start|stop|restart [--all]|status|update-manifest>",
                     context.language(),
                 )
             );
@@ -1148,6 +1149,53 @@ fn server_restart(context: i18n::cli::Context) -> Result<()> {
     Ok(())
 }
 
+/// Restart every server that was running when the command began. Stopped
+/// namespaces remain stopped. The selected session is deliberately last so a
+/// command launched from one of its panes updates every sibling first.
+fn server_restart_all(context: i18n::cli::Context) -> Result<()> {
+    let current = session::display_name();
+    let sessions = restart_all_targets(&current, session::list_sessions()?);
+    if sessions.is_empty() {
+        let sock = persist::client_socket_path();
+        print_server_card(
+            context,
+            context.text("no luvus server running"),
+            None,
+            &sock,
+        );
+        return Ok(());
+    }
+
+    let mut errors = Vec::new();
+    for info in sessions {
+        let selected = (!info.default).then_some(info.name.as_str());
+        match session::restart_session(selected) {
+            Ok(restarted) => print_server_card_for(
+                context,
+                context.text("restarted"),
+                Some(env!("CARGO_PKG_VERSION")),
+                &session::client_socket_path_for(selected),
+                &restarted.name,
+            ),
+            Err(error) => errors.push(format!("{}: {error}", info.name)),
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(errors.join("; ")))
+    }
+}
+
+fn restart_all_targets(
+    current: &str,
+    mut sessions: Vec<session::SessionInfo>,
+) -> Vec<session::SessionInfo> {
+    sessions.retain(|info| info.running);
+    sessions.sort_by_key(|info| info.name == current);
+    sessions
+}
+
 /// Poll (bounded) until the server releases its socket, so `stop`/`restart`
 /// return only once the old server is truly gone.
 fn wait_for_shutdown(_sock: &Path) -> Result<()> {
@@ -1203,11 +1251,21 @@ fn print_server_card(
     socket: &Path,
 ) {
     let session = session::display_name();
+    print_server_card_for(context, state, version, socket, &session);
+}
+
+fn print_server_card_for(
+    context: i18n::cli::Context,
+    state: &str,
+    version: Option<&str>,
+    socket: &Path,
+    session: &str,
+) {
     let socket = socket.display().to_string();
     let version = version.map(|value| format!("v{value}"));
     let mut rows = vec![
         (context.text("status"), state),
-        (context.text("session"), session.as_str()),
+        (context.text("session"), session),
     ];
     if let Some(version) = version.as_deref() {
         rows.push((context.text("version"), version));
@@ -1623,6 +1681,50 @@ mod tests {
     use super::*;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+
+    #[test]
+    fn stale_server_version_fails_before_binary_attach() {
+        let error = report_server_version("0.13.4".to_string()).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("running server is v0.13.4"));
+        assert!(message.contains("luvus server restart"));
+    }
+
+    #[test]
+    fn matching_server_version_allows_binary_attach() {
+        report_server_version(env!("CARGO_PKG_VERSION").to_string()).unwrap();
+    }
+
+    #[test]
+    fn restart_all_targets_only_running_sessions_and_puts_selected_last() {
+        let info = |name: &str, running: bool| session::SessionInfo {
+            name: name.to_string(),
+            default: name == session::DEFAULT_SESSION_NAME,
+            running,
+            socket_path: String::new(),
+            session_dir: String::new(),
+            endpoint: session::SessionEndpoint {
+                transport: "test",
+                address: String::new(),
+            },
+        };
+        let targets = restart_all_targets(
+            "alpha",
+            vec![
+                info(session::DEFAULT_SESSION_NAME, true),
+                info("alpha", true),
+                info("stopped", false),
+                info("beta", true),
+            ],
+        );
+        assert_eq!(
+            targets
+                .iter()
+                .map(|target| target.name.as_str())
+                .collect::<Vec<_>>(),
+            [session::DEFAULT_SESSION_NAME, "beta", "alpha"]
+        );
+    }
 
     #[test]
     fn send_server_stop_reports_absent_when_no_sockets() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -16,6 +16,7 @@ pub const SESSION_ENV_VAR: &str = "LUVUS_SESSION";
 pub const DEFAULT_SESSION_NAME: &str = "default";
 
 const MAX_SESSION_NAME_LEN: usize = 64;
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const STOP_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const START_TIMEOUT: Duration = Duration::from_secs(5);
@@ -36,6 +37,19 @@ pub struct SessionInfo {
 pub struct SessionEndpoint {
     pub transport: &'static str,
     pub address: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClientSessionAction {
+    Start,
+    Reuse,
+    Restart,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SessionServerIdentity {
+    version: String,
+    client_protocol: Option<u32>,
 }
 
 /// Resolve `session attach` and leading global `--session` flags before normal
@@ -286,11 +300,47 @@ pub fn list_sessions() -> std::io::Result<Vec<SessionInfo>> {
 pub fn start_client_session(name: &str) -> Result<SessionInfo, String> {
     let selected = normalize_name(name)?;
     let selected = selected.as_deref();
-    start_session(selected)?;
+    let info = session_info(selected);
+    let running_identity = info
+        .running
+        .then(|| {
+            server_identity_for(selected, CONTROL_TIMEOUT).map_err(|error| {
+                format!("session {name} is running but its version could not be checked: {error}")
+            })
+        })
+        .transpose()?;
+    match client_session_action(
+        info.running,
+        running_identity.as_ref(),
+        env!("CARGO_PKG_VERSION"),
+        crate::ipc::protocol::PROTOCOL_VERSION,
+    ) {
+        ClientSessionAction::Start => {
+            start_session(selected)?;
+        }
+        ClientSessionAction::Reuse => {}
+        ClientSessionAction::Restart => {
+            restart_session(selected)?;
+        }
+    }
     let client = client_socket_path_for(selected);
     let deadline = Instant::now() + START_TIMEOUT;
     while Instant::now() < deadline {
         if is_running_at(&client) {
+            let running = server_identity_for(selected, CONTROL_TIMEOUT).map_err(|error| {
+                format!("session {name} started but its version could not be checked: {error}")
+            })?;
+            if running.version != env!("CARGO_PKG_VERSION")
+                || running.client_protocol != Some(crate::ipc::protocol::PROTOCOL_VERSION)
+            {
+                return Err(format!(
+                    "session {name} is running luvus v{} with client protocol {}, but this client is v{} with protocol {}",
+                    running.version,
+                    running.client_protocol.map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+                    env!("CARGO_PKG_VERSION"),
+                    crate::ipc::protocol::PROTOCOL_VERSION,
+                ));
+            }
             return Ok(session_info(selected));
         }
         std::thread::sleep(STOP_POLL_INTERVAL);
@@ -299,6 +349,69 @@ pub fn start_client_session(name: &str) -> Result<SessionInfo, String> {
         "session {name} started but its client transport was unavailable after {}ms",
         START_TIMEOUT.as_millis(),
     ))
+}
+
+fn client_session_action(
+    running: bool,
+    running_identity: Option<&SessionServerIdentity>,
+    binary_version: &str,
+    client_protocol: u32,
+) -> ClientSessionAction {
+    if !running {
+        ClientSessionAction::Start
+    } else if running_identity.is_some_and(|identity| {
+        identity.version == binary_version && identity.client_protocol == Some(client_protocol)
+    }) {
+        ClientSessionAction::Reuse
+    } else {
+        ClientSessionAction::Restart
+    }
+}
+
+/// Read the selected session's version over the stable newline-delimited JSON
+/// control endpoint. This check happens before a client enters the binary
+/// protocol, whose schema is intentionally versioned and may be incompatible.
+fn server_identity_for(
+    name: Option<&str>,
+    timeout: Duration,
+) -> Result<SessionServerIdentity, String> {
+    let mut stream = crate::ipc::transport::connect_timeout(&api_socket_path_for(name), timeout)
+        .map_err(|error| error.to_string())?;
+    writeln!(
+        stream,
+        "{}",
+        serde_json::json!({"id":"session:version","method":"ping","params":{}})
+    )
+    .map_err(|error| error.to_string())?;
+    stream.flush().map_err(|error| error.to_string())?;
+    let frame = crate::ipc::api::read_response_frame_with_deadline(&mut stream, timeout)
+        .map_err(|error| error.to_string())?;
+    let response: serde_json::Value =
+        serde_json::from_str(&frame).map_err(|error| error.to_string())?;
+    if response.get("id").and_then(serde_json::Value::as_str) != Some("session:version") {
+        return Err("server control response id does not match request".to_string());
+    }
+    let result = response
+        .get("result")
+        .ok_or_else(|| "server returned an invalid ping response".to_string())?;
+    let version = result
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .map(String::from)
+        .ok_or_else(|| "server returned an invalid ping response".to_string())?;
+    let client_protocol = result
+        .get("client_protocol")
+        .map(|value| {
+            value
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or_else(|| "server returned an invalid client protocol".to_string())
+        })
+        .transpose()?;
+    Ok(SessionServerIdentity {
+        version,
+        client_protocol,
+    })
 }
 
 pub fn stop_session(name: Option<&str>) -> Result<SessionInfo, String> {
@@ -502,6 +615,46 @@ mod tests {
         let mut child = crate::platform::no_window(&mut command).spawn().unwrap();
         terminate_and_wait(&mut child).unwrap();
         assert!(child.try_wait().unwrap().is_some());
+    }
+
+    #[test]
+    fn client_session_restarts_only_a_running_stale_target() {
+        assert_eq!(
+            client_session_action(false, None, "0.14.2", 18),
+            ClientSessionAction::Start
+        );
+        let current = SessionServerIdentity {
+            version: "0.14.2".into(),
+            client_protocol: Some(18),
+        };
+        assert_eq!(
+            client_session_action(true, Some(&current), "0.14.2", 18),
+            ClientSessionAction::Reuse
+        );
+        let old_version = SessionServerIdentity {
+            version: "0.13.4".into(),
+            client_protocol: None,
+        };
+        assert_eq!(
+            client_session_action(true, Some(&old_version), "0.14.2", 18),
+            ClientSessionAction::Restart
+        );
+        let old_protocol = SessionServerIdentity {
+            version: "0.14.2".into(),
+            client_protocol: Some(17),
+        };
+        assert_eq!(
+            client_session_action(true, Some(&old_protocol), "0.14.2", 18),
+            ClientSessionAction::Restart
+        );
+        let unknown_protocol = SessionServerIdentity {
+            version: "0.14.2".into(),
+            client_protocol: None,
+        };
+        assert_eq!(
+            client_session_action(true, Some(&unknown_protocol), "0.14.2", 18),
+            ClientSessionAction::Restart
+        );
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -519,6 +519,50 @@ pub fn restart_session(name: Option<&str>) -> Result<SessionInfo, String> {
     start_session(name)
 }
 
+/// Restart one server from a detached helper process. The caller may live in a
+/// pane owned by that server, so the helper must survive the server closing the
+/// caller's PTY before the replacement server is started.
+pub fn restart_session_via_helper(name: Option<&str>) -> Result<SessionInfo, String> {
+    if let Some(name) = name {
+        validate_name(name)?;
+    }
+    let executable = std::env::current_exe().map_err(|error| error.to_string())?;
+    let mut command = Command::new(executable);
+    command
+        .arg("--session")
+        .arg(name.unwrap_or(DEFAULT_SESSION_NAME))
+        .arg("__restart-session-helper")
+        .env_remove("LUVUS_SOCKET_PATH")
+        .env_remove(SESSION_ENV_VAR)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    detach_server_command(&mut command);
+    let output = command
+        .spawn()
+        .map_err(|error| format!("could not start detached restart helper: {error}"))?
+        .wait_with_output()
+        .map_err(|error| format!("could not wait for detached restart helper: {error}"))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        let detail = detail.trim();
+        return Err(if detail.is_empty() {
+            format!("detached restart helper exited with {}", output.status)
+        } else {
+            detail.to_string()
+        });
+    }
+    let info = session_info(name);
+    if info.running {
+        Ok(info)
+    } else {
+        Err(format!(
+            "detached restart helper exited before session {} became ready",
+            name.unwrap_or(DEFAULT_SESSION_NAME)
+        ))
+    }
+}
+
 fn terminate_and_wait(child: &mut std::process::Child) -> Result<(), String> {
     let kill = child.kill();
     match child.wait() {

--- a/website/src/content/docs/docs/faq.mdx
+++ b/website/src/content/docs/docs/faq.mdx
@@ -18,7 +18,11 @@ everything is mouse-driven, and `Shift+↑` scroll mode needs no prefix.
 
 The background server is still the old version, and it keeps running across
 installs by design. Run `luvus server restart` (your session is saved and
-restored). luvus also warns about this at attach.
+restored) for the selected session, or `luvus server restart --all` to restart
+every currently running session. Stopped sessions remain stopped. The
+named-session switcher also detects another running session left on the previous
+version and restarts that session before switching; direct attaches fail with
+the restart instruction instead of entering an incompatible client connection.
 
 ## The git tab is empty / PRs are missing
 

--- a/website/src/content/docs/docs/getting-started/first-session.mdx
+++ b/website/src/content/docs/docs/getting-started/first-session.mdx
@@ -57,8 +57,10 @@ Scroll an agent's history with two-finger scroll, or press `Shift+↑` for
 Press `Ctrl+Space` then `t` to choose another named session. Switching local
 sessions keeps the client open and reconnects its display and input to the
 selected server. Both sessions keep their agents, shells, and pane processes
-running, so you can switch back and continue working. Switching does not
-restart a server or resume agents into replacement processes.
+running, so you can switch back and continue working. Normally, switching does
+not restart a server or resume agents into replacement processes. After a Luvus
+upgrade, selecting a session that is still running the previous version safely
+restarts that target session before handing the client over.
 
 ## 4. Detach: this is the magic
 

--- a/website/src/content/docs/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/docs/getting-started/installation.mdx
@@ -172,8 +172,14 @@ The running server is left alone so active panes are not interrupted. After a
 successful update, reload it when you are ready:
 
 ```sh
-luvus server restart   # your session is saved and restored
+luvus server restart         # restart only the selected session
+luvus server restart --all   # restart every currently running session
 ```
+
+Stopped sessions remain stopped. If you restart only the selected session,
+other running named sessions remain uninterrupted until you select them; the
+session switcher then detects the older server version, restarts that target,
+and completes the switch.
 
 Development binaries under `target/debug` or `target/release` are never
 overwritten by `luvus update`. Rebuild those from source instead.

--- a/website/src/content/docs/docs/reference/cli.mdx
+++ b/website/src/content/docs/docs/reference/cli.mdx
@@ -305,7 +305,7 @@ server:
   server status              is the server running, and what version
   server start               start the background server if it isn't up
   server stop                stop the server (and all panes)
-  server restart             stop + start (load a newly-installed binary)
+  server restart [--all]     stop + start (load a newly-installed binary)
   server update-manifest     fetch the latest agent-detection rules from luvus.dev
                              (applies live if the server is up; else on next start)
   integration install|uninstall <claude|copilot|codex|antigravity|opencode|kimi|grok|hermes|omp>

--- a/website/src/content/docs/docs/uhp/methods.mdx
+++ b/website/src/content/docs/docs/uhp/methods.mdx
@@ -1142,5 +1142,6 @@ subscribe-first snapshot reconciliation.
   directory. Windows uses a local-only named pipe with an owner/System DACL and
   same-user server validation. Access equals command execution as your user. See the
   [security model](/docs/explanation/security/).
-- `ping` returns the server's version and selected session name, useful for
-  health checks, upgrade detection, and routing verification.
+- `ping` returns the server version, binary-client protocol version, and selected
+  session name, useful for health checks, upgrade detection, and routing
+  verification.


### PR DESCRIPTION
Installed clients now recover stale named-session servers cleanly, including upgrades started from inside the session being restarted.

## What

- Preflight named-session handoffs over the stable control API and restart stale version or protocol targets before binary attach.
- Retain compatibility with the v0.14.1 Welcome wire position across local, federated, and SSH-backed clients.
- Add `server restart --all` for every running session while leaving stopped sessions stopped.
- Run the initiating session restart through a detached helper so its own pane teardown cannot interrupt recovery.
- Document selected-session and all-session upgrade recovery.

## Why

After installing a new Luvus version, older named-session servers could reject the new client or close it with an incomplete frame. Restarting every session from one of its own panes could also stop that selected session before the command started its replacement.

## Verification

- [ ] `cargo test --locked` — 1,862 passed locally; one pre-existing macOS zsh PTY fixture timed out, and the exact test passed with Bash.
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Focused protocol, client, server, and federated handshake tests.
- [x] `cargo build --release --locked`
- [x] Isolated live test launched `server restart --all` from session alpha's pane; alpha and beta both received new server PIDs and remained running.

## Notes

Current CI is validating the pushed head across the supported matrix.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change improves upgrade recovery for named sessions, adds restart support across running sessions, and maintains compatibility with previously released handshake layouts.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(session): preserve restart and upgra..."](https://github.com/rizriyz/luvus/commit/90e7419e122b94b9a2068d87deca5b34dd00df04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63411212)</sub>

<!-- /greptile_comment -->