### PR TITLE
feat(opencode): support official V2 CLI session integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Keyboard → Keyboard Shortcuts → Input Sources** to free `Ctrl+Space`.
 | GitHub Copilot CLI | ✓ | ✓ | ✓ |
 | Codex | ✓ | ✓ | ✓ |
 | Antigravity CLI | ✓ | ✓ | session only |
-| opencode | ✓ | ✓ | ✓ |
+| opencode (V1 / V2) | ✓ | ✓ | ✓ |
 | OpenCode 2 Preview | ✓ | exact-ID resume | No |
 | Kimi | ✓ | ✓ | ✓ |
 | Grok | ✓ | ✓ | ✓ |

--- a/plugins/luvus/skills/luvus/SKILL.md
+++ b/plugins/luvus/skills/luvus/SKILL.md
@@ -507,8 +507,10 @@ surface:
 - For Antigravity CLI, `luvus integration install antigravity` adds exact
   conversation identity for restore. It is session-only; native screen
   detection remains authoritative for agent state.
-- For OpenCode, `luvus integration install opencode` adds exact TUI-local root
-  session ownership and structured usage. Without it, usage stays unavailable.
+- For OpenCode V2, `luvus integration install opencode` registers a CLI-only
+  plugin in global `cli.json` for exact selected root-session ownership, not
+  usage. Explicit `OPENCODE_TUI_CONFIG` selects the legacy V1 session/usage
+  installer. Scheduled `opencode run --auto` requires `full_access`.
 - OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
   OpenCode V1 integration for it or infer session IDs from its live database.
 - Devin has native detection and exact-ID resume only. Do not infer session

--- a/skills/luvus/SKILL.md
+++ b/skills/luvus/SKILL.md
@@ -507,8 +507,10 @@ surface:
 - For Antigravity CLI, `luvus integration install antigravity` adds exact
   conversation identity for restore. It is session-only; native screen
   detection remains authoritative for agent state.
-- For OpenCode, `luvus integration install opencode` adds exact TUI-local root
-  session ownership and structured usage. Without it, usage stays unavailable.
+- For OpenCode V2, `luvus integration install opencode` registers a CLI-only
+  plugin in global `cli.json` for exact selected root-session ownership, not
+  usage. Explicit `OPENCODE_TUI_CONFIG` selects the legacy V1 session/usage
+  installer. Scheduled `opencode run --auto` requires `full_access`.
 - OpenCode 2 Preview is a separate `opencode2` agent. Do not install the
   OpenCode V1 integration for it or infer session IDs from its live database.
 - Devin has native detection and exact-ID resume only. Do not infer session

--- a/src/agent/opencode/config.rs
+++ b/src/agent/opencode/config.rs
@@ -131,9 +131,9 @@ fn value_end(input: &[u8], start: usize) -> Result<usize> {
         Some(_) => {
             let mut cursor = start;
             while input.get(cursor).is_some_and(|byte| {
-                !byte.is_ascii_whitespace()
-                    && !matches!(byte, b',' | b']' | b'}')
-                    && !(matches!(byte, b'/') && matches!(input.get(cursor + 1), Some(b'/' | b'*')))
+                !(byte.is_ascii_whitespace()
+                    || matches!(byte, b',' | b']' | b'}')
+                    || (matches!(byte, b'/') && matches!(input.get(cursor + 1), Some(b'/' | b'*'))))
             }) {
                 cursor += 1;
             }
@@ -220,7 +220,12 @@ fn validate_jsonc(input: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn root_object(input: &str) -> Result<RootObject> {
+    root_object_for(input, "plugin")
+}
+
+fn root_object_for(input: &str, property: &str) -> Result<RootObject> {
     if input.len() > MAX_TUI_CONFIG_BYTES {
         return Err(anyhow!("OpenCode tui config exceeds 1 MiB"));
     }
@@ -264,7 +269,7 @@ fn root_object(input: &str) -> Result<RootObject> {
         skip_trivia(bytes, &mut cursor)?;
         let start = cursor;
         let end = value_end(bytes, start)?;
-        if key == "plugin" && plugin.replace((start, end)).is_some() {
+        if key == property && plugin.replace((start, end)).is_some() {
             return Err(anyhow!(
                 "OpenCode tui config contains duplicate plugin properties"
             ));
@@ -322,8 +327,8 @@ fn array_value(input: &str, start: usize, end: usize) -> Result<ArrayValue> {
     }
 }
 
-fn plugin_elements(input: &str) -> Result<(RootObject, ArrayValue)> {
-    let root = root_object(input)?;
+fn plugin_elements_for(input: &str, property: &str) -> Result<(RootObject, ArrayValue)> {
+    let root = root_object_for(input, property)?;
     let (start, end) = root
         .plugin
         .ok_or_else(|| anyhow!("OpenCode tui config has no plugin array"))?;
@@ -353,8 +358,8 @@ fn remove_element(input: &str, array: &ArrayValue, index: usize) -> String {
     output
 }
 
-fn add_plugin(input: &str) -> Result<String> {
-    let root = root_object(input)?;
+fn add_plugin(input: &str, property: &str, spec: &str) -> Result<String> {
+    let root = root_object_for(input, property)?;
     let mut output = input.to_string();
     if root.plugin.is_none() {
         let separator = if root.properties == 0 || root.trailing_comma {
@@ -364,38 +369,47 @@ fn add_plugin(input: &str) -> Result<String> {
         };
         output.insert_str(
             root.close,
-            &format!("{separator}\n  \"plugin\": [\"{TUI_PLUGIN_SPEC}\"]\n"),
+            &format!("{separator}\n  \"{property}\": [\"{spec}\"]\n"),
         );
         return Ok(output);
     }
-    let (_, array) = plugin_elements(input)?;
+    let (_, array) = plugin_elements_for(input, property)?;
     if let Some(last) = array.elements.last() {
         if last.comma_after.is_some() {
-            output.insert_str(array.close, &format!("\"{TUI_PLUGIN_SPEC}\""));
+            output.insert_str(array.close, &format!("\"{spec}\""));
         } else {
-            output.insert_str(last.end, &format!(", \"{TUI_PLUGIN_SPEC}\""));
+            output.insert_str(last.end, &format!(", \"{spec}\""));
         }
     } else {
-        output.insert_str(array.close, &format!("\"{TUI_PLUGIN_SPEC}\""));
+        output.insert_str(array.close, &format!("\"{spec}\""));
     }
     Ok(output)
 }
 
 pub(super) fn enable(input: &str) -> Result<String> {
+    enable_for(input, "plugin", TUI_PLUGIN_SPEC, LEGACY_TUI_PLUGIN_SPEC)
+}
+
+pub(super) fn enable_for(
+    input: &str,
+    property: &str,
+    spec: &str,
+    legacy_spec: &str,
+) -> Result<String> {
     validate_jsonc(input)?;
     let mut output = input.to_string();
     loop {
-        let root = root_object(&output)?;
+        let root = root_object_for(&output, property)?;
         if root.plugin.is_none() {
-            return add_plugin(&output);
+            return add_plugin(&output, property, spec);
         }
-        let (_, array) = plugin_elements(&output)?;
+        let (_, array) = plugin_elements_for(&output, property)?;
         let mut current = Vec::new();
         let mut legacy = None;
         for (index, element) in array.elements.iter().copied().enumerate() {
             match plugin_name(&output, element).as_deref() {
-                Some(TUI_PLUGIN_SPEC) => current.push(index),
-                Some(LEGACY_TUI_PLUGIN_SPEC) => legacy = Some(index),
+                Some(value) if value == spec => current.push(index),
+                Some(value) if value == legacy_spec => legacy = Some(index),
                 _ => {}
             }
         }
@@ -406,16 +420,25 @@ pub(super) fn enable(input: &str) -> Result<String> {
         } else if current.len() == 1 {
             return Ok(output);
         } else {
-            return add_plugin(&output);
+            return add_plugin(&output, property, spec);
         }
     }
 }
 
 pub(super) fn disable(input: &str) -> Result<String> {
+    disable_for(input, "plugin", TUI_PLUGIN_SPEC, LEGACY_TUI_PLUGIN_SPEC)
+}
+
+pub(super) fn disable_for(
+    input: &str,
+    property: &str,
+    spec: &str,
+    legacy_spec: &str,
+) -> Result<String> {
     validate_jsonc(input)?;
     let mut output = input.to_string();
     loop {
-        let root = root_object(&output)?;
+        let root = root_object_for(&output, property)?;
         let Some((start, end)) = root.plugin else {
             return Ok(output);
         };
@@ -423,7 +446,7 @@ pub(super) fn disable(input: &str) -> Result<String> {
         let Some(index) = array.elements.iter().copied().position(|element| {
             matches!(
                 plugin_name(&output, element).as_deref(),
-                Some(TUI_PLUGIN_SPEC | LEGACY_TUI_PLUGIN_SPEC)
+                Some(value) if value == spec || value == legacy_spec
             )
         }) else {
             return Ok(output);
@@ -433,13 +456,17 @@ pub(super) fn disable(input: &str) -> Result<String> {
 }
 
 pub(super) fn enabled(input: &str) -> bool {
+    enabled_for(input, "plugin", TUI_PLUGIN_SPEC)
+}
+
+pub(super) fn enabled_for(input: &str, property: &str, spec: &str) -> bool {
     validate_jsonc(input).is_ok()
-        && plugin_elements(input).is_ok_and(|(_, array)| {
+        && plugin_elements_for(input, property).is_ok_and(|(_, array)| {
             array
                 .elements
                 .iter()
                 .copied()
-                .any(|element| plugin_name(input, element).as_deref() == Some(TUI_PLUGIN_SPEC))
+                .any(|element| plugin_name(input, element).as_deref() == Some(spec))
         })
 }
 

--- a/src/agent/opencode/integration.rs
+++ b/src/agent/opencode/integration.rs
@@ -7,11 +7,30 @@ use super::super::types::IntegrationOperations;
 use crate::integration;
 
 pub(super) const OPERATIONS: IntegrationOperations = IntegrationOperations {
-    install,
-    uninstall,
-    is_installed,
+    install: install_current,
+    uninstall: uninstall_current,
+    is_installed: current_installed,
     hook: None,
 };
+
+fn install_current() -> Result<()> {
+    // An explicitly selected legacy TUI config retains the V1 installer.
+    // Ordinary `opencode` installations now use the official V2 CLI contract.
+    if std::env::var_os("OPENCODE_TUI_CONFIG").is_some_and(|value| !value.is_empty()) {
+        install()
+    } else {
+        super::v2_integration::install()
+    }
+}
+
+fn uninstall_current() -> Result<()> {
+    super::v2_integration::uninstall()?;
+    uninstall()
+}
+
+fn current_installed() -> bool {
+    super::v2_integration::is_installed() || is_installed()
+}
 
 const TUI_PLUGIN: &str = include_str!("luvus-tui.js");
 

--- a/src/agent/opencode/luvus-v2.js
+++ b/src/agent/opencode/luvus-v2.js
@@ -1,0 +1,98 @@
+// OpenCode >=2.0.2 CLI integration. The CLI owns the selected pane/session;
+// the shared OpenCode service must never report ownership for another TUI.
+import net from "node:net"
+import { createEffect } from "solid-js"
+
+function samePath(left, right) {
+  if (typeof left !== "string" || typeof right !== "string") return false
+  const clean = (value) => {
+    const path = value.replaceAll("\\", "/").replace(/\/+$/, "")
+    return process.platform === "win32" ? path.toLowerCase() : path
+  }
+  return clean(left) === clean(right)
+}
+
+export function reportFor(context) {
+  const route = context.ui.router.current()
+  if (route?.type !== "session" || !route.sessionID) return
+  const info = context.data.session.get(route.sessionID)
+  if (!info || info.id !== route.sessionID || info.parentID) return
+  const location = context.location ?? context.data.location.default()
+  if (!samePath(info.directory, location?.directory)) return
+  return { pane: process.env.LUVUS_PANE_ID, agent: "opencode", session_id: info.id }
+}
+
+export default {
+  id: "luvus.session.v2",
+  setup(context) {
+    const address = process.env.LUVUS_API_ADDRESS || process.env.LUVUS_SOCKET_PATH
+    if (process.env.LUVUS_ENV !== "1" || !address || !process.env.LUVUS_PANE_ID) return
+    let disposed = false
+    let pending
+    let current
+    let last = ""
+    let sequence = 0
+    const send = () => {
+      if (disposed || current || !pending) return
+      const params = pending
+      pending = undefined
+      const fingerprint = JSON.stringify(params)
+      const id = `luvus-v2-${++sequence}`
+      const socket = net.createConnection(address)
+      current = socket
+      let response = ""
+      let bytes = 0
+      let finished = false
+      const finish = (ok) => {
+        if (finished) return
+        finished = true
+        clearTimeout(timeout)
+        socket.destroy()
+        current = undefined
+        if (ok) last = fingerprint
+        send()
+      }
+      const timeout = setTimeout(() => finish(false), 500)
+      socket.on("connect", () => socket.write(`${JSON.stringify({ id, method: "pane.report_session", params })}\n`))
+      socket.on("data", (chunk) => {
+        bytes += chunk.length
+        if (bytes > 65536) return finish(false)
+        response += chunk.toString("utf8")
+        const newline = response.indexOf("\n")
+        if (newline < 0) return
+        try {
+          const reply = JSON.parse(response.slice(0, newline))
+          finish(reply.id === id && reply.result?.type === "ok")
+        } catch { finish(false) }
+      })
+      socket.on("error", () => finish(false))
+      socket.on("end", () => finish(false))
+    }
+    const publish = () => {
+      if (disposed) return
+      const params = reportFor(context)
+      if (!params) {
+        pending = undefined
+        last = ""
+        return
+      }
+      if (JSON.stringify(params) === last) return
+      pending = params
+      send()
+    }
+    // Reactive route/session reads handle navigation without an idle poll.
+    const removeSlot = context.ui.slot({
+      append: "app",
+      render: () => { createEffect(publish); return null },
+    })
+    // A cache refresh can also make an initially cold selected session ready.
+    const stop = context.data.on("session.updated", publish)
+    return () => {
+      disposed = true
+      pending = undefined
+      current?.destroy()
+      stop()
+      removeSlot()
+    }
+  },
+}

--- a/src/agent/opencode/mod.rs
+++ b/src/agent/opencode/mod.rs
@@ -6,6 +6,7 @@ use super::types::{
 mod config;
 mod integration;
 pub(in crate::agent) mod sessions;
+mod v2_integration;
 #[cfg(test)]
 pub(super) use sessions::{latest as opencode_latest, recent as opencode_recent};
 
@@ -16,10 +17,12 @@ pub(super) const DESCRIPTOR: AgentDescriptor = AgentDescriptor {
     task_prompt_args: &["--prompt"],
     automation: Some(AutomationOperations {
         read_only: None,
-        workspace: Some(AutomationLaunch {
+        // Since 2.0.2, `opencode` is the V2 executable. --auto is not a
+        // workspace confinement policy; keep it behind explicit full access.
+        workspace: None,
+        full_access: Some(AutomationLaunch {
             args: &["run", "--auto"],
         }),
-        full_access: None,
     }),
     identity: IdentityDescriptor {
         distinct: &["opencode"],

--- a/src/agent/opencode/v2_integration.rs
+++ b/src/agent/opencode/v2_integration.rs
@@ -1,0 +1,142 @@
+//! Official OpenCode V2 CLI-only integration. No service/database mutation.
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+const SPEC: &str = "./luvus-v2";
+const TUI: &str = include_str!("luvus-v2.js");
+const PACKAGE: &str = r#"{"name":"luvus-v2","private":true,"type":"module","exports":{"./tui":"./tui.js"},"peerDependencies":{"solid-js":">=1.9.0"}}"#;
+
+fn directory() -> PathBuf {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| crate::integration::home().join(".config"))
+        .join("opencode")
+}
+
+pub(super) fn install() -> Result<()> {
+    let directory = directory();
+    let config = directory.join("cli.json");
+    let contents = match fs::read_to_string(&config) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => "{}\n".into(),
+        Err(error) => return Err(error.into()),
+    };
+    // Validate before writing assets; preserve formatting, comments and plugins.
+    let updated = super::config::enable_for(&contents, "plugins", SPEC, SPEC)?;
+    let package = directory.join("luvus-v2");
+    let assets = [("package.json", PACKAGE), ("tui.js", TUI)];
+    let mut previous = Vec::new();
+    for (name, expected) in assets {
+        let path = package.join(name);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => {
+                anyhow::ensure!(
+                    bytes == expected.as_bytes(),
+                    "preserving modified integration asset {}",
+                    path.display()
+                );
+                Some(bytes)
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        previous.push((path, bytes));
+    }
+    fs::create_dir_all(&package)?;
+    let result = (|| {
+        for (name, contents) in assets {
+            crate::integration::write_bytes_atomic(&package.join(name), contents.as_bytes())?;
+        }
+        crate::integration::write_bytes_atomic(&config, updated.as_bytes())
+    })();
+    if result.is_err() {
+        for (path, bytes) in previous {
+            if let Some(bytes) = bytes {
+                let _ = crate::integration::write_bytes_atomic(&path, &bytes);
+            } else {
+                let _ = fs::remove_file(path);
+            }
+        }
+        let _ = fs::remove_dir(package);
+    }
+    result
+}
+
+pub(super) fn uninstall() -> Result<()> {
+    let directory = directory();
+    let config = directory.join("cli.json");
+    match fs::read_to_string(&config) {
+        Ok(contents) => {
+            let updated = super::config::disable_for(&contents, "plugins", SPEC, SPEC)?;
+            if updated != contents {
+                crate::integration::write_bytes_atomic(&config, updated.as_bytes())?;
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    // Leave user-edited assets and every unrelated neighbor intact.
+    let package = directory.join("luvus-v2");
+    for (name, expected) in [("package.json", PACKAGE), ("tui.js", TUI)] {
+        let path = package.join(name);
+        if fs::read_to_string(&path).is_ok_and(|contents| contents == expected) {
+            fs::remove_file(path)?;
+        }
+    }
+    let _ = fs::remove_dir(package);
+    Ok(())
+}
+
+pub(super) fn is_installed() -> bool {
+    let directory = directory();
+    directory.join("luvus-v2/tui.js").is_file()
+        && directory.join("luvus-v2/package.json").is_file()
+        && fs::read_to_string(directory.join("cli.json"))
+            .is_ok_and(|contents| super::config::enabled_for(&contents, "plugins", SPEC))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v2_cli_install_is_surgical_idempotent_and_rejects_invalid_config() {
+        let _env = crate::persist::test_env("opencode-v2-cli");
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test-state/v2-cli");
+        let old = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", &root);
+        let directory = directory();
+        fs::create_dir_all(&directory).unwrap();
+        let config = directory.join("cli.json");
+        fs::write(
+            &config,
+            "{\n // keep\n \"plugins\": [\"other\",],\n \"theme\": \"custom\"\n}\n",
+        )
+        .unwrap();
+        install().unwrap();
+        let installed = fs::read_to_string(&config).unwrap();
+        install().unwrap();
+        assert_eq!(fs::read_to_string(&config).unwrap(), installed);
+        assert!(is_installed());
+        assert!(installed.contains("// keep"));
+        assert!(installed.contains("\"plugins\""));
+        assert!(!directory.join("opencode.json").exists());
+        fs::write(directory.join("luvus-v2/user.txt"), "keep").unwrap();
+        uninstall().unwrap();
+        assert!(!is_installed());
+        assert!(directory.join("luvus-v2/user.txt").is_file());
+        let remaining = fs::read_to_string(&config).unwrap();
+        assert!(remaining.contains("other") && remaining.contains("// keep"));
+        fs::write(&config, "{\"plugins\":\"invalid\"}").unwrap();
+        assert!(install().is_err());
+        assert!(!directory.join("luvus-v2/tui.js").exists());
+        match old {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -158,6 +158,10 @@ mod tests {
         assert!(!opencode2.supports(AutomationAccess::ReadOnly));
         assert!(!opencode2.supports(AutomationAccess::Workspace));
         assert!(opencode2.supports(AutomationAccess::FullAccess));
+        let opencode = find("opencode").unwrap().automation.unwrap();
+        assert!(!opencode.supports(AutomationAccess::ReadOnly));
+        assert!(!opencode.supports(AutomationAccess::Workspace));
+        assert!(opencode.supports(AutomationAccess::FullAccess));
     }
 
     #[test]

--- a/src/app/dispatch/tests/agents.rs
+++ b/src/app/dispatch/tests/agents.rs
@@ -83,10 +83,13 @@ fn strip_title_icon_drops_a_leading_glyph_only() {
 /// the node label.
 #[test]
 fn agent_list_labels_a_pane_with_its_node_name() {
+    let _env = crate::persist::test_env("agent-node-label");
     let (tx, _rx) = std::sync::mpsc::channel();
     let mut app = App::new(80, 24, tx).unwrap();
     // Rename the node so its label and its cwd basename can't coincide.
     app.workspaces[0].name = "renamed-node".into();
+    // This fixture is an ordinary workspace even when tests run in a worktree.
+    app.workspaces[0].worktree = None;
     app.workspaces[0].branch = Some("feat/x".into());
 
     // Make the one existing pane look like a live agent.
@@ -710,8 +713,19 @@ fn observed_prompt_no_wait_keeps_the_queued_response_and_no_ownership() {
 #[test]
 fn observed_prompt_exited_terminal_releases_ownership_before_pane_removal() {
     let _env = crate::persist::test_env("prompt-terminal-exit");
+    // Exercise prompt/exit ordering without the user's interactive shell rc.
+    #[cfg(unix)]
+    let previous_shell = std::env::var_os("LUVUS_SHELL");
+    #[cfg(unix)]
+    std::env::set_var("LUVUS_SHELL", "/bin/sh");
     let (tx, _rx) = std::sync::mpsc::channel();
-    let mut app = App::new(80, 24, tx).unwrap();
+    let app = App::new(80, 24, tx);
+    #[cfg(unix)]
+    match previous_shell {
+        Some(value) => std::env::set_var("LUVUS_SHELL", value),
+        None => std::env::remove_var("LUVUS_SHELL"),
+    }
+    let mut app = app.unwrap();
     let pane = app.layout().focus;
     mark_codex_prompt_ready(&mut app, pane);
     let (reply, response) = std::sync::mpsc::channel();

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4628,6 +4628,7 @@ mod tests {
         let _env = crate::persist::test_env("prefix-shifted-workspace-jump");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = crate::app::App::new(80, 24, tx).unwrap();
+        app.workspaces[0].worktree = None;
         let focus = app.layout().focus;
         for position in 2..=9 {
             app.workspaces[0]

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1055,6 +1055,7 @@ mod tests {
         let _env = crate::persist::test_env("jump-workspace-display-order");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
+        app.workspaces[0].worktree = None;
         let focus = app.layout().focus;
         for position in 2..=3 {
             app.workspaces.push(Workspace {
@@ -1667,6 +1668,7 @@ mod tests {
         let _env = crate::persist::test_env("focus-workspaces-command");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(80, 24, tx).unwrap();
+        app.workspaces[0].worktree = None;
         let pane = app.layout().focus;
         app.workspaces.push(Workspace {
             id: crate::ids::public_id("workspace"),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11867,7 +11867,9 @@ mod tests {
         // The bare middle of the same border row (between the title and the
         // buttons) is not chrome, so it still grabs the divider to resize.
         let divider_row = zoom.y;
-        let bare = 60u16; // mid-width: past the title, before the right-edge buttons
+        let bare = (title.right()..zoom.x)
+            .find(|&x| !app.on_pane_chrome(x, divider_row))
+            .expect("there is a bare seam between title and zoom");
         assert!(
             !app.on_pane_chrome(bare, divider_row),
             "the chosen seam cell is genuinely not chrome"

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -835,9 +835,9 @@ mod tests {
         std::env::remove_var("OPENCODE_TUI_CONFIG");
 
         install("opencode").unwrap();
-        let plugin = tmp.join("opencode").join("luvus-tui.mjs");
+        let plugin = tmp.join("opencode").join("luvus-v2/tui.js");
         let js = fs::read_to_string(&plugin).unwrap();
-        assert!(js.contains("session.created"), "hooks the session event");
+        assert!(js.contains("session.updated"), "hooks the session event");
         assert!(js.contains("pane.report_session"), "reports the session");
         assert!(
             js.contains("net.createConnection"),
@@ -845,6 +845,10 @@ mod tests {
         );
         assert!(!js.contains("child_process"));
         assert!(js.contains("opencode"));
+        assert!(
+            js.contains("export default"),
+            "V2 auto-loads this directory and rejects a module without a default"
+        );
         assert!(is_installed("opencode"));
 
         match old {

--- a/src/terminal/host_input/console.rs
+++ b/src/terminal/host_input/console.rs
@@ -290,10 +290,7 @@ fn parse_win32_record(body: &str) -> Option<ConsoleKeyRecord> {
 }
 
 fn stream_record_candidate(record: ConsoleKeyRecord) -> bool {
-    record.key_down
-        && (record.virtual_key == 0
-            || record.scan_code == 0
-            || (record.utf16 == 0x1b && record.scan_code == 0 && record.control_state == 0))
+    record.key_down && (record.virtual_key == 0 || record.scan_code == 0)
 }
 
 fn record_for_char(ch: char) -> ConsoleKeyRecord {
@@ -320,7 +317,7 @@ fn raw_escape_candidate(record: ConsoleKeyRecord) -> bool {
     record.key_down
         && record.scan_code == 0
         && record.control_state == 0
-        && (record.utf16 == 0x1b || (record.virtual_key == VK_ESCAPE && record.scan_code == 0))
+        && (record.utf16 == 0x1b || record.virtual_key == VK_ESCAPE)
 }
 
 fn control_prefix(text: &str) -> bool {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1356,6 +1356,7 @@ mod tests {
         let _env = crate::persist::test_env("agent-mention");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(120, 40, tx).unwrap();
+        app.workspaces[0].name = "project".into();
         let id = app.layout().focus;
         app.status.get_mut(&id).unwrap().agent = "claude".into();
         let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
@@ -1410,6 +1411,7 @@ mod tests {
         let _env = crate::persist::test_env("agent-meta-colour");
         let (tx, _rx) = std::sync::mpsc::channel();
         let mut app = App::new(120, 40, tx).unwrap();
+        app.workspaces[0].name = "project".into();
         let id = app.layout().focus;
         app.status.get_mut(&id).unwrap().agent = "claude".into();
         let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();

--- a/website/public/agent-readme.md
+++ b/website/public/agent-readme.md
@@ -334,9 +334,10 @@ discovery rather than inferring support from an agent name.
   conversation id needed for `agy --conversation <id>` restore; screen
   detection remains authoritative for state.
 - OpenCode detection and legacy JSON session discovery work without setup.
-  `luvus integration install opencode` adds a TUI-local plugin that reports
-  only the root session selected in that pane plus structured usage. Without
-  it, Mission Control leaves OpenCode usage unavailable instead of guessing.
+  `luvus integration install opencode` adds a V2 CLI-only plugin in global
+  `cli.json` for selected root-session identity, not usage. Explicit
+  `OPENCODE_TUI_CONFIG` selects the legacy V1 session/usage installer.
+  Scheduled `opencode run --auto` requires `full_access`.
 - OpenCode 2 Preview is detected separately as `opencode2`. Luvus can launch it
   and resume an exact known ID with `opencode2 --session <id>`, but does not
   scan its live SQLite database or reuse the OpenCode V1 integration. Its

--- a/website/src/content/docs/docs/guides/agents.mdx
+++ b/website/src/content/docs/docs/guides/agents.mdx
@@ -77,7 +77,7 @@ Click a session row to select it and update the Selected Agent panel. Use
 | Claude Code | project transcript |
 | Codex | rollout token counters |
 | GitHub Copilot CLI | session shutdown metrics |
-| opencode | selected-session integration events |
+| opencode | selected-session V1 integration events; unavailable from the V2 plugin |
 | OpenCode 2 Preview | unavailable until an exact structured counter is exposed |
 | Kimi | session status records |
 | Grok | completed-turn usage records |
@@ -246,12 +246,12 @@ or toggle it in **Settings → Integrations**. What it does per agent:
   `~/.gemini/config/hooks.json`. It reports only the exact conversation id for
   `agy --conversation <id>` restore; screen detection continues to own agent
   state, and every other named Antigravity hook is preserved.
-- **opencode**: installs a TUI-local plugin and registers it in the effective
-  `tui.json`, `tui.jsonc`, or `OPENCODE_TUI_CONFIG` file
-  without removing comments or unrelated plugins. It reports only the root
-  session selected in that pane and sends cumulative structured usage directly
-  to the inherited owner-local Luvus endpoint. No `luvus` process is spawned per
-  update and no agent database is opened.
+- **opencode**: installs a V2 CLI-only plugin in `~/.config/opencode/luvus-v2/`
+  and registers it in global `cli.json` (respecting `XDG_CONFIG_HOME`). It reports
+  only the selected root session's exact identity, not usage, directly to the
+  inherited owner-local endpoint. No agent database is opened. To install the
+  V1 session-and-usage plugin instead, explicitly set `OPENCODE_TUI_CONFIG` to
+  its `tui.json(c)`. Comments, settings and unrelated plugins are preserved.
 - **kimi**: adds a `[[hooks]]` entry to `~/.kimi-code/config.toml`, edited in
   place so your API keys, comments, and own hooks are left untouched.
 - **grok**: installs its own hook file without editing Grok's authentication

--- a/website/src/content/docs/docs/guides/automation.mdx
+++ b/website/src/content/docs/docs/guides/automation.mdx
@@ -216,7 +216,7 @@ behalf.
 | Codex | yes | yes | yes |
 | Gemini | no | yes | yes |
 | Aider | yes | no | yes |
-| opencode | no | yes | no |
+| opencode | no | no | yes |
 | OpenCode 2 Preview | no | no | yes |
 | GitHub Copilot CLI | yes | yes | yes |
 | Kimi Code CLI | no | yes | yes |

--- a/website/src/content/docs/docs/reference/agents.mdx
+++ b/website/src/content/docs/docs/reference/agents.mdx
@@ -66,13 +66,16 @@ description: What luvus supports per agent, covering live status, session resume
   remains responsible for idle/working/blocked state, and uninstall preserves
   every other named hook.
 
-  OpenCode installs `~/.config/opencode/luvus-tui.mjs`, or the equivalent under
-  `XDG_CONFIG_HOME`, and adds only that file to the TUI plugin list. The plugin
-  binds the root session selected by that specific TUI and reports its
-  structured usage over the inherited local Luvus endpoint. Background and
-  child-session events cannot claim the pane. Without the integration,
-  OpenCode detection and legacy JSON session discovery still work while usage
-  remains unavailable.
+  OpenCode V2 installs a CLI-only package at `~/.config/opencode/luvus-v2/`
+  (or under `XDG_CONFIG_HOME`) and registers it in the global `cli.json`.
+  It reports the exact selected root session over the inherited Luvus endpoint,
+  with no shared-service or database mutation. Background and child sessions
+  cannot claim the pane. The V2 plugin reports session identity, not usage.
+  Legacy JSON discovery remains available; V2 SQLite discovery is not provided.
+  For V1, explicitly set `OPENCODE_TUI_CONFIG` to its `tui.json(c)` when installing
+  the legacy plugin, which also reports structured usage. Both installers
+  preserve unrelated settings and plugins. Scheduled `opencode run --auto`
+  requires explicit **Full access**; it does not enforce workspace confinement.
 
   OpenCode 2 Preview is a separate built-in agent because its `opencode2`
   executable can run beside OpenCode V1 and uses a different service, database,


### PR DESCRIPTION
## Summary
- Add an official OpenCode V2 CLI-only plugin, registered surgically in global cli.json; report the selected root session to the inherited Luvus endpoint using bounded, coalesced socket requests.
- Preserve the legacy V1 installer when OPENCODE_TUI_CONFIG is explicitly selected. Preserve comments, unrelated plugins/settings and edited assets during install/uninstall.
- Require explicit full_access for opencode run --auto, since it does not enforce workspace confinement.
- Update public docs and bundled guidance, integration/registry tests, and checkout-dependent test fixtures. Include equivalent boolean simplifications required by strict Clippy on the current toolchain.

## Scope
The V2 plugin reports session identity only. This PR does not add V2 usage accounting or SQLite discovery. Native detection and existing legacy JSON discovery remain available. The separate opencode2 compatibility descriptor remains unchanged.

The V2 CLI/config/plugin contracts were checked against https://opencode.ai/v2/docs/cli/config and https://opencode.ai/v2/docs/build/plugins/cli. Existing installations of V1 should use an explicit OPENCODE_TUI_CONFIG for legacy installation.

## Verification
- cargo fmt --all --check
- cargo clippy --release --locked --all-targets -- -D warnings
- Isolated cargo test --locked: 1,855 passed, 0 failed, 5 ignored (including integration, detection and registry tests)
- cargo build --release --locked
- Node-based plugin selection checks: root session accepted; child, wrong ID, wrong location, cold data and home route rejected

Fresh loading of the installed plugin in the official V2 CLI and live Linux/Windows behavior remain unverified; no shared service or user configuration was modified during validation.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

## Summary

- The OpenCode V2 integration can retain a previously selected root session after the user navigates away from it.
- The retained association is persisted with the pane, so a later restore can resume a session the user no longer selected.

This must be corrected before merging.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- A second finding-proof was posted for the same P1 finding.
- Contract validation and pane session checks were executed, and the results confirmed contract behavior and data validation details.

<a href="https://app.greptile.com/trex/runs/23994056/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rizriyz%2Fluvus%22%20on%20the%20existing%20branch%20%22feat%2Fopencode-v2-cli%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fopencode-v2-cli%22.%0A%0AGreploop%20rizriyz%2Fluvus%20PR%20%23349%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=rizriyz%2Fluvus&pr=349&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rizriyz%2Fluvus%22%20on%20the%20existing%20branch%20%22feat%2Fopencode-v2-cli%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fopencode-v2-cli%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fagent%2Fopencode%2Fluvus-v2.js%3A74-77%0A**Release%20stale%20ownership**%0A%0AWhen%20the%20user%20leaves%20a%20valid%20root-session%20route%2C%20this%20branch%20clears%20only%20the%20plugin's%20local%20queue%20and%20does%20not%20release%20the%20session%20already%20reported%20for%20the%20pane.%20The%20saved%20pane%20state%20therefore%20continues%20to%20contain%20that%20old%20OpenCode%20session%20and%20can%20resume%20it%20after%20the%20user%20has%20navigated%20elsewhere.%20Add%20a%20server-side%20release%20operation%20and%20invoke%20it%20whenever%20no%20reportable%20session%20is%20selected.%20This%20must%20be%20corrected%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rizriyz%2Fluvus&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fagent%2Fopencode%2Fluvus-v2.js%3A74-77%0A**Release%20stale%20ownership**%0A%0AWhen%20the%20user%20leaves%20a%20valid%20root-session%20route%2C%20this%20branch%20clears%20only%20the%20plugin's%20local%20queue%20and%20does%20not%20release%20the%20session%20already%20reported%20for%20the%20pane.%20The%20saved%20pane%20state%20therefore%20continues%20to%20contain%20that%20old%20OpenCode%20session%20and%20can%20resume%20it%20after%20the%20user%20has%20navigated%20elsewhere.%20Add%20a%20server-side%20release%20operation%20and%20invoke%20it%20whenever%20no%20reportable%20session%20is%20selected.%20This%20must%20be%20corrected%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rizriyz%2Fluvus&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/agent/opencode/luvus-v2.js:74-77
**Release stale ownership**

When the user leaves a valid root-session route, this branch clears only the plugin's local queue and does not release the session already reported for the pane. The saved pane state therefore continues to contain that old OpenCode session and can resume it after the user has navigated elsewhere. Add a server-side release operation and invoke it whenever no reportable session is selected. This must be corrected before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(opencode): support official V2 CLI ..."](https://github.com/rizriyz/luvus/commit/85129ff2e74537ccc294212dfa434bd9c8e5f89f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63428548)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->